### PR TITLE
perf: one-request history loads, and depth changes that extend instea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.4.6]
+
+### Changed
+
+- **History loads in one request up to 5 000 bars, in 10 000-bar chunks beyond.** The load
+  used to start with a 200-bar head and widen by doubling (200 → 400 → 800 → …), which at
+  the shells' default depth meant FOUR serialized round trips before the full history was
+  there. That shape bought a faster first candle — but nothing downstream can use it: an
+  indicator's first run is held until the whole depth lands (Pine is causal, so running it
+  per chunk would repaint a different curve at every step). A round trip costs far more
+  than the extra rows, so the ordinary case is now a single request, and the progressive
+  path is reserved for genuinely deep history, where its chunks are flat 10 000-bar steps
+  rather than a ramp. A rangeless feed keeps its preview-then-full shape past the same
+  threshold, and a requested initial window still loads in one framed pass.
+
+### Fixed
+
+- **The chart-settings dialog closes when you click its ✕.** The header's drag handler
+  skipped itself for the close button by comparing `e.target` to the button — but the
+  button holds an SVG icon, so a press anywhere on the ✕ targets the icon's `<path>`
+  instead. The header therefore took pointer capture and swallowed the click: the button
+  only ever worked on the few pixels of padding around the glyph. It now tests ancestry
+  (`closest`), like the other two draggable dialog headers already did.
+- **Changing the bar count no longer rebuilds the chart.** `setMarket({ bars })` on the
+  same market went through the full reload pipeline: it handed the renderer a fresh
+  200-bar head, then doubled its way back up (200 → 400 → 800 → …), so the array was
+  wholly replaced ~6 times and momentarily held FEWER bars than before the change. Every
+  replacement was a "fresh series", which re-frames the view — the user's zoom was thrown
+  away on any depth change, in both directions. A depth-only change is now an EXTENSION:
+  growing re-enters the same backfill loop the initial load uses (older bars prepend, the
+  viewport is preserved), shrinking trims the array in place from the oldest end, and
+  neither restarts the indicator sessions. A feed with no ranged fetch, or an offline
+  `data` series, still reloads — there is nothing to extend from.
+- **An indicator no longer paints shifted while the bar array changes under it.** Anchor
+  offsets were stored only when positive, so a model whose `anchorTime` was OLDER than the
+  chart's first bar — exactly what a shorter series produces — was pinned at index 0 and
+  drawn with its first value on the chart's first bar, i.e. the whole plot shifted left,
+  for as long as the load took. Offsets are signed now: such a model skips the values that
+  fall off the left edge instead. The renderer's logical interaction anchors (zoom glide,
+  hover) learned the same symmetry — they followed a prepend but not a front trim.
+- **A value patch can clear an indicator's anchor.** `anchorTime` was omitted rather than
+  stated when a run spanned the whole chart, and an omitted key cannot undo a previous
+  anchor — the model kept the offset of an earlier, narrower run. Patches now always carry
+  the anchor, `null` included.
+- **Documentation that did not match the code.** The README advertised a screenshot
+  shortcut that never existed (`alt+S`; the binding has always been `mod+alt+S`), left
+  `vela/workspace` out of the entry-point list, described `persist` as restoring four
+  cosmetic keys when it restores the whole state document — drawings and indicators
+  included, listed two of the three `indicators` manifest forms (the async loader was
+  missing), and still passed the removed `provider` option in both quick-start snippets.
+  In the SDK, `WidgetContext.chart` claimed the shell rebuilds its chart on every
+  symbol/timeframe change; those switches are applied in place.
+
+### Added
+
+- **Renderer feature defaults for plugins: `registerRendererDefaults`.** A renderer
+  feature is per-chart state, set on an instance that does not exist yet when a plugin's
+  enabler runs — so a plugin could contribute a chart type, an engine or a panel, but not
+  "every chart should start with this feature set". This registry is the missing half,
+  shaped like the other contribution registries and the renderer-side counterpart of
+  `registerDefaultEngine`, except it reaches EVERY chart: the widget's, each workspace
+  cell's, and a bare `new Vela()`. Values apply once the renderer mounts, before the first
+  paint; they are defaults, not locks (an explicit `renderer.set(...)` or a restored
+  config still wins), and charts already built are untouched. The disposer removes
+  precisely what it set.
+
 ## [v0.4.5]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ renderer layers.
 - **`vela/ui`** — the component kit the widget is built on (design tokens + headless
   [Zag.js](https://zagjs.com) machines + vanilla views) and the `KeymapManager`.
 - **`vela/plugin`** — the extension SDK: chart types, renderer layers, native indicators.
+- **`vela/workspace`** — the multi-chart shell: a grid of full charts under one shared
+  topbar, with named cells, sync groups and one persisted state document.
 - **`vela/providers/*`** — data providers (Binance, Coinbase, Hyperliquid).
 
 ## Quick start
@@ -19,13 +21,13 @@ import { VelaWidget } from 'vela/widget';
 import { BinanceProvider } from 'vela/providers/binance';
 
 const widget = new VelaWidget('#chart', {
-    provider: 'binance',
-    symbol: 'BTCUSDT',
+    symbol: 'BTCUSDT', // bare = first declared provider listing it; 'binance:BTCUSDT' pins the venue
     timeframe: '60',
     live: true,
     theme: 'dark',
     providers: { binance: () => new BinanceProvider() },
-    persist: true,   // restore symbol/timeframe/style/timezone from localStorage
+    persist: true,   // restore the full state document — market, style, timezone, renderer
+                     // config, drawings and indicators — from localStorage
     urlState: true,  // ?symbol=…&interval=… shareable links
 });
 ```
@@ -36,7 +38,7 @@ Prefer full control? Use the headless core directly:
 import { Vela } from 'vela';
 import { BinanceProvider } from 'vela/providers/binance';
 
-const chart = new Vela('#chart', { provider: 'binance', symbol: 'BTCUSDT', timeframe: '60', live: true });
+const chart = new Vela('#chart', { symbol: 'binance:BTCUSDT', timeframe: '60', live: true });
 chart.data.registerProvider('binance', new BinanceProvider());
 await chart.ready();
 ```
@@ -64,7 +66,8 @@ value** — via `handle.context()` (read-only snapshots, worker-safe). See the
 [API reference](docs/user/api-reference.md#reading-a-scripts-execution-context), and
 [Scripting engines](docs/user/scripting-engines.md) for the addon and for writing your own.
 
-The widget takes an **indicator manifest** — inline JSON or a URL returning it:
+The widget takes an **indicator manifest** — inline JSON, a URL returning it, or an async
+loader (`() => Promise<manifest>`):
 
 ```ts
 new VelaWidget('#chart', {
@@ -77,7 +80,7 @@ new VelaWidget('#chart', {
 ## Keyboard
 
 Type a **letter** → symbol search. Type a **digit** → timeframe entry (`15`, `4h`, `D`, `3M`…).
-`alt+S` → screenshot. `?` → the shortcuts panel. Bindings are declarative
+`mod+alt+S` (Ctrl+Alt+S, ⌥⌘S on macOS) → screenshot. `?` → the shortcuts panel. Bindings are declarative
 (`widget.keymap.register({...})`) — plugins register theirs the same way.
 
 ## Extending (plugin SDK)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/src/Vela.ts
+++ b/src/Vela.ts
@@ -13,6 +13,7 @@ import type { SceneInspection } from './core/engine/inspect';
 import { resolveTheme } from './core/theme';
 import { BEARISH, BULLISH } from './core/palette';
 import { RendererControl } from './core/RendererControl';
+import { rendererDefaults } from './core/renderer-defaults';
 import { PanesControl } from './core/PanesControl';
 import { DataControl } from './core/DataControl';
 import { DrawingsControl } from './core/DrawingsControl';
@@ -116,6 +117,11 @@ export class Vela {
         this.rendererControl = new RendererControl(renderer);
         this.dataControl = new DataControl(feed);
         this.orchestrator = new EngineOrchestrator(element, renderer, feed, engines, config, this.dataControl);
+        // Plugin-contributed renderer defaults (`registerRendererDefaults`), applied once the
+        // orchestrator has mounted the renderer and before the first paint. Defaults only:
+        // an explicit `renderer.set(...)` or a restored config afterwards still wins.
+        const defaults = rendererDefaults();
+        if (Object.keys(defaults).length > 0) this.rendererControl.set(defaults);
         this.panesControl = new PanesControl(this.orchestrator);
         this.drawingsControl = new DrawingsControl(this.orchestrator.drawings);
     }

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -43,24 +43,22 @@ export interface ResolvedConfig {
 /** Coalesce rapid pan/zoom viewport events into one re-run (ms). */
 const VIEWPORT_DEBOUNCE_MS = 150;
 
-/** Bars in the quick recent-window preview painted before the full history loads. */
+/** Bars in the quick recent-window preview a RANGELESS feed paints before the deep fetch. */
 const PREVIEW_BARS = 300;
-/** Above this the full fetch paginates (Binance page size), so a preview pays off. */
-const SINGLE_REQUEST_BARS = 1000;
 /**
- * The PROGRESSIVE head (ranged feeds): the first paint is one small request of this many
- * bars — on screen while a monolithic fetch would still be in flight — and the rest of
- * the history streams in behind it in steps that DOUBLE from here to {@link CHUNK_BARS}.
- * Growth keeps the request count logarithmic: on a high-latency venue (~2s flat per
- * request, size barely matters) flat 200-bar steps made the tail 10 round-trips where
- * doubling takes 4.
+ * Depth a ranged feed serves in ONE request. A round trip costs far more than the extra
+ * rows: splitting this range into a small head plus a stream of widening chunks paid for
+ * itself only in time-to-first-candle, and nothing downstream can use those first candles
+ * anyway — an indicator's first run is held until the whole depth has landed (Pine is
+ * causal, so running it per chunk would repaint a different curve each time). Below this
+ * line, one request wins outright.
  */
-const STEP_BARS = 200;
+const SINGLE_LOAD_BARS = 5_000;
 /**
- * Deep history loads BACKWARD in chunks of this many bars: the chart is interactive after
- * the first chunk while older ones stream in behind it (each a bounded request the data
- * source answers quickly, instead of one giant fetch that stalls silently and lands as a
- * single main-thread-freezing parse). Sized so a chunk is a few provider pages.
+ * Beyond {@link SINGLE_LOAD_BARS} the history loads BACKWARD in chunks of this many bars:
+ * the chart is interactive after the first chunk while older ones stream in behind it
+ * (each a bounded request the data source answers quickly, instead of one giant fetch that
+ * stalls silently and lands as a single main-thread-freezing parse).
  */
 const CHUNK_BARS = 10_000;
 
@@ -336,19 +334,19 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
 
     /**
      * Load the configured market's history into the chart — THE shared load pipeline
-     * behind {@link init} and {@link setMarket}. On a ranged feed the load is
-     * PROGRESSIVE: one small request paints the newest {@link STEP_BARS} immediately,
-     * and the rest of the history streams in behind it through the shared backfill loop
-     * (fine steps through the near window, coarse chunks beyond) — the pipeline resolves
-     * at the first paint; await {@link historyComplete} for the full depth. Sessions
-     * started meanwhile are stamped 'backfill' and the bundled engines hold their first
-     * run until 'complete'. Offline data and small charts are a single fetch; a
-     * rangeless feed keeps the preview-then-chunk shape. A requested initial window
-     * skips the fast head: its recent-bars viewport would paint the WRONG range for a
-     * moment, then jump — one load, one paint, framed. EVERY await is followed by a
-     * generation check so a superseded load (newer setMarket, destroy) abandons without
-     * touching the chart. `firstLoad` activates the bar-following layers once (volume
-     * auto-add) — a market SWITCH must not re-add what the user has since removed.
+     * behind {@link init} and {@link setMarket}. Up to {@link SINGLE_LOAD_BARS} the whole
+     * depth comes in ONE request: a round trip dominates the row count, and splitting the
+     * range buys a faster first candle that nothing can use — an indicator's first run is
+     * held until the full depth lands anyway. DEEPER than that, the load is progressive:
+     * the newest {@link CHUNK_BARS} paint immediately and the rest streams in behind them
+     * through the shared backfill loop, so the pipeline resolves at the first paint (await
+     * {@link historyComplete} for the full depth) and sessions started meanwhile are
+     * stamped 'backfill' until 'complete'. Offline data is a single fetch; a rangeless
+     * feed keeps the preview-then-full shape, since it cannot fetch a range at all.
+     * EVERY await is followed by a generation check so a superseded load (newer
+     * setMarket, destroy) abandons without touching the chart. `firstLoad` activates the
+     * bar-following layers once (volume auto-add) — a market SWITCH must not re-add what
+     * the user has since removed.
      */
     private async loadMarket(gen: number, opts: { firstLoad: boolean }): Promise<void> {
         try {
@@ -365,24 +363,26 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         const market = this.config.market;
         const requested = market.bars ?? 500;
         const initialRange = market.visibleRange;
-        if (!market.data?.length && initialRange == null && requested > STEP_BARS && this.feed.loadRange) {
-            // Progressive head: candles are on screen after ONE small request — a monolithic
-            // fetch of the same history would still be in flight. The remaining depth rides
-            // the detached backfill loop (fine steps near the viewport, chunks beyond), so
-            // this pipeline resolves at first paint and live/indicators start immediately.
-            const head = await this.feed.load({ ...market, bars: STEP_BARS });
+        // Only a DEEP request is worth splitting, and only when a requested initial window
+        // does not pin the frame (a chunked load would paint the wrong range, then jump).
+        const deep = !market.data?.length && initialRange == null && requested > SINGLE_LOAD_BARS;
+        if (deep && this.feed.loadRange) {
+            // Paint the newest chunk, stream the rest in behind it. The first chunk is a full
+            // CHUNK_BARS, not a token head: at this depth the round trips are what cost, so
+            // each one carries as much as the source answers well.
+            const head = await this.feed.load({ ...market, bars: Math.min(requested, CHUNK_BARS) });
             if (this.generation !== gen) return;
             this.setBarSeries(head);
             if (opts.firstLoad) this.activateBarLayers(); // bar-following layers ride the FIRST candles
-            if (head.length >= STEP_BARS && requested > head.length) {
+            if (head.length > 0 && requested > head.length) {
                 this.historyState = 'backfill';
                 void this.backfillHistory(gen, requested);
             } else {
-                this.completeHistory('depth'); // the source had no more than one step of history
+                this.completeHistory('depth'); // the source had no more than one chunk of history
             }
-        } else if (!market.data?.length && requested > SINGLE_REQUEST_BARS && initialRange == null) {
-            // RANGELESS feed: stepping would re-download the head on every extension, so
-            // keep the two-fetch shape — a quick preview, then the whole depth in one load.
+        } else if (deep) {
+            // RANGELESS feed at depth: it cannot fetch a range, so chunking would re-download
+            // the head every time — keep the two-fetch shape, a quick preview then everything.
             const preview = await this.feed.load({ ...market, bars: PREVIEW_BARS });
             if (this.generation !== gen) return;
             this.setBarSeries(preview);
@@ -481,6 +481,17 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             (next.timeframe !== undefined && next.timeframe !== m.timeframe) ||
             next.data !== undefined;
         const depthChanged = next.bars !== undefined && next.bars !== m.bars;
+        // Same market, only deeper/shallower, with bars already on screen: handled by moving
+        // the array's oldest edge instead of reloading (see `extendDepth`). An offline `data`
+        // series has no source to extend from, and GROWING needs a ranged feed to fetch the
+        // missing older bars — without one the reload is the only way to get them. Shrinking
+        // needs no source at all: it is a trim of what is already held.
+        const depthOnly =
+            depthChanged &&
+            !identityChanged &&
+            this.rawBars.length > 0 &&
+            !m.data?.length &&
+            ((next.bars ?? 0) <= this.rawBars.length || typeof this.feed.loadRange === 'function');
         if (!identityChanged && !depthChanged) {
             // Nothing to reload — honor at most a framing request.
             if (typeof next.visibleRange === 'string') this.setVisibleRangePreset(next.visibleRange);
@@ -529,23 +540,38 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
                 }
             }
 
-            // Reload through the shared pipeline. The race lets a superseded caller resolve
-            // promptly (e.g. a parked load on an unresolvable symbol) instead of hanging.
-            await Promise.race([
-                this.loadMarket(gen, { firstLoad: false }),
-                new Promise<void>((resolve) => this.supersedeWaiters.push(resolve)),
-            ]);
+            // A DEPTH-ONLY change is an extension, never a reload: the bars on screen are the
+            // same series, so the requested history is a superset (growing) or a suffix
+            // (shrinking) of what is already loaded. Re-entering the loader would hand the
+            // renderer a fresh short head — a shorter, LATER-starting array — which re-frames
+            // the viewport and strands every mounted model's anchor behind the new first bar.
+            if (depthOnly) {
+                this.extendDepth(gen, m.bars ?? 500);
+            } else {
+                // Reload through the shared pipeline. The race lets a superseded caller resolve
+                // promptly (e.g. a parked load on an unresolvable symbol) instead of hanging.
+                await Promise.race([
+                    this.loadMarket(gen, { firstLoad: false }),
+                    new Promise<void>((resolve) => this.supersedeWaiters.push(resolve)),
+                ]);
+            }
             if (this.generation !== gen) return; // superseded — the newer switch owns the chart
         } finally {
             // A superseding call set its own flag — only the owning generation clears it.
             if (this.generation === gen) this.switchingMarket = false;
         }
 
-        // Restart every consumer over the new market (records/panes/drawings survive).
-        this.restartNativeIndicators();
-        this.restartChartTypeEngine();
-        this.reexecuteIndicators();
-        this.startLive();
+        // Restart every consumer over the new market (records/panes/drawings survive). A
+        // depth-only change is NOT a new market: the bars kept their identity and their
+        // indices, so tearing the sessions down would recompute everything and flash a
+        // stale plot for the whole load. The backfill pokes them per prepend instead —
+        // the same path the initial progressive load already uses.
+        if (!depthOnly) {
+            this.restartNativeIndicators();
+            this.restartChartTypeEngine();
+            this.reexecuteIndicators();
+        }
+        this.startLive(); // stopped above on every path, depth-only included
         if (identityChanged) {
             this.events.emit('market:changed', { symbol: m.symbol ?? 'TEST', timeframe: m.timeframe ?? '60', prev });
         }
@@ -597,6 +623,34 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
     }
 
     /**
+     * A depth-only reconfigure (`setMarket({ bars })` on the same market): move the array's
+     * OLDEST edge, never rebuild it. Growing re-enters the same backfill loop the initial load
+     * uses, so the extra history arrives as prepends with the viewport preserved; shrinking
+     * trims in place. Both keep the newest bars — the viewport is right-anchored, so what the
+     * user is looking at does not move, and mounted indicators keep their alignment (the
+     * renderer re-derives each model's anchor offset against the new indices, negative when
+     * the head moved forward).
+     *
+     * Sessions are NOT restarted here: the backfill pokes them per prepend (`'backfill'`), and
+     * a trim leaves every value they already computed valid.
+     */
+    private extendDepth(gen: number, requested: number): void {
+        if (this.rawBars.length > requested) {
+            this.setBarSeries(this.rawBars.slice(this.rawBars.length - requested), { preserveView: true });
+            this.completeHistory('depth');
+            return;
+        }
+        if (this.rawBars.length === requested) {
+            this.completeHistory('depth');
+            return;
+        }
+        // Detached, exactly like the initial load: `setMarket` resolves on what is already
+        // painted while the extra depth streams in behind it.
+        this.historyState = 'backfill';
+        void this.backfillHistory(gen, requested);
+    }
+
+    /**
      * The detached backward backfill: fetch chunks strictly older than the current oldest
      * bar until the requested depth (reason `'depth'`), the source's genesis (`'genesis'` —
      * a chunk added nothing older), or a fetch error (`'aborted'` — the chart keeps what
@@ -608,11 +662,10 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         try {
             while (this.generation === gen && this.rawBars.length < requested && this.rawBars.length > 0) {
                 const remaining = requested - this.rawBars.length;
-                // Each step matches what is already on the chart (≥ STEP_BARS, ≤ CHUNK_BARS),
-                // so the depth DOUBLES per request: small quick fills near the viewport, a
-                // logarithmic request count for the deep tail — high-latency venues pay per
-                // round-trip, not per bar.
-                const step = Math.min(Math.max(this.rawBars.length, STEP_BARS), CHUNK_BARS);
+                // A flat chunk per request: only depths past SINGLE_LOAD_BARS reach this loop,
+                // so there is no small near-window to fill quickly — every remaining round trip
+                // should carry as much as the source answers well.
+                const step = CHUNK_BARS;
                 const chunk = await this.feed.loadRange!(this.config.market, {
                     to: this.rawBars[0]!.time, // overlap-by-one: the boundary bar dedupes below
                     limit: Math.min(step, remaining) + 1,
@@ -1686,7 +1739,9 @@ function modelToValuePatch(model: IndicatorModel): ValuePatch {
         kind: 'value',
         indicatorId: model.id,
         dirty: { from: Number.isFinite(from) ? from : 0, to },
-        ...(model.anchorTime != null ? { anchorTime: model.anchorTime } : {}),
+        // ALWAYS stated, `null` included: an omitted key leaves the renderer on the previous
+        // run's offset, so a re-run that widened to the whole chart could not clear it.
+        anchorTime: model.anchorTime ?? null,
         series,
         lines: model.lines ?? [],
         boxes: model.boxes ?? [],

--- a/src/core/model/patch.ts
+++ b/src/core/model/patch.ts
@@ -26,9 +26,11 @@ export interface ValuePatch {
     /**
      * The emitting run's anchor (see `IndicatorModel.anchorTime`): a re-run over a
      * DIFFERENT bar window arrives as a value patch, so the anchor must travel with
-     * it for index-aligned rendering to re-derive its offset. Absent ≡ whole-chart.
+     * it for index-aligned rendering to re-derive its offset. `null` states the run
+     * spanned the WHOLE chart and clears any previous anchor — an omitted key cannot,
+     * so a model that once had an anchor would otherwise keep that stale offset.
      */
-    anchorTime?: Millis;
+    anchorTime?: Millis | null;
     series: SeriesValueDelta[];
     /**
      * Full drawing snapshots for this tick. Pine drawing containers are emitted

--- a/src/core/renderer-defaults.ts
+++ b/src/core/renderer-defaults.ts
@@ -1,0 +1,39 @@
+// Renderer FEATURE defaults contributed by plugins. A renderer feature
+// (`chart.renderer.set(key, value)`) is per-chart state set on an instance that does not
+// exist yet when an enabler runs, and no registry carried it: a plugin could contribute a
+// chart type, an engine or a panel, but not "every chart should start with this feature
+// set". This is that missing half — the same shape as the other contribution registries,
+// and the renderer-side counterpart of `registerDefaultEngine`, except it reaches EVERY
+// chart: the widget's, each workspace cell's, and a bare `new Vela()`.
+
+const defaults = new Map<string, unknown>();
+
+/**
+ * Register default values for renderer features — every chart built afterwards applies
+ * them once its renderer is mounted, before the first paint. Keys are renderer feature
+ * names (`chart.renderer.features`); one the active renderer does not support is warned
+ * about and ignored, exactly as `renderer.set()` does.
+ *
+ * These are DEFAULTS, not locks: an explicit `chart.renderer.set(...)`, an applied config
+ * template, or the user's own in-chart settings still win afterwards. Charts already
+ * built are untouched. Returns a disposer that removes precisely the values it set
+ * (leaving any later re-registration of the same key in place).
+ */
+export function registerRendererDefaults(values: Record<string, unknown>): () => void {
+    const applied = Object.entries(values);
+    for (const [key, value] of applied) defaults.set(key, value);
+    return () => {
+        for (const [key, value] of applied) if (defaults.get(key) === value) defaults.delete(key);
+    };
+}
+
+/** Drop registered defaults by key — all of them when called with no arguments. */
+export function unregisterRendererDefaults(...keys: string[]): void {
+    if (keys.length === 0) defaults.clear();
+    else for (const key of keys) defaults.delete(key);
+}
+
+/** The defaults a chart applies at construction (empty when no plugin registered any). */
+export function rendererDefaults(): Record<string, unknown> {
+    return Object.fromEntries(defaults);
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,6 +27,7 @@ export {
     type SeriesDataEngineHost,
 } from './chart-types/registry';
 export type { BarTransform } from './core/price-styles/BarTransform';
+export { registerRendererDefaults, unregisterRendererDefaults, rendererDefaults } from './core/renderer-defaults';
 export {
     registerNativeIndicator,
     unregisterNativeIndicator,

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -57,7 +57,7 @@ import { resizeSplit, type PaneSplit } from './core/paneResize';
 import { type ChartConfig, CHART_CONFIG_VERSION, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, CHROME_BORDER_COLOR, withAlpha, priceStyleIds, basePaintingOf } from './core/chartConfig';
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
 import { rendererLayers, type RendererLayerDefinition, type RendererLayerInstance } from './layers';
-import { applyAttributionMarkTheme, createAttributionMark } from './chrome/AttributionMark';
+import { applyAttributionMarkTheme, attributionMarkColor, createAttributionMark, createCustomMark } from './chrome/AttributionMark';
 import type { HostSettingsSection } from './chrome/SettingsDialog';
 import { VpvrRenderer } from './vpvr/VpvrRenderer';
 import { DARK_THEME, LIGHT_THEME } from '../../core/theme';
@@ -144,8 +144,10 @@ export class NativeRenderer implements IChartRenderer {
     private extLayers: Array<{ def: RendererLayerDefinition; instance: RendererLayerInstance; canvas: HTMLCanvasElement }> = [];
     // The attribution mark (see chrome/AttributionMark + the NOTICE file): default-on;
     // disabling requires an equivalent visible attribution elsewhere in the host UI.
-    private attributionEl: HTMLAnchorElement | null = null;
+    private attributionEl: HTMLElement | null = null;
     private attributionEnabled = true;
+    /** Host-supplied mark shown INSTEAD of the built-in one (`attribution: '<html>'`). */
+    private attributionHtml: string | null = null;
     private readonly vpvrRenderer = new VpvrRenderer();
     private resizeObserver: ResizeObserver | null = null;
     private dprMedia: MediaQueryList | null = null;
@@ -413,8 +415,11 @@ export class NativeRenderer implements IChartRenderer {
                 this.setSettingsEnabled(Boolean(value));
                 return; // owns its own DOM (gear button + dialog)
             case 'attribution':
-                this.attributionEnabled = Boolean(value);
-                if (this.attributionEl) this.attributionEl.style.display = this.attributionEnabled ? 'flex' : 'none';
+                // `false` hides it, `true` restores the built-in mark, a non-empty STRING
+                // puts the host's own mark in that corner (see the NOTICE).
+                this.attributionHtml = typeof value === 'string' && value.trim() ? value : null;
+                this.attributionEnabled = this.attributionHtml !== null || Boolean(value);
+                this.rebuildAttribution();
                 return; // own DOM, no repaint needed
             case 'dialogHost':
                 // Where MODAL dialogs mount (chart settings, indicator settings). A
@@ -467,7 +472,7 @@ export class NativeRenderer implements IChartRenderer {
             case 'tradeMarkers': return { ...this.scene.tradeMarkers, colors: { ...this.scene.tradeMarkers.colors } };
             case 'keyboard': return this.keyboardEnabled;
             case 'settings': return this.settingsEnabled;
-            case 'attribution': return this.attributionEnabled;
+            case 'attribution': return this.attributionHtml ?? this.attributionEnabled;
             case 'dialogHost': return this.dialogHost ?? undefined;
             default: return undefined;
         }
@@ -1152,7 +1157,7 @@ export class NativeRenderer implements IChartRenderer {
         this.plot.append(...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above, this.chromeCanvas, this.drawingsCanvas, this.cursorCanvas, this.overlayRoot);
         this.wrapper.appendChild(this.plot);
         this.factoryConfig = this.getConfig();
-        this.attributionEl = createAttributionMark(document, this.theme.background);
+        this.attributionEl = this.buildAttributionEl();
         if (!this.attributionEnabled) this.attributionEl.style.display = 'none';
         this.positionAttribution();
         this.wrapper.appendChild(this.attributionEl);
@@ -1464,7 +1469,8 @@ export class NativeRenderer implements IChartRenderer {
         // new scale) until the next tick re-seeds. The bars given here carry real values —
         // drop the ease; the next tick snaps fresh (liveEaseTime no longer matches).
         this.liveEaseTime = 0;
-        const prevHeadTime = this.bars[0]?.time;
+        const prevBars = this.bars;
+        const prevHeadTime = prevBars[0]?.time;
         this.bars = normalizeBars(bars);
         this.scene.bars = this.bars;
         this.coords.setBars(this.bars.map((b) => b.time));
@@ -1476,9 +1482,22 @@ export class NativeRenderer implements IChartRenderer {
         // mid-zoom would otherwise re-anchor thousands of bars into the past and teleport the
         // viewport (the "view jumps to the middle of history" bug). Same series only: on a
         // symbol/timeframe switch the head time won't match and the view re-fits anyway.
-        if (opts?.preserveView === true && prevHeadTime != null) {
-            const shift = this.bars.findIndex((b) => b.time === prevHeadTime);
-            if (shift > 0) {
+        if (opts?.preserveView === true && prevHeadTime != null && this.bars.length > 0) {
+            // The head can move BOTH ways on the same series: a backfill PREPENDS older bars
+            // (indices shift up), a shallower depth TRIMS from the front (indices shift down).
+            // Only the prepend used to be handled, so a trim left the anchors pointing past
+            // the data. The newest end is fixed either way, so the viewport itself never moves.
+            const newHeadTime = this.bars[0]!.time;
+            let shift = 0;
+            if (newHeadTime !== prevHeadTime) {
+                const prepended = this.bars.findIndex((b) => b.time === prevHeadTime);
+                if (prepended > 0) shift = prepended;
+                else {
+                    const trimmed = prevBars.findIndex((b) => b.time === newHeadTime);
+                    if (trimmed > 0) shift = -trimmed;
+                }
+            }
+            if (shift !== 0) {
                 this.zoomAnchorLogical += shift;
                 if (this.hoverLogical != null) this.hoverLogical += shift;
             }
@@ -1655,8 +1674,30 @@ export class NativeRenderer implements IChartRenderer {
      */
     private refreshAnchorOffset(model: IndicatorModel): void {
         const anchor = model.anchorTime;
-        if (anchor == null || this.bars.length === 0 || anchor <= this.bars[0]!.time) {
+        if (anchor == null || this.bars.length === 0) {
             this.scene.setAnchorOffset(model.id, 0);
+            return;
+        }
+        const head = this.bars[0]!.time;
+        if (anchor === head) {
+            this.scene.setAnchorOffset(model.id, 0);
+            return;
+        }
+        if (anchor < head) {
+            // The model starts BEFORE the chart's first bar — its own leading values fall off
+            // the left edge (the head moved forward under it: a trimmed series, or a shorter
+            // reload arriving before the model re-runs). A NEGATIVE offset skips exactly those
+            // points; treating this as "unanchored" (offset 0) is what pinned a stale model's
+            // first value onto the chart's first bar and drew the whole plot shifted.
+            const skip = leadingPointsBefore(model, head);
+            if (skip == null) {
+                // Nothing index-aligned to measure against (a drawings-only model). Keep the
+                // old, honest-but-approximate behavior rather than inventing a count.
+                console.warn(`[vela] indicator "${model.id}" starts before the first bar with no series to align on — rendering unanchored`);
+                this.scene.setAnchorOffset(model.id, 0);
+                return;
+            }
+            this.scene.setAnchorOffset(model.id, -skip);
             return;
         }
         // Lower-bound binary search over the sorted bar times.
@@ -1697,10 +1738,14 @@ export class NativeRenderer implements IChartRenderer {
     updateIndicator(handle: IndicatorRenderHandle, patch: ScenePatch): void {
         const model = this.scene.indicators.get(handle.id);
         if (!model) return;
-        // A value patch from a re-run over a DIFFERENT bar window carries its anchor.
-        if (patch.kind === 'value' && patch.anchorTime !== undefined && patch.anchorTime !== model.anchorTime) {
-            model.anchorTime = patch.anchorTime;
-            this.refreshAnchorOffset(model);
+        // A value patch from a re-run over a DIFFERENT bar window carries its anchor; `null`
+        // says the run spanned the whole chart and CLEARS the previous one.
+        if (patch.kind === 'value' && patch.anchorTime !== undefined) {
+            const next = patch.anchorTime ?? undefined;
+            if (next !== model.anchorTime) {
+                model.anchorTime = next;
+                this.refreshAnchorOffset(model);
+            }
         }
         applyPatch(model, patch);
         this.syncTables(model);
@@ -3077,6 +3122,23 @@ export class NativeRenderer implements IChartRenderer {
         this.syncSize();
     }
 
+    /** The built-in mark, or the host's own when one is set. */
+    private buildAttributionEl(): HTMLElement {
+        return this.attributionHtml !== null
+            ? createCustomMark(document, this.attributionHtml, this.theme.background)
+            : createAttributionMark(document, this.theme.background);
+    }
+
+    /** Swap the mark in place — the content kind changed (built-in ↔ host-supplied). */
+    private rebuildAttribution(): void {
+        if (!this.attributionEl) return; // pre-mount: mount() builds from the stored state
+        this.attributionEl.remove();
+        this.attributionEl = this.buildAttributionEl();
+        if (!this.attributionEnabled) this.attributionEl.style.display = 'none';
+        this.positionAttribution();
+        this.wrapper.appendChild(this.attributionEl);
+    }
+
     /** Bottom-left of the plot, above the time axis, clear of the drawings toolbar. */
     private positionAttribution(): void {
         if (!this.attributionEl) return;
@@ -3086,10 +3148,12 @@ export class NativeRenderer implements IChartRenderer {
         });
     }
 
-    /** Re-tint the LuxAlgo SVGs when the plot background flips light/dark. */
+    /** Re-tint the mark when the plot background flips light/dark. A host-supplied mark
+     *  only gets the ink color — its own artwork keeps whatever colors it declares. */
     private refreshAttributionColor(): void {
         if (!this.attributionEl) return;
-        applyAttributionMarkTheme(this.attributionEl, this.theme.background);
+        if (this.attributionHtml !== null) this.attributionEl.style.color = attributionMarkColor(this.theme.background);
+        else applyAttributionMarkTheme(this.attributionEl, this.theme.background);
     }
 
     private syncSize(): void {
@@ -3134,6 +3198,29 @@ export class NativeRenderer implements IChartRenderer {
     private applyBackground(): void {
         this.wrapper.style.background = this.theme.background;
     }
+}
+
+/**
+ * How many of a model's own index-aligned values sit strictly BEFORE `headTime` — the count
+ * to skip when the chart's first bar is later than the model's anchor. Read off the model's
+ * series, whose point/bar times ARE the bar times it ran over; a lower bound also covers a
+ * head that the model never saw (a gap) and a model that ended before the head entirely.
+ * `null` when the model carries no index-aligned series to measure.
+ */
+function leadingPointsBefore(model: IndicatorModel, headTime: number): number | null {
+    for (const s of model.series) {
+        const times: ReadonlyArray<{ time: number }> | null = s.kind === 'candle' || s.kind === 'bar' ? s.bars : isLineLikeSeries(s) ? s.points : null;
+        if (!times || times.length === 0) continue;
+        let lo = 0;
+        let hi = times.length; // lower bound: first index whose time is >= headTime
+        while (lo < hi) {
+            const mid = (lo + hi) >> 1;
+            if (times[mid]!.time < headTime) lo = mid + 1;
+            else hi = mid;
+        }
+        return lo;
+    }
+    return null;
 }
 
 /** Apply a scene patch to a stored indicator model so the next frame reflects it. */

--- a/src/renderers/native/chrome/AttributionMark.ts
+++ b/src/renderers/native/chrome/AttributionMark.ts
@@ -1,7 +1,8 @@
 // The in-chart ATTRIBUTION mark — the LuxAlgo logomark at the bottom-left of the plot,
 // expanding its wordmark on hover and linking to the project. Rendered by DEFAULT on every
 // chart. Per the NOTICE file, products may disable it (`renderer.set('attribution', false)`)
-// ONLY if they display an equivalent visible attribution elsewhere in their UI.
+// ONLY if they display an equivalent visible attribution elsewhere in their UI, which the
+// same file also allows them to restyle or reposition to fit their design.
 
 import { isDarkColor } from '../../../core/color';
 import { LUXALGO_SYMBOL_SVG, LUXALGO_WORDMARK_SVG } from './luxalgo-logos';
@@ -83,6 +84,29 @@ export function applyAttributionMarkTheme(el: HTMLElement, background: string): 
     const dark = isDarkColor(background);
     el.style.color = dark ? '#ffffff' : '#000000';
     el.style.setProperty('--vela-attr-shadow', dark ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.55)');
+}
+
+/**
+ * Build a HOST-supplied mark for the same corner. The string is inserted as HTML inside a
+ * positioned wrapper, so plain text renders as plain text and markup renders as markup —
+ * it is DEVELOPER-supplied branding, never a place to pass user input through. The
+ * wrapper carries no link and no theming of its own beyond the ink color, so the content
+ * looks exactly as its author wrote it.
+ */
+export function createCustomMark(doc: Document, html: string, background: string): HTMLElement {
+    const el = doc.createElement('div');
+    el.className = 'vela-attribution-custom';
+    Object.assign(el.style, {
+        position: 'absolute',
+        zIndex: '6',
+        pointerEvents: 'auto',
+        display: 'flex',
+        alignItems: 'center',
+        lineHeight: '1',
+    });
+    el.style.color = attributionMarkColor(background);
+    el.innerHTML = html;
+    return el;
 }
 
 /** Build the mark element (an anchor; the caller owns absolute positioning). */

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -187,7 +187,11 @@ export class SettingsDialog {
         {
             let sx = 0, sy = 0, ox = 0, oy = 0, dragging = false;
             header.addEventListener('pointerdown', (e) => {
-                if (e.target === closeBtn) return;
+                // ANCESTRY, not identity: the button holds an SVG icon, so a press on the ✕
+                // targets the `<path>`. Comparing against the button itself let the header
+                // take pointer capture, which retargets the click away — the button was dead
+                // everywhere except its few pixels of padding.
+                if ((e.target as Element | null)?.closest('.vela-sd-close')) return;
                 dragging = true;
                 sx = e.clientX - ox;
                 sy = e.clientY - oy;

--- a/src/renderers/native/core/SceneGraph.ts
+++ b/src/renderers/native/core/SceneGraph.ts
@@ -261,8 +261,13 @@ export class SceneGraph {
         return this.anchorOffsets.get(id) ?? 0;
     }
 
+    /** Offsets are SIGNED. Positive: the model starts after the chart's first bar (it ran
+     *  over a suffix) — readers skip its leading chart bars. Negative: the model starts
+     *  BEFORE it (the chart's head moved forward under a mounted model) — readers skip the
+     *  model's own leading points, `points[i - off]` reaching further in. Storing only the
+     *  positive case silently pinned such a model at index 0, i.e. drew it shifted. */
     setAnchorOffset(id: string, offset: number): void {
-        if (offset > 0) this.anchorOffsets.set(id, offset);
+        if (offset !== 0 && Number.isFinite(offset)) this.anchorOffsets.set(id, offset);
         else this.anchorOffsets.delete(id);
     }
 

--- a/src/widget/contributions.ts
+++ b/src/widget/contributions.ts
@@ -8,7 +8,9 @@ import type { ScriptingEngine } from '../core/ports/ScriptingEngine';
 
 /** The runtime surface an action's `when`/`run` receives. */
 export interface WidgetContext {
-    /** The CURRENT inner chart (a new instance after each symbol/timeframe rebuild). */
+    /** The CURRENT inner chart. Read it through this getter rather than capturing it:
+     *  a shell may replace its chart instance, and a captured one would be destroyed.
+     *  (Symbol and timeframe switches are applied IN PLACE — the instance survives them.) */
     chart: Vela;
     symbol: string;
     timeframe: string;

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -34,7 +34,8 @@ import { toolShortcutHints } from '../widget/tool-shortcuts';
 import { legendActionsProviderFor, widgetAttachments } from '../widget/contributions';
 import { resolveIndicators, type IndicatorManifest, type ResolvedIndicator } from '../widget/indicators';
 import { DrawingToolbar } from '../renderers/native/drawings/DrawingToolbar';
-import { createAttributionMark } from '../renderers/native/chrome/AttributionMark';
+import { createAttributionMark, createCustomMark } from '../renderers/native/chrome/AttributionMark';
+import { rendererDefaults } from '../core/renderer-defaults';
 import { defaultToolbar, type DrawingTypeKey, type SnapMode } from '../core/drawings';
 import { timeframeToMs } from '../data/timeframe';
 import { syncTargets, rangesWithin, type SyncKind, type SyncOptions, type SyncSetting } from './sync';
@@ -354,10 +355,21 @@ export class VelaWorkspace {
 
         // ONE attribution mark for the whole grid (bottom-left, floating above the
         // bottom-left cell's time axis) — the cells disable their per-chart marks, and
-        // this single mark is the NOTICE-required equivalent visible attribution.
-        const mark = createAttributionMark(doc, resolveTheme(opts.theme).background);
-        Object.assign(mark.style, { left: '12px', bottom: `${TIME_AXIS_H + 10}px`, zIndex: '11' });
-        this.gridEl.appendChild(mark);
+        // this single mark is the NOTICE-required equivalent visible attribution. It
+        // follows the app-wide default a plugin may have set for the attribution corner
+        // (`registerRendererDefaults({ attribution })`): the cells read it through their
+        // renderer, and the grid reads it here, so one setting covers every surface
+        // instead of leaving this mark behind as the one a host cannot reach.
+        const attribution = rendererDefaults().attribution;
+        if (attribution !== false) {
+            const background = resolveTheme(opts.theme).background;
+            const mark =
+                typeof attribution === 'string' && attribution.trim()
+                    ? createCustomMark(doc, attribution, background)
+                    : createAttributionMark(doc, background);
+            Object.assign(mark.style, { left: '12px', bottom: `${TIME_AXIS_H + 10}px`, zIndex: '11' });
+            this.gridEl.appendChild(mark);
+        }
 
         // ONE drawing toolbar for the whole grid: commands go to the ACTIVE cell's
         // `chart.drawings` facade; the cell's own in-chart bar stays hidden (the cells

--- a/test/anchor-offset.test.ts
+++ b/test/anchor-offset.test.ts
@@ -54,6 +54,31 @@ describe('SceneGraph anchor offsets', () => {
         scene.forgetAnchorOffset('b');
         expect(scene.offsetOf('b')).toBe(0);
     });
+
+    it('keeps NEGATIVE offsets — a model that starts before the chart head', () => {
+        // Dropping them (the old `if (offset > 0)`) pinned such a model at index 0, which is
+        // what drew a stale plot shifted hard to the left while a shorter series was on screen.
+        const scene = new SceneGraph();
+        scene.setAnchorOffset('a', -4);
+        expect(scene.offsetOf('a')).toBe(-4);
+        scene.setAnchorOffset('a', 0);
+        expect(scene.offsetOf('a')).toBe(0);
+        scene.setAnchorOffset('a', Number.NaN); // never storable
+        expect(scene.offsetOf('a')).toBe(0);
+    });
+});
+
+describe('autoscale with a model that starts BEFORE the chart head (negative offset)', () => {
+    it('reads the model values sitting under the visible bars, skipping its leading ones', () => {
+        // The chart holds the newest 4 bars of a series the model computed over 10: the model's
+        // first 6 values fall off the left edge, so offset = -6 and chart bar i reads value i+6.
+        const chart = bars(10).slice(6);
+        const m = lineModel('m', [1, 2, 3, 4, 5, 6, 1000, 1001, 1002, 1003]);
+        const scale = computePaneScale([m], chart, false, 0, 3, null, false, () => -6);
+        expect(scale.min).toBeLessThanOrEqual(1000);
+        expect(scale.max).toBeGreaterThanOrEqual(1003);
+        expect(scale.min).toBeGreaterThan(6); // the pre-head values (1..6) are NOT scanned
+    });
 });
 
 describe('autoscale with an anchored model', () => {

--- a/test/native-depth-change.test.ts
+++ b/test/native-depth-change.test.ts
@@ -1,0 +1,143 @@
+// What the renderer does when the bar array's HEAD moves under mounted indicators — the
+// other half of a depth change (the core half lives in set-market.test.ts). Two regressions
+// are pinned here: a model whose anchor is older than the new first bar must be placed with
+// a NEGATIVE offset (it used to be pinned at index 0, drawing the whole plot shifted left),
+// and a value patch must be able to CLEAR an anchor, not only change it.
+import { describe, it, expect } from 'vitest';
+import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+import type { OHLCV } from '../src/core/model/ohlcv';
+import type { IndicatorModel } from '../src/core/model/indicator';
+import type { ValuePatch } from '../src/core/model/patch';
+
+const T0 = 1_700_000_000_000;
+const STEP = 60_000;
+
+const mkBars = (n: number, from = 0): OHLCV[] =>
+    Array.from({ length: n }, (_, i) => ({ time: T0 + (from + i) * STEP, open: 1, high: 2, low: 0.5, close: 1.5, volume: 1 }));
+
+/** A model whose dense line series spans bars [from, from+n) of the same grid. */
+function model(id: string, n: number, from = 0): IndicatorModel {
+    return {
+        id,
+        title: id,
+        overlay: true,
+        paneHint: 'price',
+        paneId: 'price',
+        anchorTime: T0 + from * STEP,
+        series: [
+            {
+                id: `${id}:line`,
+                title: id,
+                paneId: 'price',
+                kind: 'line',
+                points: Array.from({ length: n }, (_, i) => ({ time: T0 + (from + i) * STEP, value: from + i })),
+                style: { color: '#f00', width: 1, lineStyle: 'solid' },
+            },
+        ],
+        fills: [],
+        backgrounds: [],
+        priceLines: [],
+        inputs: [],
+        inputValues: {},
+    };
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- the offset map is renderer-private; reading it IS the regression */
+function makeRenderer() {
+    const r = new NativeRenderer();
+    const anyR = r as any;
+    anyR.coords.setSize(800, 200, 1); // unmounted but sized — the index math is pure
+    if (!anyR.scheduler) anyR.scheduler = { invalidate: () => {} };
+    if (!anyR.animator) anyR.animator = { active: false, start: () => {}, stop: () => {} };
+    anyR.introPlayed = true;
+    anyR.syncTables = () => {}; // mount-owned DOM overlay, irrelevant to index math
+    return {
+        r,
+        anyR,
+        offsetOf: (id: string): number => anyR.scene.offsetOf(id),
+        /** Mount without the DOM half of `mountIndicator` (legend, panes, tables): the
+         *  scene entry plus the anchor derivation are all this file is about. */
+        mount(model: IndicatorModel): { id: string } {
+            anyR.scene.indicators.set(model.id, model);
+            anyR.refreshAnchorOffset(model);
+            return { id: model.id };
+        },
+    };
+}
+
+describe('a mounted model when the chart head moves FORWARD (a shallower series)', () => {
+    it('is placed with a negative offset — its leading values are skipped, not shifted onto bar 0', () => {
+        const { r, offsetOf, mount } = makeRenderer();
+        r.setBars(mkBars(100));
+        mount(model('m', 100)); // whole-chart model: no offset
+        expect(offsetOf('m')).toBe(0);
+
+        // The array is trimmed to its newest 40 bars — the model still holds all 100 values,
+        // now starting 60 bars before the chart does.
+        r.setBars(mkBars(40, 60), { preserveView: true });
+        expect(offsetOf('m')).toBe(-60);
+    });
+
+    it('the offset tracks the head exactly, in both directions, across successive moves', () => {
+        const { r, offsetOf, mount } = makeRenderer();
+        r.setBars(mkBars(100));
+        mount(model('m', 100));
+
+        r.setBars(mkBars(70, 30), { preserveView: true });
+        expect(offsetOf('m')).toBe(-30);
+        r.setBars(mkBars(90, 10), { preserveView: true }); // older bars come back
+        expect(offsetOf('m')).toBe(-10);
+        r.setBars(mkBars(100), { preserveView: true }); // fully restored → whole-chart again
+        expect(offsetOf('m')).toBe(0);
+    });
+
+    it('a model that ran over a SUFFIX still gets its positive offset (unchanged path)', () => {
+        const { r, offsetOf, mount } = makeRenderer();
+        r.setBars(mkBars(100));
+        mount(model('late', 40, 60)); // anchored at bar 60
+        expect(offsetOf('late')).toBe(60);
+    });
+
+    it('a model whose values all predate the chart is pushed entirely off the array', () => {
+        const { r, offsetOf, mount } = makeRenderer();
+        r.setBars(mkBars(100));
+        mount(model('old', 20)); // covers bars 0..19 only
+        r.setBars(mkBars(40, 60), { preserveView: true }); // chart now starts at bar 60
+        // Every value is older than the head: the offset skips the whole array, so nothing
+        // is drawn — the honest outcome, versus painting 20 stale values over fresh bars.
+        expect(offsetOf('old')).toBe(-20);
+    });
+});
+
+describe('logical interaction anchors follow a front trim', () => {
+    it('shift DOWN by the trimmed count, mirroring the prepend case', () => {
+        const { r, anyR } = makeRenderer();
+        r.setBars(mkBars(100));
+        anyR.zoomAnchorLogical = 90;
+        anyR.hoverLogical = 80;
+        r.setBars(mkBars(40, 60), { preserveView: true });
+        expect(anyR.zoomAnchorLogical).toBe(30); // 90 − 60
+        expect(anyR.hoverLogical).toBe(20);
+    });
+});
+
+describe('a value patch can CLEAR an anchor', () => {
+    it('null re-derives the offset as whole-chart; an omitted key leaves it alone', () => {
+        const { r, offsetOf, mount } = makeRenderer();
+        r.setBars(mkBars(100));
+        const handle = mount(model('m', 40, 60));
+        expect(offsetOf('m')).toBe(60);
+
+        // The script re-ran over the WHOLE chart: the patch says so with null.
+        const cleared: ValuePatch = { kind: 'value', indicatorId: 'm', dirty: { from: 0, to: 0 }, anchorTime: null, series: [] };
+        r.updateIndicator(handle, cleared);
+        expect(offsetOf('m')).toBe(0);
+
+        // A patch that states an anchor again moves it back…
+        r.updateIndicator(handle, { kind: 'value', indicatorId: 'm', dirty: { from: 0, to: 0 }, anchorTime: T0 + 60 * STEP, series: [] });
+        expect(offsetOf('m')).toBe(60);
+        // …and one that omits the key changes nothing.
+        r.updateIndicator(handle, { kind: 'value', indicatorId: 'm', dirty: { from: 0, to: 0 }, series: [] });
+        expect(offsetOf('m')).toBe(60);
+    });
+});

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -744,21 +744,30 @@ describe('EngineOrchestrator', () => {
         expect(engine.streamStops[ind.id]).toBe(1);
     });
 
-    it('history loads progressively: a fast 200-bar head, then doubling steps behind it', async () => {
+    it('an ordinary depth arrives in ONE request — no head, no steps', async () => {
         const renderer = new FakeRenderer();
         const chart = new Vela({} as unknown as HTMLElement, { bars: 2000 }, { renderer, engines: [new MockEngine()], dataFeed: new SizedDataFeed() });
-        await chart.ready(); // resolves at the FIRST paint (a sync feed's steps may already be racing in behind)
-        expect(renderer.setBarsCalls[0]).toEqual({ n: 200, preserveView: false });
+        await chart.ready();
         await chart.historyComplete();
-        // The head was ONE small request; behind it each step matches the painted depth,
-        // so the chart doubles per request (the last one bounded by the request).
-        expect(renderer.setBarsCalls).toEqual([
-            { n: 200, preserveView: false },
-            { n: 400, preserveView: true },
-            { n: 800, preserveView: true },
-            { n: 1600, preserveView: true },
-            { n: 2000, preserveView: true },
-        ]);
+        // Splitting this range only ever bought a faster FIRST candle, and nothing downstream
+        // can use it: an indicator's first run is held until the full depth lands anyway.
+        expect(renderer.setBarsCalls).toEqual([{ n: 2000, preserveView: false }]);
+    });
+
+    it('the single-request depth boundary: 5000 in one pass, and 5001 still one (a chunk covers it)', async () => {
+        const atLimit = new FakeRenderer();
+        const a = new Vela({} as unknown as HTMLElement, { bars: 5000 }, { renderer: atLimit, engines: [new MockEngine()], dataFeed: new SizedDataFeed() });
+        await a.ready();
+        await a.historyComplete();
+        expect(atLimit.setBarsCalls).toEqual([{ n: 5000, preserveView: false }]);
+
+        // Past the line the load is chunked, but the first chunk is 10 000 bars — so any depth
+        // up to that still lands in a single round trip.
+        const past = new FakeRenderer();
+        const b = new Vela({} as unknown as HTMLElement, { bars: 5001 }, { renderer: past, engines: [new MockEngine()], dataFeed: new SizedDataFeed() });
+        await b.ready();
+        await b.historyComplete();
+        expect(past.setBarsCalls).toEqual([{ n: 5001, preserveView: false }]);
     });
 
     it('a requested initial window loads in ONE pass and is framed BEFORE the first paint', async () => {
@@ -797,16 +806,16 @@ describe('EngineOrchestrator', () => {
             load: (cfg: { bars?: number }) => Promise.resolve(makeBars(cfg.bars ?? 500)),
             subscribe: (): Unsubscribe => () => {},
         };
-        const chart = new Vela({} as unknown as HTMLElement, { bars: 2000 }, { renderer, engines: [new MockEngine()], dataFeed: feed });
+        const chart = new Vela({} as unknown as HTMLElement, { bars: 8000 }, { renderer, engines: [new MockEngine()], dataFeed: feed });
         await chart.ready();
         await flush();
         expect(renderer.setBarsCalls).toEqual([
             { n: 300, preserveView: false },
-            { n: 2000, preserveView: true },
+            { n: 8000, preserveView: true },
         ]);
     });
 
-    it('requests at or under one step load in one shot (no progressive split)', async () => {
+    it('a small request loads in one shot', async () => {
         const renderer = new FakeRenderer();
         const chart = new Vela({} as unknown as HTMLElement, { bars: 200 }, { renderer, engines: [new MockEngine()], dataFeed: new SizedDataFeed() });
         await chart.ready();
@@ -814,23 +823,18 @@ describe('EngineOrchestrator', () => {
         expect(renderer.setBarsCalls).toEqual([{ n: 200, preserveView: false }]);
     });
 
-    it('a mid-sized chart steps to its requested depth and completes with reason depth', async () => {
+    it('a mid-sized chart loads in one pass and completes with reason depth', async () => {
         const renderer = new FakeRenderer();
         const chart = new Vela({} as unknown as HTMLElement, { bars: 500 }, { renderer, engines: [new MockEngine()], dataFeed: new SizedDataFeed() });
         const completes: { reason: string; barsLoaded: number }[] = [];
         chart.on('history:complete', (e) => completes.push(e));
         await chart.ready();
         await chart.historyComplete();
-        // 200 head + 200 step + the 100 remainder — the last step is bounded by the request.
-        expect(renderer.setBarsCalls).toEqual([
-            { n: 200, preserveView: false },
-            { n: 400, preserveView: true },
-            { n: 500, preserveView: true },
-        ]);
+        expect(renderer.setBarsCalls).toEqual([{ n: 500, preserveView: false }]);
         expect(completes).toEqual([{ reason: 'depth', oldestTime: renderer.bars[0]!.time, barsLoaded: 500 }]);
     });
 
-    it('very deep charts: doubling steps capped at the chunk size, remainder-bounded', async () => {
+    it('very deep charts: a first chunk on screen, then flat 10k steps, remainder-bounded', async () => {
         const renderer = new FakeRenderer();
         const feed = new DeepHistoryFeed(40_000);
         feed.gate = true; // park the backfill so the interactive intermediate state is observable
@@ -840,19 +844,19 @@ describe('EngineOrchestrator', () => {
         chart.on('history:progress', (e) => progress.push(e));
         chart.on('history:complete', (e) => completes.push(e));
 
-        await chart.ready(); // resolves at the FIRST paint — the chart is interactive on 200 bars
-        expect(renderer.setBarsCalls).toEqual([{ n: 200, preserveView: false }]);
+        await chart.ready(); // resolves at the FIRST paint — interactive on the first full chunk
+        expect(renderer.setBarsCalls).toEqual([{ n: 10_000, preserveView: false }]);
 
         feed.gate = false;
         feed.release(); // let the parked backfill run to completion
         await chart.historyComplete();
-        // Doubling steps behind the interactive chart, capped at 10k, then the remainder.
-        const sizes = [200, 400, 800, 1_600, 3_200, 6_400, 12_800, 22_800, 25_000];
+        // Flat chunks behind the interactive chart, the last one bounded by the remainder.
+        const sizes = [10_000, 20_000, 25_000];
         expect(renderer.setBarsCalls).toEqual(sizes.map((n, i) => ({ n, preserveView: i > 0 })));
         expect(progress).toEqual(sizes.slice(1).map((loaded) => ({ loaded, target: 25_000 })));
         expect(completes).toEqual([{ reason: 'depth', oldestTime: renderer.bars[0]!.time, barsLoaded: 25_000 }]);
         // Steps were requested backward, overlap-by-one, bounded by the remaining depth.
-        expect(feed.rangeCalls.map((r) => r.limit)).toEqual([201, 401, 801, 1_601, 3_201, 6_401, 10_001, 2_201]);
+        expect(feed.rangeCalls.map((r) => r.limit)).toEqual([10_001, 5_001]);
         // Bars stay strictly monotonic across every seam.
         for (let i = 1; i < renderer.bars.length; i += 1) expect(renderer.bars[i]!.time).toBeGreaterThan(renderer.bars[i - 1]!.time);
     });
@@ -881,8 +885,8 @@ describe('EngineOrchestrator', () => {
 
         await chart.ready();
         await chart.historyComplete();
-        expect(renderer.bars.length).toBe(200); // the painted head survives
-        expect(completes).toEqual([expect.objectContaining({ reason: 'aborted', barsLoaded: 200 })]);
+        expect(renderer.bars.length).toBe(10_000); // the painted first chunk survives
+        expect(completes).toEqual([expect.objectContaining({ reason: 'aborted', barsLoaded: 10_000 })]);
         warn.mockRestore();
     });
 
@@ -892,7 +896,7 @@ describe('EngineOrchestrator', () => {
         feed.gate = true; // hold every ranged fetch until released
         const chart = new Vela({} as unknown as HTMLElement, { bars: 25_000, volume: false }, { renderer, engines: [new MockEngine()], dataFeed: feed });
         await chart.ready();
-        expect(renderer.bars.length).toBe(200);
+        expect(renderer.bars.length).toBe(10_000);
 
         chart.destroy();
         feed.release(); // the in-flight step lands AFTER destroy — it must be discarded

--- a/test/renderer-defaults.test.ts
+++ b/test/renderer-defaults.test.ts
@@ -1,0 +1,127 @@
+// Renderer feature DEFAULTS: the registry itself, and the two things that make it useful
+// to a plugin — every chart built afterwards picks them up (a bare chart included), and
+// they are defaults, not locks. The `attribution` feature's string form rides along, since
+// it is the first feature a plugin defaults for a whole app.
+import { describe, it, expect, afterEach } from 'vitest';
+import { registerRendererDefaults, unregisterRendererDefaults, rendererDefaults } from '../src/core/renderer-defaults';
+import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+import { Vela } from '../src/index';
+import type { IChartRenderer } from '../src/core/ports/IChartRenderer';
+
+afterEach(() => unregisterRendererDefaults());
+
+/** Records what the chart pushes through the feature channel. Only the members a bare,
+ *  data-less chart touches are real; the rest satisfy the port. */
+function recordingRenderer() {
+    const applied: Array<[string, unknown]> = [];
+    const renderer = {
+        name: 'fake',
+        features: ['attribution', 'gridlines'] as readonly string[],
+        capabilities: {
+            panes: true, paneManagement: false, fills: 'native', bgcolor: 'native', hline: 'native', markers: true,
+            barcolor: 'native', perPointColor: true, drawings: true, userDrawings: false, tables: true, inputsUI: true,
+        },
+        applyFeature: (key: string, value: unknown) => void applied.push([key, value]),
+        readFeature: () => undefined,
+        mount() {}, setTheme() {}, resize() {}, destroy() {},
+        setBars() {}, updateBar() {}, ensurePane() {}, removePane() {},
+        mountIndicator: (m: { id: string }) => ({ id: m.id }),
+        updateIndicator() {}, removeIndicator() {}, setIndicatorInputs() {},
+        onInputChange: () => () => {}, onRemoveIndicator: () => () => {},
+        onCrosshairMove: () => () => {}, onClick: () => () => {},
+        getVisibleRange: () => null, setVisibleRange() {}, onViewportChange: () => () => {},
+    } as unknown as IChartRenderer;
+    return { renderer, applied };
+}
+
+describe('defaults reach the charts built afterwards', () => {
+    it('a chart applies every registered default at construction', () => {
+        registerRendererDefaults({ attribution: false, gridlines: false });
+        const { renderer, applied } = recordingRenderer();
+        new Vela({} as unknown as HTMLElement, { live: false }, { renderer, engines: [] });
+        expect(applied).toEqual(expect.arrayContaining([['attribution', false], ['gridlines', false]]));
+    });
+
+    it('a chart built BEFORE the registration is untouched, and an empty registry pushes nothing', () => {
+        const before = recordingRenderer();
+        new Vela({} as unknown as HTMLElement, { live: false }, { renderer: before.renderer, engines: [] });
+        expect(before.applied).toEqual([]); // nothing registered yet
+
+        registerRendererDefaults({ attribution: false });
+        expect(before.applied).toEqual([]); // …and registering later does not reach back
+    });
+
+    it('they are defaults, not locks: an explicit set afterwards wins', () => {
+        registerRendererDefaults({ attribution: false });
+        const { renderer, applied } = recordingRenderer();
+        const chart = new Vela({} as unknown as HTMLElement, { live: false }, { renderer, engines: [] });
+        chart.renderer.set('attribution', '<b>ACME</b>');
+        expect(applied).toEqual([['attribution', false], ['attribution', '<b>ACME</b>']]);
+    });
+});
+
+describe('the renderer-defaults registry', () => {
+    it('starts empty and collects what is registered', () => {
+        expect(rendererDefaults()).toEqual({});
+        registerRendererDefaults({ attribution: false, gridlines: false });
+        expect(rendererDefaults()).toEqual({ attribution: false, gridlines: false });
+    });
+
+    it('merges registrations, last write winning per key', () => {
+        registerRendererDefaults({ attribution: false, gridlines: false });
+        registerRendererDefaults({ attribution: '<b>ACME</b>' });
+        expect(rendererDefaults()).toEqual({ attribution: '<b>ACME</b>', gridlines: false });
+    });
+
+    it('the disposer removes exactly what it set, and never a newer value', () => {
+        const dispose = registerRendererDefaults({ attribution: false, gridlines: false });
+        registerRendererDefaults({ attribution: '<b>ACME</b>' }); // a later, different value
+        dispose();
+        expect(rendererDefaults()).toEqual({ attribution: '<b>ACME</b>' }); // kept; gridlines dropped
+    });
+
+    it('unregister drops by key, or everything when given none', () => {
+        registerRendererDefaults({ attribution: false, gridlines: false });
+        unregisterRendererDefaults('gridlines');
+        expect(rendererDefaults()).toEqual({ attribution: false });
+        unregisterRendererDefaults();
+        expect(rendererDefaults()).toEqual({});
+    });
+
+    it('hands out a snapshot — mutating it cannot poison the registry', () => {
+        registerRendererDefaults({ gridlines: false });
+        const snapshot = rendererDefaults();
+        snapshot.gridlines = true;
+        snapshot.injected = 'nope';
+        expect(rendererDefaults()).toEqual({ gridlines: false });
+    });
+});
+
+describe('the attribution feature takes host content', () => {
+    it('reads back false / true / the html string', () => {
+        const r = new NativeRenderer();
+        expect(r.readFeature('attribution')).toBe(true); // the built-in mark, by default
+
+        r.applyFeature('attribution', false);
+        expect(r.readFeature('attribution')).toBe(false);
+
+        r.applyFeature('attribution', '<img src="/acme.svg">');
+        expect(r.readFeature('attribution')).toBe('<img src="/acme.svg">');
+
+        r.applyFeature('attribution', true); // back to Vela's own mark
+        expect(r.readFeature('attribution')).toBe(true);
+    });
+
+    it('a blank string is not content — it reads as the boolean it is', () => {
+        const r = new NativeRenderer();
+        r.applyFeature('attribution', '   ');
+        expect(r.readFeature('attribution')).toBe(true); // truthy value, built-in mark
+    });
+
+    it('setting content on an unmounted renderer is remembered for mount', () => {
+        // The mark element only exists after mount(); a plugin's default lands well before.
+        const r = new NativeRenderer();
+        expect(() => r.applyFeature('attribution', '<b>ACME</b>')).not.toThrow();
+        expect(r.readFeature('attribution')).toBe('<b>ACME</b>');
+    });
+});

--- a/test/set-market.test.ts
+++ b/test/set-market.test.ts
@@ -689,7 +689,7 @@ describe('load states — the cleared chart + the loading affordance', () => {
         await pending;
     });
 
-    it('a depth-only reload keeps the bars painted and never raises the affordance', async () => {
+    it('a depth-only change keeps the bars painted, never raises the affordance, and never re-pushes the series', async () => {
         const feed = new SwitchFeed();
         const renderer = new FakeRenderer();
         const chart = make({ symbol: 'AAA', timeframe: '60', volume: false }, { renderer, engines: [], dataFeed: feed });
@@ -697,7 +697,61 @@ describe('load states — the cleared chart + the loading affordance', () => {
         renderer.timeline = [];
 
         await chart.setMarket({ bars: 80 });
-        expect(renderer.timeline).toEqual(['bars:50']); // the feed has 50 — one silent reload
+        // Same market, deeper: the loaded bars ARE the requested series, so the depth change
+        // extends instead of reloading. The feed has nothing older than its 50, so there is
+        // nothing to prepend — and therefore no series push at all. A reload here used to hand
+        // the renderer the very same 50 bars as a "fresh series", which re-framed the viewport.
+        expect(renderer.timeline).toEqual([]);
+        expect(renderer.bars).toHaveLength(50); // still painted, never blanked
+        expect(renderer.loading).toBe(false);
+    });
+
+    it('growing the depth PREPENDS older bars and keeps the view (no fresh-series re-frame)', async () => {
+        const feed = new SwitchFeed();
+        feed.depth['AAA'] = 400; // deeper history than the first load asks for
+        const renderer = new FakeRenderer();
+        const chart = make({ symbol: 'AAA', timeframe: '60', bars: 50, volume: false }, { renderer, engines: [], dataFeed: feed });
+        await chart.ready();
+        await chart.historyComplete();
+        await flush();
+        const firstHead = renderer.bars[0]!.time;
+        const newest = renderer.bars[renderer.bars.length - 1]!.time;
+        renderer.setBarsCalls = [];
+
+        await chart.setMarket({ bars: 200 });
+        await chart.historyComplete();
+        await flush();
+
+        expect(renderer.bars.length).toBeGreaterThan(50); // the extra depth arrived…
+        expect(renderer.bars[0]!.time).toBeLessThan(firstHead); // …as OLDER bars, prepended
+        expect(renderer.bars[renderer.bars.length - 1]!.time).toBe(newest); // newest end untouched
+        // EVERY push of the extension preserves the viewport — that is what stops a depth
+        // change from throwing the user's zoom away. A reload would have pushed at least one
+        // fresh (non-preserving) series first.
+        expect(renderer.setBarsCalls.length).toBeGreaterThan(0);
+        expect(renderer.setBarsCalls.every((c) => c.preserveView)).toBe(true);
+        expect(renderer.loading).toBe(false); // never re-raised: bars stayed on screen throughout
+    });
+
+    it('shrinking the depth trims in place, keeping the NEWEST bars and the view', async () => {
+        const feed = new SwitchFeed();
+        feed.depth['AAA'] = 400;
+        const renderer = new FakeRenderer();
+        const chart = make({ symbol: 'AAA', timeframe: '60', bars: 300, volume: false }, { renderer, engines: [], dataFeed: feed });
+        await chart.ready();
+        await chart.historyComplete();
+        await flush();
+        const newest = renderer.bars[renderer.bars.length - 1]!.time;
+        expect(renderer.bars.length).toBeGreaterThan(100);
+        renderer.setBarsCalls = [];
+
+        await chart.setMarket({ bars: 100 });
+        await flush();
+
+        expect(renderer.bars).toHaveLength(100);
+        expect(renderer.bars[renderer.bars.length - 1]!.time).toBe(newest); // the newest end is kept
+        expect(renderer.setBarsCalls).toEqual([{ n: 100, close: renderer.bars[0]!.close, preserveView: true }]);
+        expect(renderer.loading).toBe(false);
     });
 
     it('a failed load still ends the affordance (empty chart, no eternal dots)', async () => {


### PR DESCRIPTION
…d of rebuilding

History loaded a 200-bar head then widened by doubling, so the shells' default depth cost four serialized round trips. That shape only bought a faster first candle, which nothing can use: an indicator's first run is held until the full depth lands. Load in one request up to 5 000 bars, in flat 10 000-bar chunks beyond.

setMarket({ bars }) went through the same reload as a symbol switch — a short head, then ~6 whole-array replacements — so any depth change threw the viewport away and stranded every mounted indicator behind the new first bar. A depth-only change now extends or trims the loaded series in place, in both directions.

- signed anchor offsets: a model whose anchor predates the chart head skips its own leading values instead of being pinned at index 0 and drawn shifted
- value patches always carry anchorTime, null included, so a whole-chart re-run can clear a narrower run's offset
- the chart-settings close button tests ancestry, not identity: its SVG icon no longer lets the draggable header capture the pointer and swallow the click
- registerRendererDefaults: plugin-contributed renderer feature defaults, applied to every chart built afterwards — the widget's, each workspace cell's, and a bare chart
- README and SDK comments corrected against the code (screenshot chord, the workspace entry point, what persist restores, the async indicator manifest, a removed option)