### PR TITLE
UI/white theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **A light theme that actually works — switchable live.** `theme: 'light'` now skins the
+  whole product coherently: white surfaces with dark, readable text across the toolbar,
+  menus, dialogs, legends, axes, and pane separators. The theme can be swapped at runtime —
+  `chart.setTheme('light')`, `widget.setTheme(...)`, or `workspace.setTheme(...)` (which
+  re-skins the shared chrome and every cell together) — and users reach the same switch in
+  chart settings → Canvas → Theme. A `theme:changed` event carries the resolved theme so
+  the page around the chart can follow. Candle colors are shared between the built-in
+  themes, so switching never recolors the series. Setting just a white background on the
+  dark theme (settings → Canvas → Background) now re-bases the derived inks — text, grid,
+  axis border — so legends and axis labels stay readable, while an explicitly chosen text
+  color always wins. New text annotations (notes, callouts, price tags) pick a
+  maximum-contrast text color for the active theme at creation and keep it; existing
+  drawings are never recolored.
+
 - **Capturing what a script computes, in one subscription: `script:run`.** Reading a running
   script used to mean assembling it yourself — an event told you *that* something happened
   and handed you an id, so you looked the indicator up, awaited a snapshot, and then decoded

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -45,6 +45,7 @@ Constructing a chart renders candles immediately. Scripting engines are opt-in.
 | `setVisibleRange(range)` | Set the visible time range explicitly (epoch-ms). Returns the chart for chaining. |
 | `panBy(fraction)` | Pan by a fraction of the visible width — positive ⇒ toward the latest bars, negative ⇒ into history. Behaves exactly like dragging the chart: constant zoom, the same pan limits (forward stops at the newest candle plus the bounded empty space), eased on renderers that animate pans; repeated calls stack into one continuous scroll. The widget's `Ctrl/Cmd + ←/→` keys use it. Returns the chart for chaining. |
 | `setVisibleRangePreset(preset)` | Frame a named date range over the loaded bars: `'1D'`, `'1W'`, `'1M'`, `'3M'`, `'6M'`, `'1Y'`, `'5Y'`, `'YTD'`, or `'ALL'`. A preset deeper than the loaded history just frames everything (it doesn't fetch more bars — the widget's range chips do that for you). Returns the chart for chaining. |
+| `setTheme(theme)` | Swap the app theme at runtime — `'dark'`, `'light'`, or a full theme object (same shape as the `theme` option). Re-skins the chart surface, axes, legends and in-chart chrome live (no indicator re-run) and emits `theme:changed` with the resolved theme so surrounding host chrome can follow. Candle colors are shared across the built-in themes, so a swap never recolors the series. The same switch is available to users in chart settings → Canvas → Theme. Returns the chart for chaining. |
 | `inspect()` | A renderer-agnostic snapshot of the graphic elements the core has generated (series, fills, drawings, tables, …) — a deterministic check that a feature was produced, independent of which renderer drew it. |
 | `resize()` | Re-measure the container and relayout. Call after the container's size changes. |
 | `destroy()` | Tear down the chart, renderer, engines, and subscriptions — no leaks. |
@@ -239,6 +240,7 @@ Subscribe with `chart.on(event, handler)`; every subscription returns an unsubsc
 | `context:changed` | `{ id }` | An indicator's execution context advanced (run finished; throttled to ~1/s while streaming). Re-pull `handle.context()` if you consume it. Fires only for context-capable engines. **Prefer `script:run`**, which delivers the data rather than a signal to go fetch it. |
 | `bar` | the bar (OHLCV) | A live tick — the forming bar updated or a new bar appended. |
 | `viewport:changed` | `{ from, to }` (epoch-ms) | The visible time range moved (pan/zoom/fit) — fires per applied change, not debounced. The seam viewport-sync links between charts build on. |
+| `theme:changed` | the resolved theme object | The app theme changed — `setTheme(...)` or the in-chart settings dialog (Canvas → Theme). Host chrome around the chart (toolbars, panels, page shells) re-skins from the payload. Plot-only cosmetic edits (a `layout.background` set through the config) do **not** fire it. |
 | `alert` | engine alert | A script raised an alert. |
 | `warning` | engine warning | A script raised a warning. |
 

