### PR TITLE
attribution: change package author - PineTS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ await chart.ready();
 ## Indicators
 
 Vela runs indicator scripts through pluggable engines. The Pine engine uses
-[PineTS](https://github.com/alaa-eddine/PineTS) — an **optional peer dependency licensed
+[PineTS](https://github.com/LuxAlgo/PineTS) — an **optional peer dependency licensed
 under AGPL-3.0** (Vela itself is Apache-2.0; installing `pinets` applies its own license
 to your bundle):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vela",
-  "version": "0.1.0",
+  "name": "@luxalgo/vela",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vela",
-      "version": "0.1.0",
+      "name": "@luxalgo/vela",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "LICENSE",
     "README.md"
   ],
-  "author": "Alaa-eddine Kaddouri",
+  "author": "LuxAlgo",
   "sideEffects": false,
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata and documentation only; no runtime, API, or security-sensitive code changes.
> 
> **Overview**
> Updates **package attribution** by changing `package.json` **author** from the previous individual name to **LuxAlgo**.
> 
> The **Indicators** section in `README.md` now points the PineTS optional peer dependency link to **`github.com/LuxAlgo/PineTS`** instead of the old repository URL.
> 
> `package-lock.json` is aligned with the scoped package name **`@luxalgo/vela`** at version **0.2.0** (matching the current `package.json` metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9779c2a1cd8b7d0d0bc5b51d55aea07e60417a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->