### PR TITLE
chart settings dialog improvement - minor changes

### DIFF
--- a/docs/user/widget.md
+++ b/docs/user/widget.md
@@ -43,7 +43,7 @@ the surface it shares, name for name and meaning for meaning, with
 | `autofocus` | boolean | `false` | Focus the chart on mount so keyboard shortcuts work from the first keystroke. Off by default: an embedded chart should not steal the page's focus. |
 | `persist` | boolean \| string | `false` | Bring the chart back as you left it — the widget persists its FULL state (the unified `getState()` document: market, prefs, renderer config, user drawings, indicators) and restores it at construction (`true` = key `'vela-widget'`; a string is the key). Old three-key payloads migrate transparently. |
 | `storage` | `VelaStorage` | localStorage | The persistence backend — inject a custom adapter (see below); one contract for both shells. |
-| `urlState` | boolean | `false` | Mirror the persisted values (all but the watermark flag) in the URL query (`?symbol=…&interval=…&style=…&tz=…&bars=…`) — shareable links. A URL param **wins** over persisted state at load. |
+| `urlState` | boolean | `false` | Mirror the persisted values (all but the watermark and indicator-titles flags) in the URL query (`?symbol=…&interval=…&style=…&tz=…&bars=…`) — shareable links. A URL param **wins** over persisted state at load. |
 
 ## The indicator manifest
 
@@ -144,7 +144,7 @@ const state = widget.getState();
 // → { version: 1, layout: '1', activeCellId: 'c1', timezone, favorites?,
 //     panels?: { open?, widths? },
 //     charts: [{ id: 'c1', symbol, provider?, timeframe, priceStyle, bars?, watermark?,
