### PR TITLE
Feat/drawings improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ All notable changes to Vela, newest first.
   armed tool ready after each placement, so you can draw several of the same shape without
   re-picking the tool. Turn it off for the usual one-shot behavior; the brush family still
   stays armed either way.
+- **Position sizing on the long/short tool.** The long/short position drawing now sizes from
+  your account: open its gear settings to set a risk percentage and account balance, and the
+  chart shows the dollar loss at the stop and the matching position size alongside the usual
+  risk:reward and percentage labels. The position size is itself editable — type the size you
+  want and the risk percentage adjusts to match. Drag from the entry in the profit direction —
+  higher for a long, lower for a short — and the profit zone follows that way; the stop lands on
+  the opposite side. A direction switch in the panel turns the whole trade around in place,
+  mirroring the stop and target across the entry with the risk:reward preserved. The stop and
+  target take exact values in your choice of unit — the absolute price or points from the entry —
+  and switching the unit re-expresses the current value without moving the level. Every label has
+  its own toggle: the direction-and-ratio header, the loss-and-size line, the target and stop
+  labels, the level prices inside them, or all text at once; the profit and loss zones recolor
+  from the quick-settings bar, and the label color and size are adjustable too.
 - **Multi-chart workspaces.** The new `VelaWorkspace` puts several full charts on one screen:
   pick a grid from the layout menu in the top bar — single, two side by side, two stacked,
   four, or eight — and resize the cells by dragging the dividers between them (double-click a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,20 @@ All notable changes to Vela, newest first.
   holds across symbol and timeframe switches and across reloads, whichever way you removed it
   (the indicators dialog, the legend, or the object tree). Before, auto-added indicators could
   quietly return on the next switch or reload.
+- **Text is typed straight onto the chart.** Placing a text annotation now drops a blinking caret
+  where you clicked, next to an "Enter Text" placeholder, and the words appear on the chart as you
+  type them — no settings field in between, and a thin gray frame around the words while you are
+  editing them. Text annotations start out large, so they read at a glance without reaching for the
+  size control. Enter starts a new line; clicking away (or Ctrl/Cmd+Enter) keeps the text and
+  Escape puts back what was there; a text annotation you never typed into is
+  dropped instead of left blank on the chart. Double-clicking existing text — or a callout — opens
+  the same on-chart editor. Finished text keeps that frame as its selection cue: firm when the
+  annotation is selected, fainter under the cursor, so you can see where the words can be grabbed.
+  The quick-settings bar opens alongside the caret, as it does for every other tool, and now carries
+  the text color and size on the bar itself, with bold and italic under the text field where the
+  words are — restyle while you type and the chart follows, without the edit being interrupted.
+  Previously a text annotation arrived pre-filled with the word "Text", had to be edited through the
+  settings popup, and its formatting was two clicks deep.
 - **The data window is a docked panel, not a floating box.** It used to hover over the top-right
   corner of the chart and was switched on with the `dataWindow` option; it is now the side panel
   described above, opened from the top bar, and it never covers the candles. _(Breaking: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **Stay in drawing mode.** A toolbar toggle under the magnet (pen with a lock) keeps the
+  armed tool ready after each placement, so you can draw several of the same shape without
+  re-picking the tool. Turn it off for the usual one-shot behavior; the brush family still
+  stays armed either way.
 - **Multi-chart workspaces.** The new `VelaWorkspace` puts several full charts on one screen:
   pick a grid from the layout menu in the top bar — single, two side by side, two stacked,
   four, or eight — and resize the cells by dragging the dividers between them (double-click a

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -272,6 +272,7 @@ can't paint drawings — `chart.drawings.supported` reports this), while the **m
 | `setTool(type \| null)` | yes | Arm a tool for the next clicks; `null` returns to select/idle. |
 | `getTool()` | no | The armed tool (`null` = select/idle). Follow changes on `drawing:tool`. |
 | `setSnapMode(mode)` · `getSnapMode()` | yes / no | The magnet: `'off' \| 'weak' \| 'strong'`. Changes land on `drawing:snap`. |
+| `setStayMode(on)` · `getStayMode()` | yes / no | Stay in drawing mode: keep the tool armed after each placement. Changes land on `drawing:stay`. |
 | `setMode(mode)` · `getMode()` | yes / no | Renderer-local mode: `'measure' \| 'eraser' \| null`. Mutually exclusive with armed tools (the renderer enforces it); changes land on `drawing:mode`. |
 | `showToolbar(visible?)` | yes | Show/hide the on-chart toolbar. |
 | `setToolbar(option)` | yes | Reconfigure the toolbar groups/tools live. |
@@ -289,7 +290,7 @@ can't paint drawings — `chart.drawings.supported` reports this), while the **m
 
 Drawing lifecycle is also surfaced as chart events (`drawing:created` / `drawing:edited` /
 `drawing:removed` / `drawing:selected` / `drawing:settings`), and the tool/mode state as
-`drawing:tool` / `drawing:snap` / `drawing:mode` — the seam an external toolbar mirrors. See
+`drawing:tool` / `drawing:snap` / `drawing:stay` / `drawing:mode` — the seam an external toolbar mirrors. See
 [Drawing tools](./drawing-tools.md) for the tool catalogue, toolbar UX, and keyboard shortcuts.
 
 ---

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -34,6 +34,10 @@ right, so the bar never overlaps candles, the legend, or the axes).
   - **Magnet** — a 3-state snap toggle: **off → weak → strong**. *Strong* always snaps a new
     anchor to the nearest candle's time + OHLC; *weak* snaps only when a candle point is within a
     few pixels of the cursor. Holding **Ctrl/Cmd** is a momentary *strong* override.
+  - **Stay in drawing mode** — an on/off toggle (pen with a lock, under the magnet). When on,
+    finishing a drawing leaves the tool armed so you can keep placing the same tool without
+    re-picking it; when off, most tools disarm after one placement (the brush family always stays
+    armed either way). Click the cursor button or press Escape to return to select/idle.
 - **Tooltips.** Hovering any control for ~2 seconds shows a small label beside it.
 - **Favorites.** Every tool row in a flyout carries a **star** (revealed on row hover, gold when
   set). Starring is a user preference, not document data: the set survives symbol/timeframe
@@ -96,7 +100,7 @@ hijacked.
 
 **66 tools across 9 groups.** The **Type key** is the string you pass to
 `chart.drawings.setTool('…')` or [`chart.drawings.add('…')`](#driving-drawings-from-code). Eraser,
-Magnet, and Measure are toolbar *modes*, not placeable types, so they have no key.
+Magnet, Measure, and Stay in drawing mode are toolbar *modes*, not placeable types, so they have no key.
 
 ### Lines
 
@@ -255,27 +259,30 @@ method list and which methods are gated by renderer support.
 
 ## Tool and mode state from code
 
-The armed tool, the magnet, and the measure/eraser modes are all readable and drivable
-programmatically — the seam an external toolbar (e.g. a multi-chart workspace's shared
-bar) builds on:
+The armed tool, the magnet, stay-in-drawing-mode, and the measure/eraser modes are all
+readable and drivable programmatically — the seam an external toolbar (e.g. a multi-chart
+workspace's shared bar) builds on:
 
 ```js
 chart.drawings.getTool();               // 'trendline' | … | null (select/idle)
 chart.drawings.setSnapMode('strong');   // magnet: 'off' | 'weak' | 'strong'
 chart.drawings.getSnapMode();
+chart.drawings.setStayMode(true);       // keep the tool armed after each placement
+chart.drawings.getStayMode();
 chart.drawings.setMode('measure');      // 'measure' | 'eraser' | null (none)
 chart.drawings.getMode();
 
 // Follow every change, whatever its source (in-chart toolbar, keyboard, code):
 chart.on('drawing:tool', ({ type }) => { /* armed tool changed; null = pointer */ });
 chart.on('drawing:snap', ({ mode }) => { /* magnet mode changed */ });
+chart.on('drawing:stay', ({ on }) => { /* stay-in-drawing-mode changed */ });
 chart.on('drawing:mode', ({ mode }) => { /* measure/eraser entered or left */ });
 ```
 
 The renderer keeps owning the mutual exclusion — arming a tool exits measure/eraser
 (and vice versa), and the outcome always lands on the events, so an external UI only
 ever mirrors. One-shot tools disarm themselves after placing (back to `null` on
-`drawing:tool`); the brush family stays armed.
+`drawing:tool`) unless stay-in-drawing-mode is on; the brush family always stays armed.
 
 ## Favorite tools
 

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -219,7 +219,7 @@ whether it falls in that pattern's ideal Fibonacci band.
 | Tool | Type key | What it does |
 |---|---|---|
 | Date & Price Range | `datepricerange` | A box reporting the time span + price/% change it covers. |
-| Long/Short Position | `position` | An entry/stop/target box with the risk:reward ratio (long or short by geometry). |
+| Long/Short Position | `position` | An entry/stop/target box: click the entry, then drag in the profit direction (up for a long, down for a short). Shows risk:reward, percentages, dollar loss, and position size from your risk % and account balance (size is editable and back-solves the risk %). The gear panel has a long/short switch (mirrors the levels across the entry), exact level values in price or points, and per-label display toggles; zone colors and label styling sit on the quick bar. |
 
 ---
 

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -51,7 +51,26 @@ Select a drawing (click it) to show its **handles** and a compact **quick-settin
 beside it. The popup is built from each tool's own schema, so it shows only the controls that tool
 supports — line color/width/style, fill, text, and (for Fibonacci tools) a **gear** panel to
 enable/recolor/label each level. The popup also locks, reorders (bring-to-front /
-send-to-back), and deletes the drawing. Double-click a callout to edit its text inline.
+send-to-back), and deletes the drawing.
+
+**Text is typed on the chart.** Placing a text annotation opens a blinking caret at the click point
+next to an `Enter Text` placeholder, framed by a thin gray box that marks the text as being edited,
+and the glyphs appear exactly where they will be painted as you type, at the annotation's default
+**large** size. **Enter** starts a new line; a click elsewhere (or **Ctrl/Cmd+Enter**) keeps the
+text, and **Escape** restores what was there before — a text annotation that was never typed into is
+discarded rather than left invisible. Double-click existing text, or a callout, to reopen the same
+inline editor.
+
+Finished text keeps that frame as its selection cue: a plain text annotation shows the same thin box
+when it is selected, and a fainter one while the cursor is over it — the words are the drawing, so
+the frame is what tells you where it can be clicked, dragged, or restyled.
+
+The quick-settings popup opens alongside the caret, exactly as it does for every other tool. For
+annotations whose text _is_ the drawing — text, note, callout, comment, signpost — the text color and
+size sit on the popup's bar, so restyling while you type is one click and the words on the chart
+follow immediately; reaching for them does not end the edit. **Bold** and **italic** live under the
+field behind the popup's **Text** button, next to the text they format. On shapes that merely carry a
+label (a trend line, a box), all four controls stay in that panel with the label field.
 
 Drag a handle to reshape; drag the body to move the whole drawing.
 

--- a/src/core/DrawingsControl.ts
+++ b/src/core/DrawingsControl.ts
@@ -44,6 +44,17 @@ export class DrawingsControl {
         return this.ctrl.getSnapMode();
     }
 
+    /** Keep the armed tool after each placement (`true`) or one-shot disarm (`false`). */
+    setStayMode(on: boolean): this {
+        if (this.ok('setStayMode')) this.ctrl.setStayMode(on);
+        return this;
+    }
+
+    /** Whether tools stay armed after placement — follow changes on `drawing:stay`. */
+    getStayMode(): boolean {
+        return this.ctrl.getStayMode();
+    }
+
     /** Enter/exit a renderer-local mode: `'measure'` (transient ruler), `'eraser'`, or
      *  `null` (none). Mutually exclusive with each other and with any armed tool — the
      *  renderer enforces the exclusion and the outcome lands on `drawing:mode`. */

--- a/src/core/drawings/DrawingController.ts
+++ b/src/core/drawings/DrawingController.ts
@@ -39,6 +39,8 @@ export class DrawingController {
     private activeTool: DrawingTypeKey | null = null;
     /** Mirror of the renderer's sticky magnet mode (the renderer default is 'off'). */
     private snapMode: SnapMode = 'off';
+    /** When on, finishing a drawing leaves the tool armed (instead of one-shot disarm). */
+    private stayInDrawingMode = false;
     /** Mirror of the renderer-local mode (measure/eraser/none). */
     private mode: DrawingMode = null;
     /** FAVORITE tool types (insertion-ordered) — user prefs, not document data. */
@@ -100,6 +102,17 @@ export class DrawingController {
         this.snapMode = mode;
         this.port.setSnapMode?.(mode);
         this.events.emit('drawing:snap', { mode });
+    }
+
+    getStayMode(): boolean {
+        return this.stayInDrawingMode;
+    }
+
+    setStayMode(on: boolean): void {
+        if (!this.port || on === this.stayInDrawingMode) return;
+        this.stayInDrawingMode = on;
+        this.port.setStayMode?.(on);
+        this.events.emit('drawing:stay', { on });
     }
 
     getMode(): DrawingMode {
@@ -449,6 +462,13 @@ export class DrawingController {
                     this.events.emit('drawing:snap', { mode: i.mode });
                 }
                 break;
+            case 'stay-mode':
+                // In-chart stay-mode click (already applied renderer-side) — mirror + announce.
+                if (i.on !== this.stayInDrawingMode) {
+                    this.stayInDrawingMode = i.on;
+                    this.events.emit('drawing:stay', { on: i.on });
+                }
+                break;
             case 'mode':
                 // Measure/eraser toggled in-chart, or exited as a mutual-exclusion side effect.
                 if (i.mode !== this.mode) {
@@ -458,8 +478,8 @@ export class DrawingController {
                 break;
             case 'tool-finished':
                 // Most tools are one-shot (revert to the pointer once placed); brush-family tools
-                // stay armed so you can keep drawing strokes without re-picking them each time.
-                if (i.type !== 'freehand' && i.type !== 'highlighter') this.setTool(null);
+                // always stay armed, and stay-in-drawing-mode keeps every tool armed.
+                if (!this.stayInDrawingMode && i.type !== 'freehand' && i.type !== 'highlighter') this.setTool(null);
                 break;
             case 'undo':
                 this.undo();

--- a/src/core/drawings/index.ts
+++ b/src/core/drawings/index.ts
@@ -120,7 +120,7 @@ export { ElliottCorrection } from './types/ElliottCorrection';
 export { HeadShoulders } from './types/HeadShoulders';
 export { MeasureBox, formatDuration } from './types/MeasureBox';
 export { DatePriceRange } from './types/DatePriceRange';
-export { PositionTool } from './types/PositionTool';
+export { PositionTool, DIRECTION_OPTIONS, type PositionLevelMode } from './types/PositionTool';
 export {
     registerDrawingType,
     getDrawingType,

--- a/src/core/drawings/port.ts
+++ b/src/core/drawings/port.ts
@@ -33,6 +33,9 @@ export type DrawingIntent =
     // mirrors the value and re-emits it as a chart event; an equal value is a no-op,
     // which is what keeps the command↔intent loop convergent.
     | { kind: 'snap-mode'; mode: SnapMode }
+    /** Stay-in-drawing-mode toggled in-chart — when on, finishing a drawing leaves the
+     *  tool armed instead of reverting to the pointer. */
+    | { kind: 'stay-mode'; on: boolean }
     | { kind: 'mode'; mode: DrawingMode }
     | { kind: 'undo' }
     | { kind: 'redo' }
@@ -65,6 +68,9 @@ export interface IDrawingsRendererPort {
     /** Set the sticky magnet snap mode (off/weak/strong). Optional — a renderer without
      *  a magnet omits it; the in-chart toolbar reflects the pushed value. */
     setSnapMode?(mode: SnapMode): void;
+    /** Set stay-in-drawing-mode (tools remain armed after each placement). Optional —
+     *  the in-chart toolbar reflects the pushed value. */
+    setStayMode?(on: boolean): void;
     /** Enter/exit a renderer-local mode (measure ruler / eraser; `null` exits). The
      *  renderer keeps owning the mutual exclusion (with armed tools too) and reports
      *  every actual change back through the `mode` intent. Optional. */

--- a/src/core/drawings/schema.ts
+++ b/src/core/drawings/schema.ts
@@ -24,6 +24,12 @@ export interface SettingsField {
 
 export interface SettingsSchema {
     fields: SettingsField[];
+    /**
+     * The text **is** the drawing (a text label, a note, a callout) rather than an optional label on
+     * a shape. The settings popup then puts the text controls — color, size, bold, italic — on the
+     * bar itself instead of tucking them under the text field.
+     */
+    textIsContent?: boolean;
 }
 
 /** The line-style choices most tools expose (drives a `lineStyle` control). */

--- a/src/core/drawings/types/CalloutBase.ts
+++ b/src/core/drawings/types/CalloutBase.ts
@@ -106,6 +106,6 @@ export abstract class CalloutBase extends Drawing {
     }
 
     schema(): SettingsSchema {
-        return { fields: [...LINE_FIELDS, ...FILL_FIELDS, ...TEXT_FIELDS] };
+        return { fields: [...LINE_FIELDS, ...FILL_FIELDS, ...TEXT_FIELDS], textIsContent: true };
     }
 }

--- a/src/core/drawings/types/Note.ts
+++ b/src/core/drawings/types/Note.ts
@@ -18,6 +18,6 @@ export class Note extends PinnedLabel {
     }
 
     schema(): SettingsSchema {
-        return { fields: [...LINE_FIELDS, ...FILL_FIELDS, ...TEXT_FIELDS] };
+        return { fields: [...LINE_FIELDS, ...FILL_FIELDS, ...TEXT_FIELDS], textIsContent: true };
     }
 }

--- a/src/core/drawings/types/PinnedLabel.ts
+++ b/src/core/drawings/types/PinnedLabel.ts
@@ -27,7 +27,7 @@ export abstract class PinnedLabel extends Drawing {
     }
 
     /** Approximate pixel box of the label (the painter renders the precise glyphs). */
-    protected box(proj: Projector): { x: number; y: number; w: number; h: number } | null {
+    box(proj: Projector): { x: number; y: number; w: number; h: number } | null {
         const a = this.anchors[0];
         if (!a) return null;
         const y = proj.yOf(a.price, this.paneId);

--- a/src/core/drawings/types/PinnedLabel.ts
+++ b/src/core/drawings/types/PinnedLabel.ts
@@ -27,7 +27,7 @@ export abstract class PinnedLabel extends Drawing {
     }
 
     /** Approximate pixel box of the label (the painter renders the precise glyphs). */
-    box(proj: Projector): { x: number; y: number; w: number; h: number } | null {
+    protected box(proj: Projector): { x: number; y: number; w: number; h: number } | null {
         const a = this.anchors[0];
         if (!a) return null;
         const y = proj.yOf(a.price, this.paneId);

--- a/src/core/drawings/types/PositionTool.ts
+++ b/src/core/drawings/types/PositionTool.ts
@@ -1,25 +1,78 @@
-import { Drawing, type AnchorSlot } from '../Drawing';
+import { Drawing, type AnchorSlot, type SerializedDrawing } from '../Drawing';
 import type { Projector } from '../geometry';
 import type { SettingsSchema } from '../schema';
-import { LINE_FIELDS } from '../schema';
+import { LINE_FIELDS, TEXT_SIZE_OPTIONS } from '../schema';
 import { pointInBox, handleAt } from '../hittest';
 
+/** How the gear panel's stop/target inputs interpret their value. */
+export type PositionLevelMode = 'price' | 'points';
+
+/** Choices for the direction select (long ↔ short mirrors the levels across the entry). */
+export const DIRECTION_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+    { value: 'long', label: 'Long' },
+    { value: 'short', label: 'Short' },
+];
+
 /**
- * A long/short position tool. Two clicks place the entry (anchor[0]) + stop (anchor[1]); onPlaced
- * derives the target (anchor[2]). Drives a shaded reward zone (entry↔target, green) and risk zone
- * (entry↔stop, red) with a computed risk:reward + target/stop percentages. The direction (LONG vs
- * SHORT) follows the geometry — a stop below the entry is long, above is short — so one tool covers both.
+ * A long/short position tool. Two clicks place the entry (anchor[0]) + target (anchor[1]);
+ * onPlaced derives the stop (anchor[1] after finalize) and keeps the target as anchor[2]. The
+ * second click is the *profit* direction — dragging higher from the entry paints the green
+ * reward zone above (a long); dragging lower paints it below (a short). The shaded reward
+ * (entry↔target) and risk (entry↔stop) zones carry a computed risk:reward, target/stop
+ * percentages, and — from the account balance + risk % settings — a dollar loss and position
+ * size. Zone colors, the label text (visibility, size, color, level prices), and the three
+ * price levels are all editable through settings.
  */
 export class PositionTool extends Drawing {
     readonly type = 'position' as const;
 
-    /** Default reward:risk used to derive the target from the placed (or default) risk. */
+    /** Default reward:risk used to derive the stop from the placed (or default) target. */
     protected static readonly DEFAULT_RR = 2;
     /** Below this vertical drag (media px) a placement is treated as a bare click → default box. */
     private static readonly MIN_DRAG_PX = 6;
     private static readonly DEFAULT_RISK_PX = 64;
     private static readonly DEFAULT_WIDTH_PX = 150;
     private static readonly MIN_WIDTH_PX = 48;
+    private static readonly DEFAULT_RISK_PERCENT = 1;
+    private static readonly DEFAULT_ACCOUNT_BALANCE = 10_000;
+    private static readonly DEFAULT_PROFIT_COLOR = '#0ecb81';
+    private static readonly DEFAULT_LOSS_COLOR = '#f6465d';
+
+    // Declared with `!` so a field default never clobbers readProps (base constructor runs first).
+    /** Percent of account balance risked on the stop (drives dollar loss + position size). */
+    riskPercent!: number;
+    /** Account balance in dollars (drives dollar loss + position size). */
+    accountBalance!: number;
+    /** Master toggle for every painted label. */
+    showText!: boolean;
+    /** Show the `DIR · R:R` header line above the box. */
+    showHeader!: boolean;
+    /** Append the level price to the target/stop labels. */
+    showPrices!: boolean;
+    /** Show the `Loss $ · Size` line above the box. */
+    showLossSize!: boolean;
+    /** Show the `Target +%` label inside the reward zone. */
+    showTargetLabel!: boolean;
+    /** Show the `Stop −%` label inside the risk zone. */
+    showStopLabel!: boolean;
+    /** Fill + line color of the reward zone. */
+    profitColor!: string;
+    /** Fill + line color of the risk zone. */
+    lossColor!: string;
+
+    constructor(init: Partial<SerializedDrawing> & { paneId: string }) {
+        super(init);
+        if (this.riskPercent === undefined) this.riskPercent = PositionTool.DEFAULT_RISK_PERCENT;
+        if (this.accountBalance === undefined) this.accountBalance = PositionTool.DEFAULT_ACCOUNT_BALANCE;
+        if (this.showText === undefined) this.showText = true;
+        if (this.showHeader === undefined) this.showHeader = true;
+        if (this.showPrices === undefined) this.showPrices = false;
+        if (this.showLossSize === undefined) this.showLossSize = true;
+        if (this.showTargetLabel === undefined) this.showTargetLabel = true;
+        if (this.showStopLabel === undefined) this.showStopLabel = true;
+        if (this.profitColor === undefined) this.profitColor = PositionTool.DEFAULT_PROFIT_COLOR;
+        if (this.lossColor === undefined) this.lossColor = PositionTool.DEFAULT_LOSS_COLOR;
+    }
 
     /** `'LONG'` or `'SHORT'`, computed from geometry so it flips live as the drag crosses the
      *  entry (target above entry → long; below → short). */
@@ -28,9 +81,75 @@ export class PositionTool extends Drawing {
         return p && p.target >= p.entry ? 'LONG' : 'SHORT';
     }
 
+    /** Direction as a settings path: reading reflects the geometry; writing the opposite value
+     *  mirrors the stop AND the target across the entry, turning the trade around in place
+     *  while preserving each side's distance (and therefore the R:R). */
+    get direction(): 'long' | 'short' {
+        return this.directionLabel() === 'LONG' ? 'long' : 'short';
+    }
+    set direction(v: 'long' | 'short') {
+        const entry = this.anchors[0];
+        const stop = this.anchors[1];
+        const target = this.anchors[2];
+        if (!entry || !stop || !target) return;
+        if ((v === 'long' || v === 'short') && v !== this.direction) {
+            stop.price = 2 * entry.price - stop.price;
+            target.price = 2 * entry.price - target.price;
+        }
+    }
+
+    /** Position size as a settings path: reading returns the computed size; writing back-solves
+     *  the risk % so that `size × stop distance = balance × risk%` holds for the typed size. */
+    get quantity(): number {
+        return this.positionSize();
+    }
+    set quantity(v: number) {
+        const p = this.prices();
+        if (!p || !Number.isFinite(v) || v < 0) return;
+        const dist = Math.abs(p.entry - p.stop);
+        if (dist < 1e-9 || this.accountBalance <= 0) return;
+        this.riskPercent = ((v * dist) / this.accountBalance) * 100;
+    }
+
+    // ── price levels as settings paths (the gear panel patches these directly) ──
+
+    get entryPrice(): number {
+        return this.anchors[0]?.price ?? 0;
+    }
+    set entryPrice(v: number) {
+        const a = this.anchors[0];
+        if (a && Number.isFinite(v)) {
+            a.price = v;
+            this.constrainHandleDrag(0);
+        }
+    }
+
+    get stopPrice(): number {
+        return this.anchors[1]?.price ?? 0;
+    }
+    set stopPrice(v: number) {
+        const a = this.anchors[1];
+        if (a && Number.isFinite(v)) {
+            a.price = v;
+            this.constrainHandleDrag(1);
+        }
+    }
+
+    get targetPrice(): number {
+        return this.anchors[2]?.price ?? 0;
+    }
+    set targetPrice(v: number) {
+        const a = this.anchors[2];
+        if (a && Number.isFinite(v)) {
+            a.price = v;
+            this.constrainHandleDrag(2);
+        }
+    }
+
     anchorSchema(): { min: number; max: number; slots: AnchorSlot[] } {
-        // Click-move-click: click 1 = entry, click 2 = stop (max 2 clicks finalize). onPlaced then
-        // derives the target as a 3rd anchor. The 3 slots give all three handles their free axes.
+        // Click-move-click: click 1 = entry, click 2 = target (max 2 clicks finalize). onPlaced then
+        // derives the stop and rewrites anchors as [entry, stop, target]. The 3 slots give all three
+        // handles their free axes after placement.
         return {
             min: 2,
             max: 2,
@@ -45,10 +164,11 @@ export class PositionTool extends Drawing {
     // Placed click-move-click (the inherited 'click' mode), consistent with the box/Gann/range tools.
 
     /**
-     * Resolve the two placed anchors (entry + stop) into the final entry/stop/target box, computing
-     * the target/width in PIXEL space so the box has a consistent visual size at any scale. The
-     * direction follows the second click — a stop below the entry yields a long, above yields a short.
-     * A degenerate second click (≈ the entry) falls back to a default-sized box.
+     * Resolve the two placed anchors (entry + target) into the final entry/stop/target box,
+     * computing the stop/width in PIXEL space so the box has a consistent visual size at any
+     * scale. The second click is the profit direction — a target above the entry yields a long
+     * (stop below); below yields a short. A degenerate second click (≈ the entry) falls back to
+     * a default-sized long-facing box.
      */
     override onPlaced(proj: Projector): void {
         const e = this.anchors[0];
@@ -57,19 +177,20 @@ export class PositionTool extends Drawing {
         const ey = proj.yOf(e.price, this.paneId);
         if (ey == null) return;
 
-        const s = this.anchors[1];
-        const sy = s ? proj.yOf(s.price, this.paneId) : null;
-        let stopPx: number;
+        const t = this.anchors[1];
+        const ty = t ? proj.yOf(t.price, this.paneId) : null;
+        let targetPx: number;
         let endPx: number;
-        if (s && sy != null && Math.abs(sy - ey) >= PositionTool.MIN_DRAG_PX) {
-            stopPx = sy; // a real drag: the stop is where the user released
-            endPx = ex + Math.max(Math.abs(proj.xOf(s.time) - ex), PositionTool.MIN_WIDTH_PX);
+        if (t && ty != null && Math.abs(ty - ey) >= PositionTool.MIN_DRAG_PX) {
+            targetPx = ty; // a real drag: the target (profit) is where the user released
+            endPx = ex + Math.max(Math.abs(proj.xOf(t.time) - ex), PositionTool.MIN_WIDTH_PX);
         } else {
-            // a degenerate second click (≈ the entry): a default long-facing box (stop below the entry)
-            stopPx = ey + PositionTool.DEFAULT_RISK_PX;
+            // a degenerate second click (≈ the entry): a default long-facing box (target above)
+            targetPx = ey - PositionTool.DEFAULT_RISK_PX * PositionTool.DEFAULT_RR;
             endPx = ex + PositionTool.DEFAULT_WIDTH_PX;
         }
-        const targetPx = ey - (stopPx - ey) * PositionTool.DEFAULT_RR; // reward at R:R on the far side
+        // stop on the opposite side of the entry at 1/R:R of the reward distance
+        const stopPx = ey - (targetPx - ey) / PositionTool.DEFAULT_RR;
         const endTime = proj.pxToPoint(endPx, ey, this.paneId).time;
         this.anchors = [
             { time: e.time, price: e.price },
@@ -97,14 +218,20 @@ export class PositionTool extends Drawing {
         else target.price = 2 * entry.price - target.price; // dragged stop (or entry) → flip the target
     }
 
-    /** The three levels — entry, stop, target — deriving the target while only two anchors exist
-     *  (the live drag preview, before onPlaced sets the precise box). */
+    /** The three levels — entry, stop, target — deriving the stop while only two anchors exist
+     *  (the live drag preview, before onPlaced sets the precise box). During preview the second
+     *  anchor is the target (profit); after placement anchors are [entry, stop, target]. */
     private resolved(): Array<{ time: number; price: number }> | null {
         const e = this.anchors[0];
-        const s = this.anchors[1];
-        if (!e || !s) return null;
-        const t = this.anchors[2] ?? { time: s.time, price: e.price + PositionTool.DEFAULT_RR * (e.price - s.price) };
-        return [e, s, t];
+        const a1 = this.anchors[1];
+        if (!e || !a1) return null;
+        if (this.anchors[2]) return [e, a1, this.anchors[2]];
+        // live preview: a1 is the target; stop sits opposite at 1/R:R of the reward
+        const stop = {
+            time: a1.time,
+            price: e.price - (a1.price - e.price) / PositionTool.DEFAULT_RR,
+        };
+        return [e, stop, a1];
     }
 
     private prices(): { entry: number; stop: number; target: number } | null {
@@ -126,10 +253,73 @@ export class PositionTool extends Drawing {
         return p && p.entry !== 0 ? (Math.abs(p.target - p.entry) / p.entry) * 100 : 0;
     }
 
-    /** Risk % = |entry − stop| / entry · 100. */
+    /** Risk % of price = |entry − stop| / entry · 100 (distinct from the account riskPercent). */
     riskPct(): number {
         const p = this.prices();
         return p && p.entry !== 0 ? (Math.abs(p.entry - p.stop) / p.entry) * 100 : 0;
+    }
+
+    /** Dollar amount risked at the stop = accountBalance × riskPercent / 100. */
+    dollarLoss(): number {
+        return Math.max(0, this.accountBalance) * (Math.max(0, this.riskPercent) / 100);
+    }
+
+    /** Position size in units = dollarLoss / |entry − stop| (0 when risk is degenerate). */
+    positionSize(): number {
+        const p = this.prices();
+        if (!p) return 0;
+        const risk = Math.abs(p.entry - p.stop);
+        return risk < 1e-9 ? 0 : this.dollarLoss() / risk;
+    }
+
+    // ── painted label lines (each respects its own toggle; the painter checks showText) ──
+
+    /** `DIR · R:R x.xx` — the always-on header when text is shown. */
+    headerLabel(): string {
+        return `${this.directionLabel()}  ·  R:R ${this.rr().toFixed(2)}`;
+    }
+
+    /** `Loss $… · Size …` — the painter hides it when showLossSize is off. */
+    lossSizeLabel(): string {
+        return `Loss $${formatMoney(this.dollarLoss())}  ·  Size ${formatQty(this.positionSize())}`;
+    }
+
+    /** `Target +x.xx%`, with the level price appended when showPrices is on. */
+    targetLabel(): string {
+        const p = this.prices();
+        const at = this.showPrices && p ? `  @ ${formatPrice(p.target)}` : '';
+        return `Target +${this.rewardPct().toFixed(2)}%${at}`;
+    }
+
+    /** `Stop −x.xx%`, with the level price appended when showPrices is on. */
+    stopLabel(): string {
+        const p = this.prices();
+        const at = this.showPrices && p ? `  @ ${formatPrice(p.stop)}` : '';
+        return `Stop −${this.riskPct().toFixed(2)}%${at}`;
+    }
+
+    // ── stop/target input units (the gear panel's Price / Points dropdowns) ──
+
+    /** The stop or target expressed in the given unit: the absolute price, or the distance from
+     *  the entry in price points. */
+    levelDisplayValue(level: 'stop' | 'target', mode: PositionLevelMode): number {
+        const p = this.prices();
+        if (!p) return 0;
+        const price = level === 'stop' ? p.stop : p.target;
+        if (mode === 'price') return roundFloat(price);
+        return roundFloat(Math.abs(price - p.entry));
+    }
+
+    /** The absolute price a typed value in the given unit resolves to. Points measure the
+     *  distance from the entry; the level keeps its current side (target defaults to the profit
+     *  side, stop to the loss side, when it sits exactly on the entry). */
+    levelPriceFromDisplay(level: 'stop' | 'target', mode: PositionLevelMode, value: number): number {
+        const p = this.prices();
+        if (!p || mode === 'price') return value;
+        const current = level === 'stop' ? p.stop : p.target;
+        let side = Math.sign(current - p.entry);
+        if (side === 0) side = (level === 'target' ? 1 : -1) * (this.direction === 'long' ? 1 : -1);
+        return p.entry + side * Math.abs(value);
     }
 
     private box(proj: Projector): { x1: number; x2: number; ey: number; sy: number; ty: number } | null {
@@ -183,6 +373,86 @@ export class PositionTool extends Drawing {
     }
 
     schema(): SettingsSchema {
-        return { fields: LINE_FIELDS.filter((f) => f.path !== 'style.lineColor') };
+        return {
+            fields: [
+                { path: 'riskPercent', label: 'Risk %', kind: 'number', min: 0, max: 100, step: 0.1, group: 'behavior' },
+                { path: 'accountBalance', label: 'Account balance', kind: 'number', min: 0, max: 1e12, step: 1, group: 'behavior' },
+                { path: 'quantity', label: 'Position size', kind: 'number', group: 'behavior' },
+                { path: 'direction', label: 'Direction', kind: 'select', options: DIRECTION_OPTIONS, group: 'behavior' },
+                { path: 'entryPrice', label: 'Entry price', kind: 'number', group: 'behavior' },
+                { path: 'stopPrice', label: 'Stop price', kind: 'number', group: 'behavior' },
+                { path: 'targetPrice', label: 'Target price', kind: 'number', group: 'behavior' },
+                { path: 'showText', label: 'Show text', kind: 'boolean', group: 'behavior' },
+                { path: 'showHeader', label: 'Show direction & ratio', kind: 'boolean', group: 'behavior' },
+                { path: 'showLossSize', label: 'Show loss & size', kind: 'boolean', group: 'behavior' },
+                { path: 'showTargetLabel', label: 'Show target label', kind: 'boolean', group: 'behavior' },
+                { path: 'showStopLabel', label: 'Show stop label', kind: 'boolean', group: 'behavior' },
+                { path: 'showPrices', label: 'Show level prices', kind: 'boolean', group: 'behavior' },
+                { path: 'profitColor', label: 'Profit zone', kind: 'color', group: 'fill' },
+                { path: 'lossColor', label: 'Loss zone', kind: 'color', group: 'fill' },
+                ...LINE_FIELDS.filter((f) => f.path !== 'style.lineColor'),
+                { path: 'text.color', label: 'Text color', kind: 'color', group: 'text' },
+                { path: 'text.size', label: 'Text size', kind: 'select', options: TEXT_SIZE_OPTIONS, group: 'text' },
+            ],
+        };
     }
+
+    protected override writeProps(): Record<string, unknown> {
+        return {
+            riskPercent: this.riskPercent,
+            accountBalance: this.accountBalance,
+            showText: this.showText,
+            showHeader: this.showHeader,
+            showPrices: this.showPrices,
+            showLossSize: this.showLossSize,
+            showTargetLabel: this.showTargetLabel,
+            showStopLabel: this.showStopLabel,
+            profitColor: this.profitColor,
+            lossColor: this.lossColor,
+        };
+    }
+
+    protected override readProps(props: Record<string, unknown>): void {
+        if (typeof props.riskPercent === 'number' && Number.isFinite(props.riskPercent)) {
+            this.riskPercent = props.riskPercent;
+        }
+        if (typeof props.accountBalance === 'number' && Number.isFinite(props.accountBalance)) {
+            this.accountBalance = props.accountBalance;
+        }
+        if (typeof props.showText === 'boolean') this.showText = props.showText;
+        if (typeof props.showHeader === 'boolean') this.showHeader = props.showHeader;
+        if (typeof props.showPrices === 'boolean') this.showPrices = props.showPrices;
+        if (typeof props.showLossSize === 'boolean') this.showLossSize = props.showLossSize;
+        if (typeof props.showTargetLabel === 'boolean') this.showTargetLabel = props.showTargetLabel;
+        if (typeof props.showStopLabel === 'boolean') this.showStopLabel = props.showStopLabel;
+        if (typeof props.profitColor === 'string') this.profitColor = props.profitColor;
+        if (typeof props.lossColor === 'string') this.lossColor = props.lossColor;
+    }
+}
+
+/** Compact money string (drops trailing .00; keeps two decimals otherwise). */
+function formatMoney(n: number): string {
+    if (!Number.isFinite(n)) return '0';
+    const rounded = Math.round(n * 100) / 100;
+    return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(2);
+}
+
+/** Compact quantity string for the position size readout. */
+function formatQty(n: number): string {
+    if (!Number.isFinite(n) || n === 0) return '0';
+    if (n >= 100) return n.toFixed(2);
+    if (n >= 1) return n.toFixed(4).replace(/\.?0+$/, '');
+    return n.toPrecision(4).replace(/\.?0+$/, '');
+}
+
+/** Compact price string for the level readouts (two decimals ≥1, four significant below). */
+function formatPrice(n: number): string {
+    if (!Number.isFinite(n)) return '0';
+    if (Math.abs(n) >= 1) return n.toFixed(2);
+    return n.toPrecision(4).replace(/\.?0+$/, '');
+}
+
+/** Trim binary float noise from a converted value (points arithmetic). */
+function roundFloat(n: number): number {
+    return Math.round(n * 1e8) / 1e8;
 }

--- a/src/core/drawings/types/TextLabel.ts
+++ b/src/core/drawings/types/TextLabel.ts
@@ -10,10 +10,13 @@ export class TextLabel extends PinnedLabel {
 
     constructor(init: Partial<SerializedDrawing> & { paneId: string }) {
         super(init);
-        if (!this.text) this.text = defaultText('Text');
+        // Starts empty on purpose: placing one opens an inline editor whose placeholder invites the
+        // text, so a seeded literal would only have to be selected and deleted. Large by default —
+        // a free-floating annotation is meant to be read at a glance, unlike a label hung on a shape.
+        if (!this.text) this.text = { ...defaultText(), size: 'large' };
     }
 
     schema(): SettingsSchema {
-        return { fields: [...TEXT_FIELDS] };
+        return { fields: [...TEXT_FIELDS], textIsContent: true };
     }
 }

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -39,6 +39,9 @@ export interface VelaEventMap extends Record<string, unknown> {
     'drawing:tool': { type: DrawingTypeKey | null };
     /** The magnet snap mode changed (in-chart toolbar or `drawings.setSnapMode`). */
     'drawing:snap': { mode: SnapMode };
+    /** Stay-in-drawing-mode changed (in-chart toolbar or `drawings.setStayMode`) — when
+     *  on, finishing a drawing leaves the tool armed. */
+    'drawing:stay': { on: boolean };
     /** The renderer-local mode changed: measure ruler, eraser, or none — including the
      *  mutual-exclusion exits (arming a tool leaves measure/eraser). */
     'drawing:mode': { mode: DrawingMode };

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -684,9 +684,8 @@ export class DrawingPainter {
         ctx.textBaseline = 'middle';
         ctx.font = `${fs}px ${theme.fontFamily}`;
         const cx = x1 + w / 2;
-        // Header stack sits above the box (direction · R:R, then the optional loss + size line).
-        // Target/stop % stay centered in their zones.
-        // Header + loss/size stack above the box; whichever is shown alone takes the bottom slot.
+        // Header + loss/size stack above the box (whichever is shown alone takes the bottom
+        // slot); target/stop % stay centered in their zones.
         const topY = Math.min(ey, sy, ty) - 9;
         if (d.showHeader) ctx.fillText(d.headerLabel(), cx, d.showLossSize ? topY - Math.round(fs * 1.15) : topY);
         ctx.font = `${Math.max(10, fs - 1)}px ${theme.fontFamily}`;

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -640,15 +640,14 @@ export class DrawingPainter {
         ctx.textBaseline = 'alphabetic';
     }
 
-    /** Paint a position tool: a green reward zone (entry↔target) + red risk zone (entry↔stop),
-     *  the three level lines, and a `DIR · R:R` + target/stop % label. */
+    /** Paint a position tool: a reward zone (entry↔target) + risk zone (entry↔stop) in the
+     *  tool's own zone colors, the three level lines, and the direction / R:R / % / loss+size
+     *  labels (styled by `text`, hidden wholesale by showText). */
     private paintPosition(ctx: CanvasRenderingContext2D, d: PositionTool, proj: Projector, theme: VelaTheme): void {
         const L = d.layout(proj);
         if (!L) return;
         const { x1, x2, ey, sy, ty } = L;
         const w = x2 - x1;
-        const GREEN = '#0ecb81';
-        const RED = '#f6465d';
         const zone = (yA: number, yB: number, color: string): void => {
             ctx.save();
             ctx.globalAlpha = 0.13 * ctx.globalAlpha;
@@ -656,25 +655,32 @@ export class DrawingPainter {
             ctx.fillRect(x1, Math.min(yA, yB), w, Math.abs(yB - yA));
             ctx.restore();
         };
-        zone(ey, ty, GREEN); // reward
-        zone(ey, sy, RED); // risk
+        zone(ey, ty, d.profitColor); // reward
+        zone(ey, sy, d.lossColor); // risk
         const line = (y: number, color: string): void =>
             this.stroke(ctx, { ...d.style, lineColor: color }, () => {
                 ctx.moveTo(x1, y);
                 ctx.lineTo(x2, y);
             });
-        line(ty, GREEN);
-        line(sy, RED);
+        line(ty, d.profitColor);
+        line(sy, d.lossColor);
         line(ey, d.style.lineColor); // entry — accent
-        const cx = x1 + w / 2;
-        ctx.fillStyle = theme.textColor;
+        if (!d.showText) return;
+        const fs = namedFontSize(d.text?.size ?? 'normal');
+        ctx.fillStyle = d.text?.color ?? theme.textColor;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.font = `12px ${theme.fontFamily}`;
-        ctx.fillText(`${d.directionLabel()}  ·  R:R ${d.rr().toFixed(2)}`, cx, Math.min(ey, sy, ty) - 9);
-        ctx.font = `11px ${theme.fontFamily}`;
-        ctx.fillText(`Target +${d.rewardPct().toFixed(2)}%`, cx, (ey + ty) / 2);
-        ctx.fillText(`Stop −${d.riskPct().toFixed(2)}%`, cx, (ey + sy) / 2);
+        ctx.font = `${fs}px ${theme.fontFamily}`;
+        const cx = x1 + w / 2;
+        // Header stack sits above the box (direction · R:R, then the optional loss + size line).
+        // Target/stop % stay centered in their zones.
+        // Header + loss/size stack above the box; whichever is shown alone takes the bottom slot.
+        const topY = Math.min(ey, sy, ty) - 9;
+        if (d.showHeader) ctx.fillText(d.headerLabel(), cx, d.showLossSize ? topY - Math.round(fs * 1.15) : topY);
+        ctx.font = `${Math.max(10, fs - 1)}px ${theme.fontFamily}`;
+        if (d.showLossSize) ctx.fillText(d.lossSizeLabel(), cx, topY);
+        if (d.showTargetLabel) ctx.fillText(d.targetLabel(), cx, (ey + ty) / 2);
+        if (d.showStopLabel) ctx.fillText(d.stopLabel(), cx, (ey + sy) / 2);
         ctx.textAlign = 'left';
         ctx.textBaseline = 'alphabetic';
     }

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -1,7 +1,8 @@
 import type { Drawing, Projector, DrawingStyle } from '../../../core/drawings';
 import { SegmentDrawing, FibRatios, RadialFib, FibSpiral, GannSquare, GANN_SQUARE_ARCS, DedekindTessellation, MachFigure, MeasureBox, PositionTool, PatternDrawing, CalloutBase, Callout, Comment, PriceNote, Signpost, Note, PriceLabel, ArrowMark, GlyphStamp, RegressionChannel, AnchoredVwap, FixedRangeVolumeProfile, lineSegmentIntersection, effectiveFillColor, VALID_FILL, INVALID_FILL, DEFAULT_DRAWING_COLOR } from '../../../core/drawings';
 import type { VelaTheme } from '../../../core/options';
-import { dashPattern, extendEndpoints, namedFontSize } from '../../shared/drawing-geometry';
+import { dashPattern, extendEndpoints, namedFontSize, labelLineHeight, TEXT_FRAME_INSET, TEXT_FRAME_RISE } from '../../shared/drawing-geometry';
+import { withAlpha } from '../core/chartConfig';
 import { valueDecimals } from '../chrome/ticks';
 
 const HANDLE_RADIUS = 4.5; // px radius of the round drag handles
@@ -10,6 +11,9 @@ const HANDLE_RADIUS = 4.5; // px radius of the round drag handles
 const HANDLE_BORDER = DEFAULT_DRAWING_COLOR;
 const HANDLE_FILL = 'rgba(120, 123, 134, 0.55)';
 const GHOST_ALPHA = 0.7;
+/** The frame a text label wears when it's the target: firm once clicked, a hint under the cursor.
+ *  (Its box is the shared TEXT_FRAME inset/rise, so it coincides with the inline editor's border.) */
+const TEXT_FRAME_ALPHA = { selected: 0.3, hovered: 0.12 };
 
 /**
  * Paints user drawings onto the L1.5 canvas. The caller has already applied the DPR
@@ -18,8 +22,21 @@ const GHOST_ALPHA = 0.7;
  * {@link Projector}. Strokes/fonts reuse the shared Pine-drawing helpers so user
  * drawings match engine-drawn ones exactly.
  */
+/** The frame's transient interaction state, as the painter needs it: handles show for the
+ *  selected, dragged, and hovered drawings; a targeted text label wears its frame; a label owned
+ *  by an open inline editor is left unpainted so the two don't draw on top of each other. */
+export interface PaintTargets {
+    selected?: ReadonlySet<string>;
+    hovered?: string | null;
+    dragged?: string | null;
+    mutedLabel?: string | null;
+}
+
 export class DrawingPainter {
-    /** Paint every visible drawing, then selection handles for each highlighted id.
+    /** The current `paintAll` call's interaction state, visible to the per-type painters. */
+    private targets: PaintTargets = {};
+
+    /** Paint every visible drawing, then selection handles for the targeted ones.
      *  Each drawing is clipped to its own pane's rect (and skipped entirely while that pane
      *  is hidden — collapsed, or zeroed by another pane's maximize) so panes stay separated. */
     paintAll(
@@ -27,15 +44,23 @@ export class DrawingPainter {
         drawings: readonly Drawing[],
         proj: Projector,
         theme: VelaTheme,
-        highlightIds: ReadonlySet<string>,
+        targets: PaintTargets = {},
     ): void {
+        this.targets = targets;
         for (const d of drawings) {
             if (!d.visible) continue;
             this.paintClipped(ctx, d, proj, () => this.paintOne(ctx, d, proj, theme));
         }
-        if (highlightIds.size === 0) return;
+        this.targets = {};
+        const handleIds = new Set(targets.selected);
+        if (targets.dragged) handleIds.add(targets.dragged);
+        if (targets.hovered) handleIds.add(targets.hovered);
+        // While an inline editor owns the label the user is typing, not dragging — the anchor
+        // grip on the editor's corner would read as a resize handle on a floating window.
+        if (targets.mutedLabel) handleIds.delete(targets.mutedLabel);
+        if (handleIds.size === 0) return;
         for (const d of drawings) {
-            if (d.visible && highlightIds.has(d.id)) {
+            if (d.visible && handleIds.has(d.id)) {
                 this.paintClipped(ctx, d, proj, () => this.paintHandles(ctx, d.handlePoints(proj)));
             }
         }
@@ -377,7 +402,7 @@ export class DrawingPainter {
     /** Draw a drawing's optional text label at a type-appropriate anchor (multi-line aware). */
     private paintLabel(ctx: CanvasRenderingContext2D, d: Drawing, proj: Projector, theme: VelaTheme): void {
         const text = d.text;
-        if (!text || !text.value) return;
+        if (!text || !text.value || d.id === this.targets.mutedLabel) return;
         const layout = labelLayout(d, proj);
         if (!layout) return;
         const fs = namedFontSize(text.size);
@@ -385,9 +410,29 @@ export class DrawingPainter {
         ctx.textBaseline = 'top';
         ctx.textAlign = layout.align;
         ctx.fillStyle = text.color ?? theme.textColor;
-        const lh = fs * 1.4;
-        text.value.split('\n').forEach((line, i) => ctx.fillText(line, layout.x, layout.top + i * lh));
+        const lh = labelLineHeight(fs);
+        const lines = text.value.split('\n');
+        lines.forEach((line, i) => ctx.fillText(line, layout.x, layout.top + i * lh));
         ctx.textAlign = 'left';
+        if (d.type === 'text') this.paintTextFrame(ctx, d.id, layout.x, layout.top, lines, fs, theme);
+    }
+
+    /** Frame a plain text label while it is the target, so the text reads as a clickable object even
+     *  though it has no shape of its own: a firm frame once selected, a fainter one under the cursor.
+     *  Placed to coincide with the inline editor's frame — clicking into the text doesn't shift it. */
+    private paintTextFrame(ctx: CanvasRenderingContext2D, id: string, x: number, top: number, lines: readonly string[], fs: number, theme: VelaTheme): void {
+        const t = this.targets;
+        const alpha = t.selected?.has(id) ? TEXT_FRAME_ALPHA.selected : t.hovered === id ? TEXT_FRAME_ALPHA.hovered : 0;
+        if (alpha === 0) return;
+        const lh = labelLineHeight(fs);
+        const w = Math.max(8, ...lines.map((l) => ctx.measureText(l).width));
+        ctx.save();
+        ctx.setLineDash([]);
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = withAlpha(theme.textColor, alpha);
+        roundRect(ctx, x - TEXT_FRAME_INSET, top - (lh - fs) / 2 - TEXT_FRAME_RISE, w + TEXT_FRAME_INSET * 2, lines.length * lh + TEXT_FRAME_RISE * 2, 4);
+        ctx.stroke();
+        ctx.restore();
     }
 
     /** Paint any Fibonacci tool from its resolved entry lines: optional fill bands, then each
@@ -807,7 +852,7 @@ export class DrawingPainter {
         const tw = Math.max(8, ...lines.map((l) => ctx.measureText(l).width));
         const padX = 9;
         const padY = 6;
-        const lh = Math.round(fs * 1.4);
+        const lh = labelLineHeight(fs);
         const w = tw + padX * 2;
         const h = lines.length * lh + padY * 2;
         const x = cx - w / 2;
@@ -877,7 +922,7 @@ export class DrawingPainter {
         ctx.font = `${text?.bold ? 'bold ' : ''}${text?.italic ? 'italic ' : ''}${fs}px ${theme.fontFamily}`;
         const lines = (text?.value || fallback).split('\n');
         const tw = Math.max(8, ...lines.map((l) => ctx.measureText(l).width));
-        return { lines, tw, fs, lh: Math.round(fs * 1.4) };
+        return { lines, tw, fs, lh: labelLineHeight(fs) };
     }
 
     /** A Note: free text on a rounded plate anchored at the point (top-left). */
@@ -906,7 +951,7 @@ export class DrawingPainter {
         const padX = 9;
         const padY = 6;
         const w = ctx.measureText(priceStr).width + padX * 2;
-        const h = Math.round(fs * 1.4) + padY * 2;
+        const h = labelLineHeight(fs) + padY * 2;
         const x = cx - w / 2;
         const y = cy - h / 2;
         this.stroke(ctx, d.style, () => {
@@ -969,7 +1014,7 @@ export class DrawingPainter {
         const padY = 4;
         const ptr = 6; // left pointer width
         const w = tw + padX * 2;
-        const h = Math.round(fs * 1.4) + padY * 2;
+        const h = labelLineHeight(fs) + padY * 2;
         const y = ay - h / 2;
         const fill = effectiveFillColor(d, theme) ?? theme.background;
         ctx.save();
@@ -1379,7 +1424,7 @@ function labelLayout(d: Drawing, proj: Projector): { x: number; top: number; ali
     if (!text) return null;
     const pts = d.handlePoints(proj);
     const lines = text.value.split('\n').length;
-    const lh = namedFontSize(text.size) * 1.4;
+    const lh = labelLineHeight(namedFontSize(text.size));
     switch (d.type) {
         case 'text':
             return pts[0] ? { x: pts[0][0] + 2, top: pts[0][1] + 2, align: 'left' } : null;

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -384,7 +384,7 @@ export class DrawingSettingsPopup {
             input.style.cssText = `width:96px;flex:none;background:transparent;color:inherit;border:1px solid ${CHROME_BORDER_COLOR};border-radius:5px;padding:4px 6px;font:12px ${t.fontFamily};font-variant-numeric:tabular-nums;outline:none;`;
             return input;
         };
-        const rowShell = (label: string): { row: HTMLDivElement; } => {
+        const rowShell = (label: string): HTMLDivElement => {
             const row = document.createElement('div');
             row.style.cssText = 'display:flex;align-items:center;gap:10px;';
             const lbl = document.createElement('span');
@@ -392,7 +392,7 @@ export class DrawingSettingsPopup {
             lbl.style.cssText = 'flex:1;opacity:0.9;';
             row.appendChild(lbl);
             panel.appendChild(row);
-            return { row };
+            return row;
         };
         const onEnterCommit = (input: HTMLInputElement, commit: () => void): void => {
             input.addEventListener('change', commit);
@@ -408,7 +408,7 @@ export class DrawingSettingsPopup {
 
         type NumField = 'riskPercent' | 'accountBalance' | 'quantity' | 'entryPrice';
         const numberRow = (label: string, path: NumField, clamp?: { min: number; max: number; step: number }): void => {
-            const { row } = rowShell(label);
+            const row = rowShell(label);
             const input = numberInput();
             if (clamp) {
                 input.min = String(clamp.min);
@@ -447,7 +447,7 @@ export class DrawingSettingsPopup {
          *  typing commits in the selected unit. */
         const levelRow = (label: string, path: 'stopPrice' | 'targetPrice', level: 'stop' | 'target'): void => {
             let mode: PositionLevelMode = 'price';
-            const { row } = rowShell(label);
+            const row = rowShell(label);
             const input = numberInput();
             input.step = 'any';
             input.style.width = '84px';
@@ -484,7 +484,7 @@ export class DrawingSettingsPopup {
         };
 
         const directionRow = (): void => {
-            const { row } = rowShell('Direction');
+            const row = rowShell('Direction');
             const sel = unitSelect();
             sel.style.width = '96px';
             for (const opt of DIRECTION_OPTIONS) {

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -95,6 +95,13 @@ export class DrawingSettingsPopup {
         return this.el != null;
     }
 
+    /** Whether `node` belongs to this popup — the bar or either of its floating children (color
+     *  picker / dropdown menu), which live outside `el`. */
+    contains(node: Node | null): boolean {
+        if (!node) return false;
+        return this.el?.contains(node) === true || this.colorPop?.contains(node) === true || this.menuEl?.contains(node) === true;
+    }
+
     /** Open the quick toolbar for `drawing`, floating clear of its `anchor` box.
      *  `onClose` fires on an outside-click dismissal (not a programmatic close). */
     open(drawing: Drawing, anchor: PopupAnchor | null, actions: SettingsActions, onClose?: () => void): void {
@@ -102,7 +109,11 @@ export class DrawingSettingsPopup {
         ensureStyles();
         this.onClose = onClose ?? null;
         const t = this.theme;
-        const paths = new Set(drawing.schema().fields.map((f) => f.path));
+        const schema = drawing.schema();
+        const paths = new Set(schema.fields.map((f) => f.path));
+        // Text-first annotations (and computed labels) wear their text controls on the bar; on a
+        // shape that merely CAN carry a label they stay beside the label field.
+        const textOnBar = schema.textIsContent === true || !paths.has('text.value');
 
         const el = document.createElement('div');
         el.className = 'vela-dpop';
@@ -204,9 +215,12 @@ export class DrawingSettingsPopup {
         const toggles = drawing as unknown as { showPrice?: boolean; showDate?: boolean };
         if (paths.has('showPrice')) bar.appendChild(this.toggle('Show price', PRICE_DELTA_ICON, toggles.showPrice !== false, (v) => actions.patch({ showPrice: v })));
         if (paths.has('showDate')) bar.appendChild(this.toggle('Show date', DATE_DELTA_ICON, toggles.showDate !== false, (v) => actions.patch({ showDate: v })));
-        if (paths.has('text.color') && !paths.has('text.value')) bar.appendChild(this.colorButton('Text color', TYPE_ICON, drawing.text?.color || '#d1d4dc', (v) => actions.patch({ 'text.color': v })));
-        if (paths.has('text.size') && !paths.has('text.value')) bar.appendChild(this.dropdown('Text size', TEXT_SIZE_OPTIONS.map((o) => o.value), drawing.text?.size ?? 'normal', (s) => labelSizeIcon(s), (v) => actions.patch({ 'text.size': v }), { label: sizeLabel }));
-        if (paths.has('text.value')) bar.appendChild(this.iconBtn('Text', TYPE_ICON, () => this.toggleTextPanel(drawing, actions)));
+        if (paths.has('text.color') && textOnBar) bar.appendChild(this.colorButton('Text color', TYPE_ICON, drawing.text?.color || t.textColor, (v) => actions.patch({ 'text.color': v })));
+        if (paths.has('text.size') && textOnBar) bar.appendChild(this.dropdown('Text size', TEXT_SIZE_OPTIONS.map((o) => o.value), drawing.text?.size ?? 'normal', (s) => labelSizeIcon(s), (v) => actions.patch({ 'text.size': v }), { label: sizeLabel }));
+        // Bold/italic live under the text field; a computed label has no field, so they go on the bar.
+        if (paths.has('text.bold') && !paths.has('text.value')) bar.appendChild(this.toggle('Bold', BOLD_ICON, !!drawing.text?.bold, (v) => actions.patch({ 'text.bold': v })));
+        if (paths.has('text.italic') && !paths.has('text.value')) bar.appendChild(this.toggle('Italic', ITALIC_ICON, !!drawing.text?.italic, (v) => actions.patch({ 'text.italic': v })));
+        if (paths.has('text.value')) bar.appendChild(this.iconBtn('Text', TYPE_ICON, () => this.toggleTextPanel(drawing, actions, !textOnBar)));
         const editableLevels = drawing.editableLevels();
         if (editableLevels && !(drawing instanceof MachFigure)) {
             const fib = drawing as unknown as { numbersSize?: string; labelsSize?: string };
@@ -269,8 +283,9 @@ export class DrawingSettingsPopup {
         }
     };
 
-    /** The expandable text editor (toggled by the Text button). */
-    private toggleTextPanel(drawing: Drawing, actions: SettingsActions): void {
+    /** The expandable text editor (toggled by the Text button): the field itself, with bold/italic
+     *  under it, plus color and size when those aren't already on the bar. */
+    private toggleTextPanel(drawing: Drawing, actions: SettingsActions, withColorAndSize: boolean): void {
         if (this.textPanel) {
             this.textPanel.remove();
             this.textPanel = null;
@@ -304,10 +319,14 @@ export class DrawingSettingsPopup {
 
         const tools = document.createElement('div');
         tools.style.cssText = `display:flex;align-items:center;justify-content:flex-start;gap:0;transform:scale(0.8);transform-origin:left center;`;
-        // text color defaults to the ACTUAL rendered color (theme text color when unset)
+        if (withColorAndSize) {
+            // text color defaults to the ACTUAL rendered color (theme text color when unset)
+            tools.append(
+                this.colorButton('Text color', TYPE_ICON, text?.color || this.theme.textColor, (v) => actions.patch({ 'text.color': v }), 14),
+                this.dropdown('Text size', TEXT_SIZE_OPTIONS.map((o) => o.value), text?.size ?? 'normal', (s) => sizeIcon(s), (v) => actions.patch({ 'text.size': v }), { label: sizeLabel }),
+            );
+        }
         tools.append(
-            this.colorButton('Text color', TYPE_ICON, text?.color || this.theme.textColor, (v) => actions.patch({ 'text.color': v }), 14),
-            this.dropdown('Text size', TEXT_SIZE_OPTIONS.map((o) => o.value), text?.size ?? 'normal', (s) => sizeIcon(s), (v) => actions.patch({ 'text.size': v }), { label: sizeLabel }),
             this.toggle('Bold', BOLD_ICON, !!text?.bold, (v) => actions.patch({ 'text.bold': v })),
             this.toggle('Italic', ITALIC_ICON, !!text?.italic, (v) => actions.patch({ 'text.italic': v })),
         );

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -1,5 +1,5 @@
 import type { VelaTheme } from '../../../core/options';
-import type { Drawing, RegressionStyle, VwapStyle, FrvpStyle } from '../../../core/drawings';
+import type { Drawing, RegressionStyle, VwapStyle, FrvpStyle, PositionLevelMode } from '../../../core/drawings';
 import {
     DEFAULT_DRAWING_COLOR,
     TEXT_SIZE_OPTIONS,
@@ -11,6 +11,8 @@ import {
     MACH_NUMBER_OPTIONS,
     MachFigure,
     FixedRangeVolumeProfile,
+    PositionTool,
+    DIRECTION_OPTIONS,
     effectiveFillColor,
 } from '../../../core/drawings';
 import { buildColorPicker } from './colorPicker';
@@ -21,6 +23,8 @@ export type SettingsPatch = Record<string, unknown>;
 
 /** The actions a settings popup can invoke (wired by the controller to intents). */
 export interface SettingsActions {
+    /** The current live instance (sync rebuilds instances, so panels re-read through this). */
+    resolve(): Drawing | null;
     patch(p: SettingsPatch): void;
     setLocked(v: boolean): void;
     reorder(to: 'front' | 'back'): void;
@@ -151,6 +155,14 @@ export class DrawingSettingsPopup {
         if (paths.has('style.fillColor')) bar.appendChild(this.colorButton('Fill', BUCKET_ICON, effectiveFillColor(drawing, this.theme) ?? drawing.style.fillColor ?? DEFAULT_DRAWING_COLOR, (v) => actions.patch({ 'style.fillColor': v })));
         // Fixed-range VP: all settings live in the gear panel (nothing inline on the quick bar).
         const isFrvp = paths.has('frvp.rows') && drawing instanceof FixedRangeVolumeProfile;
+        // Position tool: zone colors sit on the bar; risk/reward numbers + display toggles live
+        // in the gear panel (they drive the loss/size labels).
+        const isPosition = paths.has('riskPercent') && drawing instanceof PositionTool;
+        if (isPosition) {
+            const pos = drawing as PositionTool;
+            bar.appendChild(this.colorButton('Profit zone', BUCKET_ICON, pos.profitColor, (v) => actions.patch({ profitColor: v })));
+            bar.appendChild(this.colorButton('Loss zone', BUCKET_ICON, pos.lossColor, (v) => actions.patch({ lossColor: v })));
+        }
         // Regression channel: per-line color + style, the two area fills, and the R² toggle.
         const reg = (drawing as unknown as { reg?: RegressionStyle }).reg;
         if (paths.has('reg.midColor') && reg) {
@@ -233,6 +245,7 @@ export class DrawingSettingsPopup {
         // and a kebab overflow (z-order + reset) sits just right of delete.
         bar.appendChild(this.divider());
         if (isFrvp) bar.appendChild(this.iconBtn('Settings', GEAR_ICON, () => this.toggleFrvpPanel(drawing as FixedRangeVolumeProfile, actions)));
+        if (isPosition) bar.appendChild(this.iconBtn('Position size', GEAR_ICON, () => this.togglePositionPanel(drawing as PositionTool, actions)));
         if (editableLevels) bar.appendChild(this.iconBtn('Levels', GEAR_ICON, () => this.toggleLevelsPanel(drawing, actions)));
         bar.appendChild(this.toggle('Lock', LOCK_ICON, drawing.locked, (v) => actions.setLocked(v)));
         const del = this.iconBtn('Delete', TRASH_ICON, () => actions.remove());
@@ -337,6 +350,220 @@ export class DrawingSettingsPopup {
         autoGrow(input); // size to initial content (multi-line aware)
         this.reposition();
         input.focus();
+    }
+
+    /** Gear panel for the position tool: account fields (risk %, balance, position size — size
+     *  back-solves the risk %), the trade levels (direction switch, entry price, stop/target with
+     *  Price / Points units), per-label display toggles, and a live loss/size summary. Every commit
+     *  re-reads the live drawing — editing one field can move another (a flipped level, a
+     *  back-solved risk %), so all fields refresh together. */
+    private togglePositionPanel(drawing: PositionTool, actions: SettingsActions): void {
+        if (this.levelsPanel) {
+            this.levelsPanel.remove();
+            this.levelsPanel = null;
+            this.reposition();
+            return;
+        }
+        const t = this.theme;
+        const panel = document.createElement('div');
+        panel.style.cssText = `padding:8px 10px;border-top:1px solid ${CHROME_BORDER_COLOR};display:flex;flex-direction:column;gap:6px;min-width:280px;`;
+
+        const live = (): PositionTool => {
+            const d = actions.resolve();
+            return d instanceof PositionTool ? d : drawing;
+        };
+        const refreshers: Array<() => void> = [];
+        const refreshAll = (): void => refreshers.forEach((f) => f());
+
+        /** Trim binary float noise so back-solved values (risk % from a typed size) stay readable. */
+        const fmt = (n: number): string => String(Math.round(n * 1e8) / 1e8);
+
+        const numberInput = (): HTMLInputElement => {
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.style.cssText = `width:96px;flex:none;background:transparent;color:inherit;border:1px solid ${CHROME_BORDER_COLOR};border-radius:5px;padding:4px 6px;font:12px ${t.fontFamily};font-variant-numeric:tabular-nums;outline:none;`;
+            return input;
+        };
+        const rowShell = (label: string): { row: HTMLDivElement; } => {
+            const row = document.createElement('div');
+            row.style.cssText = 'display:flex;align-items:center;gap:10px;';
+            const lbl = document.createElement('span');
+            lbl.textContent = label;
+            lbl.style.cssText = 'flex:1;opacity:0.9;';
+            row.appendChild(lbl);
+            panel.appendChild(row);
+            return { row };
+        };
+        const onEnterCommit = (input: HTMLInputElement, commit: () => void): void => {
+            input.addEventListener('change', commit);
+            input.addEventListener('keydown', (e) => {
+                e.stopPropagation();
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    commit();
+                    input.blur();
+                }
+            });
+        };
+
+        type NumField = 'riskPercent' | 'accountBalance' | 'quantity' | 'entryPrice';
+        const numberRow = (label: string, path: NumField, clamp?: { min: number; max: number; step: number }): void => {
+            const { row } = rowShell(label);
+            const input = numberInput();
+            if (clamp) {
+                input.min = String(clamp.min);
+                input.max = String(clamp.max);
+                input.step = String(clamp.step);
+            } else {
+                input.step = 'any';
+            }
+            input.value = fmt(live()[path]);
+            const commit = (): void => {
+                const n = parseFloat(input.value);
+                if (!Number.isFinite(n)) {
+                    input.value = fmt(live()[path]);
+                    return;
+                }
+                const v = clamp ? Math.min(clamp.max, Math.max(clamp.min, n)) : n;
+                actions.patch({ [path]: v });
+                refreshAll();
+            };
+            onEnterCommit(input, commit);
+            refreshers.push(() => {
+                if (document.activeElement !== input) input.value = fmt(live()[path]);
+            });
+            row.appendChild(input);
+        };
+
+        const unitSelect = (): HTMLSelectElement => {
+            const sel = document.createElement('select');
+            sel.style.cssText = `width:76px;flex:none;background:transparent;color:inherit;border:1px solid ${CHROME_BORDER_COLOR};border-radius:5px;padding:4px 4px;font:12px ${t.fontFamily};outline:none;cursor:pointer;`;
+            sel.addEventListener('keydown', (e) => e.stopPropagation());
+            return sel;
+        };
+
+        /** Stop/target row: the value input plus a Price / Points unit dropdown. Switching the
+         *  unit re-expresses the CURRENT level in the new unit (the level itself doesn't move);
+         *  typing commits in the selected unit. */
+        const levelRow = (label: string, path: 'stopPrice' | 'targetPrice', level: 'stop' | 'target'): void => {
+            let mode: PositionLevelMode = 'price';
+            const { row } = rowShell(label);
+            const input = numberInput();
+            input.step = 'any';
+            input.style.width = '84px';
+            const display = (): string => fmt(live().levelDisplayValue(level, mode));
+            input.value = display();
+            const commit = (): void => {
+                const n = parseFloat(input.value);
+                if (!Number.isFinite(n)) {
+                    input.value = display();
+                    return;
+                }
+                actions.patch({ [path]: live().levelPriceFromDisplay(level, mode, n) });
+                refreshAll();
+            };
+            onEnterCommit(input, commit);
+            const sel = unitSelect();
+            for (const opt of [
+                { value: 'price', label: 'Price' },
+                { value: 'points', label: 'Points' },
+            ]) {
+                const o = document.createElement('option');
+                o.value = opt.value;
+                o.textContent = opt.label;
+                sel.appendChild(o);
+            }
+            sel.addEventListener('change', () => {
+                mode = sel.value as PositionLevelMode;
+                input.value = display();
+            });
+            refreshers.push(() => {
+                if (document.activeElement !== input) input.value = display();
+            });
+            row.append(input, sel);
+        };
+
+        const directionRow = (): void => {
+            const { row } = rowShell('Direction');
+            const sel = unitSelect();
+            sel.style.width = '96px';
+            for (const opt of DIRECTION_OPTIONS) {
+                const o = document.createElement('option');
+                o.value = opt.value;
+                o.textContent = opt.label;
+                sel.appendChild(o);
+            }
+            sel.value = live().direction;
+            sel.addEventListener('change', () => {
+                actions.patch({ direction: sel.value });
+                refreshAll();
+            });
+            refreshers.push(() => {
+                sel.value = live().direction;
+            });
+            row.appendChild(sel);
+        };
+
+        type BoolField = 'showText' | 'showHeader' | 'showPrices' | 'showLossSize' | 'showTargetLabel' | 'showStopLabel';
+        const toggleRow = (label: string, path: BoolField): void => {
+            const row = document.createElement('label');
+            row.style.cssText = 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;';
+            const chk = document.createElement('input');
+            chk.type = 'checkbox';
+            chk.checked = live()[path];
+            chk.style.cssText = `accent-color:${t.textColor};width:15px;height:15px;flex:none;cursor:pointer;`;
+            chk.addEventListener('change', () => {
+                actions.patch({ [path]: chk.checked });
+                refreshAll();
+            });
+            const lbl = document.createElement('span');
+            lbl.textContent = label;
+            lbl.style.cssText = 'flex:1;opacity:0.9;';
+            refreshers.push(() => {
+                chk.checked = live()[path];
+            });
+            row.append(chk, lbl);
+            panel.appendChild(row);
+        };
+
+        const section = (label: string): void => {
+            const el = document.createElement('div');
+            el.style.cssText = `opacity:0.5;font-size:10px;letter-spacing:0.6px;text-transform:uppercase;padding-top:4px;`;
+            el.textContent = label;
+            panel.appendChild(el);
+        };
+
+        section('Account');
+        numberRow('Risk %', 'riskPercent', { min: 0, max: 100, step: 0.1 });
+        numberRow('Account balance', 'accountBalance', { min: 0, max: 1e12, step: 1 });
+        numberRow('Position size', 'quantity');
+
+        section('Levels');
+        directionRow();
+        numberRow('Entry price', 'entryPrice');
+        levelRow('Stop', 'stopPrice', 'stop');
+        levelRow('Target', 'targetPrice', 'target');
+
+        section('Display');
+        toggleRow('Show text', 'showText');
+        toggleRow('Show direction & ratio', 'showHeader');
+        toggleRow('Show loss & size', 'showLossSize');
+        toggleRow('Show target label', 'showTargetLabel');
+        toggleRow('Show stop label', 'showStopLabel');
+        toggleRow('Show level prices', 'showPrices');
+
+        const summary = document.createElement('div');
+        summary.style.cssText = `opacity:0.7;font-size:11px;line-height:1.4;border-top:1px solid ${CHROME_BORDER_COLOR};padding-top:6px;font-variant-numeric:tabular-nums;`;
+        refreshers.push(() => {
+            const d = live();
+            summary.textContent = `${d.headerLabel()}  —  ${d.lossSizeLabel()}`;
+        });
+        panel.appendChild(summary);
+        refreshAll();
+
+        this.el?.appendChild(panel);
+        this.levelsPanel = panel;
+        this.reposition();
     }
 
     /** Gear panel for Fixed Range Volume Profile: rows / VA / width / anchor, volume colors,

--- a/src/renderers/native/drawings/DrawingToolbar.ts
+++ b/src/renderers/native/drawings/DrawingToolbar.ts
@@ -21,6 +21,7 @@ export interface DrawingToolbarOptions {
  * it — its own hover target, revealed on cell hover — opens a flyout listing the group's tools. A
  * cursor button returns to select/idle; measure/eraser modes sit at the bottom, and the magnet is a
  * cell whose chevron opens an Off/Weak/Strong menu (its icon toggles the last-used strength on/off).
+ * Below the magnet, a stay-in-drawing-mode toggle keeps tools armed after each placement.
  * Hover and active tints are CSS-driven (`:hover` + `[data-active]`) so they never lag. Tooltips
  * appear after a 2s hover. Pure vanilla DOM on the host (a `pointer-events:auto` island).
  */
@@ -47,6 +48,8 @@ export class DrawingToolbar {
     private measureActive = false;
     private eraserBtn: HTMLButtonElement | null = null;
     private eraserActive = false;
+    private stayBtn: HTMLButtonElement | null = null;
+    private stayActive = false;
     private visible = false;
     private readonly tipText = new WeakMap<HTMLElement, string>(); // per-anchor tooltip text (magnet's changes with mode)
     private tooltipEl: HTMLDivElement | null = null;
@@ -64,6 +67,7 @@ export class DrawingToolbar {
         private readonly onMeasure: () => void = () => {},
         private readonly onEraser: () => void = () => {},
         private readonly onToggleFavorite: (type: DrawingTypeKey, on: boolean) => void = () => {},
+        private readonly onStayMode: (on: boolean) => void = () => {},
         options: DrawingToolbarOptions = {},
     ) {
         this.borderColor = options.borderColor ?? CHROME_BORDER_COLOR;
@@ -170,9 +174,12 @@ export class DrawingToolbar {
         this.eraserBtn = this.makeButton(ERASER_ICON, 'Eraser (click/drag to delete)', () => this.onEraser());
         this.root.appendChild(this.eraserBtn);
         this.root.appendChild(this.makeMagnetCell());
+        this.stayBtn = this.makeButton(STAY_ICON, 'Stay in drawing mode', () => this.toggleStay());
+        this.root.appendChild(this.stayBtn);
         this.paintMeasure();
         this.paintEraser();
         this.paintMagnet();
+        this.paintStay();
         this.highlight();
     }
 
@@ -313,6 +320,26 @@ export class DrawingToolbar {
         const on = this.magnetMode !== 'off';
         cell.dataset.active = on ? '1' : '';
         icon.style.opacity = on ? '1' : '0.5';
+    }
+
+    /** Toggle stay-in-drawing-mode on/off and notify the renderer. */
+    private toggleStay(): void {
+        this.stayActive = !this.stayActive;
+        this.onStayMode(this.stayActive);
+        this.paintStay();
+    }
+
+    /** Reflect stay-in-drawing-mode externally without notifying back. */
+    setStayMode(on: boolean): void {
+        this.stayActive = on;
+        this.paintStay();
+    }
+
+    private paintStay(): void {
+        const b = this.stayBtn;
+        if (!b) return;
+        b.dataset.active = this.stayActive ? '1' : '';
+        b.style.opacity = this.stayActive ? '1' : '0.5';
     }
 
     // ── flyout ──
@@ -514,6 +541,7 @@ export class DrawingToolbar {
         this.paintMeasure();
         this.paintEraser();
         this.paintMagnet();
+        this.paintStay();
     }
 
     private makeButton(icon: string, title: string, onClick: () => void): HTMLButtonElement {
@@ -623,6 +651,9 @@ const RULER_ICON =
     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.3 15.3 8.7 2.7a1 1 0 0 0-1.4 0L2.7 7.3a1 1 0 0 0 0 1.4l12.6 12.6a1 1 0 0 0 1.4 0l4.6-4.6a1 1 0 0 0 0-1.4Z"/><path d="m7.5 10.5 2 2"/><path d="m10.5 7.5 2 2"/><path d="m13.5 4.5 2 2"/><path d="m4.5 13.5 2 2"/></svg>';
 const MAGNET_ICON =
     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 15-4-4 6.75-6.77a7.79 7.79 0 0 1 11 11L13 22l-4-4 6.39-6.36a2.14 2.14 0 0 0-3-3L6 15"/><path d="m5 8 4 4"/><path d="m12 15 4 4"/></svg>';
+/** Pen with a padlock — stay-in-drawing-mode (tools remain armed after each placement). */
+const STAY_ICON =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.8 4.2a2.1 2.1 0 0 1 3 3L8.5 15.5l-3.5 1 1-3.5Z"/><rect x="13" y="14.5" width="8" height="6" rx="1.2"/><path d="M15 14.5v-1.6a2 2 0 0 1 4 0v1.6"/></svg>';
 const ERASER_ICON =
     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3a1 1 0 0 1 0-1.4L13 5a2 2 0 0 1 2.8 0l4.2 4.2a2 2 0 0 1 0 2.8L12 20"/><path d="M22 21H7"/><path d="m5 11 9 9"/></svg>';
 /** A right-pointing chevron for the group/magnet flyout arrow (beside the icon). */

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -11,9 +11,10 @@ import type {
     SnapMode,
     ToolbarDefinition,
 } from '../../../core/drawings';
-import { deserializeDrawing, resetDrawingSettings, Callout } from '../../../core/drawings';
+import { deserializeDrawing, resetDrawingSettings, Callout, TextLabel } from '../../../core/drawings';
 import type { Unsubscribe } from '../../../core/util/types';
-import { namedFontSize } from '../../shared/drawing-geometry';
+import { namedFontSize, labelLineHeight, TEXT_FRAME_INSET, TEXT_FRAME_RISE } from '../../shared/drawing-geometry';
+import { withAlpha } from '../core/chartConfig';
 import { blendOver, splitColor } from './colorPicker';
 import { DrawingPainter } from './DrawingPainter';
 import { DrawingInteraction } from './DrawingInteraction';
@@ -22,6 +23,21 @@ import { DrawingToolbar } from './DrawingToolbar';
 import { MeasureOverlay } from './MeasureOverlay';
 import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
 import { keyToDrawingAction, isEditingText } from './DrawingKeys';
+
+/** Shown in the inline editor while a label carries no text yet. */
+const TEXT_PLACEHOLDER = 'Enter Text';
+/** Extra width past the measured glyphs so the caret has somewhere to sit. */
+const CARET_ROOM = 8;
+/** The editor's border weight; its padding is the shared TEXT_FRAME inset/rise minus this, so the
+ *  border lands exactly on the frame the painter draws — the box doesn't move when editing starts. */
+const EDITOR_BORDER = 1;
+
+/** The drawings whose text is typed straight onto the chart rather than through the settings popup. */
+type InlineEditable = Callout | TextLabel;
+
+function isInlineEditable(d: Drawing | null | undefined): d is InlineEditable {
+    return d instanceof Callout || d instanceof TextLabel;
+}
 
 /** What the controller needs from the native renderer (coords + theme + dpr). */
 export interface UserDrawingDeps {
@@ -57,7 +73,10 @@ export class UserDrawingController implements IDrawingsRendererPort {
     private measureMode = false; // the ruler is armed (placing a measurement)
     private eraserMode = false; // click/drag over a drawing deletes it
     private erasing = false; // a button is held during eraser mode (so a drag erases multiple)
-    private calloutEditor: HTMLTextAreaElement | null = null; // inline text editor for the focused callout
+    // The inline on-chart text editor: its element, the id of the drawing it edits, the text it
+    // opened with (so Escape can put it back), and the text the core currently holds (so an edit is
+    // reported exactly when it actually changes).
+    private textEditor: { el: HTMLTextAreaElement; id: string; initial: string; stored: string } | null = null;
 
     private readonly painter = new DrawingPainter();
     private readonly interaction: DrawingInteraction;
@@ -110,6 +129,9 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     syncDrawings(docs: readonly SerializedDrawing[]): void {
         this.drawings = docs.map((d) => deserializeDrawing(d)).filter((d): d is Drawing => d != null);
+        // The edited drawing can vanish from under the editor (deleted, erased, undone) — take the
+        // editor with it instead of leaving a live textarea over nothing.
+        if (this.textEditor && !this.editedDrawing(this.textEditor.id)) this.closeTextEditor();
         this.render();
         this.deps.requestScaleUpdate(); // fold drawing price ranges into autoscale
     }
@@ -137,7 +159,7 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     setActiveTool(type: DrawingTypeKey | null, lastStyle?: SerializedDrawing['style']): void {
         if (type != null) {
-            this.closeCalloutEditor(); // arming a real tool cancels an open inline editor
+            this.finishTextEditor(true); // arming a real tool ends an open inline edit (keeping the text)
             // Picking a drawing tool cancels the ruler and the eraser — a mutual-exclusion
             // side effect the core (and any external toolbar) learns via the mode intent.
             this.withModeIntent(() => {
@@ -226,8 +248,12 @@ export class UserDrawingController implements IDrawingsRendererPort {
         if (hit && !hit.locked) this.emit({ kind: 'delete', ids: [hit.id] });
     }
 
-    /** Clear a finished transient measurement (the ruler vanishes on the next press / pan / zoom). */
+    /** A press landed on the chart: a finished transient measurement clears (the ruler vanishes on the
+     *  next press / pan / zoom), and an open inline edit ends. This runs for EVERY press, including the
+     *  ones the drawings layer doesn't claim — a press on empty chart is a pan, and the editor may not
+     *  hold focus (the settings popup can), so neither `pointerDown` nor blur would end the edit. */
     clearTransient(): void {
+        if (this.textEditor) this.finishTextEditor(true); // clicking off the text keeps what was typed
         if (this.measure.isFinished()) {
             this.measure.clear();
             this.render();
@@ -336,60 +362,167 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.render();
     }
 
-    /** Open an inline textarea over a callout's box so its text is edited directly on the chart
-     *  (click the text field and type). Commits on blur / Enter, cancels on Escape. */
-    private editCalloutInline(id: string): void {
-        const d = this.drawings.find((x) => x.id === id);
-        if (!(d instanceof Callout)) return;
-        this.closeCalloutEditor();
-        this.popup.close();
-        const box = d.box(this.deps.projector());
-        if (!box) return;
-        const theme = this.deps.theme();
-        const fs = namedFontSize(d.text?.size ?? 'normal');
+    /**
+     * Open an inline textarea over the drawing's own text so it is typed directly on the chart:
+     * a callout fills its bubble, a plain text label sits exactly where the glyphs paint (the
+     * canvas label is muted meanwhile, so what you type IS what the chart shows) inside a thin frame
+     * that marks the text as being edited. An empty label shows a placeholder. Enter breaks the line,
+     * a press on the chart (or Ctrl/Cmd+Enter) keeps the text, Escape puts back what was there. The
+     * editor and the settings popup are one unit: reaching for a control in the popup does not end
+     * the edit.
+     */
+    private editTextInline(id: string): void {
+        const d = this.editedDrawing(id);
+        if (!d) return;
+        this.closeTextEditor();
+        const initial = d.text?.value ?? '';
+        const css = this.inlineEditorCss(d, initial);
+        if (!css) return;
         const ta = document.createElement('textarea');
-        ta.value = d.text?.value ?? '';
+        ta.value = initial;
+        ta.placeholder = TEXT_PLACEHOLDER;
         ta.spellcheck = false;
-        ta.style.cssText =
-            `position:absolute;left:${Math.round(box.x)}px;top:${Math.round(box.y)}px;width:${Math.round(box.w)}px;height:${Math.round(box.h)}px;` +
-            `z-index:24;box-sizing:border-box;resize:none;overflow:hidden;margin:0;padding:5px 8px;border-radius:5px;` +
-            `border:1px solid ${d.style.lineColor ?? theme.borderColor};background:${blendOver(d.style.fillColor ?? theme.background, theme.background, splitColor(d.style.fillColor ?? theme.background).alpha)};color:${d.text?.color ?? theme.textColor};` +
-            `font:${fs}px ${theme.fontFamily};text-align:left;outline:none;pointer-events:auto;`;
-        ta.addEventListener('input', () => {
-            d.applySettings({ 'text.value': ta.value });
-            this.render(); // live: keep the canvas bubble sized to the text
-            const b = d.box(this.deps.projector());
-            if (b) {
-                ta.style.left = `${Math.round(b.x)}px`;
-                ta.style.top = `${Math.round(b.y)}px`;
-                ta.style.width = `${Math.round(b.w)}px`;
-                ta.style.height = `${Math.round(b.h)}px`;
-            }
-        });
+        ta.style.cssText = css;
+        // live: the canvas bubble / hit box follow the typed text (and the editor re-lays out around it)
+        const sync = (): void => {
+            this.editedDrawing(id)?.applySettings({ 'text.value': ta.value });
+            this.render();
+        };
+        ta.addEventListener('input', sync);
         ta.addEventListener('pointerdown', (e) => e.stopPropagation());
         ta.addEventListener('keydown', (e) => {
             e.stopPropagation();
-            if (e.key === 'Escape' || (e.key === 'Enter' && !e.shiftKey)) {
+            // Enter breaks the line — the break is inserted here rather than left to the textarea's
+            // default so it lands whatever else handled the key. Ctrl/Cmd+Enter is the keyboard way
+            // to finish, for anyone who'd rather not click off the text.
+            if (e.key === 'Enter' && !e.ctrlKey && !e.metaKey) {
                 e.preventDefault();
-                ta.blur();
+                const at = ta.selectionStart;
+                ta.setRangeText('\n', at, ta.selectionEnd, 'end');
+                sync();
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                this.finishTextEditor(true);
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                this.finishTextEditor(false);
             }
         });
-        ta.addEventListener('blur', () => {
-            d.applySettings({ 'text.value': ta.value });
-            this.emit({ kind: 'edit', doc: d.serialize() });
-            this.closeCalloutEditor();
+        ta.addEventListener('blur', (e) => {
+            // Reaching for a control in the settings popup keeps the edit alive — but hand the text
+            // over to the core first, so the popup's own patches build on it instead of a re-sync
+            // dropping it.
+            if (this.popup.contains((e as FocusEvent).relatedTarget as Node | null)) this.storeText(ta.value);
+            else this.finishTextEditor(true); // clicking away keeps the text
         });
         this.overlayHost.appendChild(ta);
-        this.calloutEditor = ta;
+        this.textEditor = { el: ta, id, initial, stored: initial };
         ta.focus();
-        ta.select();
+        // Caret at the end, nothing selected: reopening existing text with everything highlighted
+        // reads as a rename/resize box rather than in-place editing (and one keystroke would
+        // replace the whole annotation).
+        ta.setSelectionRange(ta.value.length, ta.value.length);
     }
 
-    private closeCalloutEditor(): void {
-        const ta = this.calloutEditor;
-        if (!ta) return;
-        this.calloutEditor = null; // null first: removing a focused textarea fires blur → re-entrant close
-        ta.remove();
+    /** Hand the edited text to the core (once per actual change) without ending the edit. */
+    private storeText(value: string): void {
+        const ed = this.textEditor;
+        const d = ed && this.editedDrawing(ed.id);
+        if (!ed || !d) return;
+        d.applySettings({ 'text.value': value });
+        if (value !== ed.stored) {
+            ed.stored = value;
+            this.emit({ kind: 'edit', doc: d.serialize() });
+        }
+    }
+
+    /** The drawing an inline editor may edit, resolved fresh from the current projection (a core
+     *  sync replaces the instances, so the editor holds an id rather than the object). */
+    private editedDrawing(id: string): InlineEditable | null {
+        const d = this.drawings.find((x) => x.id === id);
+        return isInlineEditable(d) ? d : null;
+    }
+
+    /** Close the inline editor, keeping (`commit`) or reverting the typed text. A text label left
+     *  with nothing in it would paint nothing at all, so it's dropped rather than left invisible. */
+    private finishTextEditor(commit: boolean): void {
+        const ed = this.textEditor;
+        if (!ed) return;
+        const value = commit ? ed.el.value : ed.initial;
+        this.closeTextEditor();
+        const d = this.editedDrawing(ed.id);
+        if (!d) return; // deleted from under the editor
+        d.applySettings({ 'text.value': value });
+        this.render();
+        if (d instanceof TextLabel && value.trim() === '') {
+            this.clearSelection(); // its settings popup would outlive the drawing
+            this.emit({ kind: 'delete', ids: [d.id] });
+        } else if (value !== ed.stored) this.emit({ kind: 'edit', doc: d.serialize() });
+    }
+
+    /** Absolute position + text metrics for the inline editor, so the typed glyphs land where the
+     *  painter would draw them. Null when the drawing has no on-screen box (off-pane anchor). */
+    private inlineEditorCss(d: InlineEditable, value: string): string | null {
+        const proj = this.deps.projector();
+        const theme = this.deps.theme();
+        const text = d.text;
+        const fs = namedFontSize(text?.size ?? 'normal');
+        const font = `${text?.italic ? 'italic ' : ''}${text?.bold ? 'bold ' : ''}${fs}px ${theme.fontFamily}`;
+        const base = 'position:absolute;z-index:24;box-sizing:border-box;resize:none;overflow:hidden;margin:0;outline:none;pointer-events:auto;text-align:left;';
+        if (d instanceof Callout) {
+            const box = d.box(proj);
+            if (!box) return null;
+            const fill = d.style.fillColor ?? theme.background;
+            return (
+                base +
+                `left:${Math.round(box.x)}px;top:${Math.round(box.y)}px;width:${Math.round(box.w)}px;height:${Math.round(box.h)}px;` +
+                `padding:5px 8px;border-radius:5px;border:1px solid ${d.style.lineColor ?? theme.borderColor};` +
+                `background:${blendOver(fill, theme.background, splitColor(fill).alpha)};color:${text?.color ?? theme.textColor};font:${font};`
+            );
+        }
+        const anchor = d.handlePoints(proj)[0];
+        if (!anchor) return null;
+        const lh = labelLineHeight(fs);
+        const lines = (value || TEXT_PLACEHOLDER).split('\n');
+        const w = Math.ceil(this.measureTextWidth(lines, font)) + CARET_ROOM;
+        // The painter draws the label at (anchor + 2) with a `top` baseline; a textarea centers each
+        // glyph in its line box, so lift it by half the leading to keep both in the same place. The
+        // frame then grows outwards around that origin rather than pushing the text off it.
+        return (
+            base +
+            `left:${Math.round(anchor[0] + 2) - TEXT_FRAME_INSET}px;top:${Math.round(anchor[1] + 2 - (lh - fs) / 2) - TEXT_FRAME_RISE}px;` +
+            `width:${w + TEXT_FRAME_INSET * 2}px;height:${lines.length * lh + TEXT_FRAME_RISE * 2}px;` +
+            `padding:${TEXT_FRAME_RISE - EDITOR_BORDER}px ${TEXT_FRAME_INSET - EDITOR_BORDER}px;` +
+            `border:${EDITOR_BORDER}px solid ${withAlpha(theme.textColor, 0.3)};border-radius:4px;` +
+            `background:transparent;color:${text?.color ?? theme.textColor};font:${font};line-height:${lh}px;white-space:pre;`
+        );
+    }
+
+    /** Widest of `lines` at `font`, measured on the drawings canvas (transform-independent). */
+    private measureTextWidth(lines: readonly string[], font: string): number {
+        const ctx = this.ctx;
+        if (!ctx) return 120;
+        const prev = ctx.font;
+        ctx.font = font;
+        const w = Math.max(8, ...lines.map((l) => ctx.measureText(l).width));
+        ctx.font = prev;
+        return w;
+    }
+
+    /** Keep an open editor glued to its drawing (typing, panning, zooming all move the anchor). */
+    private layoutTextEditor(): void {
+        const ed = this.textEditor;
+        if (!ed) return;
+        const d = this.editedDrawing(ed.id);
+        const css = d && this.inlineEditorCss(d, ed.el.value);
+        if (css) ed.el.style.cssText = css;
+    }
+
+    private closeTextEditor(): void {
+        const ed = this.textEditor;
+        if (!ed) return;
+        this.textEditor = null; // null first: removing a focused textarea fires blur → re-entrant close
+        ed.el.remove();
         this.render();
     }
 
@@ -404,8 +537,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
     dblClick(x: number, y: number): boolean {
         if (this.interaction.finishPlacing(true)) return true; // double-click finishes a polyline (drops the dup point)
         const hit = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE);
-        if (hit instanceof Callout) {
-            this.editCalloutInline(hit.id); // double-click a callout → edit its text in place
+        if (isInlineEditable(hit)) {
+            this.editTextInline(hit.id); // double-click a callout / text label → edit its text in place
             return true;
         }
         return hit != null;
@@ -415,6 +548,10 @@ export class UserDrawingController implements IDrawingsRendererPort {
      *  delete (multi), and arrow-nudge. Stands down while a label text field is focused. */
     handleKey(e: KeyboardEvent): boolean {
         if (e.key === 'Escape') {
+            if (this.textEditor) {
+                this.finishTextEditor(false); // cancel the edit before the popup/selection
+                return true;
+            }
             if (this.popup.isOpen()) {
                 this.clearSelection();
                 return true;
@@ -494,7 +631,7 @@ export class UserDrawingController implements IDrawingsRendererPort {
     }
 
     onResize(): void {
-        this.closeCalloutEditor();
+        this.finishTextEditor(true);
         this.popup.close();
         this.render();
     }
@@ -507,13 +644,16 @@ export class UserDrawingController implements IDrawingsRendererPort {
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
         ctx.clearRect(0, 0, this.canvas.width / dpr, this.canvas.height / dpr);
         const proj = this.deps.projector();
-        // Handles show for the selected drawings, the one being dragged, and the one under
-        // the cursor — so they appear on hover/selection and vanish when you leave / deselect.
-        const highlight = new Set(this.selectedIds);
-        const drag = this.interaction.activeDragId();
-        if (drag) highlight.add(drag);
-        if (this.hoveredId) highlight.add(this.hoveredId);
-        this.painter.paintAll(ctx, this.drawings, proj, this.deps.theme(), highlight);
+        // A transparent inline editor overlays the label it edits — mute the canvas copy so the
+        // typed text isn't drawn twice (the callout editor is opaque, so its label stays).
+        const edited = this.textEditor ? this.editedDrawing(this.textEditor.id) : null;
+        this.painter.paintAll(ctx, this.drawings, proj, this.deps.theme(), {
+            selected: this.selectedIds,
+            hovered: this.hoveredId,
+            dragged: this.interaction.activeDragId(),
+            mutedLabel: edited instanceof TextLabel ? edited.id : null,
+        });
+        this.layoutTextEditor();
         const ghost = this.interaction.ghost();
         if (ghost) this.painter.paintGhost(ctx, ghost, proj, this.deps.theme());
         // While placing, show control circles on the points clicked so far (so the user
@@ -529,7 +669,7 @@ export class UserDrawingController implements IDrawingsRendererPort {
     }
 
     destroy(): void {
-        this.closeCalloutEditor();
+        this.closeTextEditor();
         this.popup.destroy();
         this.toolbar.destroy();
         this.intentCb = null;
@@ -576,6 +716,7 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.openSettingsById(id, 0, 0);
             },
             remove: () => {
+                this.closeTextEditor(); // else the editor floats over the deleted label until it loses focus
                 this.popup.close();
                 this.emit({ kind: 'delete', ids: [id] });
             },
@@ -583,10 +724,10 @@ export class UserDrawingController implements IDrawingsRendererPort {
     }
 
     private emit(i: DrawingIntent): void {
-        // A freshly-placed drawing surfaces its editing UI by default once it's set: a callout opens
-        // its inline text editor, every other type opens its settings menu. Works for both click +
-        // drag finalize — the core reassigns the id, so we diff the drawing set around the create to
-        // find the new one.
+        // A freshly-placed drawing surfaces its editing UI by default once it's set: every type opens
+        // its settings menu, and a text label / callout additionally opens its inline editor so the
+        // caret is already waiting. Works for both click + drag finalize — the core reassigns the id,
+        // so we diff the drawing set around the create to find the new one.
         if (i.kind === 'create') {
             const before = new Set(this.drawings.map((d) => d.id));
             this.intentCb?.(i);
@@ -595,8 +736,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
             setTimeout(() => {
                 const fresh = this.drawings.find((d) => !before.has(d.id));
                 if (!fresh) return;
-                if (fresh instanceof Callout) this.editCalloutInline(fresh.id);
-                else this.openSettingsById(fresh.id, 0, 0);
+                this.openSettingsById(fresh.id, 0, 0);
+                if (isInlineEditable(fresh)) this.editTextInline(fresh.id); // focus lands in the editor, not the bar
             }, 0);
             return;
         }

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -698,6 +698,9 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.emit({ kind: 'settings', id });
         const anchor = drawing.bounds(this.deps.projector()); // float the toolbar clear of the drawing
         this.popup.open(drawing, anchor, {
+            // Sync rebuilds instances, so a panel that reads values back after a patch (e.g. the
+            // position tool's price fields, where one edit can flip another level) resolves fresh.
+            resolve: () => live() ?? null,
             patch: (p) => {
                 const d = live();
                 if (!d) return;

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -102,6 +102,7 @@ export class UserDrawingController implements IDrawingsRendererPort {
             () => this.withModeIntent(() => this.toggleMeasure()),
             () => this.withModeIntent(() => this.toggleEraser()),
             (type, on) => this.emit({ kind: 'favorite', type, on }),
+            (on) => this.emit({ kind: 'stay-mode', on }),
         );
         this.interaction = new DrawingInteraction({
             projector: () => this.deps.projector(),
@@ -185,6 +186,11 @@ export class UserDrawingController implements IDrawingsRendererPort {
     setSnapMode(mode: SnapMode): void {
         this.deps.setSnapMode(mode);
         this.toolbar.setMagnetMode(mode);
+    }
+
+    /** Core push: stay-in-drawing-mode — reflect on the toolbar without notifying back. */
+    setStayMode(on: boolean): void {
+        this.toolbar.setStayMode(on);
     }
 
     /** Core push: enter/exit measure or eraser (`null` = none). Reuses the toolbar

--- a/src/renderers/shared/drawing-geometry.ts
+++ b/src/renderers/shared/drawing-geometry.ts
@@ -139,6 +139,18 @@ export function contrastColor(bg: string | undefined): string {
     return relativeLuminance(c.r, c.g, c.b) > 0.55 ? '#000000' : '#ffffff';
 }
 
+/** Line height (px) for multi-line drawing labels — one value shared by the canvas painter and
+ *  the inline text editor, so the glyphs don't shift when an edit starts. */
+export function labelLineHeight(fontSize: number): number {
+    return Math.round(fontSize * 1.4);
+}
+
+/** How far the frame around a targeted/edited text label extends past its glyph box — horizontally
+ *  (`inset`) and vertically (`rise`). Shared by the canvas painter (selection/hover frame) and the
+ *  inline editor (border + padding), which keeps the two frames coincident by construction. */
+export const TEXT_FRAME_INSET = 5;
+export const TEXT_FRAME_RISE = 3;
+
 /** Fixed px for a named box text size; `auto` returns 0 (caller fits to box). */
 export function namedFontSize(size: BoxTextSize): number {
     switch (size) {

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -171,11 +171,12 @@ export class VelaWorkspace {
     private readonly toast: Toast;
     private readonly glider = new Glider(() => (this.activeId ? (this.cellsById.get(this.activeId)?.chart ?? null) : null));
     private readonly drawToolbar: DrawingToolbar | null;
-    /** The GLOBAL armed tool/magnet (workspace policy) — re-applied to whichever cell
+    /** The GLOBAL armed tool/magnet/stay (workspace policy) — re-applied to whichever cell
      *  takes the focus; only the ACTIVE cell ever holds a non-null tool. Measure/eraser
      *  stay transient and per-cell: they exit when the focus leaves. */
     private globalTool: DrawingTypeKey | null = null;
     private globalSnap: SnapMode = 'off';
+    private globalStay = false;
     /** Favorite drawing tools — a WORKSPACE preference (one star set, every cell). */
     private favs: string[] = [];
     /** Live sync configuration (mutable copy of the option). */
@@ -352,6 +353,10 @@ export class VelaWorkspace {
                   },
                   // No refocus on a star: the flyout stays open for more browsing.
                   (type, on) => this.active.chart.drawings.setFavorite(type, on),
+                  (on) => {
+                      this.active.chart.drawings.setStayMode(on);
+                      this.refocusActive();
+                  },
                   { dock: 'static' },
               )
             : null;
@@ -657,14 +662,16 @@ export class VelaWorkspace {
         this.bottombar?.setActiveRange(cell.activeRangeId);
         this.indicatorPicker.sync(); // the dialog may be open while the active cell changes
         this.glider.stop(); // a mid-glide switch must not steer the next cell's viewport
-        // Shared drawing toolbar ⇄ the active cell: re-apply the GLOBAL tool + magnet to
-        // the cell taking focus, and reflect its (fresh) state on the bar.
+        // Shared drawing toolbar ⇄ the active cell: re-apply the GLOBAL tool + magnet + stay
+        // to the cell taking focus, and reflect its (fresh) state on the bar.
         const d = cell.chart.drawings;
         if (d.getTool() !== this.globalTool) d.setTool(this.globalTool);
         if (d.getSnapMode() !== this.globalSnap) d.setSnapMode(this.globalSnap);
+        if (d.getStayMode() !== this.globalStay) d.setStayMode(this.globalStay);
         if (this.drawToolbar) {
             this.drawToolbar.setActiveTool(this.globalTool);
             this.drawToolbar.setMagnetMode(this.globalSnap);
+            this.drawToolbar.setStayMode(this.globalStay);
             const mode = d.getMode();
             this.drawToolbar.setMeasureActive(mode === 'measure');
             this.drawToolbar.setEraserActive(mode === 'eraser');
@@ -826,6 +833,11 @@ export class VelaWorkspace {
             if (cell.id !== this.activeId) return;
             this.globalSnap = mode;
             this.drawToolbar?.setMagnetMode(mode);
+        });
+        chart.on('drawing:stay', ({ on }) => {
+            if (cell.id !== this.activeId) return;
+            this.globalStay = on;
+            this.drawToolbar?.setStayMode(on);
         });
         chart.on('drawing:mode', ({ mode }) => {
             if (cell.id !== this.activeId) return;

--- a/test/drawings-controller.test.ts
+++ b/test/drawings-controller.test.ts
@@ -41,6 +41,10 @@ class FakePort implements IDrawingsRendererPort {
     setSnapMode(mode: string): void {
         this.snapModes.push(mode);
     }
+    stayModes: boolean[] = [];
+    setStayMode(on: boolean): void {
+        this.stayModes.push(on);
+    }
     modes: Array<string | null> = [];
     setMode(mode: string | null): void {
         this.modes.push(mode);
@@ -182,6 +186,19 @@ describe('DrawingController (enabled)', () => {
         port.fire({ kind: 'tool-finished', type: 'highlighter' });
         expect(ctrl.getTool()).toBe('highlighter');
         expect(port.activeTool).toBe('highlighter');
+    });
+
+    it('stay-in-drawing-mode keeps a one-shot tool armed after placement', () => {
+        const { port, ctrl } = setup();
+        ctrl.setStayMode(true);
+        ctrl.setTool('trendline');
+        port.fire({ kind: 'tool-finished', type: 'trendline' });
+        expect(ctrl.getTool()).toBe('trendline');
+        expect(port.activeTool).toBe('trendline');
+        // Turning it off restores one-shot disarm.
+        ctrl.setStayMode(false);
+        port.fire({ kind: 'tool-finished', type: 'trendline' });
+        expect(ctrl.getTool()).toBeNull();
     });
 });
 
@@ -555,6 +572,30 @@ describe('DrawingController — tool/mode seams (the external-toolbar surface)',
         expect(port.snapModes).toEqual([]); // an intent must never bounce back as a command
     });
 
+    it('setStayMode pushes the port command, mirrors, emits — and equal values no-op', () => {
+        const { port, events, ctrl } = setup();
+        const stays: boolean[] = [];
+        events.on('drawing:stay', (e) => stays.push(e.on));
+
+        ctrl.setStayMode(true);
+        ctrl.setStayMode(true); // no-op
+        expect(port.stayModes).toEqual([true]);
+        expect(ctrl.getStayMode()).toBe(true);
+        expect(stays).toEqual([true]);
+    });
+
+    it('an in-chart stay-mode click arrives as a stay-mode intent: mirror + event, echo-safe', () => {
+        const { port, events, ctrl } = setup();
+        const stays: boolean[] = [];
+        events.on('drawing:stay', (e) => stays.push(e.on));
+
+        port.fire({ kind: 'stay-mode', on: true });
+        port.fire({ kind: 'stay-mode', on: true }); // renderer echo of an equal value → dropped
+        expect(ctrl.getStayMode()).toBe(true);
+        expect(stays).toEqual([true]);
+        expect(port.stayModes).toEqual([]); // an intent must never bounce back as a command
+    });
+
     it('setMode pushes the port command; the renderer intent reports the outcome', () => {
         const { port, events, ctrl } = setup();
         const modes: Array<string | null> = [];
@@ -571,11 +612,13 @@ describe('DrawingController — tool/mode seams (the external-toolbar surface)',
         expect(modes).toEqual(['measure', null]);
     });
 
-    it('mode/snap setters are inert without a port (headless), like the other interactive ops', () => {
+    it('mode/snap/stay setters are inert without a port (headless), like the other interactive ops', () => {
         const { ctrl } = setup(false);
         ctrl.setSnapMode('strong');
+        ctrl.setStayMode(true);
         ctrl.setMode('eraser');
         expect(ctrl.getSnapMode()).toBe('off'); // mirrors keep their defaults
+        expect(ctrl.getStayMode()).toBe(false);
         expect(ctrl.getMode()).toBe(null);
     });
 });

--- a/test/drawings-interaction.test.ts
+++ b/test/drawings-interaction.test.ts
@@ -240,28 +240,30 @@ describe('DrawingInteraction: click-move-click placement (measurement / position
         expect(create?.kind === 'create' && create.doc.anchors).toHaveLength(2);
     });
 
-    it('a long position click-move-click → 3 anchors, target above the entry (stop below = long)', () => {
-        const h = harness('position');
-        h.it.down(20, 60); // entry (price 40)
-        h.it.move(40, 80);
-        h.it.down(40, 80); // stop below the entry (price 20) → long
-        const create = h.intents.find((i) => i.kind === 'create');
-        expect(create?.kind === 'create' && create.doc.anchors).toHaveLength(3);
-        if (create?.kind === 'create') {
-            const [entry, , target] = create.doc.anchors;
-            expect(target!.price).toBeGreaterThan(entry!.price); // reward above → long
-        }
-    });
-
-    it('placing the stop the other way flips to short (target below entry)', () => {
+    it('a long position click-move-click → 3 anchors, target above the entry (drag higher = profit)', () => {
         const h = harness('position');
         h.it.down(20, 60); // entry (price 40)
         h.it.move(40, 40);
-        h.it.down(40, 40); // stop above the entry (price 60) → short
+        h.it.down(40, 40); // target above the entry (price 60) → long (profit up)
+        const create = h.intents.find((i) => i.kind === 'create');
+        expect(create?.kind === 'create' && create.doc.anchors).toHaveLength(3);
+        if (create?.kind === 'create') {
+            const [entry, stop, target] = create.doc.anchors;
+            expect(target!.price).toBeGreaterThan(entry!.price); // reward above → long
+            expect(stop!.price).toBeLessThan(entry!.price); // stop opposite, below
+        }
+    });
+
+    it('placing the target the other way flips to short (drag lower = profit)', () => {
+        const h = harness('position');
+        h.it.down(20, 60); // entry (price 40)
+        h.it.move(40, 80);
+        h.it.down(40, 80); // target below the entry (price 20) → short (profit down)
         const create = h.intents.find((i) => i.kind === 'create');
         if (create?.kind === 'create') {
-            const [entry, , target] = create.doc.anchors;
+            const [entry, stop, target] = create.doc.anchors;
             expect(target!.price).toBeLessThan(entry!.price); // reward below → short
+            expect(stop!.price).toBeGreaterThan(entry!.price); // stop opposite, above
         }
     });
 

--- a/test/drawings-measure.test.ts
+++ b/test/drawings-measure.test.ts
@@ -61,7 +61,7 @@ describe('drawings/position tools', () => {
     it('long position: risk:reward + reward/risk %, box hit-test', () => {
         // entry 50, stop 40 (risk 10), target 70 (reward 20) → R:R 2.0
         const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })!;
-        expect(d.anchorSchema().min).toBe(2); // click entry + click stop; onPlaced derives the target
+        expect(d.anchorSchema().min).toBe(2); // click entry + click target; onPlaced derives the stop
         expect(d.anchorSchema().max).toBe(2);
         const p = d as PositionTool;
         expect(p.directionLabel()).toBe('LONG'); // target (70) above entry (50)
@@ -107,10 +107,152 @@ describe('drawings/position tools', () => {
         expect(d.anchors[2]!.price).toBe(70); // target untouched
     });
 
-    it('round-trips through serialize', () => {
-        const a = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })!.serialize();
-        expect(deserializeDrawing(a)!.serialize()).toEqual(a);
+    it('account risk % + balance drive dollar loss and position size', () => {
+        // entry 50, stop 40 → risk 10; 1% of $10_000 = $100 → size 10
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        expect(d.riskPercent).toBe(1);
+        expect(d.accountBalance).toBe(10_000);
+        expect(d.dollarLoss()).toBe(100);
+        expect(d.positionSize()).toBeCloseTo(10, 6);
+        d.applySettings({ riskPercent: 2, accountBalance: 5_000 });
+        expect(d.dollarLoss()).toBe(100); // 2% of 5000
+        expect(d.positionSize()).toBeCloseTo(10, 6);
+        expect(d.lossSizeLabel()).toMatch(/^Loss \$100/);
+    });
+
+    it('live preview treats the second anchor as the profit target (going higher → long)', () => {
+        // only entry + target above — stop is derived opposite; direction reads LONG
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 70 }] })! as PositionTool;
+        expect(d.directionLabel()).toBe('LONG');
+        expect(d.rr()).toBeCloseTo(2, 6); // reward 20 / derived risk 10
+        expect(d.layout(proj)?.ty).toBeLessThan(d.layout(proj)!.ey); // target above entry on screen (y down)
+    });
+
+    it('price-level settings paths edit the anchors and keep the stop/target opposed', () => {
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        d.applySettings({ entryPrice: 52 });
+        expect(d.anchors[0]!.price).toBe(52);
+        d.applySettings({ targetPrice: 82 });
+        expect(d.anchors[2]!.price).toBe(82);
+        expect(d.rr()).toBeCloseTo(30 / 12, 6);
+        // typing a stop past the entry flips the target to the other side (same rule as a drag)
+        d.applySettings({ stopPrice: 60 });
+        expect(d.anchors[1]!.price).toBe(60);
+        expect(d.anchors[2]!.price).toBeLessThan(52);
+        expect(d.directionLabel()).toBe('SHORT');
+    });
+
+    it('label toggles: showPrices appends levels; header/loss/size lines are separate strings', () => {
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        expect(d.showText).toBe(true);
+        expect(d.showLossSize).toBe(true);
+        expect(d.showPrices).toBe(false);
+        expect(d.headerLabel()).toBe('LONG  ·  R:R 2.00');
+        expect(d.targetLabel()).toBe('Target +40.00%');
+        expect(d.stopLabel()).toBe('Stop −20.00%');
+        d.applySettings({ showPrices: true });
+        expect(d.targetLabel()).toBe('Target +40.00%  @ 70.00');
+        expect(d.stopLabel()).toBe('Stop −20.00%  @ 40.00');
+        d.applySettings({ showText: false, showLossSize: false });
+        expect(d.showText).toBe(false);
+        expect(d.showLossSize).toBe(false);
+    });
+
+    it('the direction setting mirrors the stop and target across the entry (R:R preserved)', () => {
+        // long: entry 50, stop 40 (risk 10), target 70 (reward 20)
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        expect(d.direction).toBe('long');
+        d.applySettings({ direction: 'short' });
+        expect(d.direction).toBe('short');
+        expect(d.anchors[1]!.price).toBe(60); // stop mirrored above
+        expect(d.anchors[2]!.price).toBe(30); // target mirrored below
+        expect(d.rr()).toBeCloseTo(2, 6); // distances preserved
+        d.applySettings({ direction: 'short' }); // same value → no-op
+        expect(d.anchors[1]!.price).toBe(60);
+        d.applySettings({ direction: 'long' });
+        expect(d.anchors[1]!.price).toBe(40);
+        expect(d.anchors[2]!.price).toBe(70);
+    });
+
+    it('typing a position size back-solves the risk % (size × stop distance = balance × risk%)', () => {
+        // entry 50, stop 40 → distance 10; balance 10_000
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        expect(d.quantity).toBeCloseTo(10, 6); // 1% of 10k = $100 / 10
+        d.applySettings({ quantity: 20 });
+        expect(d.riskPercent).toBeCloseTo(2, 6); // 20 units × $10 = $200 = 2% of $10k
+        expect(d.dollarLoss()).toBeCloseTo(200, 6);
+        expect(d.positionSize()).toBeCloseTo(20, 6); // round-trips
+        d.applySettings({ quantity: -5 }); // invalid → ignored
+        expect(d.riskPercent).toBeCloseTo(2, 6);
+    });
+
+    it('stop/target convert between price and points around the entry', () => {
+        // entry 50, stop 40, target 70
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        expect(d.levelDisplayValue('stop', 'price')).toBe(40);
+        expect(d.levelDisplayValue('stop', 'points')).toBe(10);
+        expect(d.levelDisplayValue('target', 'points')).toBe(20);
+        // typed values resolve back to prices on the level's own side of the entry
+        expect(d.levelPriceFromDisplay('stop', 'price', 45)).toBe(45);
+        expect(d.levelPriceFromDisplay('stop', 'points', 5)).toBe(45); // stop below → entry − 5
+        expect(d.levelPriceFromDisplay('target', 'points', 5)).toBe(55); // target above → entry + 5
+    });
+
+    it('per-label toggles default on and round-trip through serialize', () => {
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        expect(d.showHeader).toBe(true);
+        expect(d.showTargetLabel).toBe(true);
+        expect(d.showStopLabel).toBe(true);
+        d.applySettings({ showHeader: false, showTargetLabel: false, showStopLabel: false });
+        const round = deserializeDrawing(d.serialize())! as PositionTool;
+        expect(round.showHeader).toBe(false);
+        expect(round.showTargetLabel).toBe(false);
+        expect(round.showStopLabel).toBe(false);
+    });
+
+    it('round-trips risk settings, display toggles, zone colors + text styling through serialize', () => {
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        expect(d.profitColor).toBe('#0ecb81');
+        expect(d.lossColor).toBe('#f6465d');
+        d.applySettings({
+            riskPercent: 1.5,
+            accountBalance: 25_000,
+            showText: false,
+            showPrices: true,
+            showLossSize: false,
+            profitColor: '#00ff00',
+            lossColor: '#ff0000',
+            'text.color': '#ffcc00',
+            'text.size': 'large',
+        });
+        const a = d.serialize();
+        const round = deserializeDrawing(a)! as PositionTool;
+        expect(round.serialize()).toEqual(a);
+        expect(round.riskPercent).toBe(1.5);
+        expect(round.accountBalance).toBe(25_000);
+        expect(round.showText).toBe(false);
+        expect(round.showPrices).toBe(true);
+        expect(round.showLossSize).toBe(false);
+        expect(round.profitColor).toBe('#00ff00');
+        expect(round.lossColor).toBe('#ff0000');
+        expect(round.text?.color).toBe('#ffcc00');
+        expect(round.text?.size).toBe('large');
         expect(a.type).toBe('position');
+    });
+
+    it('the settings schema drops bold/italic and exposes the new controls', () => {
+        const d = createDrawing('position', { paneId: 'price', anchors: [{ time: 0, price: 50 }, { time: 5 * HR, price: 40 }, { time: 10 * HR, price: 70 }] })! as PositionTool;
+        const paths = d.schema().fields.map((f) => f.path);
+        expect(paths).not.toContain('text.bold');
+        expect(paths).not.toContain('text.italic');
+        expect(paths).toEqual(expect.arrayContaining([
+            'riskPercent', 'accountBalance', 'quantity', 'direction',
+            'entryPrice', 'stopPrice', 'targetPrice',
+            'showText', 'showHeader', 'showPrices', 'showLossSize', 'showTargetLabel', 'showStopLabel',
+            'profitColor', 'lossColor',
+            'text.color', 'text.size',
+        ]));
+        expect(paths).not.toContain('tickSize');
     });
 });
 

--- a/test/drawings-model.test.ts
+++ b/test/drawings-model.test.ts
@@ -115,13 +115,15 @@ describe('drawings/Ray Box TextLabel', () => {
         expect(b.priceRange()).toEqual({ min: 0, max: 50 });
         expect(b.handlePoints(proj)).toEqual([[0, 100], [50, 50]]);
     });
-    it('TextLabel seeds default text + an approximate hit box', () => {
+    it('TextLabel starts empty (typed inline) with an approximate hit box', () => {
         const t = createDrawing('text', { paneId: 'price', anchors: [{ time: 10, price: 50 }] })!;
-        expect(t.text?.value).toBe('Text');
+        expect(t.text?.value).toBe(''); // no seeded literal — the inline editor's placeholder invites the text
+        expect(t.text?.size).toBe('large'); // reads at a glance without reaching for the size control
         expect(t.hitTest(20, 60, proj, 5)).toBe(true);
         expect(t.hitTest(400, 400, proj, 5)).toBe(false);
         // round-trips the text block
-        expect(deserializeDrawing(t.serialize())!.serialize().text?.value).toBe('Text');
+        t.applySettings({ 'text.value': 'Buy zone' });
+        expect(deserializeDrawing(t.serialize())!.serialize().text?.value).toBe('Buy zone');
     });
 });
 
@@ -131,6 +133,17 @@ describe('drawings/text on every type', () => {
             const d = createDrawing(type, { paneId: 'price', anchors: [{ time: 0, price: 1 }, { time: 1, price: 2 }] })!;
             const paths = d.schema().fields.map((f) => f.path);
             expect(paths).toEqual(expect.arrayContaining(['text.value', 'text.color', 'text.size', 'text.bold', 'text.italic']));
+        }
+    });
+    it('annotations whose text IS the drawing declare it, shapes that merely carry a label do not', () => {
+        // Drives where the popup puts the text controls: on the bar, or under the label field.
+        for (const type of ['text', 'note', 'callout', 'comment', 'signpost'] as const) {
+            const d = createDrawing(type, { paneId: 'price', anchors: [{ time: 0, price: 1 }, { time: 1, price: 2 }] })!;
+            expect(d.schema().textIsContent).toBe(true);
+        }
+        for (const type of ['trendline', 'hline', 'ray', 'box'] as const) {
+            const d = createDrawing(type, { paneId: 'price', anchors: [{ time: 0, price: 1 }, { time: 1, price: 2 }] })!;
+            expect(d.schema().textIsContent).toBeFalsy();
         }
     });
     it('setting text on a line lazily creates a well-formed text block', () => {
@@ -203,7 +216,7 @@ describe('drawings/resetDrawingSettings', () => {
         resetDrawingSettings(d);
         expect(d.text?.value).toBe('Buy zone');
         expect(d.text?.color).toBeUndefined();
-        expect(d.text?.size).toBe('normal');
+        expect(d.text?.size).toBe('large'); // back to the type's own default, not the global one
         expect(d.text?.bold).toBeUndefined();
     });
 

--- a/test/drawings-painter.test.ts
+++ b/test/drawings-painter.test.ts
@@ -23,8 +23,10 @@ function recordingCtx() {
         setTransform() {},
         clearRect() {},
         beginPath() {},
+        closePath() {},
         moveTo() {},
         lineTo() {},
+        arcTo() {},
         stroke() {},
         fill() {},
         setLineDash() {},
@@ -45,18 +47,89 @@ const theme = { textColor: '#fff', fontFamily: 'sans-serif' } as unknown as Vela
 const hline = (id: string, price: number) => createDrawing('hline', { id, paneId: 'price', anchors: [{ time: 10, price }] })!;
 
 describe('DrawingPainter.paintAll handle highlighting', () => {
-    it('paints handles for every id in the highlight set', () => {
+    it('paints handles for every selected id', () => {
         const drawings = [hline('a', 30), hline('b', 50)];
         const { ctx, arcs } = recordingCtx();
-        new DrawingPainter().paintAll(ctx, drawings, fakeProjector(), theme, new Set(['a', 'b']));
+        new DrawingPainter().paintAll(ctx, drawings, fakeProjector(), theme, { selected: new Set(['a', 'b']) });
         expect(arcs()).toBe(2); // one handle per selected hline
     });
 
-    it('paints no handles when the highlight set is empty', () => {
+    it('paints handles for the hovered and dragged drawings too', () => {
         const drawings = [hline('a', 30), hline('b', 50)];
         const { ctx, arcs } = recordingCtx();
-        new DrawingPainter().paintAll(ctx, drawings, fakeProjector(), theme, new Set());
+        new DrawingPainter().paintAll(ctx, drawings, fakeProjector(), theme, { hovered: 'a', dragged: 'b' });
+        expect(arcs()).toBe(2);
+    });
+
+    it('paints no handles when nothing is targeted', () => {
+        const drawings = [hline('a', 30), hline('b', 50)];
+        const { ctx, arcs } = recordingCtx();
+        new DrawingPainter().paintAll(ctx, drawings, fakeProjector(), theme);
         expect(arcs()).toBe(0);
+    });
+});
+
+describe('DrawingPainter.paintAll muted label', () => {
+    /** A ctx that records the strings passed to `fillText`. */
+    function textCountingCtx() {
+        const base = recordingCtx();
+        const texts: string[] = [];
+        (base.ctx as unknown as Record<string, unknown>).fillText = (s: string) => { texts.push(s); };
+        return { ctx: base.ctx, texts: () => texts };
+    }
+
+    const label = (id: string) => createDrawing('text', { id, paneId: 'price', anchors: [{ time: 10, price: 50 }], text: { value: 'Buy zone', size: 'normal', hAlign: 'left', vAlign: 'top' } })!;
+
+    it('paints a text label normally', () => {
+        const { ctx, texts } = textCountingCtx();
+        new DrawingPainter().paintAll(ctx, [label('a')], fakeProjector(), theme);
+        expect(texts()).toEqual(['Buy zone']);
+    });
+
+    it('leaves the muted label to its inline editor (and only that one)', () => {
+        const { ctx, texts } = textCountingCtx();
+        new DrawingPainter().paintAll(ctx, [label('a'), label('b')], fakeProjector(), theme, { mutedLabel: 'a' });
+        expect(texts()).toEqual(['Buy zone']); // 'b' still painted, 'a' muted
+    });
+
+    it('hides the muted label\u2019s drag handle too (typing, not dragging)', () => {
+        const { ctx, arcs } = recordingCtx();
+        new DrawingPainter().paintAll(ctx, [label('a')], fakeProjector(), theme, { selected: new Set(['a']), mutedLabel: 'a' });
+        expect(arcs()).toBe(0);
+    });
+});
+
+describe('DrawingPainter.paintAll text label frame', () => {
+    /** A ctx that records the stroke color of every `stroke()` (the frame is the only stroke here). */
+    function strokeRecordingCtx() {
+        const base = recordingCtx();
+        const strokes: string[] = [];
+        const ctx = base.ctx as unknown as Record<string, unknown>;
+        ctx.strokeStyle = '';
+        ctx.stroke = () => { strokes.push(String(ctx.strokeStyle)); };
+        return { ctx: base.ctx, strokes: () => strokes };
+    }
+
+    const label = (id: string) => createDrawing('text', { id, paneId: 'price', anchors: [{ time: 10, price: 50 }], text: { value: 'Buy zone', size: 'normal', hAlign: 'left', vAlign: 'top' } })!;
+    const frame = (targets: { selected?: ReadonlySet<string>; hovered?: string | null }): string[] => {
+        const { ctx, strokes } = strokeRecordingCtx();
+        new DrawingPainter().paintAll(ctx, [label('a')], fakeProjector(), theme, targets);
+        // Targeting also paints the handle (a hex-colored border); the frame is the themed rgba stroke.
+        return strokes().filter((s) => s.startsWith('rgba('));
+    };
+
+    it('frames a selected text label, and a hovered one more faintly', () => {
+        const selected = frame({ selected: new Set(['a']) });
+        const hovered = frame({ hovered: 'a' });
+        expect(selected).toHaveLength(1);
+        expect(hovered).toHaveLength(1);
+        expect(selected[0]).toContain('0.3'); // firm once clicked
+        expect(hovered[0]).toContain('0.12'); // a hint under the cursor
+    });
+
+    it('leaves an untargeted label unframed', () => {
+        expect(frame({})).toEqual([]);
+        expect(frame({ selected: new Set(['other']), hovered: 'other' })).toEqual([]);
     });
 });
 
@@ -85,14 +158,14 @@ describe('DrawingPainter.paintAll pane separation', () => {
     it('clips each drawing to its pane rect', () => {
         const drawings = [hline('a', 30), hline('b', 50)];
         const { ctx, clips } = clipCountingCtx();
-        new DrawingPainter().paintAll(ctx, drawings, paneAwareProjector(), theme, new Set());
+        new DrawingPainter().paintAll(ctx, drawings, paneAwareProjector(), theme);
         expect(clips()).toBe(2); // one clip per painted drawing
     });
 
     it('skips drawings on a hidden (zero-height) pane entirely — body and handles', () => {
         const onHidden = createDrawing('hline', { id: 'h', paneId: 'hidden', anchors: [{ time: 10, price: 30 }] })!;
         const { ctx, arcs, strokes } = clipCountingCtx();
-        new DrawingPainter().paintAll(ctx, [onHidden], paneAwareProjector(), theme, new Set(['h']));
+        new DrawingPainter().paintAll(ctx, [onHidden], paneAwareProjector(), theme, { selected: new Set(['h']) });
         expect(strokes()).toBe(0); // nothing painted
         expect(arcs()).toBe(0); // no handles either
     });
@@ -100,7 +173,7 @@ describe('DrawingPainter.paintAll pane separation', () => {
     it('paints unclipped when the projector exposes no pane geometry (back-compat)', () => {
         const drawings = [hline('a', 30)];
         const { ctx, clips, strokes } = clipCountingCtx();
-        new DrawingPainter().paintAll(ctx, drawings, fakeProjector(), theme, new Set());
+        new DrawingPainter().paintAll(ctx, drawings, fakeProjector(), theme);
         expect(clips()).toBe(0);
         expect(strokes()).toBeGreaterThan(0);
     });


### PR DESCRIPTION
- Add drawing mode to keep drawings armed
- Improve text drawing tool
- Complete long/short position tool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core drawing lifecycle (tool-finished, placement UX) and substantially changes position anchor semantics and serialization; inline editing adds focus/blur edge cases with the settings popup, but changes are well-covered by tests and mostly additive for API consumers.
> 
> **Overview**
> Adds **stay in drawing mode** (toolbar lock under the magnet) so one-shot tools stay armed after each placement unless you turn it off; brush/highlighter behavior is unchanged. Exposed on `chart.drawings` via `setStayMode` / `getStayMode` and the `drawing:stay` event, with the same core↔renderer mirroring as snap and measure modes. Multi-chart workspaces keep a global stay preference across cells.
> 
> **Text annotations** no longer seed `"Text"` or force the settings dialog: placement opens an on-chart caret with an `Enter Text` placeholder, default **large** size, live painting while typing, and a shared frame aligned with selection/hover. Empty labels are removed on commit; double-click reopens inline edit for text and callouts. Quick-settings puts color/size on the bar for `textIsContent` tools; bold/italic stay with the text field when there is one.
> 
> The **long/short position** tool is reworked: the second click defines the **target** (profit direction); stop is derived. New persisted fields drive risk %, account balance, editable position size (back-solves risk), long/short flip across entry, stop/target in price or points, per-label visibility, and profit/loss zone colors on the quick bar, with a gear panel for the rest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4189d4f05156a283a2e3c9866068980158fdc2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->