--- a/docs/user/options.md
+++ b/docs/user/options.md
@@ -115,6 +115,16 @@ const midnight = {
 new Vela('#chart', { data: bars, theme: midnight });
 ```
 
+The theme can also be swapped at runtime — `chart.setTheme('light')` (or a full theme
+object) re-skins the chart live and emits `theme:changed` so your surrounding UI can
+follow; users reach the same switch in chart settings → Canvas → Theme. The built-in
+dark and light themes share the same candle colors, so switching never recolors the
+series. Setting only a background color through the settings dialog (or `applyConfig`)
+keeps the app theme: when that background lands in the other luminance class (a white
+plot on the dark theme), the derived inks — text, grid, axis border — re-base
+automatically so legends and axis labels stay readable, while any explicitly chosen
+text color wins.
+
 ### Capability-gated options
 
 Some options only take effect when the active backend supports them. **`glow` is WebGL2-only** — it is silently ignored on the canvas2d backend. If you force `nativeBackend: 'canvas2d'`, glow has no effect.

--- a/docs/user/widget.md
+++ b/docs/user/widget.md
@@ -217,6 +217,14 @@ their factories, manifest indicators re-added) only at construction. `widget.cha
 still points at the **current** inner chart — prefer reading it at the point of use
 rather than caching it long-term.
 
+## Theming
+
+The `theme` option (`'dark'`, `'light'`, or a full theme object) skins the whole widget —
+chart, topbar, menus, panels. Swap it at runtime with `widget.setTheme(...)`: the chart
+re-skins live and the widget chrome follows, no rebuild. Users reach the same switch in
+chart settings → Canvas → Theme. The built-in themes share the same candle colors, so
+switching never recolors the series.
+
 ## Customization
 
 Three levels, shallow to deep:

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -60,6 +60,7 @@ ws.cell('eth');          // a specific cell BY IDENTITY — the durable handle t
 ws.cells();              // every live cell, in slot order
 ws.setActiveCell('sol');
 ws.setLayout('8');       // cells diff BY IDENTITY; identities past the new size pool their state
+ws.setTheme('light');    // re-skins the shared chrome + EVERY cell live (also reachable from any cell's chart settings → Canvas → Theme)
 ws.on('cell:active' | 'layout:changed' | 'cell:created' | 'cell:destroyed' | 'state:changed', cb);
 ```
 

--- a/playground/widget.ts
+++ b/playground/widget.ts
@@ -74,6 +74,12 @@ const widget = new VelaWidget('#chart', {
 
 void widget.chart.ready().then(() => console.log('[vela-dev] chart ready'));
 
+// The page shell follows the app theme — flip it from chart settings → Canvas → Theme
+// (or `widget.setTheme('light')` in the console) and the body around the chart follows.
+widget.chart.on('theme:changed', (t) => {
+    document.body.style.background = t.background;
+});
+
 // Handy for poking around from the browser console.
 (window as unknown as { widget: VelaWidget }).widget = widget;
 

--- a/playground/workspace.ts
+++ b/playground/workspace.ts
@@ -76,6 +76,15 @@ const ws = new VelaWorkspace('#workspace', {
     //                                 //  (browser WebGL-context budget; glow unavailable there)
 });
 
+// The page shell follows the app theme — flip it from any cell's chart settings →
+// Canvas → Theme (or `__ws.setTheme('light')` in the console); every LIVE cell relays
+// the change, and cells minted by later layout switches are wired as they appear.
+const syncShellTheme = (t: { background: string }): void => {
+    document.body.style.background = t.background;
+};
+for (const cell of ws.cells()) cell.chart.on('theme:changed', syncShellTheme);
+ws.on('cell:created', ({ id }) => ws.cell(id)?.chart.on('theme:changed', syncShellTheme));
+
 // Handy for poking around from the browser console (and for the automated probes).
 (window as unknown as { __ws: VelaWorkspace }).__ws = ws;
 

--- a/src/Vela.ts
+++ b/src/Vela.ts
@@ -2,7 +2,7 @@ import type { IChartRenderer, VisibleRange } from './core/ports/IChartRenderer';
 import type { ScriptingEngine } from './core/ports/ScriptingEngine';
 import type { MarketDataFeed } from './core/ports/MarketDataFeed';
 import type { VisibleRangePreset } from './core/visible-range';
-import type { VelaOptions, MarketSwitch, MarketSnapshot, AddIndicatorOptions } from './core/options';
+import type { VelaOptions, VelaTheme, ThemeName, MarketSwitch, MarketSnapshot, AddIndicatorOptions } from './core/options';
 import type { InputValue } from './core/model/inputs';
 import type { IndicatorHandle } from './core/IndicatorHandle';
 import type { EngineContextSnapshot } from './core/ports/ScriptingEngine';
@@ -406,6 +406,19 @@ export class Vela {
 
     resize(): void {
         this.orchestrator.resize();
+    }
+
+    /**
+     * Swap the app theme at runtime — `'dark'`, `'light'`, or a full custom
+     * {@link VelaTheme}. Re-skins the chart surface, axes, legends and in-chart chrome
+     * live (no indicator re-run, no rebuild) and emits `theme:changed` with the resolved
+     * theme so host chrome around the chart can follow. Explicitly customized plot
+     * cosmetics (a config-set background or series color) are re-based only when they
+     * were inherited from the previous theme.
+     */
+    setTheme(theme: ThemeName | VelaTheme): this {
+        this.orchestrator.setTheme(resolveTheme(theme));
+        return this;
     }
 
     destroy(): void {

--- a/src/core/drawings/types/CalloutBase.ts
+++ b/src/core/drawings/types/CalloutBase.ts
@@ -18,7 +18,9 @@ export abstract class CalloutBase extends Drawing {
     constructor(init: Partial<SerializedDrawing> & { paneId: string }) {
         super(init);
         // `defaultLabel()` dispatches to the subclass (a prototype method, available during super()).
-        if (!this.text) this.text = { ...defaultText(this.defaultLabel()), color: '#ffffff' };
+        // No color seed: the interactive creation path fixes a theme-contrast ink on the
+        // fresh drawing; until then the painter auto-contrasts (`undefined` semantics).
+        if (!this.text) this.text = defaultText(this.defaultLabel());
     }
 
     /** The placeholder text seeded for a fresh annotation. */

--- a/src/core/drawings/types/Note.ts
+++ b/src/core/drawings/types/Note.ts
@@ -10,7 +10,9 @@ export class Note extends PinnedLabel {
 
     constructor(init: Partial<SerializedDrawing> & { paneId: string }) {
         super(init);
-        if (!this.text) this.text = { ...defaultText('Note'), color: '#ffffff' };
+        // No color seed: the interactive creation path fixes a theme-contrast ink on the
+        // fresh drawing; until then the painter auto-contrasts (`undefined` semantics).
+        if (!this.text) this.text = defaultText('Note');
     }
 
     protected override defaultLabel(): string {

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -29,6 +29,7 @@ import { timeframeToMs } from '../../data/timeframe';
 import { parseSymbol } from '../../data/ProviderRegistry';
 import { barTransformFor, parseExtendedTicker, type BarTransform } from '../price-styles/BarTransform';
 import { chartType, type SeriesDataEngine } from '../../chart-types/registry';
+import { resolveTheme } from '../theme';
 
 export interface ResolvedConfig {
     market: MarketConfig;
@@ -184,6 +185,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         this.renderer.onChartTypeSettingsChange?.((typeId, values) => this.typeEngines.get(typeId)?.onSettings?.(values));
         // The renderer's legend "Move to" menu / row drag reports a move here → route it.
         this.renderer.onMoveIndicator?.((id, target) => this.moveIndicator(id, target));
+        // The renderer's in-chart theme control (settings dialog Canvas → Theme) reports a
+        // request here — the core owns the canonical theme, applies it, and announces it.
+        this.renderer.onThemeSelect?.((name) => this.setTheme(resolveTheme(name)));
         // Pan/zoom → re-run ONLY visible-range-dependent scripts (e.g. visible-range
         // volume profile) with the new window. Debounced so a drag re-runs once.
         this.viewportUnsub = this.renderer.onViewportChange((range) => this.onViewportChange(range));
@@ -1193,6 +1197,20 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
 
     resize(): void {
         this.renderer.resize();
+    }
+
+    /**
+     * Swap the app theme live: re-skins the renderer (surfaces, axes, legends, in-chart
+     * chrome) and emits `theme:changed` so host chrome around the chart follows. No-ops
+     * when the resolved theme is already active — which also breaks the echo when a host
+     * reacts to `theme:changed` by calling back into `setTheme`.
+     */
+    setTheme(theme: VelaTheme): void {
+        const cur = this.config.theme;
+        if ((Object.keys(theme) as Array<keyof VelaTheme>).every((k) => theme[k] === cur[k])) return;
+        this.config.theme = theme;
+        this.renderer.setTheme(theme);
+        this.events.emit('theme:changed', theme);
     }
 
     /** The current visible time range (left/right bar times), or null before data loads. */

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -1,6 +1,7 @@
 import type { EngineAlert, EngineWarning } from '../ports/ScriptingEngine';
 import type { ScriptRun } from '../script-run';
 import type { OHLCV } from '../model/ohlcv';
+import type { VelaTheme } from '../options';
 import type { DrawingTypeKey } from '../drawings/Drawing';
 import type { SnapMode } from '../drawings/geometry';
 import type { DrawingMode } from '../drawings/port';
@@ -44,6 +45,14 @@ export interface VelaEventMap extends Record<string, unknown> {
     'indicator:visibility': { id: string; visible: boolean };
     /** A pane's layout changed: order, collapse/maximize, creation or removal. */
     'pane:changed': undefined;
+    /**
+     * The app theme changed — `chart.setTheme(...)` or the in-chart settings dialog's
+     * Canvas → Theme row. Payload is the RESOLVED theme; host chrome around the chart
+     * (toolbars, panels, page shells) re-skins from it. Not fired for plot-only
+     * cosmetic edits (`layout.background` through the config), which deliberately
+     * leave the app theme alone.
+     */
+    'theme:changed': VelaTheme;
     /** A study pane was reordered one slot (`dir`) — carries enough to invert for undo/redo. */
     'pane:moved': { paneId: string; dir: 'up' | 'down' };
     /** A user drawing was created (interactively or via `chart.drawings.add`). */

--- a/src/core/palette.ts
+++ b/src/core/palette.ts
@@ -58,9 +58,6 @@ export const CROSSHAIR = '#9aa0ad';
 export const SLATE_DEEP = '#1e293b';
 export const SLATE = '#475569';
 
-/** Pane separator line on the dark chrome. */
-export const SEPARATOR = '#2e2e2e';
-
 /** Strategy trade markers — entry arrows per position side, and the exits' shared violet.
  *  The entry pair deliberately reuses the accent blue / bearish red (the reference palette
  *  of order-fill marks); the violet keeps exits apart from both directions. */

--- a/src/core/ports/IChartRenderer.ts
+++ b/src/core/ports/IChartRenderer.ts
@@ -4,7 +4,7 @@ import type { IndicatorModel } from '../model/indicator';
 import type { ScenePatch } from '../model/patch';
 import type { InputValue, SymbolPickerFn } from '../model/inputs';
 import type { Millis } from '../model/time';
-import type { VelaTheme, MoveTarget, PriceStyle } from '../options';
+import type { VelaTheme, ThemeName, MoveTarget, PriceStyle } from '../options';
 import type { Unsubscribe } from '../util/types';
 import type { IDrawingsRendererPort } from '../drawings/port';
 
@@ -347,6 +347,15 @@ export interface IChartRenderer {
      * with `applyConfig`.
      */
     onConfigChanged?(cb: () => void): Unsubscribe;
+
+    /**
+     * The renderer reports a user request to switch the APP THEME, made from its own
+     * in-chart UI (the settings dialog's Canvas → Theme row). The core owns the
+     * canonical theme: it resolves the name, calls {@link setTheme}, and emits
+     * `theme:changed` so host chrome follows. Optional — a renderer without an
+     * in-chart theme control omits it.
+     */
+    onThemeSelect?(cb: (theme: ThemeName) => void): Unsubscribe;
 
     /**
      * Move keyboard focus onto the chart's interactive surface (the element its keyboard

--- a/src/core/theme.ts
+++ b/src/core/theme.ts
@@ -16,10 +16,14 @@ export const DARK_THEME: VelaTheme = {
 export const LIGHT_THEME: VelaTheme = {
     background: '#ffffff',
     textColor: '#1e293b',
-    gridColor: '#e2e8f0',
-    borderColor: '#cbd5e1',
-    upColor: '#26a69a',
-    downColor: '#ef5350',
+    // Soft chrome on white: grid is a neutral wash; pane separator / axis border
+    // (they inherit `borderColor`) sit a step darker so stacked panes stay distinct.
+    gridColor: '#cccccc',
+    borderColor: '#d4dae3',
+    // Candle hues are shared across themes: switching themes recolors surfaces and
+    // text, never the series (a green candle stays the same green on white).
+    upColor: BULLISH,
+    downColor: BEARISH,
     fontFamily: 'sans-serif',
 };
 

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -23,7 +23,7 @@ import type { Pane } from '../../core/model/scene';
 import type { IndicatorModel } from '../../core/model/indicator';
 import type { ScenePatch } from '../../core/model/patch';
 import type { InputValue, SymbolPickerFn } from '../../core/model/inputs';
-import type { RendererDisplayOptions, NativeBackend, PriceStyle, MoveTarget } from '../../core/options';
+import type { RendererDisplayOptions, NativeBackend, PriceStyle, MoveTarget, ThemeName } from '../../core/options';
 import type { Unsubscribe } from '../../core/util/types';
 import { isLineLikeSeries } from '../../core/model/series';
 import { InputsUI } from '../shared/InputsUI';
@@ -54,7 +54,7 @@ import { computePaneScale, expandScaleByPixels } from './core/autoscale';
 import { mergeTradeMarkersState, tradesPriceHints, type TradeMarkerHints } from '../shared/trade-markers';
 import { rescaleAround, shiftScale } from './core/manualScale';
 import { resizeSplit, type PaneSplit } from './core/paneResize';
-import { type ChartConfig, CHART_CONFIG_VERSION, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, CHROME_BORDER_COLOR, withAlpha, priceStyleIds, basePaintingOf } from './core/chartConfig';
+import { type ChartConfig, CHART_CONFIG_VERSION, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf } from './core/chartConfig';
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
 import { rendererLayers, type RendererLayerDefinition, type RendererLayerInstance } from './layers';
 import { applyAttributionMarkTheme, attributionMarkColor, createAttributionMark, createCustomMark } from './chrome/AttributionMark';
@@ -265,6 +265,8 @@ export class NativeRenderer implements IChartRenderer {
     private readonly crosshairCbs = new Set<(e: CrosshairEvent) => void>();
     private readonly chartTypeSettingsCbs = new Set<(typeId: string, values: Record<string, unknown>) => void>();
     private readonly configChangedCbs = new Set<() => void>();
+    /** The settings dialog's Canvas → Theme row raises the pick here; the host applies it. */
+    private readonly themeSelectCbs = new Set<(theme: ThemeName) => void>();
     /** First-run config snapshot — what "Reset defaults" restores. */
     private factoryConfig: ChartConfig | null = null;
     private hostSettingsSections: HostSettingsSection[] = [];
@@ -703,12 +705,35 @@ export class NativeRenderer implements IChartRenderer {
         // owned by the app theme (mount/setTheme) alone, so background edits — whether typed
         // live in the settings dialog or replayed from a persisted config — recolor only the
         // plot and never bleed into the chrome.
-        // layout → theme (mutate our copy; mount/setTheme own the canonical one)
-        this.theme = { ...this.theme, background: next.layout.background, textColor: next.layout.textColor, fontFamily: next.layout.fontFamily };
+        // layout → theme (mutate our copy; mount/setTheme own the canonical one).
+        // A background edit that lands the plot in the OTHER luminance class (a dark theme
+        // with a white background typed into the settings dialog) would leave the derived
+        // inks unreadable — light-gray legends and axis text on white. When the resulting
+        // text/background pair falls in the SAME luminance class and the patch itself did
+        // not choose a text color, re-base the derived inks (text/grid/border) from the
+        // built-in theme of the new class. An explicit `layout.textColor` in the same
+        // patch always wins (this also keeps full persisted configs, which serialize every
+        // value, byte-exact on restore).
+        const layoutPatch = config && typeof config === 'object' ? (config as { layout?: unknown }).layout : undefined;
+        const patchTextColor = layoutPatch && typeof layoutPatch === 'object' ? (layoutPatch as { textColor?: unknown }).textColor : undefined;
+        const explicitTextColor = typeof patchTextColor === 'string' && patchTextColor.trim().length > 0;
+        const prevTheme = this.theme;
+        let inks = { textColor: next.layout.textColor, gridColor: prevTheme.gridColor, borderColor: prevTheme.borderColor };
+        if (!explicitTextColor && isDarkColor(next.layout.textColor) === isDarkColor(next.layout.background)) {
+            const rebase = isDarkColor(next.layout.background) ? DARK_THEME : LIGHT_THEME;
+            inks = { textColor: rebase.textColor, gridColor: rebase.gridColor, borderColor: rebase.borderColor };
+        }
+        this.theme = { ...this.theme, background: next.layout.background, textColor: inks.textColor, gridColor: inks.gridColor, borderColor: inks.borderColor, fontFamily: next.layout.fontFamily };
         s.fontSize = next.layout.fontSize;
+        // `mergeConfig` runs over the RESOLVED getConfig(), so a live "inherit the theme"
+        // sentinel (null) comes back as its concrete value even when the patch never named
+        // the field. Writing that back would pin the old theme's color forever; keep the
+        // sentinel whenever the merged value is just the resolved echo of it.
+        const keepInherit = (cur: string | null, merged: string, resolved: string): string | null =>
+            cur === null && merged === resolved ? null : merged;
         // grid
-        s.gridVert = { visible: next.grid.vertLines.visible, color: next.grid.vertLines.color };
-        s.gridHorz = { visible: next.grid.horzLines.visible, color: next.grid.horzLines.color };
+        s.gridVert = { visible: next.grid.vertLines.visible, color: keepInherit(s.gridVert.color, next.grid.vertLines.color, prevTheme.gridColor) };
+        s.gridHorz = { visible: next.grid.horzLines.visible, color: keepInherit(s.gridHorz.color, next.grid.horzLines.color, prevTheme.gridColor) };
         // crosshair
         s.crosshair = {
             color: next.crosshair.color,
@@ -721,14 +746,14 @@ export class NativeRenderer implements IChartRenderer {
         this.scene.scaleMode = next.priceScale.mode;
         this.scene.logScale = next.priceScale.log;
         this.scene.invertScale = next.priceScale.invert;
-        s.borderColor = next.priceScale.borderColor;
+        s.borderColor = keepInherit(s.borderColor, next.priceScale.borderColor, prevTheme.borderColor);
         this.scene.showAxisLabels = next.priceScale.labelsVisible;
         this.scene.showPriceLine = next.priceScale.currentPriceLine;
         this.scene.showPriceLabel = next.priceScale.priceLabel;
         this.scene.showCountdown = next.priceScale.countdown;
         this.syncCountdownTimer();
         // panes
-        s.separatorColor = next.panes.separatorColor;
+        s.separatorColor = keepInherit(s.separatorColor, next.panes.separatorColor, prevTheme.borderColor);
         // trade markers
         this.scene.tradeMarkers = {
             visible: next.trades.visible,
@@ -868,6 +893,16 @@ export class NativeRenderer implements IChartRenderer {
         this.toggleSettingsDialog(section);
     }
 
+    /** (Re)aim the dialog's Canvas → Theme row: the current selection reflects the STABLE
+     *  app-theme surface (not the plot background, which the config recolors
+     *  independently); a pick is raised to the host (`onThemeSelect`), which owns the
+     *  canonical theme. */
+    private syncThemeControl(): void {
+        this.settingsDialog?.setThemeControl(isDarkColor(this.surfaceBackground) ? 'dark' : 'light', (name) => {
+            for (const cb of this.themeSelectCbs) cb(name);
+        });
+    }
+
     private toggleSettingsDialog(section?: string): void {
         if (!this.settingsDialog) return;
         // A caller asking for a section wants to SEE it: an open dialog switches tabs
@@ -878,6 +913,7 @@ export class NativeRenderer implements IChartRenderer {
         }
         this.settingsDialog.setTheme(this.theme);
         this.settingsDialog.setHostSections(this.hostSettingsSections);
+        this.syncThemeControl();
         this.settingsDialog.toggle(
             this.getConfig(),
             (patch) => this.applyConfig(patch),
@@ -1415,6 +1451,10 @@ export class NativeRenderer implements IChartRenderer {
         this.applyBackground();
         this.inputsUI.setTheme(theme);
         this.paneControls?.setTheme(this.theme);
+        // An open dialog rebuilds on setTheme — hand it the re-based config + the new
+        // current of its Theme row first, so the rebuilt controls show live values.
+        this.settingsDialog?.refreshConfig(this.getConfig());
+        this.syncThemeControl();
         this.settingsDialog?.setTheme(this.theme);
         if (this.settingsButton) {
             this.settingsButton.style.background = this.theme.background;
@@ -1893,6 +1933,11 @@ export class NativeRenderer implements IChartRenderer {
     onConfigChanged(cb: () => void): Unsubscribe {
         this.configChangedCbs.add(cb);
         return () => this.configChangedCbs.delete(cb);
+    }
+
+    onThemeSelect(cb: (theme: ThemeName) => void): Unsubscribe {
+        this.themeSelectCbs.add(cb);
+        return () => this.themeSelectCbs.delete(cb);
     }
 
     onCrosshairMove(cb: (e: CrosshairEvent) => void): Unsubscribe {

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -1,11 +1,11 @@
-import type { VelaTheme } from '../../../core/options';
+import type { VelaTheme, ThemeName } from '../../../core/options';
 import type { ChartConfig } from '../core/chartConfig';
 import { chartType, chartTypes } from '../../../chart-types/registry';
 import { toHex6, withAlpha } from '../../../core/color';
 import { iconAt } from '../../../core/icons';
 import { TIMEZONES, tzMenuLabel, normalizeTimezone } from '../../../core/timezones';
 import { colorField, closeColorPopover } from './ColorField';
-import { priceStyleIds, CHROME_BORDER_COLOR } from '../core/chartConfig';
+import { priceStyleIds } from '../core/chartConfig';
 
 /** A nested partial of `ChartConfig` — what a single control edit emits. */
 type ConfigPatch = Record<string, unknown>;
@@ -111,6 +111,10 @@ export class SettingsDialog {
     private config: ChartConfig | null = null;
     private syncTypeTabs: ((style: string) => void) | null = null;
     private hostSections: HostSettingsSection[] = [];
+    /** The Canvas → Theme row: current app theme + where a pick is raised. The row is a
+     *  host callback, NOT a config patch — the app theme stays out of the persisted
+     *  `ChartConfig`, so exported templates never carry it. */
+    private themeControl: { current: ThemeName; onSelect: (name: ThemeName) => void } | null = null;
     /** The built tabs, by title — how `showSection` reaches a pane while the dialog is open. */
     private tabs: Array<{ title: string; show: () => void }> = [];
     /** The tab currently shown, so a theme change (which rebuilds) lands back on it. */
@@ -119,6 +123,18 @@ export class SettingsDialog {
     /** Host-app sections (e.g. the widget's Status line tab) — re-shown on next open. */
     setHostSections(sections: HostSettingsSection[]): void {
         this.hostSections = sections;
+    }
+
+    /** Configure the Canvas → Theme row (see {@link themeControl}); null hides the row. */
+    setThemeControl(current: ThemeName, onSelect: (name: ThemeName) => void): void {
+        this.themeControl = { current, onSelect };
+    }
+
+    /** Refresh the stored config snapshot — a theme swap re-bases layout values while the
+     *  dialog is open, and the rebuilt controls must show the live ones, not the open-time
+     *  snapshot. */
+    refreshConfig(config: ChartConfig): void {
+        if (this.config) this.config = config;
     }
 
     constructor(
@@ -361,6 +377,11 @@ export class SettingsDialog {
         body.append(this.toggleRow('Horizontal', config.grid.horzLines.visible, (v) => this.emit({ grid: { horzLines: { visible: v } } }), [
             this.swatch(config.grid.horzLines.color, (v) => this.emit({ grid: { horzLines: { color: v } } })),
         ]));
+        if (this.themeControl) {
+            const tc = this.themeControl;
+            body.append(this.sectionTitle('Theme'));
+            body.append(this.selectRow('Color theme', tc.current === 'dark' ? 'Dark' : 'Light', ['Dark', 'Light'], (v) => tc.onSelect(v === 'Dark' ? 'dark' : 'light')));
+        }
 
         // ══ CHART-TYPE SDK SECTIONS — each registered type's declarative settings tab.
         //    visibility 'active' (default) shows the tab only while the style is active;

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -1,8 +1,7 @@
 import type { LineStyle } from '../../../core/model/series';
 import { chartTypes } from '../../../chart-types/registry';
 import { withAlpha } from '../../../core/color';
-import { BEARISH, BULLISH, CROSSHAIR, SEPARATOR, SERIES_LINE, SLATE } from '../../../core/palette';
-import { DARK_THEME } from '../../../core/theme';
+import { BEARISH, BULLISH, CROSSHAIR, SERIES_LINE, SLATE } from '../../../core/palette';
 import type { PriceStyle } from '../../../core/options';
 import type { ScaleMode } from './SceneGraph';
 
@@ -38,11 +37,6 @@ export const BASELINE_BOTTOM_LINE = BEARISH;
 export const BASELINE_FILL_ALPHA = 0.25;
 export const BASELINE_FILL_ALPHA_FAR = 0.05;
 export const BASELINE_LEVEL_DEFAULT = 50;
-
-/** Chrome divider fallback for chrome built before a theme is applied — the dark theme's
- *  border. Live chrome reads `--vela-border` instead (see the UI token layer). */
-export const CHROME_BORDER_COLOR = DARK_THEME.borderColor;
-
 
 export { withAlpha } from '../../../core/color';
 
@@ -153,8 +147,8 @@ export function defaultChartStyle(): ChartStyle {
         fontSize: 11,
         gridVert: { visible: true, color: null },
         gridHorz: { visible: true, color: null },
-        borderColor: CHROME_BORDER_COLOR,
-        separatorColor: SEPARATOR,
+        borderColor: null,
+        separatorColor: null,
         crosshair: { color: CROSSHAIR, width: 1, style: 'dashed', opacity: 0.4, labelBackground: SLATE },
         candle: {
             bodyVisible: true,

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -1,7 +1,7 @@
 import type { Drawing, Projector, DrawingStyle } from '../../../core/drawings';
 import { SegmentDrawing, FibRatios, RadialFib, FibSpiral, GannSquare, GANN_SQUARE_ARCS, DedekindTessellation, MachFigure, MeasureBox, PositionTool, PatternDrawing, CalloutBase, Callout, Comment, PriceNote, Signpost, Note, PriceLabel, ArrowMark, GlyphStamp, RegressionChannel, AnchoredVwap, FixedRangeVolumeProfile, lineSegmentIntersection, effectiveFillColor, VALID_FILL, INVALID_FILL, DEFAULT_DRAWING_COLOR } from '../../../core/drawings';
 import type { VelaTheme } from '../../../core/options';
-import { dashPattern, extendEndpoints, namedFontSize, labelLineHeight, TEXT_FRAME_INSET, TEXT_FRAME_RISE } from '../../shared/drawing-geometry';
+import { contrastColor, dashPattern, extendEndpoints, namedFontSize, labelLineHeight, TEXT_FRAME_INSET, TEXT_FRAME_RISE } from '../../shared/drawing-geometry';
 import { BEARISH, BULLISH, NEUTRAL, SLATE, SLATE_DEEP } from '../../../core/palette';
 import { withAlpha } from '../../../core/color';
 import { valueDecimals } from '../chrome/ticks';
@@ -913,7 +913,9 @@ export class DrawingPainter {
         ctx.stroke();
         ctx.setLineDash([]);
 
-        ctx.fillStyle = text?.color ?? theme.textColor;
+        // No explicit ink ⇒ auto-contrast against the plate the text actually sits on
+        // (the safety net for documents that predate the creation-time ink fixation).
+        ctx.fillStyle = text?.color ?? contrastColor(effectiveFillColor(d, theme) ?? theme.background);
         ctx.textBaseline = 'top';
         ctx.textAlign = 'left';
         lines.forEach((line, i) => ctx.fillText(line, x + padX, y + padY + i * lh));
@@ -931,7 +933,7 @@ export class DrawingPainter {
         roundRect(ctx, x, y, w, h, 5);
         ctx.stroke();
         ctx.setLineDash([]);
-        ctx.fillStyle = d.text?.color ?? theme.textColor;
+        ctx.fillStyle = d.text?.color ?? contrastColor(effectiveFillColor(d, theme) ?? theme.background);
         ctx.textBaseline = 'top';
         ctx.textAlign = 'left';
         lines.forEach((line, i) => ctx.fillText(line, x + padX, y + padY + i * lh));
@@ -993,7 +995,7 @@ export class DrawingPainter {
         roundRect(ctx, x, y, w, h, 5);
         ctx.stroke();
         ctx.setLineDash([]);
-        ctx.fillStyle = text?.color ?? '#ffffff';
+        ctx.fillStyle = text?.color ?? contrastColor(effectiveFillColor(d, theme) ?? theme.background);
         ctx.textBaseline = 'middle';
         ctx.textAlign = 'center';
         ctx.fillText(priceStr, cx, cy + 0.5);
@@ -1054,7 +1056,7 @@ export class DrawingPainter {
         roundRect(ctx, ax + ptr, y, w, h, 4);
         ctx.stroke();
         ctx.setLineDash([]);
-        ctx.fillStyle = text?.color ?? '#ffffff';
+        ctx.fillStyle = text?.color ?? contrastColor(fill);
         ctx.textBaseline = 'middle';
         ctx.textAlign = 'left';
         ctx.fillText(priceStr, ax + ptr + padX, ay + 0.5);

--- a/src/renderers/native/drawings/DrawingToolbar.ts
+++ b/src/renderers/native/drawings/DrawingToolbar.ts
@@ -4,7 +4,6 @@ import type { ToolbarDefinition, ToolGroup, ToolSection } from '../../../core/dr
 import { icon } from '../../../core/icons';
 import { applyChromeTokens } from '../../shared/theme-tokens';
 import { attachChromeTooltip } from '../../shared/chrome-tooltip';
-import { CHROME_BORDER_COLOR } from '../core/chartConfig';
 
 /** Expanded bar width in px — a docked host's left-gutter reservation must match it. */
 export const TOOLBAR_WIDTH = 44;
@@ -13,7 +12,7 @@ export const TOOLBAR_COLLAPSED_WIDTH = 16;
 
 /** Cosmetic/placement options — defaults reproduce the in-renderer docked bar exactly. */
 export interface DrawingToolbarOptions {
-    /** Border/divider color. Default: the chrome divider color. */
+    /** Border/divider color. Default: the theme's border color (follows theme swaps). */
     borderColor?: string;
     /** Bar width in px. In docked (`'absolute'`) use it MUST match the host renderer's
      *  left-gutter reservation ({@link TOOLBAR_WIDTH}, 44). Default 44. */
@@ -70,7 +69,8 @@ export class DrawingToolbar {
     /** Chrome-tooltip disposers — flushed whenever the cells are recreated (rebuild/destroy). */
     private tipDisposers: Array<() => void> = [];
 
-    private readonly borderColor: string;
+    /** Explicit border override from options; `null` follows the live theme's border. */
+    private readonly borderOverride: string | null;
     private readonly width: number;
     private readonly dock: 'absolute' | 'static';
     private readonly onCollapse: (collapsed: boolean) => void;
@@ -86,7 +86,7 @@ export class DrawingToolbar {
         private readonly onStayMode: (on: boolean) => void = () => {},
         options: DrawingToolbarOptions = {},
     ) {
-        this.borderColor = options.borderColor ?? CHROME_BORDER_COLOR;
+        this.borderOverride = options.borderColor ?? null;
         this.width = options.width ?? TOOLBAR_WIDTH;
         this.dock = options.dock ?? 'absolute';
         this.onCollapse = options.onCollapse ?? (() => {});
@@ -95,6 +95,12 @@ export class DrawingToolbar {
         this.root.className = 'vela-dtb';
         this.styleRoot();
         host.appendChild(this.root);
+    }
+
+    /** Live divider/border ink — the option override, else the current theme's border
+     *  (so a theme swap re-inks the bar without a rebuild option). */
+    private get borderColor(): string {
+        return this.borderOverride ?? this.theme.borderColor;
     }
 
     /** Flush vertical bar pinned to the left gutter (full height, right border, no card chrome).

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -13,7 +13,7 @@ import type {
 } from '../../../core/drawings';
 import { deserializeDrawing, resetDrawingSettings, Callout, TextLabel } from '../../../core/drawings';
 import type { Unsubscribe } from '../../../core/util/types';
-import { namedFontSize, labelLineHeight, TEXT_FRAME_INSET, TEXT_FRAME_RISE } from '../../shared/drawing-geometry';
+import { contrastColor, namedFontSize, labelLineHeight, TEXT_FRAME_INSET, TEXT_FRAME_RISE } from '../../shared/drawing-geometry';
 import { withAlpha } from '../core/chartConfig';
 import { blendOver, splitColor } from './colorPicker';
 import { DrawingPainter, handleIdsFor, type PaintTargets } from './DrawingPainter';
@@ -891,6 +891,13 @@ export class UserDrawingController implements IDrawingsRendererPort {
         // caret is already waiting. Works for both click + drag finalize — the core reassigns the id,
         // so we diff the drawing set around the create to find the new one.
         if (i.kind === 'create') {
+            // A fresh annotation FIXES its text ink at creation: max contrast against the
+            // live theme's plot background, stored on the drawing itself — so a later theme
+            // or background change never recolors what is already placed. A color the user
+            // chose (or a deserialized document carries) always passes through untouched.
+            if (i.doc.text && i.doc.text.color === undefined) {
+                i.doc.text = { ...i.doc.text, color: contrastColor(this.deps.theme().background) };
+            }
             const before = new Set(this.drawings.map((d) => d.id));
             this.intentCb?.(i);
             // Defer past the sync + the placing click (which would otherwise steal focus / dismiss

--- a/src/renderers/native/drawings/colorPicker.ts
+++ b/src/renderers/native/drawings/colorPicker.ts
@@ -1,7 +1,6 @@
 import type { VelaTheme } from '../../../core/options';
 import { DEFAULT_DRAWING_COLOR } from '../../../core/drawings';
 import { ACCENT, BEARISH, BULLISH, NEUTRAL, WARNING } from '../../../core/palette';
-import { CHROME_BORDER_COLOR } from '../core/chartConfig';
 
 /** Split a color into its `#RRGGBB` part + alpha 0..1 (handles `#RGB`, `#RRGGBB(AA)`, `rgba()`). */
 export function splitColor(color: string): { hex6: string; alpha: number } {

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -343,8 +343,10 @@ export class InputsUI {
         const bounds = this.paneBoundsOf ? this.paneBoundsOf(paneId) : { top: 0, height: Infinity };
         // A pane hidden by a maximize elsewhere collapses to ~0 height — hide its legend entirely
         // (a collapsed strip keeps a small height, so its title still shows). Titles switched
-        // off (the settings toggle) hide every pane's container the same way.
-        lg.style.display = bounds.height < 4 || !this.titlesVisible ? 'none' : '';
+        // off (the settings toggle) hide every pane's container the same way. Restore to 'flex'
+        // (the container's intended layout — set in its cssText), NOT '' which would revert it
+        // to block: block children stretch to the widest row, fusing the chips into one slab.
+        lg.style.display = bounds.height < 4 || !this.titlesVisible ? 'none' : 'flex';
         // A collapsed pane is a legend-only strip: show just its master indicator's row. Restore
         // hidden rows to 'flex' (their intended layout — set in the row's cssText), NOT '' which
         // would revert them to block and break the inline button row (hide/show, settings, …).
@@ -453,10 +455,10 @@ export class InputsUI {
         // hidden) — enough wash to keep the label legible when candles reach it, without a
         // solid block over the plot. Hovering/selecting fills the chip with the solid chart
         // background so the revealed outline and controls stay readable (see setRowHighlighted).
-        // No left padding: the title's left edge must share the statusline avatar's left
-        // edge (both sit at the legend column's left:10px). Right/vertical padding stay so
-        // the chip still clears the controls when the row opens.
-        el.style.cssText = `pointer-events:auto;display:flex;align-items:center;gap:6px;background:${this.idleRowFill()};border-radius:4px;padding:2px 7px 2px 0;color:${this.theme.textColor};user-select:none;-webkit-user-select:none;`;
+        // Symmetric 7px padding keeps the title clear of the hover outline on BOTH sides; the
+        // negative left margin cancels the left padding so the title's left edge still shares
+        // the statusline avatar's left edge (both sit at the legend column's left:10px).
+        el.style.cssText = `pointer-events:auto;display:flex;align-items:center;gap:6px;background:${this.idleRowFill()};border-radius:4px;padding:2px 7px;margin-left:-7px;color:${this.theme.textColor};user-select:none;-webkit-user-select:none;`;
         el.addEventListener('mouseenter', () => this.setRowHighlighted(id, true));
         el.addEventListener('mouseleave', () => { if (this.selectedId !== id) this.setRowHighlighted(id, false); });
         // Left-click the row (but not one of its control buttons) selects the indicator,

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -2,7 +2,7 @@
 // agnostic); views are thin vanilla projections over the design tokens. Adding a component
 // = the uniform skeleton `components/<name>/{controller,view,styles,index}.ts`.
 export { injectStyles, withAlpha } from './styles';
-export { applyThemeTokens, ensureUIHost } from './tokens';
+export { applyThemeTokens, applyPlotOverlayTokens, ensureUIHost } from './tokens';
 export { registerIcon, iconMarkup, iconEl, svg16, svg24 } from './icons';
 export { runMachine, nextUid, normalizeProps, spreadProps, type MachineHandle } from './zag';
 export { KeymapManager, type KeyBindingDescriptor, type ResolvedBinding, type KeymapOptions } from './keymap';

--- a/src/ui/tokens.ts
+++ b/src/ui/tokens.ts
@@ -33,6 +33,18 @@ export function applyThemeTokens(el: HTMLElement, t: VelaTheme): void {
     for (const key in tokens) el.style.setProperty(key, tokens[key]!);
 }
 
+/** Re-token a chart-overlay host (statusline, watermark, toast, context menu — chrome
+ *  floating OVER the plot) from the LIVE plot surface: a config edit can recolor the
+ *  plot background independently of the app theme (a white plot typed into settings on
+ *  the dark theme), and the overlay ink must stay readable either way. `config` is the
+ *  renderer's `getConfig()` snapshot; a missing/shapeless one falls back to the base
+ *  app theme. */
+export function applyPlotOverlayTokens(host: HTMLElement, base: VelaTheme, config: unknown): void {
+    const layout = (config as { layout?: { background?: string; textColor?: string } } | null)?.layout;
+    const t = layout?.background && layout.textColor ? { ...base, background: layout.background, textColor: layout.textColor } : base;
+    applyThemeTokens(host, t);
+}
+
 /** Mark an element as a kit host: static token sheet + the `.vela-ui` class. */
 export function ensureUIHost(el: HTMLElement, theme?: VelaTheme): void {
     injectStyles(STATIC_ID, STATIC_CSS, el.getRootNode() as Document | ShadowRoot);

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -11,7 +11,7 @@ import type { VelaOptions } from '../core/options';
 import { resolveTheme } from '../core/theme';
 import type { DataProvider } from '../core/ports/DataProvider';
 import type { ScriptingEngine } from '../core/ports/ScriptingEngine';
-import { ensureUIHost, injectStyles } from '../ui';
+import { applyPlotOverlayTokens, ensureUIHost, injectStyles } from '../ui';
 import { isEditableTarget, KeymapManager } from '../ui/keymap';
 import { Topbar } from './topbar';
 import { Statusline, statuslineInkOf } from './statusline';
@@ -696,6 +696,25 @@ export class VelaWidget {
         this.statusline.setDirectionColors(...statuslineInkOf(this.inner.renderer, this.priceStyle));
     }
 
+    /** The widget shell (topbar, panels) keeps the app theme; the chart host's tokens
+     *  re-derive from the LIVE plot surface (see {@link applyPlotOverlayTokens}). */
+    private syncPlotOverlayTokens(): void {
+        applyPlotOverlayTokens(this.chartHost, resolveTheme(this.opts.theme), this.inner?.renderer.getConfig() ?? null);
+    }
+
+    /**
+     * Swap the widget theme at runtime — `'dark'`, `'light'`, or a full custom theme.
+     * Applied LIVE: the inner chart re-skins through `Vela.setTheme` and its
+     * `theme:changed` event re-tokens the widget chrome (topbar, menus, panels) in
+     * place; the choice also persists into rebuilds. Same switch the user reaches from
+     * chart settings → Canvas → Theme.
+     */
+    setTheme(theme: NonNullable<VelaOptions['theme']>): void {
+        if (this.destroyed) return;
+        this.opts.theme = theme;
+        this.inner?.setTheme(theme);
+    }
+
     /** Applied LIVE (renderer feature) — no rebuild; persists across rebuilds. */
     setTimezone(zone: string): void {
         this.timezone = zone;
@@ -882,6 +901,15 @@ export class VelaWidget {
         // resting OHLC belongs to the old market, and an out-of-band switch (host code calling
         // chart.setMarket directly) must still update the chrome. The widget's own setters
         // already synced most of it — the guards make this a cheap no-op then.
+        // The app theme changed — `widget.setTheme(...)` or the chart's in-chart settings
+        // dialog (Canvas → Theme). The widget chrome is token-driven, so re-writing the
+        // tokens on the root re-skins topbar/menus/panels in place; the resolved theme is
+        // kept on the options so a later `rebuild()` reconstructs with it.
+        chart.on('theme:changed', (t) => {
+            this.opts.theme = t;
+            ensureUIHost(this.root, t);
+            this.syncPlotOverlayTokens();
+        });
         chart.on('market:changed', ({ symbol, timeframe }) => {
             this.refreshNativeCatalog();
             if (this.statusline) this.statusline.onChart(chart); // drop the old market's resting OHLC
@@ -944,7 +972,9 @@ export class VelaWidget {
                 this.setTimezone(normalizeTimezone(zone));
             }
             this.syncStatuslineColors(); // a settings edit may have recolored the active style
+            this.syncPlotOverlayTokens(); // a background edit may have flipped the plot's luminance
         });
+        this.syncPlotOverlayTokens();
         this.statusline?.onChart(chart);
         this.syncStatuslineColors();
         const advanced = {

--- a/src/widget/statusline.ts
+++ b/src/widget/statusline.ts
@@ -28,9 +28,19 @@ const CSS = `
     gap: var(--vela-space-2);
     color: var(--vela-fg);
     font-size: var(--vela-font-size-md);
-    pointer-events: none;
-    text-shadow: 0 1px 2px rgba(0,0,0,0.4);
+    /* Same chip treatment as the indicator legend rows (InputsUI): a translucent wash of
+     * the chart background when idle — enough to keep the readout legible when candles
+     * reach it — and the solid chart background on hover. Symmetric 7px padding with a
+     * compensating negative margin (mirroring the legend rows) keeps the avatar's left
+     * edge on the legend column's left edge (both at left:10px) while the chip itself
+     * extends 7px further left, so both columns' chips share the same left edge. */
+    pointer-events: auto;
+    background: color-mix(in srgb, var(--vela-bg) 60%, transparent);
+    border-radius: 4px;
+    padding: 2px 7px;
+    margin-left: -7px;
 }
+.vela-statusline:hover { background: var(--vela-bg); }
 .vela-statusline .vela-sl-avatar {
     width: 18px;
     height: 18px;
@@ -46,10 +56,7 @@ const CSS = `
 }
 .vela-statusline .vela-sl-symbol { font-weight: 600; font-size: var(--vela-font-size-lg); }
 .vela-statusline .vela-sl-meta { color: var(--vela-fg-muted); font-size: var(--vela-font-size-md); font-weight: 600; }
-/* Market status badge — icon-only 16px circle, label on hover (kit tooltip). The
- * statusline container is pointer-events:none; the badge opts back in so it can hover.
- * text-shadow is cleared: the statusline's readout halo inherits onto the SVG and
- * optically pulls the strokes off-center inside the disc. */
+/* Market status badge — icon-only 16px circle, label on hover (kit tooltip). */
 .vela-statusline .vela-sl-market {
     display: inline-grid;
     place-items: center;
@@ -59,8 +66,6 @@ const CSS = `
     flex: none;
     align-self: center;
     line-height: 0;
-    text-shadow: none;
-    pointer-events: auto;
     cursor: default;
 }
 .vela-statusline .vela-sl-market svg {

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -25,6 +25,7 @@ import { legendActionsProviderFor, resolveEngines, type WidgetContext } from '..
 import { prefixedSymbol, type CellState } from '../state/document';
 import { parseSymbol } from '../data/ProviderRegistry';
 import { normalizeTimezone } from '../core/timezones';
+import { applyPlotOverlayTokens } from '../ui';
 
 /** The seed/mutable market state of one cell (all optional — an empty cell parks).
  *  The SAME vocabulary as the widget's chart options: the workspace's top-level chart
@@ -153,6 +154,9 @@ export class ChartCell {
     activeRangeId: string | null = null;
 
     private inner: Vela | null;
+    /** The live app theme — seeded from deps, updated on `theme:changed` (the base the
+     *  plot-overlay tokens re-derive from). */
+    private appTheme: VelaTheme;
     private readonly statusline: Statusline | null;
     private readonly watermark: Watermark | null;
     private readonly contextMenu: ChartContextMenu;
@@ -185,6 +189,7 @@ export class ChartCell {
         seed: CellBoot,
         private readonly deps: CellDeps,
     ) {
+        this.appTheme = deps.theme;
         // The canonical symbol form: pre-prefix pooled/persisted states carried the venue
         // in `provider` beside a bare symbol — weld them back together once, at boot.
         const symbol = prefixedSymbol(seed);
@@ -250,7 +255,15 @@ export class ChartCell {
                 this.deps.setTimezone(normalizeTimezone(zone));
             }
             this.syncStatuslineColors(); // a settings edit may have recolored the active style
+            this.syncPlotOverlayTokens(); // a background edit may have flipped the plot's luminance
         });
+        // A live theme swap re-bases this cell's overlay tokens too (the workspace already
+        // re-skins the shared chrome).
+        this.inner.on('theme:changed', (t) => {
+            this.appTheme = t;
+            this.syncPlotOverlayTokens();
+        });
+        this.syncPlotOverlayTokens();
         // Pool restore: cosmetics + drawings round-trip (both validate untrusted input).
         if (seed.rendererConfig != null) this.inner.renderer.applyConfig(seed.rendererConfig);
         if (seed.drawings != null) this.inner.drawings.fromJSON(seed.drawings);
@@ -487,6 +500,12 @@ export class ChartCell {
     private syncStatuslineColors(): void {
         if (!this.statusline || !this.inner) return;
         this.statusline.setDirectionColors(...statuslineInkOf(this.inner.renderer, this.priceStyle));
+    }
+
+    /** The workspace shell keeps the app theme; the cell host's tokens re-derive from
+     *  the LIVE plot surface (see {@link applyPlotOverlayTokens}). */
+    private syncPlotOverlayTokens(): void {
+        applyPlotOverlayTokens(this.host, this.appTheme, this.inner?.renderer.getConfig() ?? null);
     }
 
     /**

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -35,7 +35,7 @@ import { toolShortcutHints } from '../widget/tool-shortcuts';
 import { legendActionsProviderFor, widgetAttachments } from '../widget/contributions';
 import { resolveIndicators, type IndicatorManifest, type ResolvedIndicator } from '../widget/indicators';
 import { DrawingToolbar } from '../renderers/native/drawings/DrawingToolbar';
-import { createAttributionMark, createCustomMark } from '../renderers/native/chrome/AttributionMark';
+import { applyAttributionMarkTheme, createAttributionMark, createCustomMark } from '../renderers/native/chrome/AttributionMark';
 import { rendererDefaults } from '../core/renderer-defaults';
 import { defaultToolbar, type DrawingTypeKey, type SnapMode } from '../core/drawings';
 import { timeframeToMs } from '../data/timeframe';
@@ -231,6 +231,8 @@ export class VelaWorkspace {
     private alerts: Array<{ cellId: string; symbol: string; title: string; message: string; time: number }> = [];
     private alertsMenu: Menu | null = null;
     private readonly attachmentDisposers = new Map<string, () => void>();
+    /** The single grid-wide attribution mark — re-inked on a live theme swap. */
+    private attributionMark: HTMLElement | null = null;
     private readonly onRootKeydown = (ev: KeyboardEvent): void => this.routeTyping(ev);
 
     constructor(container: HTMLElement | string, opts: VelaWorkspaceOptions = {}) {
@@ -379,6 +381,7 @@ export class VelaWorkspace {
                     : createAttributionMark(doc, background);
             Object.assign(mark.style, { left: '12px', bottom: `${TIME_AXIS_H + 10}px`, zIndex: '11' });
             this.gridEl.appendChild(mark);
+            this.attributionMark = mark; // kept so a live theme swap re-inks it
         }
 
         // ONE drawing toolbar for the whole grid: commands go to the ACTIVE cell's
@@ -649,6 +652,24 @@ export class VelaWorkspace {
         this.bottombar?.setTimezone(zone);
         for (const cell of this.cellsById.values()) cell.chart.renderer.set('timezone', zone);
         this.markStateDirty();
+    }
+
+    /**
+     * Swap the workspace theme at runtime — `'dark'`, `'light'`, or a full custom theme,
+     * applied to the shared chrome (topbar, panels, drawing toolbar) and EVERY cell.
+     * Also reached from any cell's chart settings → Canvas → Theme. The choice sticks:
+     * cells rebuilt by later layout switches reconstruct with it.
+     */
+    setTheme(theme: NonNullable<VelaWorkspaceOptions['theme']>): void {
+        if (this.destroyed) return;
+        const t = resolveTheme(theme);
+        this.opts.theme = theme;
+        ensureUIHost(this.root, t); // token re-write re-skins all token-driven chrome in place
+        this.drawToolbar?.setTheme(t);
+        if (this.attributionMark) applyAttributionMarkTheme(this.attributionMark, t.background);
+        // Each cell's own `setTheme` no-ops once the theme already matches, so the
+        // per-cell `theme:changed` echoes (see wireCell) terminate immediately.
+        for (const cell of this.cellsById.values()) cell.chart.setTheme(t);
     }
 
     // ── layout ──────────────────────────────────────────────────
@@ -957,6 +978,9 @@ export class VelaWorkspace {
         });
         // Viewport sync: every applied pan/zoom/fit propagates to the same-group cells.
         chart.on('viewport:changed', (range) => this.propagateViewport(cell.id, range));
+        // A theme picked in ONE cell (its settings dialog's Canvas → Theme) re-skins the
+        // WHOLE workspace — shared chrome plus every other cell.
+        chart.on('theme:changed', (t) => this.setTheme(t));
     }
 
     // ── sync links ──────────────────────────────────────────────

--- a/test/drawings-annotations.test.ts
+++ b/test/drawings-annotations.test.ts
@@ -47,6 +47,17 @@ describe('drawings/annotations (Wave 13)', () => {
         expect(mk('signpost', 2).text?.value).toBe('Signpost');
     });
 
+    it('seeds NO text color — the creation path fixes a theme-contrast ink instead', () => {
+        // A forced white seed would be invisible on a light plate; `undefined` lets the
+        // renderer fix the ink against the active theme (and auto-contrast until then).
+        for (const [t, n] of [['note', 1], ['pricenote', 2], ['comment', 2], ['pricelabel', 1], ['signpost', 2], ['callout', 2]] as const) {
+            expect(mk(t, n).text?.color).toBeUndefined();
+        }
+        // …while an explicit color (a deserialized document) passes through untouched.
+        const kept = createDrawing('note', { paneId: 'price', anchors: [{ time: 0, price: 1 }], text: { value: 'x', color: '#ffffff', size: 'normal', hAlign: 'left', vAlign: 'top' } })!;
+        expect(kept.text?.color).toBe('#ffffff');
+    });
+
     it('round-trips through serialize', () => {
         for (const [t, n] of [['note', 1], ['pricenote', 2], ['comment', 2], ['pricelabel', 1], ['signpost', 2]] as const) {
             const a = mk(t, n).serialize();

--- a/test/native-chart-config.test.ts
+++ b/test/native-chart-config.test.ts
@@ -104,8 +104,10 @@ describe('defaultChartStyle', () => {
         expect(s.fontSize).toBe(11);
         expect(s.gridVert).toEqual({ visible: true, color: null });
         expect(s.gridHorz).toEqual({ visible: true, color: null });
-        expect(s.borderColor).toBe('#2a2b30');
-        expect(s.separatorColor).toBe('#2e2e2e');
+        // Axis border + pane separator inherit the theme border, so a light theme
+        // resolves light chrome lines instead of the dark constants.
+        expect(s.borderColor).toBeNull();
+        expect(s.separatorColor).toBeNull();
         expect(s.crosshair).toEqual({ color: '#9aa0ad', width: 1, style: 'dashed', opacity: 0.4, labelBackground: '#475569' });
         expect(s.candle.borderVisible).toBe(false);
         expect(s.candle.wickVisible).toBe(true);
@@ -121,7 +123,7 @@ describe('NativeRenderer.getConfig — defaults resolve to concrete values', () 
         expect(cfg.grid.horzLines).toEqual({ visible: true, color: '#20222c' });
         expect(cfg.crosshair).toEqual({ color: '#9aa0ad', width: 1, style: 'dashed', opacity: 0.4, labelBackground: '#475569' });
         expect(cfg.priceScale).toEqual({ mode: 'price', log: false, invert: false, borderColor: '#2a2b30', labelsVisible: true, currentPriceLine: true, priceLabel: true, countdown: true });
-        expect(cfg.panes).toEqual({ separatorColor: '#2e2e2e' });
+        expect(cfg.panes).toEqual({ separatorColor: '#2a2b30' }); // inherits the theme border
         expect(cfg.timeScale).toEqual({ timezone: 'UTC' });
         expect(cfg.candles.upColor).toBe('#089981');
         expect(cfg.candles.downColor).toBe('#f23645');
@@ -197,6 +199,36 @@ describe('NativeRenderer.applyConfig — applies + syncs the live scene fields',
         r.applyConfig({ candles: { upColor: '#101010', downColor: '#202020' } });
         expect(r.readFeature('upColor')).toBe('#101010');
         expect(r.readFeature('downColor')).toBe('#202020');
+    });
+
+    it('re-bases the derived inks when the background flips luminance class', () => {
+        const r = new NativeRenderer();
+        // Dark theme + a white background typed alone (no textColor in the patch):
+        // the light-gray dark-theme text would be unreadable → light-theme inks apply.
+        r.applyConfig({ layout: { background: '#ffffff' } });
+        let cfg = r.getConfig();
+        expect(cfg.layout.background).toBe('#ffffff');
+        expect(cfg.layout.textColor).toBe('#1e293b'); // LIGHT_THEME ink
+        expect(cfg.grid.vertLines.color).toBe('#cccccc'); // grid inherits the re-based theme
+        expect(cfg.priceScale.borderColor).toBe('#d4dae3'); // axis border follows too
+        expect(cfg.panes.separatorColor).toBe('#d4dae3');
+        // …and flipping back to a dark background restores the dark inks.
+        r.applyConfig({ layout: { background: '#151619' } });
+        cfg = r.getConfig();
+        expect(cfg.layout.textColor).toBe('#b2b5be');
+        expect(cfg.grid.vertLines.color).toBe('#20222c');
+    });
+
+    it('an explicit textColor in the same patch wins over the ink re-base', () => {
+        const r = new NativeRenderer();
+        r.applyConfig({ layout: { background: '#ffffff', textColor: '#fafafa' } });
+        expect(r.getConfig().layout.textColor).toBe('#fafafa'); // user's choice, even if low-contrast
+    });
+
+    it('does not re-base inks for a same-class background edit', () => {
+        const r = new NativeRenderer();
+        r.applyConfig({ layout: { background: '#000000' } }); // still dark
+        expect(r.getConfig().layout.textColor).toBe('#b2b5be'); // untouched
     });
 
     it('restores the stacking keys — and pre-seeds an indicator that has not mounted yet', () => {

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -73,7 +73,8 @@ class FakeRenderer implements IChartRenderer {
     private removeCb: ((id: string) => void) | null = null;
 
     mount(_c: HTMLElement, _t: VelaTheme): void { this.mounted = true; }
-    setTheme(): void {}
+    themes: VelaTheme[] = [];
+    setTheme(t: VelaTheme): void { this.themes.push(t); }
     resize(): void {}
     readonly name = 'fake';
     readonly features: readonly string[] = [];
@@ -379,6 +380,25 @@ describe('EngineOrchestrator', () => {
         expect(renderer.mountedModels.length).toBe(beforeMounts + 1);
         expect(renderer.mountedModels[renderer.mountedModels.length - 1]?.id).toBe(ema.id);
         expect(renderer.removed).toHaveLength(0);
+    });
+
+    it('setTheme re-skins the renderer and emits theme:changed; a same-theme call no-ops', async () => {
+        const renderer = new FakeRenderer();
+        const chart = new Vela({} as unknown as HTMLElement, { live: false }, { renderer, engines: [], dataFeed: new MockDataFeed() });
+        await chart.ready();
+        const seen: string[] = [];
+        chart.on('theme:changed', (t) => seen.push(t.background));
+        chart.setTheme('light');
+        expect(renderer.themes.map((t) => t.background)).toEqual(['#ffffff']);
+        expect(seen).toEqual(['#ffffff']);
+        // Candle hues are shared across themes — a theme swap never recolors the series.
+        expect(renderer.themes[0]!.upColor).toBe(BULLISH);
+        expect(renderer.themes[0]!.downColor).toBe(BEARISH);
+        chart.setTheme('light'); // already active → no re-skin, no event (breaks host echo loops)
+        expect(renderer.themes).toHaveLength(1);
+        expect(seen).toHaveLength(1);
+        chart.setTheme('dark');
+        expect(seen).toHaveLength(2);
     });
 
     it('the in-chart legend ✕ removes the indicator (renderer teardown + stream stop + event)', async () => {


### PR DESCRIPTION
- Added white theme
- Improved adjustments when chart bgcolor becomes lighter/darker
- Minor changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad native-renderer and widget UI changes (theme, config merge, undo routing, legend/toolbar layout) affect everyday interaction but stay in presentation and input layers rather than data loading or scripting engines.
> 
> **Overview**
> **Ships a coherent light theme and live theme switching** via `chart.setTheme` / widget/workspace equivalents, chart settings → Canvas → Theme, and `theme:changed` for host shells. Built-in dark and light share candle colors; plot-only background edits re-base text/grid/border when the plot flips luminance without an explicit text color, while toolbar/scale chrome stays on the app theme.
> 
> **Renderer and host integration** adds `renderer.onConfigChanged`, optional `historyChords` (so widget unified undo can own Ctrl+Z/Y), read-only `baselinePrice`, `indicatorTitles`, and `--vela-toolbar-gutter` on the mount for overlays like the status line. Settings dialog gains a shared timezone catalog, a theme row, and layout/hover fixes.
> 
> **In-chart UX** includes collapsible drawing toolbar, chart-wide indicator legend fold, bottom-bar clock opening the zone picker, legend rows that follow background/theme, status-line readout ink tied to the active price style (including baseline split), bare ticker labels (no `venue:` prefix), and attribution anchored to the lowest open pane.
> 
> **Drawings** fix contrast for new text annotations at creation (existing placements unchanged) and drawing undo/redo behavior when mixed with indicator history; indicator removals from the legend enter undo history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a743b335b59f6b18c83c85b3b29aa3948b60c23e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->