-//                rendererConfig, drawings, indicators }] }
+//                indicatorTitles?, rendererConfig, drawings, indicators }] }
 
 widget.applyState(state); // untrusted-safe; applied IN PLACE (the chart survives)
 widget.on('state:changed', () => {

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -124,7 +124,7 @@ const state = ws.getState();
 // → { version: 1, layout, trackSizes?, activeCellId?, sync?, timezone?, favorites?, charts: […] }
 // One ORDERED `charts` entry per cell, live AND dormant — array position i restores
 // into slot i, `id` is the cell's durable name: { id: 'btc', symbol, provider?, timeframe,
-//   priceStyle, bars?, watermark?, rendererConfig (renderer.getConfig() document),
+//   priceStyle, bars?, watermark?, indicatorTitles?, rendererConfig (renderer.getConfig() document),
 //   drawings (drawings.toJSON() document), indicators: { manifest: string[], natives: string[] } }
 
 ws.applyState(state); // untrusted-safe: malformed fields dropped, whole grid rebuilt

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -165,6 +165,8 @@ export class NativeRenderer implements IChartRenderer {
     private input!: InputController;
     private inputsUI!: InputsUI;
     private symbolPicker: SymbolPickerFn | null = null;
+    /** Indicator titles (the legend rows) shown — held here so a remount re-applies it. */
+    private indicatorTitlesOn = true;
     /** Host-contributed legend actions — held here so a rebuild of the legend re-wires them. */
     private legendActionsProvider: ((indicatorId: string) => LegendActionView[]) | null = null;
     // ── keyboard navigation / accessibility (item 11) ──
@@ -293,7 +295,7 @@ export class NativeRenderer implements IChartRenderer {
     }
 
     readonly name = 'native';
-    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers'];
+    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles'];
 
     /** Apply a render feature live — mutate the field + invalidate, no engine re-run. */
     applyFeature(key: string, value: unknown): void {
@@ -422,6 +424,12 @@ export class NativeRenderer implements IChartRenderer {
             case 'settings':
                 this.setSettingsEnabled(Boolean(value));
                 return; // owns its own DOM (gear button + dialog)
+            case 'indicatorTitles':
+                // Show/hide the indicator legend rows chart-wide (the settings dialog's
+                // Indicators toggle drives it through the host section).
+                this.indicatorTitlesOn = value !== false;
+                this.inputsUI?.setTitlesVisible(this.indicatorTitlesOn);
+                return; // own DOM, no repaint needed
             case 'attribution':
                 // `false` hides it, `true` restores the built-in mark, a non-empty STRING
                 // puts the host's own mark in that corner (see the NOTICE).
@@ -489,6 +497,7 @@ export class NativeRenderer implements IChartRenderer {
             case 'keyboard': return this.keyboardEnabled;
             case 'historyChords': return this.historyChordsEnabled;
             case 'settings': return this.settingsEnabled;
+            case 'indicatorTitles': return this.indicatorTitlesOn;
             case 'attribution': return this.attributionHtml ?? this.attributionEnabled;
             case 'dialogHost': return this.dialogHost ?? undefined;
             default: return undefined;
@@ -1270,6 +1279,7 @@ export class NativeRenderer implements IChartRenderer {
         this.setKeyboardEnabled(this.keyboardEnabled); // accessible by default; wires focus + ARIA
 
         this.inputsUI = new InputsUI(this.plot, theme, (paneId) => this.paneBoundsFor(paneId));
+        this.inputsUI.setTitlesVisible(this.indicatorTitlesOn); // a remount keeps the toggle state
         this.inputsUI.setDialogHost(this.dialogHost);
         this.inputsUI.setSymbolPicker(this.symbolPicker);
         this.inputsUI.setLegendActions(this.legendActionsProvider);

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -22,8 +22,10 @@ type ConfigPatch = Record<string, unknown>;
  * dependency-free and themed to match the chart, mirroring `InputsUI`.
  */
 
-/** A host-contributed settings row: callback-based (the host owns the state). */
+/** A host-contributed settings row: callback-based (the host owns the state).
+ *  `heading` opens a titled group inside the tab (an in-pane section title). */
 export type HostSettingsRow =
+    | { kind: 'heading'; label: string }
     | { kind: 'toggle'; label: string; get: () => boolean; set: (v: boolean) => void }
     | { kind: 'select'; label: string; options: readonly string[]; get: () => string; set: (v: string) => void };
 
@@ -86,8 +88,16 @@ function ensureControlStyles(): void {
 .vela-sd-toggle::after{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--vela-fg-muted);transition:transform var(--vela-dur-med) ease,background var(--vela-dur-med) ease;}
 .vela-sd-toggle.on{background:var(--vela-active);border-color:var(--vela-selected-bg);}
 .vela-sd-toggle.on::after{transform:translateX(16px);background:var(--vela-selected-bg);}
-.vela-sd-tab:hover{background:var(--vela-hover);}
-.vela-sd-btn:hover{border-color:var(--vela-border-strong);}
+/* Tab rail / footer button / header close: base styles live HERE, not inline on the
+   elements — inline declarations always beat stylesheet :hover rules, which is exactly
+   what killed these hovers before. Active tab state is the .on class (like .vela-sd-check),
+   hover fills follow the app convention (--vela-hover + --vela-fg-bright, fast transition). */
+.vela-sd-tab{text-align:left;padding:9px 12px;background:transparent;border:none;border-radius:var(--vela-radius-md);color:var(--vela-fg-muted);font-weight:600;font-size:13px;font-family:inherit;cursor:pointer;transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
+.vela-sd-tab:hover{background:var(--vela-hover);color:var(--vela-fg-bright);}
+.vela-sd-tab.on{background:var(--vela-active);color:var(--vela-fg-bright);}
+.vela-sd-btn{height:30px;padding:0 14px;font-size:var(--vela-font-size-md);color:var(--vela-fg);background:var(--vela-surface-sunken);border:1px solid var(--vela-border);border-radius:var(--vela-radius-md);cursor:pointer;font-family:inherit;transition:background var(--vela-dur-fast) ease,border-color var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
+.vela-sd-btn:hover{background:var(--vela-hover);border-color:var(--vela-border-strong);color:var(--vela-fg-bright);}
+.vela-sd-close{cursor:pointer;display:inline-flex;align-items:center;justify-content:center;background:transparent;border:none;color:var(--vela-fg-muted);line-height:0;width:30px;height:30px;border-radius:var(--vela-radius-sm);transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
 .vela-sd-close:hover{background:var(--vela-hover);color:var(--vela-fg-bright);}
 `;
     document.head.appendChild(st);
@@ -169,7 +179,10 @@ export class SettingsDialog {
         const dlg = document.createElement('div');
         // `cursor:default` shields the dialog from the plot's crosshair cursor; interactive
         // controls re-declare their own.
-        dlg.style.cssText = `width:min(720px,94vw);max-height:70vh;display:flex;flex-direction:column;background:${SETTINGS_SURFACE};border:1px solid ${SETTINGS_BORDER};border-radius:var(--vela-radius-lg);box-shadow:var(--vela-shadow-dialog);color:${SETTINGS_TEXT};font:13px var(--vela-font);overflow:hidden;cursor:default;`;
+        // Shrink-to-fit width (mirrors the indicator dialog's `w-fit` card): the box is only
+        // as wide as the rail + widest visible pane content needs, between a floor that keeps
+        // sparse tabs from looking cramped and the old 720px cap.
+        dlg.style.cssText = `width:fit-content;min-width:min(560px,94vw);max-width:min(720px,94vw);max-height:70vh;display:flex;flex-direction:column;background:${SETTINGS_SURFACE};border:1px solid ${SETTINGS_BORDER};border-radius:var(--vela-radius-lg);box-shadow:var(--vela-shadow-dialog);color:${SETTINGS_TEXT};font:13px var(--vela-font);overflow:hidden;cursor:default;`;
 
         const header = document.createElement('div');
         header.style.cssText = `display:flex;justify-content:space-between;align-items:center;padding:9px 9px 9px 16px;border-bottom:1px solid ${SETTINGS_BORDER};flex:0 0 auto;user-select:none;`;
@@ -181,7 +194,6 @@ export class SettingsDialog {
         closeBtn.innerHTML = iconAt('close', 15);
         closeBtn.title = 'Close';
         closeBtn.className = 'vela-sd-close';
-        closeBtn.style.cssText = 'cursor:pointer;display:inline-flex;align-items:center;justify-content:center;background:transparent;border:none;color:var(--vela-fg-muted);line-height:0;width:30px;height:30px;border-radius:var(--vela-radius-sm);';
         closeBtn.addEventListener('click', () => this.close());
         header.append(hTitle, closeBtn);
         header.style.cursor = 'move';
@@ -301,7 +313,8 @@ export class SettingsDialog {
                 // 'symbol' inlines rows into the CURRENT pane (a section title, no tab).
                 body.append(placement === 'symbol' ? this.sectionTitle(hs.title) : this.section(hs.title));
                 for (const hr of hs.rows) {
-                    if (hr.kind === 'toggle') body.append(this.boolRow(hr.label, hr.get(), (v) => hr.set(v)));
+                    if (hr.kind === 'heading') body.append(this.sectionTitle(hr.label));
+                    else if (hr.kind === 'toggle') body.append(this.boolRow(hr.label, hr.get(), (v) => hr.set(v)));
                     else body.append(this.selectRowLabeled(hr.label, hr.get() as string, hr.options.map((o) => [o, o] as const), (v) => hr.set(v)));
                 }
             }
@@ -397,10 +410,6 @@ export class SettingsDialog {
                 tab.type = 'button';
                 tab.textContent = title;
                 tab.className = 'vela-sd-tab';
-                // Longhands on purpose: `font: 600 13px inherit` is an invalid shorthand
-                // (CSS-wide keywords can't be a shorthand component), so browsers drop it
-                // whole and the rail renders at weight 400.
-                tab.style.cssText = 'text-align:left;padding:9px 12px;background:transparent;border:none;border-radius:var(--vela-radius-md);color:var(--vela-fg-muted);font-weight:600;font-size:13px;font-family:inherit;cursor:pointer;';
                 panes.push({ title, el, tab, style: child.dataset.sdStyle, visibility: child.dataset.sdVisibility });
                 current = el;
                 child.remove();
@@ -423,8 +432,7 @@ export class SettingsDialog {
         const activate = (idx: number): void => {
             panes.forEach((p, i) => {
                 p.el.style.display = i === idx ? 'block' : 'none';
-                p.tab.style.background = i === idx ? 'var(--vela-active)' : 'transparent';
-                p.tab.style.color = i === idx ? 'var(--vela-fg-bright)' : 'var(--vela-fg-muted)';
+                p.tab.classList.toggle('on', i === idx);
             });
             this.activeSection = panes[idx]?.title ?? null;
         };
@@ -445,6 +453,9 @@ export class SettingsDialog {
         scrim.appendChild(dlg);
         this.container.appendChild(scrim);
         this.root = scrim;
+        // Pane-wide label column — must run after mount so label clones can be measured
+        // against the live dialog (detached/`display:none` trees report width 0).
+        for (const p of panes) this.layoutSettingsGrids(p.el, dlg);
     }
 
     close(): void {
@@ -474,7 +485,8 @@ export class SettingsDialog {
      *  is what separates groups — whitespace, not rules. */
     private sectionTitle(text: string): HTMLElement {
         const el = document.createElement('div');
-        el.style.cssText = 'margin:24px 0 6px;font-size:var(--vela-font-size-sm);font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--vela-fg-muted);';
+        el.className = 'vela-sd-sect';
+        el.style.cssText = 'margin:24px 0 0;padding-bottom:8px;font-size:var(--vela-font-size-sm);font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--vela-fg-muted);';
         el.textContent = text;
         return el;
     }
@@ -483,8 +495,68 @@ export class SettingsDialog {
      *  so no drawn rule. */
     private separator(): HTMLElement {
         const el = document.createElement('div');
+        el.className = 'vela-sd-sep';
         el.style.cssText = 'height:14px;';
         return el;
+    }
+
+    /**
+     * One pane-wide control column (section-agnostic), sized to the longest setting
+     * title — same idea as the indicator settings dialog's `minmax(..., auto)` label
+     * track, but shared across every section in the tab.
+     *
+     * `measureHost` must be a visible, in-document ancestor (the dialog): panes are
+     * `display:none` until selected, which would zero layout measurements.
+     */
+    private layoutSettingsGrids(pane: HTMLElement, measureHost: HTMLElement): void {
+        if (pane.childElementCount === 0) return;
+        const rows = [...pane.querySelectorAll('.vela-sd-row')] as HTMLElement[];
+
+        // Clone labels into a visible host so hidden price-style groups still contribute
+        // (switching Type must not jump the column) and spanning bool/section rows can't
+        // inflate the track.
+        const probe = document.createElement('div');
+        probe.style.cssText = 'position:absolute;left:-9999px;top:0;visibility:hidden;display:flex;flex-direction:column;font:13px var(--vela-font);pointer-events:none;';
+        measureHost.appendChild(probe);
+        let widest = 0;
+        for (const row of rows) {
+            const cell = row.children[0];
+            if (!cell) continue;
+            const clone = cell.cloneNode(true) as HTMLElement;
+            probe.appendChild(clone);
+            widest = Math.max(widest, clone.getBoundingClientRect().width);
+        }
+        probe.remove();
+
+        // A pane of only spanning rows (toggles, section titles) has no label column to
+        // measure — it still gets the grid, so its rows share the same 16px rhythm.
+        const labelTrack = widest > 0 ? `${Math.ceil(widest)}px` : 'max-content';
+        const grid = document.createElement('div');
+        grid.style.cssText =
+            `display:grid;grid-template-columns:${labelTrack} max-content;align-items:center;column-gap:12px;row-gap:16px;`;
+        while (pane.firstChild) grid.appendChild(pane.firstChild);
+        pane.appendChild(grid);
+        this.prepareGridItems(grid);
+    }
+
+    /** Mark rows/titles/bools so they participate in the pane grid; `display:contents`
+     *  groups dissolve so their children land on the same tracks. */
+    private prepareGridItems(container: HTMLElement): void {
+        for (const kid of [...container.children] as HTMLElement[]) {
+            if (kid.dataset.sdGroup !== undefined) {
+                this.prepareGridItems(kid);
+                continue;
+            }
+            if (kid.classList.contains('vela-sd-row')) {
+                kid.style.display = 'contents';
+            } else if (
+                kid.classList.contains('vela-sd-bool')
+                || kid.classList.contains('vela-sd-sect')
+                || kid.classList.contains('vela-sd-sep')
+            ) {
+                kid.style.gridColumn = '1 / -1';
+            }
+        }
     }
 
     /** A bare color swatch input (for toggle-row right groups / swatch pairs). */
@@ -493,7 +565,7 @@ export class SettingsDialog {
         return colorField(this.theme, () => current, (v) => { current = v; onChange(v); });
     }
 
-    /** A label row with arbitrary right-aligned controls (no toggle). */
+    /** A label row with arbitrary controls in the shared control column (no toggle). */
     private rowWith(label: string, controls: HTMLElement[]): HTMLElement {
         const { wrap } = this.row(label);
         const box = document.createElement('div');
@@ -515,6 +587,7 @@ export class SettingsDialog {
      *  (contents ⇄ none) shows/hides the set without disturbing the body flex layout. */
     private group(): HTMLElement {
         const el = document.createElement('div');
+        el.dataset.sdGroup = '';
         el.style.cssText = 'display:contents;';
         return el;
     }
@@ -522,12 +595,13 @@ export class SettingsDialog {
     private row(label: string): { wrap: HTMLDivElement } {
         // A DIV, not a <label>: a label forwards a click anywhere on the row to its embedded
         // control (opening a color picker from the row's empty space) — only the control
-        // itself should respond.
+        // itself should respond. `layoutSettingsGrids` later sets `display:contents` so the
+        // label + control participate in the pane's shared grid.
         const wrap = document.createElement('div');
-        wrap.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:16px;min-height:24px;padding:8px 0;';
+        wrap.className = 'vela-sd-row';
         const lbl = document.createElement('span');
         lbl.textContent = label;
-        lbl.style.cssText = 'opacity:0.85;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;';
+        lbl.style.cssText = 'opacity:0.85;white-space:nowrap;';
         wrap.appendChild(lbl);
         return { wrap };
     }
@@ -544,14 +618,13 @@ export class SettingsDialog {
         return this.toggleRow(label, value, onChange, []);
     }
 
-    /** An enable row: checkbox + label on the left, dependent controls right-aligned;
-     *  the control group dims and ignores input while the toggle is off. With no
-     *  controls it reads like a plain toggle row. */
+    /** An enable row: checkbox + label in the label column, dependent controls in the
+     *  shared control column; the control group dims and ignores input while the toggle
+     *  is off. With no controls it reads like a plain toggle row (full-width in the grid). */
     private toggleRow(label: string, value: boolean, onToggle: (v: boolean) => void, controls: HTMLElement[]): HTMLElement {
         const wrap = document.createElement('div');
         // No cursor on the row itself: only the checkbox is clickable, so a row-wide
         // pointer would promise a click target that isn't there.
-        wrap.style.cssText = 'display:flex;align-items:center;gap:8px;min-height:22px;padding:5px 0;';
         const cb = document.createElement('button');
         cb.type = 'button';
         cb.className = 'vela-sd-check' + (value ? ' on' : '');
@@ -564,14 +637,20 @@ export class SettingsDialog {
         };
         const lbl = document.createElement('span');
         lbl.textContent = label;
-        lbl.style.cssText = 'opacity:0.85;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;';
-        wrap.append(cb, lbl);
+        lbl.style.cssText = 'opacity:0.85;white-space:nowrap;';
         if (controls.length === 0) {
+            wrap.className = 'vela-sd-bool';
+            wrap.style.cssText = 'display:flex;align-items:center;gap:8px;min-height:22px;';
+            wrap.append(cb, lbl);
             cb.addEventListener('click', () => onToggle(cbToggle()));
             return wrap;
         }
+        wrap.className = 'vela-sd-row';
+        const left = document.createElement('div');
+        left.style.cssText = 'display:flex;align-items:center;gap:8px;';
+        left.append(cb, lbl);
         const box = document.createElement('div');
-        box.style.cssText = 'margin-left:auto;display:flex;align-items:center;gap:6px;flex:0 0 auto;';
+        box.style.cssText = 'display:flex;align-items:center;gap:6px;';
         for (const c of controls) box.appendChild(c);
         const syncDim = (on: boolean): void => {
             box.style.opacity = on ? '1' : '0.4';
@@ -579,7 +658,7 @@ export class SettingsDialog {
         };
         syncDim(value);
         cb.addEventListener('click', () => { const v = cbToggle(); onToggle(v); syncDim(v); });
-        wrap.appendChild(box);
+        wrap.append(left, box);
         return wrap;
     }
 
@@ -694,7 +773,7 @@ export class SettingsDialog {
         const { wrap } = this.row(label);
         const sel = document.createElement('select');
         sel.className = 'vela-sd-select';
-        sel.style.cssText = 'max-width:180px;flex:0 0 auto;';
+        sel.style.cssText = 'max-width:140px;flex:0 0 auto;';
         for (const [val, lbl] of options) {
             const o = document.createElement('option');
             o.value = val;
@@ -711,7 +790,7 @@ export class SettingsDialog {
         const { wrap } = this.row(label);
         const sel = document.createElement('select');
         sel.className = 'vela-sd-select';
-        sel.style.cssText = 'max-width:180px;flex:0 0 auto;';
+        sel.style.cssText = 'max-width:140px;flex:0 0 auto;';
         for (const opt of options) {
             const o = document.createElement('option');
             o.value = opt;
@@ -734,7 +813,6 @@ export class SettingsDialog {
         resetBtn.type = 'button';
         resetBtn.textContent = 'Reset defaults';
         resetBtn.className = 'vela-sd-btn';
-        resetBtn.style.cssText = `height:30px;padding:0 14px;font-size:var(--vela-font-size-md);color:${SETTINGS_TEXT};background:var(--vela-surface-sunken);border:1px solid ${SETTINGS_BORDER};border-radius:var(--vela-radius-md);cursor:pointer;font-family:inherit;`;
         resetBtn.addEventListener('click', () => this.onReset?.());
         foot.appendChild(resetBtn);
         return foot;

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -106,6 +106,9 @@ export class InputsUI {
      *  pane's rows hide (a pane-collapse strip keeps its master label, its only marker),
      *  unlike {@link paneCollapse} which collapses one pane to a strip. */
     private legendFolded = false;
+    /** Titles switched off entirely (a settings toggle): every pane's legend container
+     *  hides — rows, fold chevron and all — unlike the fold, which leaves its chip. */
+    private titlesVisible = true;
     /** The single fold toggle, on the price-pane legend: a bordered ^ chevron under the
      *  rows, or the bordered "˅ N" chip (N counts every pane's indicators) when folded. */
     private foldToggle: HTMLButtonElement | null = null;
@@ -234,6 +237,13 @@ export class InputsUI {
         for (const [paneId, lg] of this.legends) this.positionLegend(lg, paneId);
     }
 
+    /** Show/hide the indicator titles chart-wide (the settings dialog's Indicators toggle). */
+    setTitlesVisible(visible: boolean): void {
+        if (this.titlesVisible === visible) return;
+        this.titlesVisible = visible;
+        this.reposition(); // positionLegend applies the flag per pane
+    }
+
     // ── legend move/merge (menu + drag) ─────────────────────────────────────
 
     /** Open the "Move to" menu for a row, anchored under its move button. */
@@ -332,8 +342,9 @@ export class InputsUI {
     private positionLegend(lg: HTMLElement, paneId: string): void {
         const bounds = this.paneBoundsOf ? this.paneBoundsOf(paneId) : { top: 0, height: Infinity };
         // A pane hidden by a maximize elsewhere collapses to ~0 height — hide its legend entirely
-        // (a collapsed strip keeps a small height, so its title still shows).
-        lg.style.display = bounds.height < 4 ? 'none' : '';
+        // (a collapsed strip keeps a small height, so its title still shows). Titles switched
+        // off (the settings toggle) hide every pane's container the same way.
+        lg.style.display = bounds.height < 4 || !this.titlesVisible ? 'none' : '';
         // A collapsed pane is a legend-only strip: show just its master indicator's row. Restore
         // hidden rows to 'flex' (their intended layout — set in the row's cssText), NOT '' which
         // would revert them to block and break the inline button row (hide/show, settings, …).

--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -59,6 +59,8 @@ export interface CellState {
     bars?: number;
     /** Symbol watermark visibility — a per-chart display pref. */
     watermark?: boolean;
+    /** Indicator titles (the in-chart legend rows) visibility — a per-chart display pref. */
+    indicatorTitles?: boolean;
     /** The renderer's cosmetic config document (`renderer.getConfig()`). */
     rendererConfig?: unknown;
     /** The user-drawings document (`drawings.toJSON()`). */
@@ -168,6 +170,7 @@ function sanitizeCell(raw: unknown): CellState | null {
     if (typeof c.priceStyle === 'string') out.priceStyle = c.priceStyle;
     if (typeof c.bars === 'number' && Number.isFinite(c.bars) && c.bars > 0) out.bars = c.bars;
     if (typeof c.watermark === 'boolean') out.watermark = c.watermark;
+    if (typeof c.indicatorTitles === 'boolean') out.indicatorTitles = c.indicatorTitles;
     if (c.rendererConfig != null && typeof c.rendererConfig === 'object') out.rendererConfig = c.rendererConfig;
     if (c.drawings != null && typeof c.drawings === 'object') out.drawings = c.drawings;
     const ind = c.indicators as Record<string, unknown> | undefined;

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -175,6 +175,7 @@ export class VelaWidget {
         this.timezone = fromUrl.timezone ?? boot?.timezone ?? opts.timezone ?? 'Etc/UTC';
         this.bars = Number(fromUrl.bars ?? bootCell?.bars ?? opts.bars ?? 1000);
         this.watermarkOn = bootCell?.watermark !== undefined ? bootCell.watermark : opts.watermark !== false;
+        this.indicatorTitlesOn = bootCell?.indicatorTitles ?? true;
         this.favs = boot?.favorites ? [...boot.favorites] : [];
         this.savedConfig = bootCell?.rendererConfig ?? null;
         this.savedDrawings = bootCell?.drawings ?? null;
@@ -513,6 +514,7 @@ export class VelaWidget {
         cell.priceStyle = this.priceStyle;
         if (this.bars > 0) cell.bars = this.bars;
         cell.watermark = this.watermarkOn;
+        cell.indicatorTitles = this.indicatorTitlesOn;
         if (this.inner) {
             cell.rendererConfig = this.inner.renderer.getConfig();
             cell.drawings = this.inner.drawings.toJSON();
@@ -563,6 +565,7 @@ export class VelaWidget {
             const style = fromUrl.priceStyle ?? cell.priceStyle;
             if (style && style !== this.priceStyle) this.setPriceStyle(style);
             if (cell.watermark !== undefined && cell.watermark !== this.watermarkOn) this.setWatermarkVisible(cell.watermark);
+            if (cell.indicatorTitles !== undefined && cell.indicatorTitles !== this.indicatorTitlesOn) this.setIndicatorTitlesVisible(cell.indicatorTitles);
             if (cell.rendererConfig != null) {
                 this.savedConfig = cell.rendererConfig;
                 this.inner?.renderer.applyConfig(cell.rendererConfig);
@@ -666,6 +669,13 @@ export class VelaWidget {
     setWatermarkVisible(visible: boolean): void {
         this.watermarkOn = visible;
         this.watermark?.setVisible(visible);
+        this.markStateDirty();
+    }
+
+    /** Show/hide the indicator titles — the in-chart legend rows (persisted). */
+    setIndicatorTitlesVisible(visible: boolean): void {
+        this.indicatorTitlesOn = visible;
+        this.inner?.renderer.set('indicatorTitles', visible);
         this.markStateDirty();
     }
 
@@ -982,10 +992,7 @@ export class VelaWidget {
                             kind: 'toggle',
                             label: 'Titles',
                             get: () => this.indicatorTitlesOn,
-                            set: (v: boolean) => {
-                                this.indicatorTitlesOn = v;
-                                chart.renderer.set('indicatorTitles', v);
-                            },
+                            set: (v: boolean) => this.setIndicatorTitlesVisible(v),
                         },
                     ],
                 },

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -96,6 +96,8 @@ export class VelaWidget {
     private timezone: string;
     private bars: number;
     private watermarkOn: boolean;
+    /** Indicator titles (the in-chart legend rows) shown — reapplied across rebuilds. */
+    private indicatorTitlesOn = true;
     private pendingRange: RangePreset | null = null;
     /** Symbol already reported as unservable (the core re-reports on every index settle). */
     private unresolvedToasted: string | null = null;
@@ -921,6 +923,7 @@ export class VelaWidget {
         // Cosmetic state carried across rebuilds (renderer defaults are candles/UTC).
         if (this.priceStyle !== 'candles') chart.renderer.set('priceStyle', this.priceStyle);
         if (this.timezone !== 'Etc/UTC') chart.renderer.set('timezone', this.timezone);
+        if (!this.indicatorTitlesOn) chart.renderer.set('indicatorTitles', false);
         // The renderer's settings dialog owns a Time zone row too (it commits through
         // applyConfig) — mirror it back so the bottom-bar clock/label and the persisted
         // state never disagree with the axis. `renderer.set` is a feature write, not an
@@ -969,10 +972,21 @@ export class VelaWidget {
                 {
                     title: 'Status line',
                     rows: [
+                        { kind: 'heading', label: 'Status line' },
                         { kind: 'toggle', label: 'Symbol name', get: () => sl.partVisible('name'), set: (v: boolean) => sl.setPartVisible('name', v) },
                         { kind: 'toggle', label: 'Market status', get: () => sl.partVisible('market'), set: (v: boolean) => sl.setPartVisible('market', v) },
                         { kind: 'toggle', label: 'OHLC values', get: () => sl.partVisible('ohlc'), set: (v: boolean) => sl.setPartVisible('ohlc', v) },
                         { kind: 'toggle', label: 'Bar change values', get: () => sl.partVisible('change'), set: (v: boolean) => sl.setPartVisible('change', v) },
+                        { kind: 'heading', label: 'Indicators' },
+                        {
+                            kind: 'toggle',
+                            label: 'Titles',
+                            get: () => this.indicatorTitlesOn,
+                            set: (v: boolean) => {
+                                this.indicatorTitlesOn = v;
+                                chart.renderer.set('indicatorTitles', v);
+                            },
+                        },
                     ],
                 },
                 advanced,

--- a/src/widget/object-tree.ts
+++ b/src/widget/object-tree.ts
@@ -185,7 +185,7 @@ const CSS = `
 /* Buttons would only invite a click that a drag is about to swallow. */
 .vela-ot .vela-panel-body[data-dragging] .vela-ot-btn { visibility: hidden; }
 
-/* The band between two pane blocks: a hairline at rest, an accent bar when dropping there
+/* The band between two pane blocks: a hairline at rest, a bright bar when dropping there
    would open a new pane. Doubles as the plain separator when dragging isn't available. */
 .vela-ot-gap { position: relative; height: 11px; border-radius: 3px; margin: 0 8px; }
 .vela-ot-gap::before {
@@ -198,14 +198,14 @@ const CSS = `
     background: var(--vela-border);
     transform: translateY(-50%);
 }
-.vela-ot-gap[data-drop] { height: 4px; background: var(--vela-accent); }
+.vela-ot-gap[data-drop] { height: 4px; background: var(--vela-fg-bright); }
 .vela-ot-gap[data-drop]::before { display: none; }
 /* A whole container accepts the drop: merging into a pane, or a pane with no drawings yet.
    The pane block's transparent border reserves the room for this outline. */
-.vela-ot [data-drop='target'] { border-color: var(--vela-accent); background: var(--vela-hover); }
+.vela-ot [data-drop='target'] { border-color: var(--vela-fg-bright); background: var(--vela-hover); }
 /* Where a reorder would insert. */
-.vela-ot [data-drop='before'] { box-shadow: inset 0 2px 0 var(--vela-accent); }
-.vela-ot [data-drop='after'] { box-shadow: inset 0 -2px 0 var(--vela-accent); }
+.vela-ot [data-drop='before'] { box-shadow: inset 0 2px 0 var(--vela-fg-bright); }
+.vela-ot [data-drop='after'] { box-shadow: inset 0 -2px 0 var(--vela-fg-bright); }
 
 .vela-ot-ghost {
     position: fixed;
@@ -213,7 +213,7 @@ const CSS = `
     pointer-events: none;
     max-width: 220px;
     padding: 3px 10px;
-    border: 1px solid var(--vela-accent);
+    border: 1px solid var(--vela-fg-bright);
     border-radius: var(--vela-radius-sm);
     background: var(--vela-surface-overlay);
     color: var(--vela-fg);

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -175,6 +175,8 @@ export class ChartCell {
     private rangeBars = 0;
     private pendingRange: RangePreset | null = null;
     private watermarkOn: boolean;
+    /** Indicator titles (this cell's in-chart legend rows) shown. */
+    private indicatorTitlesOn = true;
     private destroyed = false;
 
     constructor(
@@ -379,10 +381,21 @@ export class ChartCell {
                 {
                     title: 'Status line',
                     rows: [
+                        { kind: 'heading', label: 'Status line' },
                         { kind: 'toggle', label: 'Symbol name', get: () => sl.partVisible('name'), set: (v: boolean) => sl.setPartVisible('name', v) },
                         { kind: 'toggle', label: 'Market status', get: () => sl.partVisible('market'), set: (v: boolean) => sl.setPartVisible('market', v) },
                         { kind: 'toggle', label: 'OHLC values', get: () => sl.partVisible('ohlc'), set: (v: boolean) => sl.setPartVisible('ohlc', v) },
                         { kind: 'toggle', label: 'Bar change values', get: () => sl.partVisible('change'), set: (v: boolean) => sl.setPartVisible('change', v) },
+                        { kind: 'heading', label: 'Indicators' },
+                        {
+                            kind: 'toggle',
+                            label: 'Titles',
+                            get: () => this.indicatorTitlesOn,
+                            set: (v: boolean) => {
+                                this.indicatorTitlesOn = v;
+                                this.inner?.renderer.set('indicatorTitles', v);
+                            },
+                        },
                     ],
                 },
                 advanced,

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -133,7 +133,7 @@ export interface CellDeps {
     /** The cell's indicator ledger changed (count/picker refresh upstream). */
     onIndicatorsChanged(id: string): void;
     /** Persistable per-cell state changed outside the market/indicator channels
-     *  (bars budget, watermark toggle) — the workspace debounces a save. */
+     *  (bars budget, watermark/titles toggles) — the workspace debounces a save. */
     onStateDirty(): void;
 }
 
@@ -271,6 +271,8 @@ export class ChartCell {
         const tz = deps.timezone();
         if (tz !== 'Etc/UTC') this.inner.renderer.set('timezone', tz);
 
+        this.indicatorTitlesOn = seed.indicatorTitles ?? true;
+        if (!this.indicatorTitlesOn) this.inner.renderer.set('indicatorTitles', false);
         this.watermarkOn = seed.watermark ?? deps.watermark;
         this.watermark = deps.watermark ? new Watermark(this.host, symbol ?? '', seed.timeframe ?? '60') : null;
         if (!this.watermarkOn) this.watermark?.setVisible(false);
@@ -344,8 +346,9 @@ export class ChartCell {
 
         // HOST settings sections — the same set the widget contributes, per cell
         // (the shared topbar gear opens the ACTIVE cell's dialog): status line parts,
-        // the per-cell fetch depth, and the per-cell watermark toggle. Bars/watermark
-        // are persistable cell state; a depth-only reload is silent, so mark dirty here.
+        // the per-cell fetch depth, and the per-cell watermark/titles toggles.
+        // Bars/watermark/titles are persistable cell state; a depth-only reload is
+        // silent, so mark dirty here.
         const advanced = {
             title: 'Advanced',
             placement: 'end' as const,
@@ -391,10 +394,7 @@ export class ChartCell {
                             kind: 'toggle',
                             label: 'Titles',
                             get: () => this.indicatorTitlesOn,
-                            set: (v: boolean) => {
-                                this.indicatorTitlesOn = v;
-                                this.inner?.renderer.set('indicatorTitles', v);
-                            },
+                            set: (v: boolean) => this.setIndicatorTitlesVisible(v),
                         },
                     ],
                 },
@@ -425,6 +425,13 @@ export class ChartCell {
     setWatermarkVisible(visible: boolean): void {
         this.watermarkOn = visible;
         this.watermark?.setVisible(visible);
+        this.deps.onStateDirty();
+    }
+
+    /** Show/hide this cell's indicator titles — the in-chart legend rows (persisted per cell). */
+    setIndicatorTitlesVisible(visible: boolean): void {
+        this.indicatorTitlesOn = visible;
+        this.inner?.renderer.set('indicatorTitles', visible);
         this.deps.onStateDirty();
     }
 
@@ -688,6 +695,7 @@ export class ChartCell {
             ...(live ? { symbol: live.symbol, provider: live.provider, timeframe: live.timeframe } : {}),
             priceStyle: this.priceStyle,
             watermark: this.watermarkOn,
+            indicatorTitles: this.indicatorTitlesOn,
             rendererConfig: this.inner?.renderer.getConfig() ?? undefined,
             drawings: this.inner ? this.inner.drawings.toJSON() : undefined,
             // Natives from the chart's SYNC registry read — an async catalog mirror here

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -131,7 +131,7 @@ const CSS = `
     content: '';
     position: absolute;
     inset: 0;
-    border: 2px solid var(--vela-accent-bright, var(--vela-accent));
+    border: 2px solid var(--vela-fg-bright);
     pointer-events: none;
     z-index: 10;
 }

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -23,6 +23,7 @@ const fullDoc: WorkspaceState = {
             priceStyle: 'candles',
             bars: 500,
             watermark: false,
+            indicatorTitles: false,
             rendererConfig: { theme: 'dark', nested: { any: ['shape'] } },
             drawings: { version: 1, items: [{ type: 'trendline' }] },
             indicators: { manifest: ['EMA 20'], natives: ['volume'] },
@@ -109,16 +110,16 @@ describe('sanitizeState (the applyState gate)', () => {
         expect(doc!.sync).toEqual({ symbol: { c1: 'a' } }); // timeframe record emptied → dropped
     });
 
-    it('filters shared favorites and per-chart watermark by type', () => {
+    it('filters shared favorites and per-chart display toggles by type', () => {
         const doc = sanitizeState({
             version: 1,
             layout: '1',
             favorites: ['trendline', 7, null, 'hline'],
-            charts: [{ id: 'c1', watermark: 'yes' }, { id: 'c2', watermark: false }],
+            charts: [{ id: 'c1', watermark: 'yes', indicatorTitles: 0 }, { id: 'c2', watermark: false, indicatorTitles: false }],
         });
         expect(doc!.favorites).toEqual(['trendline', 'hline']); // non-strings dropped
-        expect(doc!.charts[0]).toEqual({ id: 'c1' }); // non-boolean watermark dropped
-        expect(doc!.charts[1]).toEqual({ id: 'c2', watermark: false });
+        expect(doc!.charts[0]).toEqual({ id: 'c1' }); // non-boolean toggles dropped
+        expect(doc!.charts[1]).toEqual({ id: 'c2', watermark: false, indicatorTitles: false });
         // an all-junk favorites array disappears entirely
         expect(sanitizeState({ version: 1, layout: '1', favorites: [1, 2], charts: [] })!.favorites).toBeUndefined();
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display prefs and UI chrome only; state codec adds one optional boolean with sanitization tests—no auth, data, or trading paths touched.
> 
> **Overview**
> Adds a **persisted per-chart preference** to show or hide indicator legend titles (the in-chart legend rows), wired through a new native renderer feature `indicatorTitles`, `InputsUI.setTitlesVisible`, and `indicatorTitles` on the shared state document. Widget and workspace cells expose a **Titles** toggle under an **Indicators** section in chart settings (with **heading** rows grouping Status line vs Indicators), and the preference survives rebuilds and `getState`/`applyState` like watermark.
> 
> The **chart settings dialog** gets layout and interaction polish: dialog width shrink-to-fit between min/max caps; a shared pane grid aligns label columns across sections; tab rail, footer buttons, and close control styles move to CSS so **:hover** works (inline styles had blocked hovers); active tabs use a `.on` class.
> 
> Minor chrome tweaks use `--vela-fg-bright` instead of accent for object-tree drag hints and the workspace active-cell ring. Docs note `indicatorTitles` in state snapshots and that `urlState` still omits watermark and indicator-titles flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb989365913f9747a844ac2b35fbc83bda1a1ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->