### PR TITLE
chore: add prepare script so Vela builds when installed as a git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
+    "prepare": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Why

We need to consume `@luxalgo/vela` from the app repo **now**, before it's published to a registry. The standard way is a git dependency:

```json
"@luxalgo/vela": "github:LuxAlgo/Vela#<ref>"
```

But `dist/` is gitignored (not committed), and there's no `prepare` script — so a git-dependency install pulls the **source only** and never builds `dist/`. The package's `exports` point at `dist/*`, so imports fail and the consumer's CI goes red.

## Change

Add a single script:

```diff
  "build": "tsup",
+ "prepare": "tsup",
```

`prepare` is the npm/pnpm lifecycle hook that runs automatically when a package is installed from git: the manager installs devDeps (incl. `tsup`), runs `prepare` to build `dist/`, then prunes. Result: `github:LuxAlgo/Vela#<sha>` installs a fully-built package, exactly like an npm release.

## Verified

Simulated a clean git-dep install locally — removed `dist/`, ran `prepare`, confirmed all consumer entry points rebuild:

```
dist/index.js  dist/index.cjs  dist/index.d.ts  dist/workspace.js   ✓
```

(`dist/workspace.js` is the `@luxalgo/vela/workspace` subpath the app's workspace integration imports.)

## Notes

- `dist/` stays gitignored — this builds on install, it does **not** commit artifacts.
- `prepare` also runs on a normal local `npm install` in this repo, which just rebuilds `dist/` (harmless; same as running `npm run build`).
- No effect on the `file:../Vela` links Vela-pinets / Vela-pro use — those already build via the workspace's own flow; `prepare` is additive.

Once this merges, the app can pin `github:LuxAlgo/Vela#<commit-sha>` and CI will build Vela cleanly.