### PR TITLE
Feat: Multi charts improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,8 @@ All notable changes to Vela, newest first.
   type far wider than itself, spilling the text across its neighbors. The mark now measures
   itself against its own chart and shrinks to fit — a lone full-size chart keeps the large
   type, a dense grid gets proportionally smaller marks, and dragging a divider refits them
-  live.
+  live. The mark also fits and centers on the plot itself rather than the full chart, so in
+  a narrow cell the text no longer runs under the price scale's numbers.
 - **Resizing no longer makes charts flash or shake.** Two resize bugs, most visible in a
   workspace: dragging a divider across a chart mid-animation (a live tick easing in, a zoom
   glide) could blank it for a frame on every move, because the resized canvases waited for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,27 @@ All notable changes to Vela, newest first.
   renderer now publishes its toolbar gutter as `--vela-toolbar-gutter` on the mount
   container and the status line anchors to it, keeping the two in one column in every
   shell and toolbar state.
+- **Workspace dividers stay between charts.** In a mixed layout — say three charts stacked
+  on the left beside two taller ones on the right — the divider between two stacked charts
+  used to run the full width of the grid, so hovering or dragging over a neighboring chart
+  could grab the divider instead of the chart under the pointer. A divider now covers only
+  the stretch where two charts actually meet. Its hover highlight also matches the pane
+  dividers inside a chart — the same soft band with a solid center line, in the theme's
+  text color — instead of the old blue accent strip.
+- **The symbol watermark stays inside its own chart.** The faded "SYMBOL · TF" mark was
+  sized against the browser window, so in a multi-chart workspace a small cell could get
+  type far wider than itself, spilling the text across its neighbors. The mark now measures
+  itself against its own chart and shrinks to fit — a lone full-size chart keeps the large
+  type, a dense grid gets proportionally smaller marks, and dragging a divider refits them
+  live.
+- **Resizing no longer makes charts flash or shake.** Two resize bugs, most visible in a
+  workspace: dragging a divider across a chart mid-animation (a live tick easing in, a zoom
+  glide) could blank it for a frame on every move, because the resized canvases waited for
+  the next animation frame to repaint — they now repaint immediately. And a resize or layout
+  change could leave a chart trembling rapidly (and burning a full animation loop in the
+  background) until it was clicked: the zoom limits move with the chart's width, and an
+  in-flight zoom or scroll animation whose destination fell outside the new limits kept
+  chasing it forever. The animation now settles on the nearest reachable point and stops.
 
 ## [v0.4.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Drawings sync across a workspace grid.** A new `drawings` sync kind
+  (`ws.sync.set('drawings', true)`, also a toggle on the shared drawing toolbar) links
+  drawings across same-group cells: a newly created drawing is copied onto the others
+  (anchors are time+price, so it lands at the same spot whatever each cell shows), and
+  the set stays linked — moving, restyling or deleting any member follows on its peers.
+  Placement mirrors **live**: while anchors are still being clicked, linked charts show
+  the in-progress shape as a reduced-opacity ghost. The link is session-scoped (a
+  reload leaves existing drawings independent) and persists like the other sync kinds.
+- **Plugin SDK: a draft seam on the drawings port.** `DrawingIntent` gains an optional
+  `draft` arm (placement progress, `null` at the end) surfaced as the `drawing:draft`
+  chart event, and `IDrawingsRendererPort` gains an optional `setExternalGhost(doc)` —
+  the drawings twin of `setExternalCrosshair`. Both are additive: a renderer that
+  implements neither keeps today's behavior (sync at completion, no remote preview).
+
 ## [v0.5.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ All notable changes to Vela, newest first.
   (anchors are time+price, so it lands at the same spot whatever each cell shows), and
   the set stays linked — moving, restyling or deleting any member follows on its peers.
   Placement mirrors **live**: while anchors are still being clicked, linked charts show
-  the in-progress shape as a reduced-opacity ghost. The link is session-scoped (a
-  reload leaves existing drawings independent) and persists like the other sync kinds.
+  the in-progress shape as a reduced-opacity ghost. Link membership is session-scoped
+  and survives a toggle-off (re-enabling resumes edit/delete for drawings paired
+  earlier; drawings created while off stay independent), and a reload leaves every
+  drawing unpaired again. The on/off setting persists like the other sync kinds.
 - **Plugin SDK: a draft seam on the drawings port.** `DrawingIntent` gains an optional
   `draft` arm (placement progress, `null` at the end) surfaced as the `drawing:draft`
   chart event, and `IDrawingsRendererPort` gains an optional `setExternalGhost(doc)` —

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -13,7 +13,7 @@ import { PineWorkerEngine } from '@luxalgo/vela-pinets'; // Vela ships no engine
 import { BinanceProvider } from 'vela/providers/binance';
 
 const ws = new VelaWorkspace('#app', {
-    layout: '4', // '1' | '2h' | '2v' | '4' | '8' | a registerLayout() id
+    layout: '4', // '1' | '2h' | '2v' | '4' | '8' | picker ids ('g3x2', 'p3-2') | a registerLayout() id
     // Chart options at the TOP LEVEL are every cell's DEFAULT — the same words the
     // widget (and the bare chart) use. `cells` overrides them per cell; a cell's NAME
     // is its durable identity, DECLARATION ORDER fills the layout's slots:
@@ -69,9 +69,31 @@ layout (`cell:destroyed`). Host code that tracks cells should **follow
 `cell:created`/`cell:destroyed`** rather than snapshot `ws.cells()` once: a later
 `setLayout` (or a restored document) mints cells that a one-time snapshot never sees.
 
-Layouts live in a registry (`registerLayout` from `vela/workspace`) — a plugin-added
-grid appears in the topbar's layout dropdown automatically. Splitters between cells
-resize the grid tracks (double-click a divider for an even split).
+Layouts live in a registry (`registerLayout` from `vela/workspace`), and the topbar's
+**layout dropdown** composes them on a 4×4 grid canvas, driven by an icon-only
+orientation switch (Grid / Columns / Rows — the last Columns/Rows choice sticks
+across reopen until you switch):
+
+- **Grid** — hover previews the full *columns × rows* rectangle from the top-left
+  (the table-insert idiom); a click applies it immediately. Rectangles matching a
+  classic preset (`1`, `2h`, `2v`, `4`, `8`) reuse it; anything else gets a
+  self-describing dynamic id (`g3x2` = 3 rows × 2 columns).
+- **Columns / Rows** — each click sets a **chart stack** along that orientation
+  (clicking a stack's exact end clears it), and **Apply** commits. Switching between
+  the two orientations keeps the painted pattern in place, re-reading it along the
+  other axis. Mixed stacks (say 3 charts in the first column, 2 in the second)
+  render as full-height columns via LCM row tracks; their ids are `p3-2`-style
+  (`r3-2` for row-based mixes).
+
+Both id families resolve without registration (persisted picks restore across boots).
+Plugin layouts the canvas cannot express (bespoke `areas`) list as labeled rows under
+the canvas, so `registerLayout` contributions keep appearing automatically. In code,
+the same compositions are `layoutForGrid(rows, cols)` / `layoutForColumns(counts)` /
+`layoutForRows(counts)` (all exported from `vela/workspace`), handed to
+`ws.setLayout(...)`.
+
+Splitters between cells resize the grid tracks (double-click a divider for an even
+split).
 
 ## Sync links
 
@@ -82,10 +104,14 @@ finer-timeframe cell clamps the window to its own minimum zoom).
 
 `crosshair` mirrors the pointer's TIME onto same-group cells as a **ghost crosshair**
 (a dimmed vertical line snapped to each follower's own bar, with its time chip);
-leaving the origin clears every ghost. It is also a **toggle in the topbar's layout
-dropdown** ("Sync crosshair"). The ghost needs the renderer's optional
+leaving the origin clears every ghost. The ghost needs the renderer's optional
 `setExternalCrosshair` seam — the native renderer has it; a custom renderer without it
 simply never shows one (enabling warns only when NO cell could).
+
+**Symbol**, **Interval** (timeframe) and **Crosshair** are also switches in the
+topbar's layout dropdown (its SYNC section). A switch reflects the simple all-cells
+form (`true`/off); flipping one overrides a host-set group record with plain on/off —
+group records stay an API-only shape.
 
 ```ts
 ws.sync.set('viewport', true); // aligns followers to the active cell, then follows pans
@@ -191,8 +217,9 @@ new VelaWorkspace('#app', { persist: 'main', storage: restStorage /* … */ });
 
 Notes: writes are fire-and-forget (the UI never blocks on storage); a remote adapter
 that must survive tab-close should use `navigator.sendBeacon` in its `set`. A saved
-state referencing a custom layout id restores only if that layout is registered
-(`registerLayout`) before `applyState` runs.
+state referencing a plugin layout id restores only if that layout is registered
+(`registerLayout`) before `applyState` runs; the layout picker's dynamic ids (`g3x2`,
+`p3-2`) are self-describing and always resolve.
 
 ## Options (summary)
 
@@ -230,7 +257,7 @@ silently reorder them).
 
 | Option | Default | What it does |
 | --- | --- | --- |
-| `layout` | `'4'` | Initial grid — preset id, `registerLayout()` id, or inline definition. |
+| `layout` | `'4'` | Initial grid — preset id, picker id (`g3x2`, `p3-2`), `registerLayout()` id, or inline definition. |
 | `cells` | — | Per-cell overrides, keyed by FREE-FORM name = the cell's durable identity; declaration order fills the layout's slots (see above). |
 | `sync` | off | Initial sync links (see above). |
 | `drawingToolbar` | `true` | The one shared drawing toolbar (acts on the active cell). |

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -70,20 +70,22 @@ layout (`cell:destroyed`). Host code that tracks cells should **follow
 `setLayout` (or a restored document) mints cells that a one-time snapshot never sees.
 
 Layouts live in a registry (`registerLayout` from `vela/workspace`), and the topbar's
-**layout dropdown** composes them on a 4×4 grid canvas, driven by an icon-only
-orientation switch (Grid / Columns / Rows — the last Columns/Rows choice sticks
-across reopen until you switch):
+**layout dropdown** offers two tabs:
 
-- **Grid** — hover previews the full *columns × rows* rectangle from the top-left
-  (the table-insert idiom); a click applies it immediately. Rectangles matching a
-  classic preset (`1`, `2h`, `2v`, `4`, `8`) reuse it; anything else gets a
-  self-describing dynamic id (`g3x2` = 3 rows × 2 columns).
-- **Columns / Rows** — each click sets a **chart stack** along that orientation
-  (clicking a stack's exact end clears it), and **Apply** commits. Switching between
-  the two orientations keeps the painted pattern in place, re-reading it along the
-  other axis. Mixed stacks (say 3 charts in the first column, 2 in the second)
-  render as full-height columns via LCM row tracks; their ids are `p3-2`-style
-  (`r3-2` for row-based mixes).
+- **Presets** — curated multi-chart splits as clickable pictogram tiles, the most
+  useful setups first (2 × 2 grid, 2 side by side, 2 stacked, 1 large + 2 small,
+  1 large + 3 small, 1 wide + 2 below, 1 wide + 3 below, 3 × 2 grid). The **⇄** tile
+  mirrors the asymmetric splits (large pane right/bottom instead of left/top). A
+  click applies the preset immediately. Mixed splits render as full-height columns
+  via LCM row tracks; their ids are `p1-2`-style (`r1-2` for row-based splits).
+- **Grid** — a 4×4 canvas with an icon-only mode trio. In *Grid* mode, hover
+  previews the full *columns × rows* rectangle from the top-left (the table-insert
+  idiom) and a click applies it immediately; rectangles matching a classic preset
+  (`1`, `2h`, `2v`, `4`, `8`) reuse it, anything else gets a self-describing dynamic
+  id (`g3x2` = 3 rows × 2 columns). In *Columns* / *Rows* mode, each click sets a
+  **chart stack** along that orientation (clicking a stack's exact end clears it)
+  and **Apply** commits — switching between the two keeps the painted pattern in
+  place, re-reading it along the other axis.
 
 Both id families resolve without registration (persisted picks restore across boots).
 Plugin layouts the canvas cannot express (bespoke `areas`) list as labeled rows under

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -87,10 +87,10 @@ split).
 
 ## Sync links
 
-Per kind — `viewport`, `symbol`, `timeframe`, `crosshair` — link every cell (`true`) or
-named groups keyed by cell IDENTITY (`{ btc: 'a', eth: 'a', sol: 'b' }`: only same-group
-cells follow each other). Cross-timeframe viewport groups align on the **right edge** (a
-finer-timeframe cell clamps the window to its own minimum zoom).
+Per kind — `viewport`, `symbol`, `timeframe`, `crosshair`, `drawings` — link every cell
+(`true`) or named groups keyed by cell IDENTITY (`{ btc: 'a', eth: 'a', sol: 'b' }`:
+only same-group cells follow each other). Cross-timeframe viewport groups align on the
+**right edge** (a finer-timeframe cell clamps the window to its own minimum zoom).
 
 `crosshair` mirrors the pointer's TIME onto same-group cells as a **ghost crosshair**
 (a dimmed vertical line snapped to each follower's own bar, with its time chip);
@@ -98,17 +98,29 @@ leaving the origin clears every ghost. The ghost needs the renderer's optional
 `setExternalCrosshair` seam — the native renderer has it; a custom renderer without it
 simply never shows one (enabling warns only when NO cell could).
 
+`drawings` copies each **newly created** drawing onto its same-group cells — the
+anchors are time+price, so the copy lands at the same spot whatever each follower
+shows — and keeps the set **linked**: moving/restyling/deleting any member follows on
+its peers (while the link stays on). Placement itself mirrors **live**: while you are
+still clicking anchors, the followers show the in-progress shape as a reduced-opacity
+ghost (the same seam as crosshair ghosts — a custom renderer without it simply syncs
+at completion). The link is session-scoped: after a reload, previously synced drawings
+are independent again, and turning the link on syncs nothing retroactively — only
+drawings created under it.
+
 **Symbol**, **Interval** (timeframe) and **Crosshair** are also switches in the
-topbar's layout dropdown (its SYNC section). A switch reflects the simple all-cells
-form (`true`/off); flipping one overrides a host-set group record with plain on/off —
-group records stay an API-only shape.
+topbar's layout dropdown (its SYNC section), and **Drawings** is a toggle on the
+shared drawing toolbar (the pen-with-panes icon under stay-in-drawing-mode). A
+switch reflects the simple all-cells form (`true`/off); flipping one overrides a
+host-set group record with plain on/off — group records stay an API-only shape.
 
 ```ts
 ws.sync.set('viewport', true); // aligns followers to the active cell, then follows pans
 ws.sync.set('symbol', { btc: 'watch', eth: 'watch' });
 ws.sync.set('crosshair', true); // hover any cell → ghost time-line on all the others
+ws.sync.set('drawings', true); // draw on any cell → the same drawing on all the others
 ws.sync.get('viewport'); // true
-ws.sync.state(); // { viewport: true, symbol: {...}, crosshair: true }
+ws.sync.state(); // { viewport: true, symbol: {...}, crosshair: true, drawings: true }
 ```
 
 ## Watching what the cells compute

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -13,7 +13,7 @@ import { PineWorkerEngine } from '@luxalgo/vela-pinets'; // Vela ships no engine
 import { BinanceProvider } from 'vela/providers/binance';
 
 const ws = new VelaWorkspace('#app', {
-    layout: '4', // '1' | '2h' | '2v' | '4' | '8' | picker ids ('g3x2', 'p3-2') | a registerLayout() id
+    layout: '4', // '1' | '2h' | '2v' | '4' | '8' | picker ids ('g3x2') | a registerLayout() id
     // Chart options at the TOP LEVEL are every cell's DEFAULT — the same words the
     // widget (and the bare chart) use. `cells` overrides them per cell; a cell's NAME
     // is its durable identity, DECLARATION ORDER fills the layout's slots:
@@ -70,29 +70,15 @@ layout (`cell:destroyed`). Host code that tracks cells should **follow
 `setLayout` (or a restored document) mints cells that a one-time snapshot never sees.
 
 Layouts live in a registry (`registerLayout` from `vela/workspace`), and the topbar's
-**layout dropdown** offers two tabs:
-
-- **Presets** — curated multi-chart splits as clickable pictogram tiles, the most
-  useful setups first (2 × 2 grid, 2 side by side, 2 stacked, 1 large + 2 small,
-  1 large + 3 small, 1 wide + 2 below, 1 wide + 3 below, 3 × 2 grid). The **⇄** tile
-  mirrors the asymmetric splits (large pane right/bottom instead of left/top). A
-  click applies the preset immediately. Mixed splits render as full-height columns
-  via LCM row tracks; their ids are `p1-2`-style (`r1-2` for row-based splits).
-- **Grid** — a 4×4 canvas with an icon-only mode trio. In *Grid* mode, hover
-  previews the full *columns × rows* rectangle from the top-left (the table-insert
-  idiom) and a click applies it immediately; rectangles matching a classic preset
-  (`1`, `2h`, `2v`, `4`, `8`) reuse it, anything else gets a self-describing dynamic
-  id (`g3x2` = 3 rows × 2 columns). In *Columns* / *Rows* mode, each click sets a
-  **chart stack** along that orientation (clicking a stack's exact end clears it)
-  and **Apply** commits — switching between the two keeps the painted pattern in
-  place, re-reading it along the other axis.
-
-Both id families resolve without registration (persisted picks restore across boots).
+**layout dropdown** composes them on a 4×4 grid canvas: hover previews the full
+*columns × rows* rectangle from the top-left (the table-insert idiom); a click
+applies it immediately. Rectangles matching a classic preset (`1`, `2h`, `2v`, `4`,
+`8`) reuse it; anything else gets a self-describing dynamic id (`g3x2` = 3 rows ×
+2 columns) that resolves without registration (persisted picks restore across boots).
 Plugin layouts the canvas cannot express (bespoke `areas`) list as labeled rows under
 the canvas, so `registerLayout` contributions keep appearing automatically. In code,
-the same compositions are `layoutForGrid(rows, cols)` / `layoutForColumns(counts)` /
-`layoutForRows(counts)` (all exported from `vela/workspace`), handed to
-`ws.setLayout(...)`.
+the same composition is `layoutForGrid(rows, cols)` (exported from `vela/workspace`),
+handed to `ws.setLayout(...)`.
 
 Splitters between cells resize the grid tracks (double-click a divider for an even
 split).
@@ -220,8 +206,8 @@ new VelaWorkspace('#app', { persist: 'main', storage: restStorage /* … */ });
 Notes: writes are fire-and-forget (the UI never blocks on storage); a remote adapter
 that must survive tab-close should use `navigator.sendBeacon` in its `set`. A saved
 state referencing a plugin layout id restores only if that layout is registered
-(`registerLayout`) before `applyState` runs; the layout picker's dynamic ids (`g3x2`,
-`p3-2`) are self-describing and always resolve.
+(`registerLayout`) before `applyState` runs; the layout picker's dynamic ids (`g3x2`)
+are self-describing and always resolve.
 
 ## Options (summary)
 
@@ -259,7 +245,7 @@ silently reorder them).
 
 | Option | Default | What it does |
 | --- | --- | --- |
-| `layout` | `'4'` | Initial grid — preset id, picker id (`g3x2`, `p3-2`), `registerLayout()` id, or inline definition. |
+| `layout` | `'4'` | Initial grid — preset id, picker id (`g3x2`), `registerLayout()` id, or inline definition. |
 | `cells` | — | Per-cell overrides, keyed by FREE-FORM name = the cell's durable identity; declaration order fills the layout's slots (see above). |
 | `sync` | off | Initial sync links (see above). |
 | `drawingToolbar` | `true` | The one shared drawing toolbar (acts on the active cell). |

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -60,6 +60,8 @@ ws.cell('eth');          // a specific cell BY IDENTITY — the durable handle t
 ws.cells();              // every live cell, in slot order
 ws.setActiveCell('sol');
 ws.setLayout('8');       // cells diff BY IDENTITY; identities past the new size pool their state
+// Shrinking never pools the ACTIVE chart: if its slot would leave the layout, it
+// moves into the last surviving slot instead (the other cells keep their order).
 ws.on('cell:active' | 'layout:changed' | 'cell:created' | 'cell:destroyed' | 'state:changed', cb);
 ```
 

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -104,9 +104,12 @@ shows — and keeps the set **linked**: moving/restyling/deleting any member fol
 its peers (while the link stays on). Placement itself mirrors **live**: while you are
 still clicking anchors, the followers show the in-progress shape as a reduced-opacity
 ghost (the same seam as crosshair ghosts — a custom renderer without it simply syncs
-at completion). The link is session-scoped: after a reload, previously synced drawings
-are independent again, and turning the link on syncs nothing retroactively — only
-drawings created under it.
+at completion). Link membership is session-scoped and survives a toggle-off: turning
+the link off freezes create/edit/delete propagation (and clears placement ghosts) but
+keeps the in-memory pairs, so re-enabling resumes edit/delete for drawings that were
+linked earlier in the session. Drawings created while the link was off stay
+independent — re-enabling never copies or pairs them. A reload (or `applyState`)
+drops the pairs, so previously synced drawings are independent again.
 
 **Symbol**, **Interval** (timeframe) and **Crosshair** are also switches in the
 topbar's layout dropdown (its SYNC section), and **Drawings** is a toggle on the

--- a/src/core/DrawingsControl.ts
+++ b/src/core/DrawingsControl.ts
@@ -88,6 +88,15 @@ export class DrawingsControl {
         return this;
     }
 
+    /** Display another chart's in-progress placement as a GHOST at reduced opacity
+     *  (`null` clears it) — how a multi-chart host mirrors `drawing:draft` onto linked
+     *  charts. Never a real drawing: no store entry, no selection, no persistence.
+     *  Silently inert on a renderer without the optional seam. */
+    setExternalGhost(doc: SerializedDrawing | null): this {
+        this.ctrl.setExternalGhost(doc);
+        return this;
+    }
+
     /** Create a drawing programmatically (no clicking). Returns it, or null if unsupported. */
     add(type: DrawingTypeKey, init: AddInit = {}): Drawing | null {
         if (!this.ok('add')) return null;

--- a/src/core/drawings/DrawingController.ts
+++ b/src/core/drawings/DrawingController.ts
@@ -170,6 +170,12 @@ export class DrawingController {
         this.port?.setToolbar(buildToolbar(option).definition);
     }
 
+    /** Display (or clear) another chart's in-progress placement as a ghost — silently
+     *  inert on a renderer without the optional `setExternalGhost` seam. */
+    setExternalGhost(doc: SerializedDrawing | null): void {
+        this.port?.setExternalGhost?.(doc);
+    }
+
     /** Push per-tool shortcut hints (pre-formatted display strings) to the toolbar flyouts. */
     setToolShortcuts(map: Readonly<Partial<Record<DrawingTypeKey, string>>>): void {
         this.port?.setToolShortcuts?.(map);
@@ -439,6 +445,11 @@ export class DrawingController {
         switch (i.kind) {
             case 'arm':
                 this.setTool(i.type); // toolbar click → core-authoritative tool state
+                break;
+            case 'draft':
+                // Placement progress — transient, no store mutation. Re-emitted so a
+                // multi-chart host can mirror the ghost on linked charts live.
+                this.events.emit('drawing:draft', { doc: i.doc });
                 break;
             case 'create': {
                 const before = this.store.serialize();

--- a/src/core/drawings/port.ts
+++ b/src/core/drawings/port.ts
@@ -19,6 +19,12 @@ export type DrawingMode = 'measure' | 'eraser' | null;
  */
 export type DrawingIntent =
     | { kind: 'arm'; type: DrawingTypeKey | null }
+    /** Placement in progress: the ghost's current shape after every anchor click and
+     *  cursor move; `null` when placement ends (finalized OR cancelled). No store
+     *  mutation — the core only re-emits it (`drawing:draft`) so a multi-chart host
+     *  can mirror the ghost live. Optional — a renderer that never emits it simply
+     *  syncs at completion. */
+    | { kind: 'draft'; doc: SerializedDrawing | null }
     | { kind: 'create'; doc: SerializedDrawing }
     | { kind: 'edit'; doc: SerializedDrawing }
     | { kind: 'edit-many'; docs: SerializedDrawing[] } // atomic multi-drag / multi-nudge (one undo entry)
@@ -81,6 +87,11 @@ export interface IDrawingsRendererPort {
     setMode?(mode: DrawingMode): void;
     /** Open a drawing's settings popup (selecting it too) — the programmatic twin of a click on it. */
     openSettings(id: string): void;
+    /** Display another chart's in-progress placement as a GHOST at reduced opacity
+     *  (`null` clears it) — the drawings-sync twin of `setExternalCrosshair`. Never a
+     *  store drawing: no selection, no hit-testing, no persistence. Optional — a
+     *  renderer without it simply never previews remote placements. */
+    setExternalGhost?(doc: SerializedDrawing | null): void;
     /**
      * The pane's SERIES stack in z terms, for renderers whose drawings share one draw-order
      * space with the series (`drawingDepth`): the extremes ("bring to front" beats `front`,

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -1,7 +1,7 @@
 import type { EngineAlert, EngineWarning } from '../ports/ScriptingEngine';
 import type { ScriptRun } from '../script-run';
 import type { OHLCV } from '../model/ohlcv';
-import type { DrawingTypeKey } from '../drawings/Drawing';
+import type { DrawingTypeKey, SerializedDrawing } from '../drawings/Drawing';
 import type { SnapMode } from '../drawings/geometry';
 import type { DrawingMode } from '../drawings/port';
 
@@ -48,6 +48,11 @@ export interface VelaEventMap extends Record<string, unknown> {
     'pane:moved': { paneId: string; dir: 'up' | 'down' };
     /** A user drawing was created (interactively or via `chart.drawings.add`). */
     'drawing:created': { id: string };
+    /** An interactive placement is in progress — the ghost's current shape after each
+     *  anchor click / cursor move, `null` when placement ends (finalized or
+     *  cancelled). Transient: nothing is in the store yet. Multi-chart hosts mirror
+     *  it on linked charts via `drawings.setExternalGhost`. */
+    'drawing:draft': { doc: SerializedDrawing | null };
     /** A user drawing's anchors/style/text changed. */
     'drawing:edited': { id: string };
     /** Selection changed (`id` is null when nothing is selected). */

--- a/src/core/icons.ts
+++ b/src/core/icons.ts
@@ -174,6 +174,11 @@ registerIcon(
     'pen-lock',
     svg24('<path d="M13.8 4.2a2.1 2.1 0 0 1 3 3L8.5 15.5l-3.5 1 1-3.5Z"/><rect x="13" y="14.5" width="8" height="6" rx="1.2"/><path d="M15 14.5v-1.6a2 2 0 0 1 4 0v1.6"/>'),
 );
+registerIcon(
+    'pen-sync',
+    // Pen + two stacked panes — drawing onto every linked chart at once.
+    svg24('<path d="M13.8 4.2a2.1 2.1 0 0 1 3 3L8.5 15.5l-3.5 1 1-3.5Z"/><rect x="12.5" y="13.5" width="6" height="4.8" rx="1"/><path d="M15.5 18.3v1a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2.8a1 1 0 0 0-1-1h-1"/>'),
+);
 registerIcon('brush', svg24('<path d="M9.5 12 17 4.5a2.12 2.12 0 0 1 3 3L12.5 15"/><path d="M7 14a3 3 0 0 0-3 3c0 1.3-1.2 1.5-1.5 2 .8.9 2 1.5 3.5 1.5a3.5 3.5 0 0 0 3.5-3.5 3 3 0 0 0-2.5-3Z"/>'));
 registerIcon(
     'bucket',

--- a/src/core/tokens.ts
+++ b/src/core/tokens.ts
@@ -67,6 +67,11 @@ export function themeTokens(t: VelaTheme): Record<string, string> {
         '--vela-hover-strong': wash(0.16),
         '--vela-focus': withAlpha(t.textColor, 0.5),
         '--vela-focus-soft': withAlpha(t.textColor, 0.12),
+        // Separator hover — the SAME wash the chart's pane separators paint on hover
+        // (soft full-thickness band + solid 2px center line), so DOM-drawn dividers
+        // (the workspace grid) and canvas-drawn ones read as one family.
+        '--vela-separator-hover-band': withAlpha(t.textColor, 0.1),
+        '--vela-separator-hover-line': withAlpha(t.textColor, 0.55),
         '--vela-scroll': withAlpha(t.textColor, 0.3),
         '--vela-accent': ACCENT,
         '--vela-accent-bright': ACCENT_BRIGHT,

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1123,7 +1123,7 @@ export class NativeRenderer implements IChartRenderer {
     // ── lifecycle ──
     mount(container: HTMLElement, theme: VelaTheme): void {
         this.mountContainer = container;
-        this.publishToolbarGutter();
+        this.publishGutters();
         this.theme = this.deriveTheme(theme);
         // provisional chrome surface (refined by the first applyConfig)
         this.surfaceBackground = theme.background;
@@ -1487,6 +1487,7 @@ export class NativeRenderer implements IChartRenderer {
         this.attributionEl?.remove();
         this.attributionEl = null;
         this.mountContainer?.style.removeProperty('--vela-toolbar-gutter');
+        this.mountContainer?.style.removeProperty('--vela-scale-gutter');
         this.mountContainer = null;
         this.wrapper?.remove();
     }
@@ -1691,6 +1692,7 @@ export class NativeRenderer implements IChartRenderer {
         const w = RIGHT_AXIS_W + AXIS_COL_W * this.maxOwnScaleColumns();
         if (w === this.rightAxisW) return false;
         this.rightAxisW = w;
+        this.publishGutters();
         if (this.coords.width > 0) this.syncSize();
         return true;
     }
@@ -3163,16 +3165,19 @@ export class NativeRenderer implements IChartRenderer {
     private setToolbarGutter(px: number): void {
         if (px === this.toolbarGutter) return;
         this.toolbarGutter = px;
-        this.publishToolbarGutter();
+        this.publishGutters();
         this.positionAttribution();
         this.syncSize();
     }
 
-    /** Publish the gutter on the mount container as `--vela-toolbar-gutter`, so host
-     *  overlays sharing that container (a status line, a custom legend) can anchor to
-     *  the plot's left edge without reaching into the renderer's DOM. */
-    private publishToolbarGutter(): void {
+    /** Publish the gutters on the mount container as `--vela-toolbar-gutter` (left,
+     *  drawings toolbar) and `--vela-scale-gutter` (right, the full price-scale width
+     *  incl. merged own-scale columns), so host overlays sharing that container (a
+     *  status line, a watermark, a custom legend) can anchor to the plot's edges
+     *  without reaching into the renderer's DOM. */
+    private publishGutters(): void {
         this.mountContainer?.style.setProperty('--vela-toolbar-gutter', `${this.toolbarGutter}px`);
+        this.mountContainer?.style.setProperty('--vela-scale-gutter', `${this.rightAxisW}px`);
     }
 
     /** The built-in mark, or the host's own when one is set. */

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -2063,7 +2063,15 @@ export class NativeRenderer implements IChartRenderer {
             }
         }
 
-        this.coords.setViewport(this.clampViewport(barSpacing, rightOffset));
+        const clamped = this.clampViewport(barSpacing, rightOffset);
+        // The clamp bounds depend on the chart WIDTH, so a resize (splitter drag, layout
+        // change) can strand a target outside the reachable range mid-ease. Snap a target
+        // the clamp rejected onto the bound it chose — otherwise the ease above re-arms
+        // forever: a permanent rAF loop emitting a viewport change every frame and
+        // jittering rightOffset through the zoom anchor until a pointerdown re-aligns it.
+        if (clamped.barSpacing !== barSpacing) this.targetBarSpacing = clamped.barSpacing;
+        if (this.scrollTargetRO != null && clamped.rightOffset !== rightOffset) this.scrollTargetRO = clamped.rightOffset;
+        this.coords.setViewport(clamped);
         this.computeScales(); // sets pane.scaleTarget (animator active → no snap)
         if (this.easeScales(dtMs)) active = true;
         if (this.easeLiveBar(dtMs)) active = true; // glide the forming bar toward the latest tick
@@ -3247,7 +3255,18 @@ export class NativeRenderer implements IChartRenderer {
             this.fitContent();
             this.didInitialFit = true;
         }
-        this.scheduler.flushNow(InvalidateLevel.Full);
+        if (this.animator.active) {
+            // The width/height assignments above just CLEARED every canvas, and renderFrame
+            // yields to the Animator while it runs — so a scheduler flush would paint
+            // nothing and the browser would present blank canvases until the animator's
+            // next rAF tick (a visible flash on every splitter/divider move of an
+            // animating chart, live-bar easing included). Paint synchronously instead.
+            this.computeScales();
+            this.paintData();
+            this.crosshairLayer.render(this.scene, this.coords, this.theme, this.hoverSeparatorY, this.externalCrossPx());
+        } else {
+            this.scheduler.flushNow(InvalidateLevel.Full);
+        }
     }
 
     private applyBackground(): void {

--- a/src/renderers/native/drawings/DrawingToolbar.ts
+++ b/src/renderers/native/drawings/DrawingToolbar.ts
@@ -24,6 +24,11 @@ export interface DrawingToolbarOptions {
     /** Collapse/expand notification — a docked host resizes its gutter reservation to
      *  {@link TOOLBAR_COLLAPSED_WIDTH} / the full width (a static bar reflows on its own). */
     onCollapse?: (collapsed: boolean) => void;
+    /** When given, a drawings-sync toggle renders below the stay button: enabled, every
+     *  NEWLY CREATED drawing is copied onto the other linked charts and the set stays
+     *  linked — edits and removals follow (a multi-chart host's concern — a
+     *  single-chart bar omits the callback and never shows it). */
+    onDrawingsSync?: (on: boolean) => void;
 }
 
 /**
@@ -63,6 +68,8 @@ export class DrawingToolbar {
     private eraserActive = false;
     private stayBtn: HTMLButtonElement | null = null;
     private stayActive = false;
+    private syncBtn: HTMLButtonElement | null = null;
+    private syncActive = false;
     private collapseBtn: HTMLButtonElement | null = null;
     private collapsed = false;
     private visible = false;
@@ -74,6 +81,7 @@ export class DrawingToolbar {
     private readonly width: number;
     private readonly dock: 'absolute' | 'static';
     private readonly onCollapse: (collapsed: boolean) => void;
+    private readonly onDrawingsSync: ((on: boolean) => void) | null;
 
     constructor(
         private readonly host: HTMLElement,
@@ -90,6 +98,7 @@ export class DrawingToolbar {
         this.width = options.width ?? TOOLBAR_WIDTH;
         this.dock = options.dock ?? 'absolute';
         this.onCollapse = options.onCollapse ?? (() => {});
+        this.onDrawingsSync = options.onDrawingsSync ?? null;
         ensureStyles();
         this.root = document.createElement('div');
         this.root.className = 'vela-dtb';
@@ -204,6 +213,11 @@ export class DrawingToolbar {
         this.root.appendChild(this.makeMagnetCell());
         this.stayBtn = this.makeButton(STAY_ICON, 'Stay in drawing mode', () => this.toggleStay());
         this.root.appendChild(this.stayBtn);
+        // Drawings-sync toggle — only a multi-chart host provides the callback.
+        if (this.onDrawingsSync) {
+            this.syncBtn = this.makeButton(SYNC_ICON, 'Sync drawings on all charts', () => this.toggleDrawingsSync());
+            this.root.appendChild(this.syncBtn);
+        }
         // Collapse/expand toggle — pinned to the bottom; the only child a collapsed strip shows.
         this.collapseBtn = this.makeButton(COLLAPSE_ICON, 'Collapse toolbar', () => this.toggleCollapsed());
         this.collapseBtn.classList.add('vela-dtb-collapse');
@@ -212,6 +226,7 @@ export class DrawingToolbar {
         this.paintEraser();
         this.paintMagnet();
         this.paintStay();
+        this.paintDrawingsSync();
         this.paintCollapse();
         this.highlight();
     }
@@ -393,6 +408,26 @@ export class DrawingToolbar {
         if (!b) return;
         b.dataset.active = this.stayActive ? '1' : '';
         b.style.opacity = this.stayActive ? '1' : '0.5';
+    }
+
+    /** Toggle drawings sync on/off and notify the host. */
+    private toggleDrawingsSync(): void {
+        this.syncActive = !this.syncActive;
+        this.onDrawingsSync?.(this.syncActive);
+        this.paintDrawingsSync();
+    }
+
+    /** Reflect drawings sync externally (e.g. set through the API) without notifying back. */
+    setDrawingsSyncMode(on: boolean): void {
+        this.syncActive = on;
+        this.paintDrawingsSync();
+    }
+
+    private paintDrawingsSync(): void {
+        const b = this.syncBtn;
+        if (!b) return;
+        b.dataset.active = this.syncActive ? '1' : '';
+        b.style.opacity = this.syncActive ? '1' : '0.5';
     }
 
     // ── flyout ──
@@ -695,6 +730,8 @@ const EXPAND_ICON = icon('chevrons-right');
 const MAGNET_ICON = icon('magnet');
 /** Pen with a padlock — stay-in-drawing-mode (tools remain armed after each placement). */
 const STAY_ICON = icon('pen-lock');
+/** Pen with stacked panes — sync new drawings onto every linked chart. */
+const SYNC_ICON = icon('pen-sync');
 const ERASER_ICON = icon('eraser');
 /** A right-pointing chevron for the group/magnet flyout arrow (beside the icon). */
 const ARROW_ICON = icon('chevron-right');

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -102,6 +102,10 @@ export class UserDrawingController implements IDrawingsRendererPort {
     private activeTool: DrawingTypeKey | null = null;
     private activeToolStyle: SerializedDrawing['style'] | undefined; // last-used style for the armed tool (seeds the placement ghost)
     private intentCb: ((i: DrawingIntent) => void) | null = null;
+    /** Another chart's in-progress placement, mirrored here as a ghost (drawings sync). */
+    private externalGhost: Drawing | null = null;
+    /** Last draft fingerprint reported upstream — gates the per-render emission to actual changes. */
+    private lastDraftKey: string | null = null;
     private readonly measure = new MeasureOverlay(); // transient ruler — not a persistent drawing
     private toolbarVisible = false; // mirrors showToolbar (drives the gutter reservation)
     private toolbarCollapsed = false; // the bar is a slim expand-strip (narrower gutter)
@@ -180,6 +184,12 @@ export class UserDrawingController implements IDrawingsRendererPort {
     /** The gutter follows the bar's current footprint: hidden 0, collapsed a slim strip, else full width. */
     private syncToolbarGutter(): void {
         this.deps.setToolbarGutter(this.toolbarVisible ? (this.toolbarCollapsed ? TOOLBAR_COLLAPSED_WIDTH : TOOLBAR_WIDTH) : 0);
+    }
+
+    /** Core push: mirror (or clear) another chart's in-progress placement as a ghost. */
+    setExternalGhost(doc: SerializedDrawing | null): void {
+        this.externalGhost = doc ? deserializeDrawing(doc) : null;
+        this.render();
     }
 
     syncDrawings(docs: readonly SerializedDrawing[]): void {
@@ -815,6 +825,11 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.layoutTextEditor();
         const ghost = this.interaction.ghost();
         if (ghost) this.painter.paintGhost(ctx, ghost, proj, this.deps.theme());
+        // A remote placement mirrored here (drawings sync) paints as the same ghost.
+        if (this.externalGhost) this.painter.paintGhost(ctx, this.externalGhost, proj, this.deps.theme());
+        // Every placing change re-renders (deps.changed), so this catches each anchor
+        // click, cursor move and cancel; the fingerprint gate drops the no-change frames.
+        this.emitDraft(ghost);
         // While placing, show control circles on the points clicked so far (so the user
         // sees where each anchor — e.g. a pitchfork's pivot — landed before it completes).
         const markers = this.interaction.placingMarkers(proj);
@@ -883,6 +898,18 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.emit({ kind: 'delete', ids: [id] });
             },
         }, () => this.clearSelection()); // dismiss-on-outside-click also clears the selection/highlight
+    }
+
+    /** Report placement progress upstream (`draft` intent) so the drawings sync can
+     *  mirror the ghost live on linked charts. Called from every render; only actual
+     *  shape changes emit, and the end of a placement emits one `null`. */
+    private emitDraft(ghost: Drawing | null): void {
+        const key = ghost
+            ? JSON.stringify({ t: ghost.type, p: ghost.paneId, a: ghost.anchors, s: ghost.style, x: ghost.text })
+            : null;
+        if (key === this.lastDraftKey) return;
+        this.lastDraftKey = key;
+        this.intentCb?.({ kind: 'draft', doc: ghost ? ghost.serialize() : null });
     }
 
     private emit(i: DrawingIntent): void {

--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -12,8 +12,11 @@
 
 /** The linkable dimensions. `crosshair` mirrors the pointer time onto same-group
  *  cells as GHOST crosshairs (renderers without the optional `setExternalCrosshair`
- *  seam simply never display one). */
-export type SyncKind = 'viewport' | 'symbol' | 'timeframe' | 'crosshair';
+ *  seam simply never display one). `drawings` copies each NEWLY CREATED drawing onto
+ *  same-group cells and keeps the set linked: edits and removals of any member
+ *  follow. The link itself is session-scoped — after a reload, existing drawings
+ *  are independent again (new ones link as usual). */
+export type SyncKind = 'viewport' | 'symbol' | 'timeframe' | 'crosshair' | 'drawings';
 
 /**
  * One link's configuration: `false`/absent = off; `true` = ALL cells linked (one
@@ -27,6 +30,7 @@ export interface SyncOptions {
     symbol?: SyncSetting;
     timeframe?: SyncSetting;
     crosshair?: SyncSetting;
+    drawings?: SyncSetting;
 }
 
 /** Splitter track weights along each grid axis. */
@@ -186,7 +190,7 @@ function sanitizeSync(raw: unknown): SyncOptions | null {
     if (raw == null || typeof raw !== 'object') return null;
     const s = raw as Record<string, unknown>;
     const out: SyncOptions = {};
-    for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair'] as const) {
+    for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair', 'drawings'] as const) {
         const v = s[kind];
         if (v === true) out[kind] = true;
         else if (v != null && typeof v === 'object') {

--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -14,8 +14,9 @@
  *  cells as GHOST crosshairs (renderers without the optional `setExternalCrosshair`
  *  seam simply never display one). `drawings` copies each NEWLY CREATED drawing onto
  *  same-group cells and keeps the set linked: edits and removals of any member
- *  follow. The link itself is session-scoped — after a reload, existing drawings
- *  are independent again (new ones link as usual). */
+ *  follow. Link membership is session-scoped and survives a toggle-off (re-enabling
+ *  resumes edit/delete for drawings paired earlier; drawings created while off stay
+ *  independent). After a reload, every drawing is unpaired again. */
 export type SyncKind = 'viewport' | 'symbol' | 'timeframe' | 'crosshair' | 'drawings';
 
 /**

--- a/src/widget/layout-picker.ts
+++ b/src/widget/layout-picker.ts
@@ -1,12 +1,12 @@
-// Layout picker — the topbar's LAYOUT dropdown. Instead of choosing from a fixed
-// preset list, the panel composes the layout on a bounded 4×4 grid canvas, driven by
-// ONE three-way switch:
-//   • Grid — hover previews the full rows×cols rectangle from the top-left (the
-//     table-insert idiom); a click applies it immediately.
-//   • Columns / Rows — each click sets a track's chart stack along that orientation
-//     (clicking a stack's exact end clears it); Apply commits. Switching between the
-//     two orientations keeps the painted pattern in place (its conjugate) instead of
-//     transposing it.
+// Layout picker — the topbar's LAYOUT dropdown, two tabs over one canvas column:
+//   • Presets — curated multi-chart splits as clickable pictogram tiles (1 large +
+//     2 small, 1 wide + 2 below, column/row stripes, …); the ⇄ tile mirrors the
+//     asymmetric splits. A click applies the preset immediately.
+//   • Grid — a bounded 4×4 canvas with an icon-only mode trio under it: Grid mode
+//     hover-previews the full rows×cols rectangle from the top-left (the
+//     table-insert idiom) and applies on click; Columns/Rows modes paint per-track
+//     chart stacks (click a stack's exact end to clear it) and commit via Apply.
+//     Switching Columns ↔ Rows keeps the painted pattern in place (its conjugate).
 // Registered layouts that are NOT expressible on the canvas (bespoke plugin presets)
 // list as labeled rows under it, and the workspace SYNC switches sit beside the grid.
 //
@@ -23,7 +23,7 @@ registerIcon('layout-grid', svg16('<rect x="1.5" y="1.5" width="5.5" height="5.5
 registerIcon('layout-columns', svg16('<rect x="1.5" y="1.5" width="5.5" height="13" rx="1"/><rect x="9" y="1.5" width="5.5" height="13" rx="1"/>'));
 registerIcon('layout-rows', svg16('<rect x="1.5" y="1.5" width="13" height="5.5" rx="1"/><rect x="1.5" y="9" width="13" height="5.5" rx="1"/>'));
 
-const STYLE_ID = 'vela-widget-layout-picker-v7';
+const STYLE_ID = 'vela-widget-layout-picker-v11';
 // One monochrome selection language across the panel: lit cells, the active
 // orientation segment, sync ON switches, and Apply all speak --vela-selected-*.
 const CSS = `
@@ -75,12 +75,51 @@ const CSS = `
 .vela-lp-badge:hover { color: var(--vela-fg-bright); border-color: var(--vela-fg-muted); }
 .vela-lp-tip { display: flex; flex-direction: column; gap: 4px; max-width: 230px; white-space: normal; }
 .vela-lp-vsep { width: 1px; flex: none; align-self: stretch; background: var(--vela-border-faint); }
-/* LAYOUT column sized to the canvas — caption stacks under it, not beside it. */
-.vela-lp-layout { width: 148px; display: flex; flex-direction: column; align-items: center; }
+/* Layout column sized to the preset tiles; the Grid canvas centers inside it. */
+.vela-lp-layout { width: 168px; display: flex; flex-direction: column; align-items: center; }
 .vela-lp-layout > .vela-lp-heading,
-.vela-lp-layout > .vela-lp-caption-row,
+.vela-lp-layout > .vela-lp-tabs-row,
+.vela-lp-layout > .vela-lp-tools,
 .vela-lp-layout > .vela-lp-presets { align-self: stretch; }
-.vela-lp-grid { display: grid; grid-template-columns: repeat(4, 24px); grid-auto-rows: 24px; gap: 4px; }
+/* Presets | Grid tabs with the "?" help badge to their right. */
+.vela-lp-tabs-row { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+.vela-lp-tabs { display: flex; flex: 1 1 auto; gap: 2px; padding: 2px; background: var(--vela-hover); border-radius: 6px; box-sizing: border-box; min-width: 0; }
+.vela-lp-tab {
+    all: unset;
+    flex: 1 1 0;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: var(--vela-font-size-md);
+    font-weight: 550;
+    color: var(--vela-fg-muted);
+    transition: color var(--vela-dur-fast) var(--vela-ease), background var(--vela-dur-fast) var(--vela-ease);
+}
+.vela-lp-tab:hover { color: var(--vela-fg-bright); }
+.vela-lp-tab[data-active='1'] { background: var(--vela-hover-strong); color: var(--vela-fg-bright); }
+/* Preset tiles: mini layout pictograms; the flip tile mirrors the asymmetric splits. */
+.vela-lp-tiles { display: grid; grid-template-columns: repeat(3, 52px); grid-auto-rows: 52px; gap: 6px; }
+.vela-lp-tile {
+    all: unset;
+    box-sizing: border-box;
+    position: relative;
+    border-radius: 6px;
+    background: var(--vela-hover);
+    border: 1px solid var(--vela-border-faint);
+    cursor: pointer;
+    transition: background var(--vela-dur-fast) var(--vela-ease), border-color var(--vela-dur-fast) var(--vela-ease), transform 120ms var(--vela-ease);
+}
+.vela-lp-tile:hover { background: var(--vela-hover-strong); border-color: var(--vela-border-strong); }
+.vela-lp-tile:active { transform: scale(0.96); }
+.vela-lp-tile[data-checked='1'] { border-color: var(--vela-fg-bright); box-shadow: 0 0 0 1px var(--vela-fg-bright); }
+.vela-lp-tile-canvas { position: absolute; inset: 6px; }
+.vela-lp-tile-pane { position: absolute; border-radius: 2px; background: var(--vela-fg-faint); transition: background var(--vela-dur-fast) var(--vela-ease); }
+.vela-lp-tile:hover .vela-lp-tile-pane { background: var(--vela-fg-muted); }
+.vela-lp-tile[data-checked='1'] .vela-lp-tile-pane { background: var(--vela-selected-bg); }
+.vela-lp-tile-flip { display: inline-flex; align-items: center; justify-content: center; font-size: 15px; color: var(--vela-fg-muted); }
+.vela-lp-tile-flip:hover { color: var(--vela-fg-bright); }
+.vela-lp-grid { display: grid; grid-template-columns: repeat(4, 24px); grid-auto-rows: 24px; gap: 4px; margin-top: 3px; }
 .vela-lp-sq {
     all: unset;
     box-sizing: border-box;
@@ -96,24 +135,12 @@ const CSS = `
     background: var(--vela-selected-bg);
     border-color: var(--vela-selected-bg);
 }
-/* Two-line caption left, icon-only orientation trio right. */
-.vela-lp-caption-row {
+/* Mode trio under the canvas (Grid tab only) — icon always, label only when active. */
+.vela-lp-tools {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 6px;
-    margin-top: 8px;
-}
-.vela-lp-caption {
-    display: flex;
-    flex-direction: column;
-    gap: 1px;
-    min-width: 0;
-    color: var(--vela-fg-muted);
-    font-size: var(--vela-font-size-sm);
-    line-height: 1.25;
-    letter-spacing: 0.3px;
-    font-variant-numeric: tabular-nums;
+    justify-content: center;
+    margin-top: 10px;
 }
 .vela-lp-presets { display: flex; flex-direction: column; gap: 2px; margin-top: 8px; }
 .vela-lp-preset { all: unset; padding: 5px 8px; border-radius: 4px; cursor: pointer; color: var(--vela-fg-muted); font-size: 12px; white-space: nowrap; transition: transform 120ms var(--vela-ease); }
@@ -148,24 +175,29 @@ const CSS = `
 }
 .vela-lp-switch.on { background: var(--vela-selected-bg); border-color: var(--vela-selected-bg); }
 .vela-lp-switch.on::after { transform: translateX(16px); background: var(--vela-selected-fg); }
-/* Icon-only orientation trio — pictograms are self-explanatory; tooltips name them. */
 .vela-lp-modes { display: inline-flex; flex: none; gap: 2px; padding: 2px; background: var(--vela-hover); border-radius: 6px; }
 .vela-lp-mode {
     all: unset;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 20px;
+    gap: 4px;
+    min-width: 24px;
+    height: 22px;
+    padding: 0 5px;
     border-radius: 4px;
     cursor: pointer;
+    font-size: var(--vela-font-size-sm);
+    font-weight: 550;
     color: var(--vela-fg-muted);
-    transition: color var(--vela-dur-fast) var(--vela-ease), background var(--vela-dur-fast) var(--vela-ease), transform 120ms var(--vela-ease);
+    transition: color var(--vela-dur-fast) var(--vela-ease), background var(--vela-dur-fast) var(--vela-ease), transform 120ms var(--vela-ease), padding 120ms var(--vela-ease);
 }
-.vela-lp-mode .vela-icon { font-size: 13px; width: 13px; height: 13px; }
+.vela-lp-mode .vela-icon { font-size: 13px; width: 13px; height: 13px; flex: none; }
+.vela-lp-mode .vela-lp-mode-label { display: none; }
 .vela-lp-mode:hover { color: var(--vela-fg-bright); }
 .vela-lp-mode:active { transform: scale(0.96); }
-.vela-lp-mode[data-active='1'] { background: var(--vela-selected-bg); color: var(--vela-selected-fg); }
+.vela-lp-mode[data-active='1'] { background: var(--vela-selected-bg); color: var(--vela-selected-fg); padding: 0 8px; }
+.vela-lp-mode[data-active='1'] .vela-lp-mode-label { display: inline; }
 /* Commit footer: full panel width, right-aligned. */
 .vela-lp-commit {
     display: flex;
@@ -209,6 +241,47 @@ export type LayoutPickerAxis = 'columns' | 'rows';
 /** The three-way switch: uniform grid, column stacks, or row stacks. */
 type PickerMode = 'grid' | LayoutPickerAxis;
 
+/** The two panel tabs. */
+type PickerTab = 'presets' | 'grid';
+
+/** A Presets-tab tile: a stack split committed through onSelectStacks. */
+interface TilePreset {
+    counts: readonly number[];
+    axis: LayoutPickerAxis;
+    label: string;
+    /** Label once the ⇄ tile has mirrored the split (counts reversed). */
+    flipLabel?: string;
+}
+
+/** Curated splits, the most useful multi-chart setups first. */
+const TILE_PRESETS: readonly TilePreset[] = [
+    { counts: [2, 2], axis: 'columns', label: '2 × 2 grid' },
+    { counts: [1, 1], axis: 'columns', label: '2 side by side' },
+    { counts: [1, 1], axis: 'rows', label: '2 stacked' },
+    { counts: [1, 2], axis: 'columns', label: '1 large + 2 small', flipLabel: '2 small + 1 large' },
+    { counts: [1, 3], axis: 'columns', label: '1 large + 3 small', flipLabel: '3 small + 1 large' },
+    { counts: [1, 2], axis: 'rows', label: '1 wide + 2 below', flipLabel: '2 above + 1 wide' },
+    { counts: [1, 3], axis: 'rows', label: '1 wide + 3 below', flipLabel: '3 above + 1 wide' },
+    { counts: [2, 2, 2], axis: 'columns', label: '3 × 2 grid' },
+];
+
+/** Canonical key for a stack split — uniform splits collapse to their grid key. */
+function stacksKey(counts: readonly number[], axis: LayoutPickerAxis): string {
+    if (counts.every((n) => n === counts[0])) {
+        const rows = axis === 'columns' ? counts[0] : counts.length;
+        const cols = axis === 'columns' ? counts.length : counts[0];
+        return `g${rows}x${cols}`;
+    }
+    return `${axis}:${counts.join('-')}`;
+}
+
+/** Canonical key for the current layout shape (null = not canvas-expressible). */
+function shapeKey(shape: LayoutPickerShape | null): string | null {
+    if (!shape) return null;
+    if ('rows' in shape) return `g${shape.rows}x${shape.cols}`;
+    return stacksKey(shape.counts, shape.axis);
+}
+
 /** The current layout's footprint on the canvas (mirrors the workspace's LayoutShape). */
 export type LayoutPickerShape = { rows: number; cols: number } | { counts: number[]; axis: LayoutPickerAxis };
 
@@ -236,17 +309,25 @@ export class LayoutPicker {
     private readonly doc: Document;
     private readonly layer: HTMLElement;
     private readonly squares: HTMLButtonElement[] = []; // row-major, 16 entries
-    private readonly caption: HTMLElement;
     private readonly infoTip: Tooltip;
     private readonly modeTips: Tooltip[] = [];
     private readonly modeBtns: Record<PickerMode, HTMLButtonElement>;
+    private readonly tabBtns: Record<PickerTab, HTMLButtonElement>;
+    private readonly tilesEl: HTMLElement;
+    private readonly canvasEl: HTMLElement;
+    private readonly modesEl: HTMLElement;
+    private readonly toolsEl: HTMLElement;
     private readonly presetsEl: HTMLElement;
     private readonly syncEl: HTMLElement;
     private readonly commitEl: HTMLElement;
     private readonly applyBtn: HTMLButtonElement;
 
     private isOpen = false;
-    /** The three-way switch state: 'grid' picks rectangles, the axes paint stacks. */
+    /** Active panel tab (sticky across close/reopen). */
+    private tab: PickerTab = 'presets';
+    /** ⇄ state: mirrors the asymmetric preset splits (large pane right/bottom). */
+    private flipped = false;
+    /** Three-way switch state: 'grid' picks rectangles, the axes paint stacks. */
     private mode: PickerMode = 'grid';
     /** Stack-mode stacks along the active axis (0 = empty track). */
     private counts: number[] = [0, 0, 0, 0];
@@ -279,23 +360,45 @@ export class LayoutPicker {
         cols.className = 'vela-lp-cols';
         panel.appendChild(cols);
 
-        // ── left column: the LAYOUT canvas ──
+        // ── left column: Presets | Grid tabs over the picker canvas ──
         const layoutCol = doc.createElement('div');
         layoutCol.className = 'vela-lp-layout';
-        const layoutHeading = doc.createElement('div');
-        layoutHeading.className = 'vela-lp-heading';
-        const headingText = doc.createElement('span');
-        headingText.textContent = 'Layout';
+        const tabsRow = doc.createElement('div');
+        tabsRow.className = 'vela-lp-tabs-row';
+        const tabs = doc.createElement('div');
+        tabs.className = 'vela-lp-tabs';
+        const tabBtn = (label: string, tab: PickerTab): HTMLButtonElement => {
+            const b = doc.createElement('button');
+            b.className = 'vela-lp-tab';
+            b.textContent = label;
+            b.addEventListener('click', () => {
+                if (this.tab === tab) return;
+                this.tab = tab;
+                this.hover = null;
+                this.infoTip.setContent(() => this.tipNode());
+                this.render();
+            });
+            tabs.appendChild(b);
+            return b;
+        };
+        this.tabBtns = { presets: tabBtn('Presets', 'presets'), grid: tabBtn('Grid', 'grid') };
+        tabsRow.appendChild(tabs);
         const badge = doc.createElement('span');
         badge.className = 'vela-lp-badge';
         badge.textContent = '?';
-        layoutHeading.append(headingText, badge);
-        layoutCol.appendChild(layoutHeading);
+        tabsRow.appendChild(badge);
         this.infoTip = new Tooltip(badge, {
             host: opts.host,
             placement: 'bottom',
             content: () => this.tipNode(),
         });
+        layoutCol.appendChild(tabsRow);
+
+        // Presets tab: curated split pictograms (built by buildTiles, rebuilt on ⇄).
+        this.tilesEl = doc.createElement('div');
+        this.tilesEl.className = 'vela-lp-tiles';
+        layoutCol.appendChild(this.tilesEl);
+        this.buildTiles();
 
         const grid = doc.createElement('div');
         grid.className = 'vela-lp-grid';
@@ -311,14 +414,10 @@ export class LayoutPicker {
             }
         }
         layoutCol.appendChild(grid);
+        this.canvasEl = grid;
 
-        // Caption + icon-only orientation trio on one row (pictograms name themselves;
-        // tooltips reassure on hover). No ORIENTATION heading — it belongs to Layout.
-        const captionRow = doc.createElement('div');
-        captionRow.className = 'vela-lp-caption-row';
-        this.caption = doc.createElement('div');
-        this.caption.className = 'vela-lp-caption';
-        captionRow.appendChild(this.caption);
+        // Grid-tab mode trio: rectangle pick (Grid) or composable per-track stacks
+        // (Columns/Rows). Icon always; label only on the active segment.
         const modes = doc.createElement('div');
         modes.className = 'vela-lp-modes';
         const modeBtn = (label: string, icon: string, mode: PickerMode): HTMLButtonElement => {
@@ -326,6 +425,10 @@ export class LayoutPicker {
             b.className = 'vela-lp-mode';
             b.setAttribute('aria-label', label);
             b.append(iconEl(icon, doc));
+            const text = doc.createElement('span');
+            text.className = 'vela-lp-mode-label';
+            text.textContent = label;
+            b.appendChild(text);
             b.addEventListener('click', () => this.setMode(mode));
             this.modeTips.push(new Tooltip(b, { host: opts.host, placement: 'bottom', content: label }));
             modes.appendChild(b);
@@ -336,8 +439,12 @@ export class LayoutPicker {
             columns: modeBtn('Columns', 'layout-columns', 'columns'),
             rows: modeBtn('Rows', 'layout-rows', 'rows'),
         };
-        captionRow.appendChild(modes);
-        layoutCol.appendChild(captionRow);
+        this.modesEl = modes;
+
+        this.toolsEl = doc.createElement('div');
+        this.toolsEl.className = 'vela-lp-tools';
+        this.toolsEl.appendChild(modes);
+        layoutCol.appendChild(this.toolsEl);
 
         this.presetsEl = doc.createElement('div');
         this.presetsEl.className = 'vela-lp-presets';
@@ -426,14 +533,28 @@ export class LayoutPicker {
     open(): void {
         if (this.isOpen) return;
         this.isOpen = true;
-        // Mode is sticky: Columns/Rows stay selected across close/reopen until the
-        // user switches. Only the canvas is re-seeded from the live layout shape.
+        // The canvas starts on the CURRENT layout: rectangle pick for grids, the
+        // matching stack mode for column/row splits.
         const shape = this.opts.shape();
+        this.mode = shape && 'counts' in shape ? shape.axis : 'grid';
         this.counts = this.seedCounts(shape);
-        if (this.mode !== 'grid' && shape && 'counts' in shape && shape.axis !== this.mode) {
-            this.counts = conjugate(this.counts);
-        }
         this.hover = null;
+        // Open on the tab that shows the CURRENT layout: Presets when a tile matches
+        // (following the ⇄ state the layout was made with), Grid for anything else
+        // the canvas can express; otherwise keep the last tab (sticky).
+        const key = shapeKey(shape);
+        const keysFor = (flipped: boolean) =>
+            TILE_PRESETS.map((def) => stacksKey(flipped ? [...def.counts].reverse() : [...def.counts], def.axis));
+        if (key && keysFor(this.flipped).includes(key)) {
+            this.tab = 'presets';
+        } else if (key && keysFor(!this.flipped).includes(key)) {
+            this.flipped = !this.flipped;
+            this.buildTiles();
+            this.tab = 'presets';
+        } else if (shape) {
+            this.tab = 'grid';
+        }
+        this.infoTip.setContent(() => this.tipNode());
         this.refresh();
         this.layer.style.display = '';
         this.position();
@@ -514,21 +635,79 @@ export class LayoutPicker {
         this.render();
     }
 
-    /** Mode-aware help copy for the LAYOUT "?" badge. */
+    /** Tab- and mode-aware help copy for the "?" badge. */
     private tipNode(): HTMLElement {
         const tip = this.doc.createElement('div');
         tip.className = 'vela-lp-tip';
         tip.textContent =
-            this.mode === 'grid'
-                ? 'Click a square to apply that columns × rows layout.'
-                : this.mode === 'columns'
-                  ? "Click squares to set each column's chart stack, then Apply."
-                  : "Click squares to set each row's chart stack, then Apply.";
+            this.tab !== 'grid'
+                ? 'Click a preset to apply it — ⇄ mirrors the split presets.'
+                : this.mode === 'grid'
+                  ? 'Click a square to apply that columns × rows layout.'
+                  : this.mode === 'columns'
+                    ? "Click squares to set each column's chart stack, then Apply."
+                    : "Click squares to set each row's chart stack, then Apply.";
         return tip;
     }
 
-    /** Project the interaction state onto the DOM (squares, caption, switch, Apply). */
+    /** (Re)build the preset tiles for the current ⇄ state. */
+    private buildTiles(): void {
+        const doc = this.doc;
+        this.tilesEl.replaceChildren();
+        for (const def of TILE_PRESETS) {
+            const counts = this.flipped ? [...def.counts].reverse() : [...def.counts];
+            const label = (this.flipped ? def.flipLabel : undefined) ?? def.label;
+            const tile = doc.createElement('button');
+            tile.className = 'vela-lp-tile';
+            tile.dataset.key = stacksKey(counts, def.axis);
+            tile.setAttribute('aria-label', label);
+            const canvas = doc.createElement('span');
+            canvas.className = 'vela-lp-tile-canvas';
+            for (let i = 0; i < counts.length; i += 1) {
+                const size = counts[i] ?? 0;
+                for (let j = 0; j < size; j += 1) {
+                    const pane = doc.createElement('span');
+                    pane.className = 'vela-lp-tile-pane';
+                    const [x, y, w, h] =
+                        def.axis === 'columns'
+                            ? [i / counts.length, j / size, 1 / counts.length, 1 / size]
+                            : [j / size, i / counts.length, 1 / size, 1 / counts.length];
+                    pane.style.left = `calc(${x * 100}% + 1px)`;
+                    pane.style.top = `calc(${y * 100}% + 1px)`;
+                    pane.style.width = `calc(${w * 100}% - 2px)`;
+                    pane.style.height = `calc(${h * 100}% - 2px)`;
+                    canvas.appendChild(pane);
+                }
+            }
+            tile.appendChild(canvas);
+            tile.addEventListener('click', () => {
+                this.close();
+                this.opts.onSelectStacks([...counts], def.axis);
+            });
+            this.tilesEl.appendChild(tile);
+        }
+        // ⇄ — mirror the asymmetric splits (large pane right/bottom instead of left/top).
+        const flip = doc.createElement('button');
+        flip.className = 'vela-lp-tile vela-lp-tile-flip';
+        flip.textContent = '⇄';
+        flip.setAttribute('aria-label', 'Mirror presets');
+        flip.addEventListener('click', () => {
+            this.flipped = !this.flipped;
+            this.buildTiles();
+            this.render();
+        });
+        this.tilesEl.appendChild(flip);
+    }
+
+    /** Project the interaction state onto the DOM (tabs, tiles, squares, mode). */
     private render(): void {
+        for (const [tab, btn] of Object.entries(this.tabBtns)) {
+            btn.dataset.active = this.tab === tab ? '1' : '';
+        }
+        this.tilesEl.style.display = this.tab === 'presets' ? '' : 'none';
+        this.canvasEl.style.display = this.tab === 'grid' ? '' : 'none';
+        this.toolsEl.style.display = this.tab === 'grid' ? '' : 'none';
+        this.modesEl.style.display = '';
         const preview = this.mode === 'grid' ? (this.hover ?? this.gridShape()) : null;
         for (const sq of this.squares) {
             const { r, c } = this.squarePos(sq);
@@ -544,35 +723,17 @@ export class LayoutPicker {
         for (const [mode, btn] of Object.entries(this.modeBtns)) {
             btn.dataset.active = this.mode === mode ? '1' : '';
         }
-        if (this.mode === 'grid') {
-            this.setCaption(preview ? [`${preview.cols} × ${preview.rows}`] : ['Pick a grid']);
-            this.commitEl.style.display = 'none';
-        } else {
-            const active = this.counts.filter((n) => n > 0);
-            const total = active.reduce((a, b) => a + b, 0);
-            const noun = this.mode === 'columns' ? 'column' : 'row';
-            this.setCaption(
-                total > 0
-                    ? [
-                          `${total} chart${total === 1 ? '' : 's'}`,
-                          `${active.length} ${noun}${active.length === 1 ? '' : 's'}`,
-                      ]
-                    : ['Click to add'],
-            );
-            this.commitEl.style.display = '';
-            this.applyBtn.disabled = total === 0;
+        // Tile checked state mirrors the CURRENT layout, whichever tab is visible.
+        const key = shapeKey(this.opts.shape());
+        for (const tile of this.tilesEl.querySelectorAll<HTMLElement>('.vela-lp-tile')) {
+            tile.dataset.checked = tile.dataset.key && tile.dataset.key === key ? '1' : '';
         }
-    }
-
-    /** Stack caption lines under the canvas (n charts / n columns — not one long inline). */
-    private setCaption(lines: readonly string[]): void {
-        this.caption.replaceChildren(
-            ...lines.map((t) => {
-                const line = this.doc.createElement('span');
-                line.textContent = t;
-                return line;
-            }),
-        );
+        // Apply commits stack painting; rectangle picks and presets apply on click.
+        const stackMode = this.tab === 'grid' && this.mode !== 'grid';
+        this.commitEl.style.display = stackMode ? '' : 'none';
+        if (stackMode) {
+            this.applyBtn.disabled = this.counts.every((n) => n <= 0);
+        }
     }
 
     private gridShape(): { rows: number; cols: number } | null {

--- a/src/widget/layout-picker.ts
+++ b/src/widget/layout-picker.ts
@@ -1,0 +1,635 @@
+// Layout picker — the topbar's LAYOUT dropdown. Instead of choosing from a fixed
+// preset list, the panel composes the layout on a bounded 4×4 grid canvas, driven by
+// ONE three-way switch:
+//   • Grid — hover previews the full rows×cols rectangle from the top-left (the
+//     table-insert idiom); a click applies it immediately.
+//   • Columns / Rows — each click sets a track's chart stack along that orientation
+//     (clicking a stack's exact end clears it); Apply commits. Switching between the
+//     two orientations keeps the painted pattern in place (its conjugate) instead of
+//     transposing it.
+// Registered layouts that are NOT expressible on the canvas (bespoke plugin presets)
+// list as labeled rows under it, and the workspace SYNC switches sit beside the grid.
+//
+// The panel is a lightweight anchored popover (outside-pointerdown + Escape dismiss)
+// rather than a kit Menu: it mixes a canvas, a mode switch and switch rows, which is
+// beyond the menu machine's item model. The host element provides the theme
+// tokens (the panel portals inside it, same as the menu positioner).
+import { injectStyles } from '../ui/styles';
+import { iconEl, registerIcon, svg16 } from '../ui/icons';
+import { Tooltip } from '../ui/components/tooltip';
+
+// Switch glyphs: a uniform 2×2 grid, full-height columns, full-width rows.
+registerIcon('layout-grid', svg16('<rect x="1.5" y="1.5" width="5.5" height="5.5" rx="1"/><rect x="9" y="1.5" width="5.5" height="5.5" rx="1"/><rect x="1.5" y="9" width="5.5" height="5.5" rx="1"/><rect x="9" y="9" width="5.5" height="5.5" rx="1"/>'));
+registerIcon('layout-columns', svg16('<rect x="1.5" y="1.5" width="5.5" height="13" rx="1"/><rect x="9" y="1.5" width="5.5" height="13" rx="1"/>'));
+registerIcon('layout-rows', svg16('<rect x="1.5" y="1.5" width="13" height="5.5" rx="1"/><rect x="1.5" y="9" width="13" height="5.5" rx="1"/>'));
+
+const STYLE_ID = 'vela-widget-layout-picker-v7';
+// One monochrome selection language across the panel: lit cells, the active
+// orientation segment, sync ON switches, and Apply all speak --vela-selected-*.
+const CSS = `
+.vela-lp-layer { position: absolute; z-index: var(--vela-z-menu); }
+.vela-lp {
+    background: var(--vela-surface-elev);
+    color: var(--vela-fg);
+    border: 1px solid var(--vela-border-strong);
+    border-radius: 8px;
+    box-shadow: var(--vela-shadow);
+    padding: 10px 12px 10px;
+    font-size: 13px;
+    user-select: none;
+    transform-origin: top;
+    animation: vela-lp-in var(--vela-dur-fast) var(--vela-ease);
+}
+@keyframes vela-lp-in {
+    from { opacity: 0; transform: translateY(-4px) scale(0.98); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.vela-lp-cols { display: flex; align-items: stretch; gap: 14px; }
+.vela-lp-heading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    color: var(--vela-fg-faint);
+    margin-bottom: 10px;
+}
+/* "?" help badge: hover it for the mode explainer. */
+.vela-lp-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 1px solid var(--vela-border-strong);
+    color: var(--vela-fg-muted);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0;
+    cursor: default;
+    transition: color var(--vela-dur-fast) var(--vela-ease), border-color var(--vela-dur-fast) var(--vela-ease);
+}
+.vela-lp-badge:hover { color: var(--vela-fg-bright); border-color: var(--vela-fg-muted); }
+.vela-lp-tip { display: flex; flex-direction: column; gap: 4px; max-width: 230px; white-space: normal; }
+.vela-lp-vsep { width: 1px; flex: none; align-self: stretch; background: var(--vela-border-faint); }
+/* LAYOUT column sized to the canvas — caption stacks under it, not beside it. */
+.vela-lp-layout { width: 148px; display: flex; flex-direction: column; align-items: center; }
+.vela-lp-layout > .vela-lp-heading,
+.vela-lp-layout > .vela-lp-caption-row,
+.vela-lp-layout > .vela-lp-presets { align-self: stretch; }
+.vela-lp-grid { display: grid; grid-template-columns: repeat(4, 24px); grid-auto-rows: 24px; gap: 4px; }
+.vela-lp-sq {
+    all: unset;
+    box-sizing: border-box;
+    border-radius: 4px;
+    background: var(--vela-hover);
+    border: 1px solid var(--vela-border-faint);
+    cursor: pointer;
+    transition: background var(--vela-dur-fast) var(--vela-ease), border-color var(--vela-dur-fast) var(--vela-ease);
+}
+.vela-lp-sq:hover { background: var(--vela-hover-strong); border-color: var(--vela-border-strong); }
+/* Selected/previewed squares — same inverse chip as the active mode + Apply. */
+.vela-lp-sq[data-on='1'] {
+    background: var(--vela-selected-bg);
+    border-color: var(--vela-selected-bg);
+}
+/* Two-line caption left, icon-only orientation trio right. */
+.vela-lp-caption-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    margin-top: 8px;
+}
+.vela-lp-caption {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+    color: var(--vela-fg-muted);
+    font-size: var(--vela-font-size-sm);
+    line-height: 1.25;
+    letter-spacing: 0.3px;
+    font-variant-numeric: tabular-nums;
+}
+.vela-lp-presets { display: flex; flex-direction: column; gap: 2px; margin-top: 8px; }
+.vela-lp-preset { all: unset; padding: 5px 8px; border-radius: 4px; cursor: pointer; color: var(--vela-fg-muted); font-size: 12px; white-space: nowrap; transition: transform 120ms var(--vela-ease); }
+.vela-lp-preset:hover { background: var(--vela-hover); }
+.vela-lp-preset:active { transform: scale(0.98); }
+.vela-lp-preset[data-checked='1'] { background: var(--vela-hover-strong); color: var(--vela-fg-bright); }
+.vela-lp-sync { display: flex; flex-direction: column; gap: 4px; min-width: 118px; }
+.vela-lp-sync-row { all: unset; display: flex; align-items: center; gap: 14px; padding: 6px 8px; border-radius: 5px; cursor: pointer; }
+.vela-lp-sync-row:hover { background: var(--vela-hover); }
+.vela-lp-sync-row .vela-lp-label { flex: 1 1 auto; }
+/* Toggle pill — same control language as the menu's switch rows, monochrome ON state. */
+.vela-lp-switch {
+    position: relative;
+    flex: none;
+    width: 34px;
+    height: 18px;
+    border-radius: 9px;
+    background: var(--vela-hover);
+    border: 1px solid var(--vela-border-soft);
+    transition: background 0.16s ease, border-color 0.16s ease;
+}
+.vela-lp-switch::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--vela-fg-muted);
+    transition: transform 0.16s ease, background 0.16s ease;
+}
+.vela-lp-switch.on { background: var(--vela-selected-bg); border-color: var(--vela-selected-bg); }
+.vela-lp-switch.on::after { transform: translateX(16px); background: var(--vela-selected-fg); }
+/* Icon-only orientation trio — pictograms are self-explanatory; tooltips name them. */
+.vela-lp-modes { display: inline-flex; flex: none; gap: 2px; padding: 2px; background: var(--vela-hover); border-radius: 6px; }
+.vela-lp-mode {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--vela-fg-muted);
+    transition: color var(--vela-dur-fast) var(--vela-ease), background var(--vela-dur-fast) var(--vela-ease), transform 120ms var(--vela-ease);
+}
+.vela-lp-mode .vela-icon { font-size: 13px; width: 13px; height: 13px; }
+.vela-lp-mode:hover { color: var(--vela-fg-bright); }
+.vela-lp-mode:active { transform: scale(0.96); }
+.vela-lp-mode[data-active='1'] { background: var(--vela-selected-bg); color: var(--vela-selected-fg); }
+/* Commit footer: full panel width, right-aligned. */
+.vela-lp-commit {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--vela-border-faint);
+}
+.vela-lp-apply {
+    all: unset;
+    padding: 5px 18px;
+    border-radius: 5px;
+    background: var(--vela-selected-bg);
+    color: var(--vela-selected-fg);
+    font-size: var(--vela-font-size-md);
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity var(--vela-dur-fast) var(--vela-ease), transform 120ms var(--vela-ease);
+}
+.vela-lp-apply:hover:not(:disabled) { opacity: 0.85; }
+.vela-lp-apply:active:not(:disabled) { transform: scale(0.96); }
+.vela-lp-apply:disabled { opacity: 0.35; cursor: default; }
+`;
+
+/** The picker canvas is a fixed 4×4 — 16 cells, the workspace pool capacity. */
+const GRID = 4;
+
+/**
+ * Re-read a stack staircase along the other axis: track i's new count is how many
+ * old tracks reached past i. Same lit cells on the canvas, other orientation.
+ */
+function conjugate(counts: readonly number[]): number[] {
+    const next = [0, 0, 0, 0];
+    for (let i = 0; i < GRID; i += 1) next[i] = counts.filter((n) => n > i).length;
+    return next;
+}
+
+/** Custom-mode stacking orientation. */
+export type LayoutPickerAxis = 'columns' | 'rows';
+
+/** The three-way switch: uniform grid, column stacks, or row stacks. */
+type PickerMode = 'grid' | LayoutPickerAxis;
+
+/** The current layout's footprint on the canvas (mirrors the workspace's LayoutShape). */
+export type LayoutPickerShape = { rows: number; cols: number } | { counts: number[]; axis: LayoutPickerAxis };
+
+export interface LayoutPickerOptions {
+    /** Topbar button that toggles the panel. */
+    trigger: HTMLElement;
+    /** Positioning/theming host (the widget root — the panel portals inside it). */
+    host: HTMLElement;
+    /** Current layout's canvas shape (null = a preset the canvas cannot express). */
+    shape: () => LayoutPickerShape | null;
+    /** Registered layouts NOT expressible on the canvas — rendered as labeled rows. */
+    presets: () => Array<{ id: string; label: string; checked: boolean }>;
+    onSelectGrid: (rows: number, cols: number) => void;
+    /** Stack-mode commit: per-column or per-row chart stacks, per `axis`. */
+    onSelectStacks: (counts: number[], axis: LayoutPickerAxis) => void;
+    onSelectPreset: (id: string) => void;
+    /** SYNC switch rows (re-read on every open and after every toggle). */
+    syncs: () => Array<{ id: string; label: string; checked: boolean }>;
+    onToggleSync: (id: string) => void;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export class LayoutPicker {
+    private readonly opts: LayoutPickerOptions;
+    private readonly doc: Document;
+    private readonly layer: HTMLElement;
+    private readonly squares: HTMLButtonElement[] = []; // row-major, 16 entries
+    private readonly caption: HTMLElement;
+    private readonly infoTip: Tooltip;
+    private readonly modeTips: Tooltip[] = [];
+    private readonly modeBtns: Record<PickerMode, HTMLButtonElement>;
+    private readonly presetsEl: HTMLElement;
+    private readonly syncEl: HTMLElement;
+    private readonly commitEl: HTMLElement;
+    private readonly applyBtn: HTMLButtonElement;
+
+    private isOpen = false;
+    /** The three-way switch state: 'grid' picks rectangles, the axes paint stacks. */
+    private mode: PickerMode = 'grid';
+    /** Stack-mode stacks along the active axis (0 = empty track). */
+    private counts: number[] = [0, 0, 0, 0];
+    /** Grid-mode hover preview (1-based rows/cols), null = show current shape. */
+    private hover: { rows: number; cols: number } | null = null;
+
+    private readonly onDocPointerDown = (e: PointerEvent): void => {
+        const t = e.target as Node | null;
+        if (t && (this.layer.contains(t) || this.opts.trigger.contains(t))) return;
+        this.close();
+    };
+    private readonly onDocKeydown = (e: KeyboardEvent): void => {
+        if (e.key === 'Escape') this.close();
+    };
+
+    constructor(opts: LayoutPickerOptions) {
+        this.opts = opts;
+        this.doc = opts.host.ownerDocument;
+        injectStyles(STYLE_ID, CSS, this.doc);
+        const doc = this.doc;
+
+        this.layer = doc.createElement('div');
+        this.layer.className = 'vela-ui-layer vela-lp-layer';
+        this.layer.style.display = 'none';
+        const panel = doc.createElement('div');
+        panel.className = 'vela-lp';
+        this.layer.appendChild(panel);
+
+        const cols = doc.createElement('div');
+        cols.className = 'vela-lp-cols';
+        panel.appendChild(cols);
+
+        // ── left column: the LAYOUT canvas ──
+        const layoutCol = doc.createElement('div');
+        layoutCol.className = 'vela-lp-layout';
+        const layoutHeading = doc.createElement('div');
+        layoutHeading.className = 'vela-lp-heading';
+        const headingText = doc.createElement('span');
+        headingText.textContent = 'Layout';
+        const badge = doc.createElement('span');
+        badge.className = 'vela-lp-badge';
+        badge.textContent = '?';
+        layoutHeading.append(headingText, badge);
+        layoutCol.appendChild(layoutHeading);
+        this.infoTip = new Tooltip(badge, {
+            host: opts.host,
+            placement: 'bottom',
+            content: () => this.tipNode(),
+        });
+
+        const grid = doc.createElement('div');
+        grid.className = 'vela-lp-grid';
+        for (let r = 0; r < GRID; r += 1) {
+            for (let c = 0; c < GRID; c += 1) {
+                const sq = doc.createElement('button');
+                sq.className = 'vela-lp-sq';
+                sq.dataset.r = String(r);
+                sq.dataset.c = String(c);
+                sq.setAttribute('aria-label', `${c + 1} × ${r + 1}`);
+                this.squares.push(sq);
+                grid.appendChild(sq);
+            }
+        }
+        layoutCol.appendChild(grid);
+
+        // Caption + icon-only orientation trio on one row (pictograms name themselves;
+        // tooltips reassure on hover). No ORIENTATION heading — it belongs to Layout.
+        const captionRow = doc.createElement('div');
+        captionRow.className = 'vela-lp-caption-row';
+        this.caption = doc.createElement('div');
+        this.caption.className = 'vela-lp-caption';
+        captionRow.appendChild(this.caption);
+        const modes = doc.createElement('div');
+        modes.className = 'vela-lp-modes';
+        const modeBtn = (label: string, icon: string, mode: PickerMode): HTMLButtonElement => {
+            const b = doc.createElement('button');
+            b.className = 'vela-lp-mode';
+            b.setAttribute('aria-label', label);
+            b.append(iconEl(icon, doc));
+            b.addEventListener('click', () => this.setMode(mode));
+            this.modeTips.push(new Tooltip(b, { host: opts.host, placement: 'bottom', content: label }));
+            modes.appendChild(b);
+            return b;
+        };
+        this.modeBtns = {
+            grid: modeBtn('Grid', 'layout-grid', 'grid'),
+            columns: modeBtn('Columns', 'layout-columns', 'columns'),
+            rows: modeBtn('Rows', 'layout-rows', 'rows'),
+        };
+        captionRow.appendChild(modes);
+        layoutCol.appendChild(captionRow);
+
+        this.presetsEl = doc.createElement('div');
+        this.presetsEl.className = 'vela-lp-presets';
+        layoutCol.appendChild(this.presetsEl);
+        cols.appendChild(layoutCol);
+
+        const vsep = doc.createElement('div');
+        vsep.className = 'vela-lp-vsep';
+        cols.appendChild(vsep);
+
+        // ── right column: the SYNC switches ──
+        const syncCol = doc.createElement('div');
+        const syncHeading = doc.createElement('div');
+        syncHeading.className = 'vela-lp-heading';
+        syncHeading.textContent = 'Sync';
+        syncCol.appendChild(syncHeading);
+        this.syncEl = doc.createElement('div');
+        this.syncEl.className = 'vela-lp-sync';
+        syncCol.appendChild(this.syncEl);
+        cols.appendChild(syncCol);
+
+        // ── Commit footer: Apply alone, full panel width (stack modes only) ──
+        const commit = doc.createElement('div');
+        commit.className = 'vela-lp-commit';
+        this.applyBtn = doc.createElement('button');
+        this.applyBtn.className = 'vela-lp-apply';
+        this.applyBtn.textContent = 'Apply';
+        this.applyBtn.addEventListener('click', () => {
+            if (this.mode === 'grid') return;
+            const counts = this.counts.filter((n) => n > 0);
+            if (counts.length === 0) return;
+            this.close();
+            this.opts.onSelectStacks(counts, this.mode);
+        });
+        commit.appendChild(this.applyBtn);
+        panel.appendChild(commit);
+        this.commitEl = commit;
+
+        // ── canvas interactions ──
+        grid.addEventListener('pointerdown', (e) => {
+            const sq = this.squareAt(e);
+            if (!sq) return;
+            e.preventDefault();
+            const { r, c } = this.squarePos(sq);
+            if (this.mode === 'grid') {
+                this.close();
+                this.opts.onSelectGrid(r + 1, c + 1);
+                return;
+            }
+            // Stack modes: a click on a stack's exact end toggles that track off, any
+            // other square sets the stack size — so one click grows, shrinks, or
+            // clears without a separate eraser. The track/size axes follow the mode.
+            const track = this.mode === 'columns' ? c : r;
+            const size = this.mode === 'columns' ? r + 1 : c + 1;
+            this.counts[track] = this.counts[track] === size ? 0 : size;
+            this.render();
+        });
+        grid.addEventListener('pointermove', (e) => {
+            if (this.mode !== 'grid') return;
+            const sq = this.squareAt(e);
+            if (!sq) return;
+            const { r, c } = this.squarePos(sq);
+            if (this.hover?.rows !== r + 1 || this.hover?.cols !== c + 1) {
+                this.hover = { rows: r + 1, cols: c + 1 };
+                this.render();
+            }
+        });
+        grid.addEventListener('pointerleave', () => {
+            if (this.mode === 'grid' && this.hover) {
+                this.hover = null;
+                this.render();
+            }
+        });
+
+        opts.trigger.addEventListener('click', () => this.toggle());
+        opts.trigger.setAttribute('aria-haspopup', 'true');
+        opts.trigger.setAttribute('aria-expanded', 'false');
+        opts.host.appendChild(this.layer);
+    }
+
+    toggle(): void {
+        if (this.isOpen) this.close();
+        else this.open();
+    }
+
+    open(): void {
+        if (this.isOpen) return;
+        this.isOpen = true;
+        // Mode is sticky: Columns/Rows stay selected across close/reopen until the
+        // user switches. Only the canvas is re-seeded from the live layout shape.
+        const shape = this.opts.shape();
+        this.counts = this.seedCounts(shape);
+        if (this.mode !== 'grid' && shape && 'counts' in shape && shape.axis !== this.mode) {
+            this.counts = conjugate(this.counts);
+        }
+        this.hover = null;
+        this.refresh();
+        this.layer.style.display = '';
+        this.position();
+        this.opts.trigger.setAttribute('aria-expanded', 'true');
+        this.doc.addEventListener('pointerdown', this.onDocPointerDown, true);
+        this.doc.addEventListener('keydown', this.onDocKeydown, true);
+        this.opts.onOpenChange?.(true);
+    }
+
+    close(): void {
+        if (!this.isOpen) return;
+        this.isOpen = false;
+        this.layer.style.display = 'none';
+        this.opts.trigger.setAttribute('aria-expanded', 'false');
+        this.doc.removeEventListener('pointerdown', this.onDocPointerDown, true);
+        this.doc.removeEventListener('keydown', this.onDocKeydown, true);
+        this.opts.onOpenChange?.(false);
+    }
+
+    /** Re-read shape/presets/syncs and re-render (no-op while closed — `open` re-reads). */
+    refresh(): void {
+        if (!this.isOpen) return;
+        this.renderPresets();
+        this.renderSyncs();
+        this.render();
+    }
+
+    destroy(): void {
+        this.close();
+        this.infoTip.destroy();
+        for (const tip of this.modeTips) tip.destroy();
+        this.layer.remove();
+    }
+
+    // ── internals ──
+    /** Stacks along the given axis seeded from a shape (uniform grids become stacks). */
+    private seedCounts(shape: LayoutPickerShape | null): number[] {
+        const counts = [0, 0, 0, 0];
+        if (shape && 'counts' in shape) {
+            for (const [i, n] of shape.counts.slice(0, GRID).entries()) counts[i] = Math.min(GRID, n);
+        } else if (shape) {
+            const axis = this.mode === 'rows' ? 'rows' : 'columns';
+            const tracks = axis === 'columns' ? shape.cols : shape.rows;
+            const size = axis === 'columns' ? shape.rows : shape.cols;
+            for (let i = 0; i < Math.min(GRID, tracks); i += 1) counts[i] = Math.min(GRID, size);
+        }
+        return counts;
+    }
+
+    private squareAt(e: PointerEvent): HTMLButtonElement | null {
+        const sq = (e.target as Element | null)?.closest?.('.vela-lp-sq');
+        return sq instanceof HTMLButtonElement ? sq : null;
+    }
+
+    private squarePos(sq: HTMLButtonElement): { r: number; c: number } {
+        return { r: Number(sq.dataset.r), c: Number(sq.dataset.c) };
+    }
+
+    private setMode(mode: PickerMode): void {
+        if (this.mode === mode) return;
+        const from = this.mode;
+        this.mode = mode;
+        this.hover = null;
+        if (mode !== 'grid') {
+            if (from === 'grid') {
+                // Entering a stack mode starts from what the canvas currently shows —
+                // including a stack layout painted along the OTHER axis.
+                const shape = this.opts.shape();
+                this.counts = this.seedCounts(shape);
+                if (shape && 'counts' in shape && shape.axis !== mode) this.counts = conjugate(this.counts);
+            } else {
+                // Columns ↔ Rows keeps the PAINTED PATTERN in place instead of
+                // transposing it, re-reading the same staircase along the other axis.
+                this.counts = conjugate(this.counts);
+            }
+        }
+        this.infoTip.setContent(() => this.tipNode());
+        this.render();
+    }
+
+    /** Mode-aware help copy for the LAYOUT "?" badge. */
+    private tipNode(): HTMLElement {
+        const tip = this.doc.createElement('div');
+        tip.className = 'vela-lp-tip';
+        tip.textContent =
+            this.mode === 'grid'
+                ? 'Click a square to apply that columns × rows layout.'
+                : this.mode === 'columns'
+                  ? "Click squares to set each column's chart stack, then Apply."
+                  : "Click squares to set each row's chart stack, then Apply.";
+        return tip;
+    }
+
+    /** Project the interaction state onto the DOM (squares, caption, switch, Apply). */
+    private render(): void {
+        const preview = this.mode === 'grid' ? (this.hover ?? this.gridShape()) : null;
+        for (const sq of this.squares) {
+            const { r, c } = this.squarePos(sq);
+            const on =
+                this.mode === 'grid'
+                    ? preview !== null && r < preview.rows && c < preview.cols
+                    : this.mode === 'columns'
+                      ? r < (this.counts[c] ?? 0)
+                      : c < (this.counts[r] ?? 0);
+            if (on) sq.dataset.on = '1';
+            else delete sq.dataset.on;
+        }
+        for (const [mode, btn] of Object.entries(this.modeBtns)) {
+            btn.dataset.active = this.mode === mode ? '1' : '';
+        }
+        if (this.mode === 'grid') {
+            this.setCaption(preview ? [`${preview.cols} × ${preview.rows}`] : ['Pick a grid']);
+            this.commitEl.style.display = 'none';
+        } else {
+            const active = this.counts.filter((n) => n > 0);
+            const total = active.reduce((a, b) => a + b, 0);
+            const noun = this.mode === 'columns' ? 'column' : 'row';
+            this.setCaption(
+                total > 0
+                    ? [
+                          `${total} chart${total === 1 ? '' : 's'}`,
+                          `${active.length} ${noun}${active.length === 1 ? '' : 's'}`,
+                      ]
+                    : ['Click to add'],
+            );
+            this.commitEl.style.display = '';
+            this.applyBtn.disabled = total === 0;
+        }
+    }
+
+    /** Stack caption lines under the canvas (n charts / n columns — not one long inline). */
+    private setCaption(lines: readonly string[]): void {
+        this.caption.replaceChildren(
+            ...lines.map((t) => {
+                const line = this.doc.createElement('span');
+                line.textContent = t;
+                return line;
+            }),
+        );
+    }
+
+    private gridShape(): { rows: number; cols: number } | null {
+        const shape = this.opts.shape();
+        return shape && 'rows' in shape ? shape : null;
+    }
+
+    private renderPresets(): void {
+        const doc = this.doc;
+        this.presetsEl.replaceChildren();
+        const presets = this.opts.presets();
+        this.presetsEl.style.display = presets.length > 0 ? '' : 'none';
+        for (const p of presets) {
+            const b = doc.createElement('button');
+            b.className = 'vela-lp-preset';
+            b.textContent = p.label;
+            if (p.checked) b.dataset.checked = '1';
+            b.addEventListener('click', () => {
+                this.close();
+                this.opts.onSelectPreset(p.id);
+            });
+            this.presetsEl.appendChild(b);
+        }
+    }
+
+    private renderSyncs(): void {
+        const doc = this.doc;
+        this.syncEl.replaceChildren();
+        for (const s of this.opts.syncs()) {
+            const row = doc.createElement('button');
+            row.className = 'vela-lp-sync-row';
+            const label = doc.createElement('span');
+            label.className = 'vela-lp-label';
+            label.textContent = s.label;
+            const pill = doc.createElement('span');
+            pill.className = 'vela-lp-switch' + (s.checked ? ' on' : '');
+            pill.setAttribute('aria-hidden', 'true');
+            row.setAttribute('role', 'switch');
+            row.setAttribute('aria-checked', String(s.checked));
+            row.append(label, pill);
+            row.addEventListener('click', () => {
+                this.opts.onToggleSync(s.id);
+                this.renderSyncs(); // switches stay open — flip, see, flip again
+            });
+            this.syncEl.appendChild(row);
+        }
+    }
+
+    /** Anchor under the trigger, clamped to the host's right edge. */
+    private position(): void {
+        const hostRect = this.opts.host.getBoundingClientRect();
+        const trigRect = this.opts.trigger.getBoundingClientRect();
+        let left = trigRect.left - hostRect.left;
+        const top = trigRect.bottom - hostRect.top + 4;
+        const width = this.layer.offsetWidth;
+        if (left + width > hostRect.width - 8) left = Math.max(8, hostRect.width - 8 - width);
+        this.layer.style.left = `${left}px`;
+        this.layer.style.top = `${top}px`;
+    }
+}

--- a/src/widget/layout-picker.ts
+++ b/src/widget/layout-picker.ts
@@ -1,31 +1,19 @@
-// Layout picker — the topbar's LAYOUT dropdown, two tabs over one canvas column:
-//   • Presets — curated multi-chart splits as clickable pictogram tiles (1 large +
-//     2 small, 1 wide + 2 below, column/row stripes, …); the ⇄ tile mirrors the
-//     asymmetric splits. A click applies the preset immediately.
-//   • Grid — a bounded 4×4 canvas with an icon-only mode trio under it: Grid mode
-//     hover-previews the full rows×cols rectangle from the top-left (the
-//     table-insert idiom) and applies on click; Columns/Rows modes paint per-track
-//     chart stacks (click a stack's exact end to clear it) and commit via Apply.
-//     Switching Columns ↔ Rows keeps the painted pattern in place (its conjugate).
-// Registered layouts that are NOT expressible on the canvas (bespoke plugin presets)
-// list as labeled rows under it, and the workspace SYNC switches sit beside the grid.
+// Layout picker — the topbar's LAYOUT dropdown. A bounded 4×4 grid canvas: hover
+// previews the full rows×cols rectangle from the top-left (the table-insert idiom);
+// a click applies it immediately. Registered layouts that are NOT expressible on the
+// canvas (bespoke plugin presets) list as labeled rows under it, and the workspace
+// SYNC switches sit beside the grid.
 //
 // The panel is a lightweight anchored popover (outside-pointerdown + Escape dismiss)
-// rather than a kit Menu: it mixes a canvas, a mode switch and switch rows, which is
-// beyond the menu machine's item model. The host element provides the theme
-// tokens (the panel portals inside it, same as the menu positioner).
+// rather than a kit Menu: it mixes a canvas and switch rows, which is beyond the menu
+// machine's item model. The host element provides the theme tokens (the panel portals
+// inside it, same as the menu positioner).
 import { injectStyles } from '../ui/styles';
-import { iconEl, registerIcon, svg16 } from '../ui/icons';
 import { Tooltip } from '../ui/components/tooltip';
 
-// Switch glyphs: a uniform 2×2 grid, full-height columns, full-width rows.
-registerIcon('layout-grid', svg16('<rect x="1.5" y="1.5" width="5.5" height="5.5" rx="1"/><rect x="9" y="1.5" width="5.5" height="5.5" rx="1"/><rect x="1.5" y="9" width="5.5" height="5.5" rx="1"/><rect x="9" y="9" width="5.5" height="5.5" rx="1"/>'));
-registerIcon('layout-columns', svg16('<rect x="1.5" y="1.5" width="5.5" height="13" rx="1"/><rect x="9" y="1.5" width="5.5" height="13" rx="1"/>'));
-registerIcon('layout-rows', svg16('<rect x="1.5" y="1.5" width="13" height="5.5" rx="1"/><rect x="1.5" y="9" width="13" height="5.5" rx="1"/>'));
-
-const STYLE_ID = 'vela-widget-layout-picker-v11';
-// One monochrome selection language across the panel: lit cells, the active
-// orientation segment, sync ON switches, and Apply all speak --vela-selected-*.
+const STYLE_ID = 'vela-widget-layout-picker-v14';
+// One monochrome selection language across the panel: lit cells and sync ON
+// switches both speak --vela-selected-*.
 const CSS = `
 .vela-lp-layer { position: absolute; z-index: var(--vela-z-menu); }
 .vela-lp {
@@ -56,7 +44,7 @@ const CSS = `
     color: var(--vela-fg-faint);
     margin-bottom: 10px;
 }
-/* "?" help badge: hover it for the mode explainer. */
+/* "?" help badge: hover it for the canvas explainer. */
 .vela-lp-badge {
     display: inline-flex;
     align-items: center;
@@ -75,51 +63,10 @@ const CSS = `
 .vela-lp-badge:hover { color: var(--vela-fg-bright); border-color: var(--vela-fg-muted); }
 .vela-lp-tip { display: flex; flex-direction: column; gap: 4px; max-width: 230px; white-space: normal; }
 .vela-lp-vsep { width: 1px; flex: none; align-self: stretch; background: var(--vela-border-faint); }
-/* Layout column sized to the preset tiles; the Grid canvas centers inside it. */
-.vela-lp-layout { width: 168px; display: flex; flex-direction: column; align-items: center; }
+.vela-lp-layout { width: 132px; display: flex; flex-direction: column; align-items: center; }
 .vela-lp-layout > .vela-lp-heading,
-.vela-lp-layout > .vela-lp-tabs-row,
-.vela-lp-layout > .vela-lp-tools,
 .vela-lp-layout > .vela-lp-presets { align-self: stretch; }
-/* Presets | Grid tabs with the "?" help badge to their right. */
-.vela-lp-tabs-row { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
-.vela-lp-tabs { display: flex; flex: 1 1 auto; gap: 2px; padding: 2px; background: var(--vela-hover); border-radius: 6px; box-sizing: border-box; min-width: 0; }
-.vela-lp-tab {
-    all: unset;
-    flex: 1 1 0;
-    text-align: center;
-    padding: 5px 0;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: var(--vela-font-size-md);
-    font-weight: 550;
-    color: var(--vela-fg-muted);
-    transition: color var(--vela-dur-fast) var(--vela-ease), background var(--vela-dur-fast) var(--vela-ease);
-}
-.vela-lp-tab:hover { color: var(--vela-fg-bright); }
-.vela-lp-tab[data-active='1'] { background: var(--vela-hover-strong); color: var(--vela-fg-bright); }
-/* Preset tiles: mini layout pictograms; the flip tile mirrors the asymmetric splits. */
-.vela-lp-tiles { display: grid; grid-template-columns: repeat(3, 52px); grid-auto-rows: 52px; gap: 6px; }
-.vela-lp-tile {
-    all: unset;
-    box-sizing: border-box;
-    position: relative;
-    border-radius: 6px;
-    background: var(--vela-hover);
-    border: 1px solid var(--vela-border-faint);
-    cursor: pointer;
-    transition: background var(--vela-dur-fast) var(--vela-ease), border-color var(--vela-dur-fast) var(--vela-ease), transform 120ms var(--vela-ease);
-}
-.vela-lp-tile:hover { background: var(--vela-hover-strong); border-color: var(--vela-border-strong); }
-.vela-lp-tile:active { transform: scale(0.96); }
-.vela-lp-tile[data-checked='1'] { border-color: var(--vela-fg-bright); box-shadow: 0 0 0 1px var(--vela-fg-bright); }
-.vela-lp-tile-canvas { position: absolute; inset: 6px; }
-.vela-lp-tile-pane { position: absolute; border-radius: 2px; background: var(--vela-fg-faint); transition: background var(--vela-dur-fast) var(--vela-ease); }
-.vela-lp-tile:hover .vela-lp-tile-pane { background: var(--vela-fg-muted); }
-.vela-lp-tile[data-checked='1'] .vela-lp-tile-pane { background: var(--vela-selected-bg); }
-.vela-lp-tile-flip { display: inline-flex; align-items: center; justify-content: center; font-size: 15px; color: var(--vela-fg-muted); }
-.vela-lp-tile-flip:hover { color: var(--vela-fg-bright); }
-.vela-lp-grid { display: grid; grid-template-columns: repeat(4, 24px); grid-auto-rows: 24px; gap: 4px; margin-top: 3px; }
+.vela-lp-grid { display: grid; grid-template-columns: repeat(4, 24px); grid-auto-rows: 24px; gap: 4px; }
 .vela-lp-sq {
     all: unset;
     box-sizing: border-box;
@@ -130,17 +77,10 @@ const CSS = `
     transition: background var(--vela-dur-fast) var(--vela-ease), border-color var(--vela-dur-fast) var(--vela-ease);
 }
 .vela-lp-sq:hover { background: var(--vela-hover-strong); border-color: var(--vela-border-strong); }
-/* Selected/previewed squares — same inverse chip as the active mode + Apply. */
+/* Selected/previewed squares — the shared monochrome selection chip. */
 .vela-lp-sq[data-on='1'] {
     background: var(--vela-selected-bg);
     border-color: var(--vela-selected-bg);
-}
-/* Mode trio under the canvas (Grid tab only) — icon always, label only when active. */
-.vela-lp-tools {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 10px;
 }
 .vela-lp-presets { display: flex; flex-direction: column; gap: 2px; margin-top: 8px; }
 .vela-lp-preset { all: unset; padding: 5px 8px; border-radius: 4px; cursor: pointer; color: var(--vela-fg-muted); font-size: 12px; white-space: nowrap; transition: transform 120ms var(--vela-ease); }
@@ -175,115 +115,13 @@ const CSS = `
 }
 .vela-lp-switch.on { background: var(--vela-selected-bg); border-color: var(--vela-selected-bg); }
 .vela-lp-switch.on::after { transform: translateX(16px); background: var(--vela-selected-fg); }
-.vela-lp-modes { display: inline-flex; flex: none; gap: 2px; padding: 2px; background: var(--vela-hover); border-radius: 6px; }
-.vela-lp-mode {
-    all: unset;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 4px;
-    min-width: 24px;
-    height: 22px;
-    padding: 0 5px;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: var(--vela-font-size-sm);
-    font-weight: 550;
-    color: var(--vela-fg-muted);
-    transition: color var(--vela-dur-fast) var(--vela-ease), background var(--vela-dur-fast) var(--vela-ease), transform 120ms var(--vela-ease), padding 120ms var(--vela-ease);
-}
-.vela-lp-mode .vela-icon { font-size: 13px; width: 13px; height: 13px; flex: none; }
-.vela-lp-mode .vela-lp-mode-label { display: none; }
-.vela-lp-mode:hover { color: var(--vela-fg-bright); }
-.vela-lp-mode:active { transform: scale(0.96); }
-.vela-lp-mode[data-active='1'] { background: var(--vela-selected-bg); color: var(--vela-selected-fg); padding: 0 8px; }
-.vela-lp-mode[data-active='1'] .vela-lp-mode-label { display: inline; }
-/* Commit footer: full panel width, right-aligned. */
-.vela-lp-commit {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px solid var(--vela-border-faint);
-}
-.vela-lp-apply {
-    all: unset;
-    padding: 5px 18px;
-    border-radius: 5px;
-    background: var(--vela-selected-bg);
-    color: var(--vela-selected-fg);
-    font-size: var(--vela-font-size-md);
-    font-weight: 600;
-    cursor: pointer;
-    transition: opacity var(--vela-dur-fast) var(--vela-ease), transform 120ms var(--vela-ease);
-}
-.vela-lp-apply:hover:not(:disabled) { opacity: 0.85; }
-.vela-lp-apply:active:not(:disabled) { transform: scale(0.96); }
-.vela-lp-apply:disabled { opacity: 0.35; cursor: default; }
 `;
 
 /** The picker canvas is a fixed 4×4 — 16 cells, the workspace pool capacity. */
 const GRID = 4;
 
-/**
- * Re-read a stack staircase along the other axis: track i's new count is how many
- * old tracks reached past i. Same lit cells on the canvas, other orientation.
- */
-function conjugate(counts: readonly number[]): number[] {
-    const next = [0, 0, 0, 0];
-    for (let i = 0; i < GRID; i += 1) next[i] = counts.filter((n) => n > i).length;
-    return next;
-}
-
-/** Custom-mode stacking orientation. */
-export type LayoutPickerAxis = 'columns' | 'rows';
-
-/** The three-way switch: uniform grid, column stacks, or row stacks. */
-type PickerMode = 'grid' | LayoutPickerAxis;
-
-/** The two panel tabs. */
-type PickerTab = 'presets' | 'grid';
-
-/** A Presets-tab tile: a stack split committed through onSelectStacks. */
-interface TilePreset {
-    counts: readonly number[];
-    axis: LayoutPickerAxis;
-    label: string;
-    /** Label once the ⇄ tile has mirrored the split (counts reversed). */
-    flipLabel?: string;
-}
-
-/** Curated splits, the most useful multi-chart setups first. */
-const TILE_PRESETS: readonly TilePreset[] = [
-    { counts: [2, 2], axis: 'columns', label: '2 × 2 grid' },
-    { counts: [1, 1], axis: 'columns', label: '2 side by side' },
-    { counts: [1, 1], axis: 'rows', label: '2 stacked' },
-    { counts: [1, 2], axis: 'columns', label: '1 large + 2 small', flipLabel: '2 small + 1 large' },
-    { counts: [1, 3], axis: 'columns', label: '1 large + 3 small', flipLabel: '3 small + 1 large' },
-    { counts: [1, 2], axis: 'rows', label: '1 wide + 2 below', flipLabel: '2 above + 1 wide' },
-    { counts: [1, 3], axis: 'rows', label: '1 wide + 3 below', flipLabel: '3 above + 1 wide' },
-    { counts: [2, 2, 2], axis: 'columns', label: '3 × 2 grid' },
-];
-
-/** Canonical key for a stack split — uniform splits collapse to their grid key. */
-function stacksKey(counts: readonly number[], axis: LayoutPickerAxis): string {
-    if (counts.every((n) => n === counts[0])) {
-        const rows = axis === 'columns' ? counts[0] : counts.length;
-        const cols = axis === 'columns' ? counts.length : counts[0];
-        return `g${rows}x${cols}`;
-    }
-    return `${axis}:${counts.join('-')}`;
-}
-
-/** Canonical key for the current layout shape (null = not canvas-expressible). */
-function shapeKey(shape: LayoutPickerShape | null): string | null {
-    if (!shape) return null;
-    if ('rows' in shape) return `g${shape.rows}x${shape.cols}`;
-    return stacksKey(shape.counts, shape.axis);
-}
-
 /** The current layout's footprint on the canvas (mirrors the workspace's LayoutShape). */
-export type LayoutPickerShape = { rows: number; cols: number } | { counts: number[]; axis: LayoutPickerAxis };
+export type LayoutPickerShape = { rows: number; cols: number };
 
 export interface LayoutPickerOptions {
     /** Topbar button that toggles the panel. */
@@ -295,8 +133,6 @@ export interface LayoutPickerOptions {
     /** Registered layouts NOT expressible on the canvas — rendered as labeled rows. */
     presets: () => Array<{ id: string; label: string; checked: boolean }>;
     onSelectGrid: (rows: number, cols: number) => void;
-    /** Stack-mode commit: per-column or per-row chart stacks, per `axis`. */
-    onSelectStacks: (counts: number[], axis: LayoutPickerAxis) => void;
     onSelectPreset: (id: string) => void;
     /** SYNC switch rows (re-read on every open and after every toggle). */
     syncs: () => Array<{ id: string; label: string; checked: boolean }>;
@@ -310,28 +146,11 @@ export class LayoutPicker {
     private readonly layer: HTMLElement;
     private readonly squares: HTMLButtonElement[] = []; // row-major, 16 entries
     private readonly infoTip: Tooltip;
-    private readonly modeTips: Tooltip[] = [];
-    private readonly modeBtns: Record<PickerMode, HTMLButtonElement>;
-    private readonly tabBtns: Record<PickerTab, HTMLButtonElement>;
-    private readonly tilesEl: HTMLElement;
-    private readonly canvasEl: HTMLElement;
-    private readonly modesEl: HTMLElement;
-    private readonly toolsEl: HTMLElement;
     private readonly presetsEl: HTMLElement;
     private readonly syncEl: HTMLElement;
-    private readonly commitEl: HTMLElement;
-    private readonly applyBtn: HTMLButtonElement;
 
     private isOpen = false;
-    /** Active panel tab (sticky across close/reopen). */
-    private tab: PickerTab = 'presets';
-    /** ⇄ state: mirrors the asymmetric preset splits (large pane right/bottom). */
-    private flipped = false;
-    /** Three-way switch state: 'grid' picks rectangles, the axes paint stacks. */
-    private mode: PickerMode = 'grid';
-    /** Stack-mode stacks along the active axis (0 = empty track). */
-    private counts: number[] = [0, 0, 0, 0];
-    /** Grid-mode hover preview (1-based rows/cols), null = show current shape. */
+    /** Hover preview (1-based rows/cols), null = show current shape. */
     private hover: { rows: number; cols: number } | null = null;
 
     private readonly onDocPointerDown = (e: PointerEvent): void => {
@@ -360,45 +179,23 @@ export class LayoutPicker {
         cols.className = 'vela-lp-cols';
         panel.appendChild(cols);
 
-        // ── left column: Presets | Grid tabs over the picker canvas ──
+        // ── left column: the LAYOUT canvas ──
         const layoutCol = doc.createElement('div');
         layoutCol.className = 'vela-lp-layout';
-        const tabsRow = doc.createElement('div');
-        tabsRow.className = 'vela-lp-tabs-row';
-        const tabs = doc.createElement('div');
-        tabs.className = 'vela-lp-tabs';
-        const tabBtn = (label: string, tab: PickerTab): HTMLButtonElement => {
-            const b = doc.createElement('button');
-            b.className = 'vela-lp-tab';
-            b.textContent = label;
-            b.addEventListener('click', () => {
-                if (this.tab === tab) return;
-                this.tab = tab;
-                this.hover = null;
-                this.infoTip.setContent(() => this.tipNode());
-                this.render();
-            });
-            tabs.appendChild(b);
-            return b;
-        };
-        this.tabBtns = { presets: tabBtn('Presets', 'presets'), grid: tabBtn('Grid', 'grid') };
-        tabsRow.appendChild(tabs);
+        const layoutHeading = doc.createElement('div');
+        layoutHeading.className = 'vela-lp-heading';
+        const headingText = doc.createElement('span');
+        headingText.textContent = 'Layout';
         const badge = doc.createElement('span');
         badge.className = 'vela-lp-badge';
         badge.textContent = '?';
-        tabsRow.appendChild(badge);
+        layoutHeading.append(headingText, badge);
+        layoutCol.appendChild(layoutHeading);
         this.infoTip = new Tooltip(badge, {
             host: opts.host,
             placement: 'bottom',
             content: () => this.tipNode(),
         });
-        layoutCol.appendChild(tabsRow);
-
-        // Presets tab: curated split pictograms (built by buildTiles, rebuilt on ⇄).
-        this.tilesEl = doc.createElement('div');
-        this.tilesEl.className = 'vela-lp-tiles';
-        layoutCol.appendChild(this.tilesEl);
-        this.buildTiles();
 
         const grid = doc.createElement('div');
         grid.className = 'vela-lp-grid';
@@ -414,37 +211,6 @@ export class LayoutPicker {
             }
         }
         layoutCol.appendChild(grid);
-        this.canvasEl = grid;
-
-        // Grid-tab mode trio: rectangle pick (Grid) or composable per-track stacks
-        // (Columns/Rows). Icon always; label only on the active segment.
-        const modes = doc.createElement('div');
-        modes.className = 'vela-lp-modes';
-        const modeBtn = (label: string, icon: string, mode: PickerMode): HTMLButtonElement => {
-            const b = doc.createElement('button');
-            b.className = 'vela-lp-mode';
-            b.setAttribute('aria-label', label);
-            b.append(iconEl(icon, doc));
-            const text = doc.createElement('span');
-            text.className = 'vela-lp-mode-label';
-            text.textContent = label;
-            b.appendChild(text);
-            b.addEventListener('click', () => this.setMode(mode));
-            this.modeTips.push(new Tooltip(b, { host: opts.host, placement: 'bottom', content: label }));
-            modes.appendChild(b);
-            return b;
-        };
-        this.modeBtns = {
-            grid: modeBtn('Grid', 'layout-grid', 'grid'),
-            columns: modeBtn('Columns', 'layout-columns', 'columns'),
-            rows: modeBtn('Rows', 'layout-rows', 'rows'),
-        };
-        this.modesEl = modes;
-
-        this.toolsEl = doc.createElement('div');
-        this.toolsEl.className = 'vela-lp-tools';
-        this.toolsEl.appendChild(modes);
-        layoutCol.appendChild(this.toolsEl);
 
         this.presetsEl = doc.createElement('div');
         this.presetsEl.className = 'vela-lp-presets';
@@ -466,44 +232,16 @@ export class LayoutPicker {
         syncCol.appendChild(this.syncEl);
         cols.appendChild(syncCol);
 
-        // ── Commit footer: Apply alone, full panel width (stack modes only) ──
-        const commit = doc.createElement('div');
-        commit.className = 'vela-lp-commit';
-        this.applyBtn = doc.createElement('button');
-        this.applyBtn.className = 'vela-lp-apply';
-        this.applyBtn.textContent = 'Apply';
-        this.applyBtn.addEventListener('click', () => {
-            if (this.mode === 'grid') return;
-            const counts = this.counts.filter((n) => n > 0);
-            if (counts.length === 0) return;
-            this.close();
-            this.opts.onSelectStacks(counts, this.mode);
-        });
-        commit.appendChild(this.applyBtn);
-        panel.appendChild(commit);
-        this.commitEl = commit;
-
-        // ── canvas interactions ──
+        // ── canvas interactions: hover previews the rectangle, click applies it ──
         grid.addEventListener('pointerdown', (e) => {
             const sq = this.squareAt(e);
             if (!sq) return;
             e.preventDefault();
             const { r, c } = this.squarePos(sq);
-            if (this.mode === 'grid') {
-                this.close();
-                this.opts.onSelectGrid(r + 1, c + 1);
-                return;
-            }
-            // Stack modes: a click on a stack's exact end toggles that track off, any
-            // other square sets the stack size — so one click grows, shrinks, or
-            // clears without a separate eraser. The track/size axes follow the mode.
-            const track = this.mode === 'columns' ? c : r;
-            const size = this.mode === 'columns' ? r + 1 : c + 1;
-            this.counts[track] = this.counts[track] === size ? 0 : size;
-            this.render();
+            this.close();
+            this.opts.onSelectGrid(r + 1, c + 1);
         });
         grid.addEventListener('pointermove', (e) => {
-            if (this.mode !== 'grid') return;
             const sq = this.squareAt(e);
             if (!sq) return;
             const { r, c } = this.squarePos(sq);
@@ -513,7 +251,7 @@ export class LayoutPicker {
             }
         });
         grid.addEventListener('pointerleave', () => {
-            if (this.mode === 'grid' && this.hover) {
+            if (this.hover) {
                 this.hover = null;
                 this.render();
             }
@@ -533,28 +271,7 @@ export class LayoutPicker {
     open(): void {
         if (this.isOpen) return;
         this.isOpen = true;
-        // The canvas starts on the CURRENT layout: rectangle pick for grids, the
-        // matching stack mode for column/row splits.
-        const shape = this.opts.shape();
-        this.mode = shape && 'counts' in shape ? shape.axis : 'grid';
-        this.counts = this.seedCounts(shape);
         this.hover = null;
-        // Open on the tab that shows the CURRENT layout: Presets when a tile matches
-        // (following the ⇄ state the layout was made with), Grid for anything else
-        // the canvas can express; otherwise keep the last tab (sticky).
-        const key = shapeKey(shape);
-        const keysFor = (flipped: boolean) =>
-            TILE_PRESETS.map((def) => stacksKey(flipped ? [...def.counts].reverse() : [...def.counts], def.axis));
-        if (key && keysFor(this.flipped).includes(key)) {
-            this.tab = 'presets';
-        } else if (key && keysFor(!this.flipped).includes(key)) {
-            this.flipped = !this.flipped;
-            this.buildTiles();
-            this.tab = 'presets';
-        } else if (shape) {
-            this.tab = 'grid';
-        }
-        this.infoTip.setContent(() => this.tipNode());
         this.refresh();
         this.layer.style.display = '';
         this.position();
@@ -585,25 +302,10 @@ export class LayoutPicker {
     destroy(): void {
         this.close();
         this.infoTip.destroy();
-        for (const tip of this.modeTips) tip.destroy();
         this.layer.remove();
     }
 
     // ── internals ──
-    /** Stacks along the given axis seeded from a shape (uniform grids become stacks). */
-    private seedCounts(shape: LayoutPickerShape | null): number[] {
-        const counts = [0, 0, 0, 0];
-        if (shape && 'counts' in shape) {
-            for (const [i, n] of shape.counts.slice(0, GRID).entries()) counts[i] = Math.min(GRID, n);
-        } else if (shape) {
-            const axis = this.mode === 'rows' ? 'rows' : 'columns';
-            const tracks = axis === 'columns' ? shape.cols : shape.rows;
-            const size = axis === 'columns' ? shape.rows : shape.cols;
-            for (let i = 0; i < Math.min(GRID, tracks); i += 1) counts[i] = Math.min(GRID, size);
-        }
-        return counts;
-    }
-
     private squareAt(e: PointerEvent): HTMLButtonElement | null {
         const sq = (e.target as Element | null)?.closest?.('.vela-lp-sq');
         return sq instanceof HTMLButtonElement ? sq : null;
@@ -613,132 +315,23 @@ export class LayoutPicker {
         return { r: Number(sq.dataset.r), c: Number(sq.dataset.c) };
     }
 
-    private setMode(mode: PickerMode): void {
-        if (this.mode === mode) return;
-        const from = this.mode;
-        this.mode = mode;
-        this.hover = null;
-        if (mode !== 'grid') {
-            if (from === 'grid') {
-                // Entering a stack mode starts from what the canvas currently shows —
-                // including a stack layout painted along the OTHER axis.
-                const shape = this.opts.shape();
-                this.counts = this.seedCounts(shape);
-                if (shape && 'counts' in shape && shape.axis !== mode) this.counts = conjugate(this.counts);
-            } else {
-                // Columns ↔ Rows keeps the PAINTED PATTERN in place instead of
-                // transposing it, re-reading the same staircase along the other axis.
-                this.counts = conjugate(this.counts);
-            }
-        }
-        this.infoTip.setContent(() => this.tipNode());
-        this.render();
-    }
-
-    /** Tab- and mode-aware help copy for the "?" badge. */
+    /** Help copy for the LAYOUT "?" badge. */
     private tipNode(): HTMLElement {
         const tip = this.doc.createElement('div');
         tip.className = 'vela-lp-tip';
-        tip.textContent =
-            this.tab !== 'grid'
-                ? 'Click a preset to apply it — ⇄ mirrors the split presets.'
-                : this.mode === 'grid'
-                  ? 'Click a square to apply that columns × rows layout.'
-                  : this.mode === 'columns'
-                    ? "Click squares to set each column's chart stack, then Apply."
-                    : "Click squares to set each row's chart stack, then Apply.";
+        tip.textContent = 'Click a square to apply that columns × rows layout.';
         return tip;
     }
 
-    /** (Re)build the preset tiles for the current ⇄ state. */
-    private buildTiles(): void {
-        const doc = this.doc;
-        this.tilesEl.replaceChildren();
-        for (const def of TILE_PRESETS) {
-            const counts = this.flipped ? [...def.counts].reverse() : [...def.counts];
-            const label = (this.flipped ? def.flipLabel : undefined) ?? def.label;
-            const tile = doc.createElement('button');
-            tile.className = 'vela-lp-tile';
-            tile.dataset.key = stacksKey(counts, def.axis);
-            tile.setAttribute('aria-label', label);
-            const canvas = doc.createElement('span');
-            canvas.className = 'vela-lp-tile-canvas';
-            for (let i = 0; i < counts.length; i += 1) {
-                const size = counts[i] ?? 0;
-                for (let j = 0; j < size; j += 1) {
-                    const pane = doc.createElement('span');
-                    pane.className = 'vela-lp-tile-pane';
-                    const [x, y, w, h] =
-                        def.axis === 'columns'
-                            ? [i / counts.length, j / size, 1 / counts.length, 1 / size]
-                            : [j / size, i / counts.length, 1 / size, 1 / counts.length];
-                    pane.style.left = `calc(${x * 100}% + 1px)`;
-                    pane.style.top = `calc(${y * 100}% + 1px)`;
-                    pane.style.width = `calc(${w * 100}% - 2px)`;
-                    pane.style.height = `calc(${h * 100}% - 2px)`;
-                    canvas.appendChild(pane);
-                }
-            }
-            tile.appendChild(canvas);
-            tile.addEventListener('click', () => {
-                this.close();
-                this.opts.onSelectStacks([...counts], def.axis);
-            });
-            this.tilesEl.appendChild(tile);
-        }
-        // ⇄ — mirror the asymmetric splits (large pane right/bottom instead of left/top).
-        const flip = doc.createElement('button');
-        flip.className = 'vela-lp-tile vela-lp-tile-flip';
-        flip.textContent = '⇄';
-        flip.setAttribute('aria-label', 'Mirror presets');
-        flip.addEventListener('click', () => {
-            this.flipped = !this.flipped;
-            this.buildTiles();
-            this.render();
-        });
-        this.tilesEl.appendChild(flip);
-    }
-
-    /** Project the interaction state onto the DOM (tabs, tiles, squares, mode). */
+    /** Project the interaction state onto the DOM (the hover/current rectangle). */
     private render(): void {
-        for (const [tab, btn] of Object.entries(this.tabBtns)) {
-            btn.dataset.active = this.tab === tab ? '1' : '';
-        }
-        this.tilesEl.style.display = this.tab === 'presets' ? '' : 'none';
-        this.canvasEl.style.display = this.tab === 'grid' ? '' : 'none';
-        this.toolsEl.style.display = this.tab === 'grid' ? '' : 'none';
-        this.modesEl.style.display = '';
-        const preview = this.mode === 'grid' ? (this.hover ?? this.gridShape()) : null;
+        const preview = this.hover ?? this.opts.shape();
         for (const sq of this.squares) {
             const { r, c } = this.squarePos(sq);
-            const on =
-                this.mode === 'grid'
-                    ? preview !== null && r < preview.rows && c < preview.cols
-                    : this.mode === 'columns'
-                      ? r < (this.counts[c] ?? 0)
-                      : c < (this.counts[r] ?? 0);
+            const on = preview !== null && r < preview.rows && c < preview.cols;
             if (on) sq.dataset.on = '1';
             else delete sq.dataset.on;
         }
-        for (const [mode, btn] of Object.entries(this.modeBtns)) {
-            btn.dataset.active = this.mode === mode ? '1' : '';
-        }
-        // Tile checked state mirrors the CURRENT layout, whichever tab is visible.
-        const key = shapeKey(this.opts.shape());
-        for (const tile of this.tilesEl.querySelectorAll<HTMLElement>('.vela-lp-tile')) {
-            tile.dataset.checked = tile.dataset.key && tile.dataset.key === key ? '1' : '';
-        }
-        // Apply commits stack painting; rectangle picks and presets apply on click.
-        const stackMode = this.tab === 'grid' && this.mode !== 'grid';
-        this.commitEl.style.display = stackMode ? '' : 'none';
-        if (stackMode) {
-            this.applyBtn.disabled = this.counts.every((n) => n <= 0);
-        }
-    }
-
-    private gridShape(): { rows: number; cols: number } | null {
-        const shape = this.opts.shape();
-        return shape && 'rows' in shape ? shape : null;
     }
 
     private renderPresets(): void {

--- a/src/widget/topbar.ts
+++ b/src/widget/topbar.ts
@@ -2,6 +2,7 @@
 // every chart type registered through the plugin SDK, labels from the registry).
 import { Menu, type MenuItemDescriptor } from '../ui/components/menu';
 import { Tooltip } from '../ui/components/tooltip';
+import { LayoutPicker, type LayoutPickerShape } from './layout-picker';
 import { iconEl, iconMarkup, registerIcon } from '../ui/icons';
 import { injectStyles } from '../ui/styles';
 import { chartType } from '../chart-types/registry';
@@ -135,16 +136,23 @@ export interface TopbarOptions {
     priceStyle: string;
     onTimeframe: (tf: string) => void;
     onPriceStyle: (style: string) => void;
-    /** Optional workspace LAYOUT dropdown (rendered after the style dropdown when given).
-     *  `options` is read live, so plugin-registered layouts appear automatically. */
+    /** Optional workspace LAYOUT dropdown (rendered after the style dropdown when
+     *  given) — the grid-canvas picker composing uniform grids and per-column stacks,
+     *  with the workspace SYNC switches beside it. Everything is read live, so
+     *  plugin-registered layouts and setting flips appear automatically. */
     layout?: {
         current: string;
-        options: () => Array<{ id: string; label: string }>;
-        onSelect: (id: string) => void;
-        /** Optional TOGGLE rows appended under the layout presets (e.g. the workspace's
-         *  "Sync crosshair"). Re-read on every open/refresh; `onToggle` flips one. */
-        toggles?: () => Array<{ id: string; label: string; checked: boolean }>;
-        onToggle?: (id: string) => void;
+        /** Current layout's picker-canvas shape (null = not canvas-expressible). */
+        shape: () => LayoutPickerShape | null;
+        /** Registered layouts the canvas cannot express — rendered as labeled rows. */
+        presets: () => Array<{ id: string; label: string }>;
+        onSelectGrid: (rows: number, cols: number) => void;
+        /** Custom-mode commit: per-column or per-row chart stacks, per `axis`. */
+        onSelectStacks: (counts: number[], axis: 'columns' | 'rows') => void;
+        onSelectPreset: (id: string) => void;
+        /** SYNC switch rows (re-read on every open and after each toggle). */
+        syncs: () => Array<{ id: string; label: string; checked: boolean }>;
+        onToggleSync: (id: string) => void;
     };
     onIndicatorsClick?: () => void;
     /** Unified undo/redo (same stack as Ctrl+Z / Ctrl+Y). Enabled state is pushed with
@@ -163,7 +171,7 @@ export class Topbar {
     private readonly tfButton: HTMLElement;
     private readonly styleButton: HTMLElement;
     private layoutButton: HTMLElement | null = null;
-    private layoutMenu: Menu | null = null;
+    private layoutPicker: LayoutPicker | null = null;
     private layoutId: string | null = null;
     private readonly tfMenu: Menu;
     private readonly styleMenu: Menu;
@@ -268,21 +276,17 @@ export class Topbar {
         this.tooltips.push(new Tooltip(this.styleButton, { content: 'Chart style', triggerId: 'vela-topbar-style', host }));
         if (this.layoutButton && opts.layout) {
             this.tooltips.push(new Tooltip(this.layoutButton, { content: 'Layout', triggerId: 'vela-topbar-layout', host }));
-            this.layoutMenu = new Menu({
+            const layout = opts.layout;
+            this.layoutPicker = new LayoutPicker({
                 trigger: this.layoutButton,
-                triggerId: 'vela-topbar-layout',
                 host,
-                items: this.layoutItems(),
-                onSelect: (id) => {
-                    // Toggle rows flip their setting and stay reflected on next open;
-                    // every other id is a layout preset.
-                    if (id.startsWith('toggle:')) {
-                        opts.layout!.onToggle?.(id.slice('toggle:'.length));
-                        this.layoutMenu?.setItems(this.layoutItems());
-                        return;
-                    }
-                    opts.layout!.onSelect(id);
-                },
+                shape: () => layout.shape(),
+                presets: () => layout.presets().map((p) => ({ ...p, checked: p.id === this.layoutId })),
+                onSelectGrid: (rows, cols) => layout.onSelectGrid(rows, cols),
+                onSelectStacks: (counts, axis) => layout.onSelectStacks(counts, axis),
+                onSelectPreset: (id) => layout.onSelectPreset(id),
+                syncs: () => layout.syncs(),
+                onToggleSync: (id) => layout.onToggleSync(id),
             });
         }
         this.tfMenu = new Menu({
@@ -325,7 +329,7 @@ export class Topbar {
         if (!this.layoutButton) return;
         this.layoutId = id;
         this.renderLayoutButton(this.layoutButton.ownerDocument);
-        this.layoutMenu?.setItems(this.layoutItems());
+        this.layoutPicker?.refresh();
     }
 
     private renderLayoutButton(doc: Document): void {
@@ -336,12 +340,6 @@ export class Topbar {
         if (iconMarkup('layout')) this.layoutButton.appendChild(iconEl('layout', doc));
         else this.layoutButton.appendChild(doc.createTextNode(this.layoutId ?? ''));
         this.layoutButton.setAttribute('aria-label', `Layout — ${this.layoutId ?? ''}`);
-    }
-
-    private layoutItems(): MenuItemDescriptor[] {
-        const presets = (this.opts.layout?.options() ?? []).map((l) => ({ id: l.id, label: l.label, checked: l.id === this.layoutId }));
-        const toggles = (this.opts.layout?.toggles?.() ?? []).map((t, i) => ({ id: `toggle:${t.id}`, label: t.label, checked: t.checked, toggle: true, separatorBefore: i === 0 }));
-        return [...presets, ...toggles];
     }
 
     private renderStyleButton(doc: Document): void {
@@ -418,7 +416,7 @@ export class Topbar {
         if (this.hairlineRaf) win?.cancelAnimationFrame(this.hairlineRaf);
         this.tfMenu.destroy();
         this.styleMenu.destroy();
-        this.layoutMenu?.destroy();
+        this.layoutPicker?.destroy();
         for (const t of [...this.tooltips, ...this.panelTooltips]) t.destroy();
         this.el.remove();
     }

--- a/src/widget/topbar.ts
+++ b/src/widget/topbar.ts
@@ -137,9 +137,9 @@ export interface TopbarOptions {
     onTimeframe: (tf: string) => void;
     onPriceStyle: (style: string) => void;
     /** Optional workspace LAYOUT dropdown (rendered after the style dropdown when
-     *  given) — the grid-canvas picker composing uniform grids and per-column stacks,
-     *  with the workspace SYNC switches beside it. Everything is read live, so
-     *  plugin-registered layouts and setting flips appear automatically. */
+     *  given) — the grid-canvas picker composing uniform grids, with the workspace
+     *  SYNC switches beside it. Everything is read live, so plugin-registered
+     *  layouts and setting flips appear automatically. */
     layout?: {
         current: string;
         /** Current layout's picker-canvas shape (null = not canvas-expressible). */
@@ -147,8 +147,6 @@ export interface TopbarOptions {
         /** Registered layouts the canvas cannot express — rendered as labeled rows. */
         presets: () => Array<{ id: string; label: string }>;
         onSelectGrid: (rows: number, cols: number) => void;
-        /** Custom-mode commit: per-column or per-row chart stacks, per `axis`. */
-        onSelectStacks: (counts: number[], axis: 'columns' | 'rows') => void;
         onSelectPreset: (id: string) => void;
         /** SYNC switch rows (re-read on every open and after each toggle). */
         syncs: () => Array<{ id: string; label: string; checked: boolean }>;
@@ -283,7 +281,6 @@ export class Topbar {
                 shape: () => layout.shape(),
                 presets: () => layout.presets().map((p) => ({ ...p, checked: p.id === this.layoutId })),
                 onSelectGrid: (rows, cols) => layout.onSelectGrid(rows, cols),
-                onSelectStacks: (counts, axis) => layout.onSelectStacks(counts, axis),
                 onSelectPreset: (id) => layout.onSelectPreset(id),
                 syncs: () => layout.syncs(),
                 onToggleSync: (id) => layout.onToggleSync(id),

--- a/src/widget/watermark.ts
+++ b/src/widget/watermark.ts
@@ -3,6 +3,13 @@ import { injectStyles } from '../ui/styles';
 import { timeframeLabel } from './timeframe';
 import { parseSymbol } from '../data/ProviderRegistry';
 
+/** The watermark's largest type size — a lone full-size chart renders at this cap. */
+const MAX_FONT_PX = 72;
+/** Floor for tiny cells — the mark is a 5%-opacity background, small is fine. */
+const MIN_FONT_PX = 12;
+/** Share of the chart width the text may occupy (breathing room at both edges). */
+const FILL = 0.9;
+
 const STYLE_ID = 'vela-widget-watermark';
 const CSS = `
 .vela-watermark {
@@ -15,7 +22,7 @@ const CSS = `
     z-index: 1;
     color: var(--vela-fg);
     opacity: 0.05;
-    font-size: clamp(28px, 7vw, 72px);
+    font-size: ${MAX_FONT_PX}px;
     font-weight: 700;
     letter-spacing: 0.04em;
     user-select: none;
@@ -23,14 +30,36 @@ const CSS = `
 }
 `;
 
+/**
+ * The font size that fits `textPxAtMax` (the text's width measured AT the cap) into
+ * `availPx` of chart width — PURE. Text width scales linearly with font size, so one
+ * measurement at the cap decides the whole fit; the size is bounded to
+ * [{@link MIN_FONT_PX}, {@link MAX_FONT_PX}]. The chart's OWN width is what bounds the
+ * mark — a viewport-relative size overflows small cells in a multi-chart grid.
+ */
+export function watermarkFontPx(availPx: number, textPxAtMax: number): number {
+    if (textPxAtMax <= 0) return MAX_FONT_PX;
+    return Math.max(MIN_FONT_PX, Math.min(MAX_FONT_PX, Math.floor((MAX_FONT_PX * availPx * FILL) / textPxAtMax)));
+}
+
 export class Watermark {
     readonly el: HTMLElement;
+    private readonly text: HTMLElement;
+    private readonly resizeObserver: ResizeObserver | null = null;
 
     constructor(host: HTMLElement, symbol: string, timeframe: string) {
         injectStyles(STYLE_ID, CSS, host.ownerDocument);
         this.el = host.ownerDocument.createElement('div');
         this.el.className = 'vela-watermark';
+        this.text = host.ownerDocument.createElement('span');
+        this.el.appendChild(this.text);
         host.appendChild(this.el);
+        // The el is inset:0, so observing it tracks the chart's size (splitter drags,
+        // layout changes) — refit whenever the space changes.
+        if (typeof ResizeObserver !== 'undefined') {
+            this.resizeObserver = new ResizeObserver(() => this.fit());
+            this.resizeObserver.observe(this.el);
+        }
         this.update(symbol, timeframe);
     }
 
@@ -40,10 +69,20 @@ export class Watermark {
 
     update(symbol: string, timeframe: string): void {
         // Bare ticker — the venue prefix is routing identity, not something to watermark.
-        this.el.textContent = symbol ? `${parseSymbol(symbol).ticker} · ${timeframeLabel(timeframe)}` : '';
+        this.text.textContent = symbol ? `${parseSymbol(symbol).ticker} · ${timeframeLabel(timeframe)}` : '';
+        this.fit();
+    }
+
+    /** Measure the text at the cap and shrink it to the chart's own width. */
+    private fit(): void {
+        if (this.el.clientWidth <= 0 || !this.text.textContent) return;
+        this.el.style.fontSize = `${MAX_FONT_PX}px`;
+        const px = watermarkFontPx(this.el.clientWidth, this.text.getBoundingClientRect().width);
+        if (px !== MAX_FONT_PX) this.el.style.fontSize = `${px}px`;
     }
 
     destroy(): void {
+        this.resizeObserver?.disconnect();
         this.el.remove();
     }
 }

--- a/src/widget/watermark.ts
+++ b/src/widget/watermark.ts
@@ -14,7 +14,14 @@ const STYLE_ID = 'vela-widget-watermark';
 const CSS = `
 .vela-watermark {
     position: absolute;
-    inset: 0;
+    /* Insets follow the renderer-published gutters (mount container), so the mark
+     * centers and fits within the PLOT — never bleeding into the drawings toolbar
+     * on the left or the price scale on the right (visible in small multi-chart
+     * cells, where the scale is a large share of the width). */
+    top: 0;
+    bottom: 0;
+    left: var(--vela-toolbar-gutter, 0px);
+    right: var(--vela-scale-gutter, 0px);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -49,6 +49,7 @@ import {
     layouts,
     gridStyles,
     activeAfterLayout,
+    orderAfterLayout,
     ensureLayout,
     layoutForGrid,
     layoutShape,
@@ -688,6 +689,10 @@ export class VelaWorkspace {
         const next = this.resolveLayout(layout);
         const nextBackend = this.backendFor(next);
         const rebuildAll = nextBackend !== this.cellBackend;
+        // The ACTIVE chart always survives a shrink — it moves into the last kept
+        // slot instead of pooling, so changing the grid never hides the chart the
+        // user is working in.
+        this.order = orderAfterLayout(this.order, next.cells.length, this.activeId);
         const keep = new Set(this.order.slice(0, next.cells.length));
         for (const [id, cell] of [...this.cellsById]) {
             if (!keep.has(id) || rebuildAll) {

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -46,10 +46,14 @@ import { ChartCell, seedDefaults, cellChartDefaults, type CellSeed, type CellBoo
 import { buildContext, type WorkspaceWidgetContext } from './context';
 import {
     registerBuiltinLayouts,
-    layoutDefinition,
     layouts,
     gridStyles,
     activeAfterLayout,
+    ensureLayout,
+    layoutForGrid,
+    layoutForColumns,
+    layoutForRows,
+    layoutShape,
     type LayoutDefinition,
     type TrackSizes,
 } from './layouts';
@@ -126,8 +130,10 @@ const CSS = `
 .vela-ws-grid { position: relative; flex: 1 1 auto; min-width: 0; display: grid; gap: ${GAP_PX}px; background: var(--vela-border-soft); }
 .vela-cell { background: var(--vela-bg); position: relative; }
 /* Active-cell highlight: an overlay ring ABOVE the chart's own canvas stack (a plain
-   outline on the cell is painted under them) — inert to the pointer. */
-.vela-cell[data-active='1']::after {
+   outline on the cell is painted under them) — inert to the pointer. Scoped to
+   multi-cell grids ([data-multi]): a single-cell layout always has an active cell,
+   and ringing the only chart would just be noise. */
+.vela-ws-grid[data-multi='1'] .vela-cell[data-active='1']::after {
     content: '';
     position: absolute;
     inset: 0;
@@ -259,7 +265,7 @@ export class VelaWorkspace {
         for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair'] as const) {
             this.applySyncSetting(kind, sync?.[kind]);
         }
-        this.def = this.resolveLayout(boot?.layout && layoutDefinition(boot.layout) ? boot.layout : (opts.layout ?? '4'));
+        this.def = this.resolveLayout(boot?.layout && ensureLayout(boot.layout) ? boot.layout : (opts.layout ?? '4'));
         if (boot?.trackSizes) for (const [id, ts] of Object.entries(boot.trackSizes)) this.trackSizes.set(id, ts);
         if (boot?.charts) for (const { id, ...cs } of boot.charts) this.pool.set(id, cs);
         // Identity ↔ slot mapping: the persisted document's chart order wins (it IS the
@@ -323,14 +329,24 @@ export class VelaWorkspace {
             onPriceStyle: (style) => this.active.setPriceStyle(style),
             layout: {
                 current: this.def.id,
-                options: () => layouts().map((l) => ({ id: l.id, label: l.label })),
-                onSelect: (id) => this.setLayout(id),
-                // Workspace-wide view toggles live under the grid presets. The check
-                // reflects the simple all-cells form; flipping OVERRIDES a host-set
-                // group record with plain on/off (groups stay an API-only shape).
-                toggles: () => [{ id: 'crosshair-sync', label: 'Sync crosshair', checked: this.syncOpts.crosshair === true }],
-                onToggle: (id) => {
-                    if (id === 'crosshair-sync') this.sync.set('crosshair', this.syncOpts.crosshair ? false : true);
+                // The picker composes dynamic layouts on its grid canvas; registered
+                // presets the canvas cannot express (bespoke plugin areas) list as rows.
+                shape: () => layoutShape(this.def),
+                presets: () => layouts().filter((l) => layoutShape(l) === null).map((l) => ({ id: l.id, label: l.label })),
+                onSelectGrid: (rows, cols) => this.setLayout(layoutForGrid(rows, cols)),
+                onSelectStacks: (counts, axis) => this.setLayout(axis === 'rows' ? layoutForRows(counts) : layoutForColumns(counts)),
+                onSelectPreset: (id) => this.setLayout(id),
+                // The SYNC switches reflect the simple all-cells form; flipping one
+                // OVERRIDES a host-set group record with plain on/off (groups stay an
+                // API-only shape).
+                syncs: () => [
+                    { id: 'symbol', label: 'Symbol', checked: this.syncOpts.symbol === true },
+                    { id: 'timeframe', label: 'Interval', checked: this.syncOpts.timeframe === true },
+                    { id: 'crosshair', label: 'Crosshair', checked: this.syncOpts.crosshair === true },
+                ],
+                onToggleSync: (id) => {
+                    const kind = id as SyncKind;
+                    this.sync.set(kind, this.syncOpts[kind] ? false : true);
                 },
             },
             getContext: () => this.context(),
@@ -629,7 +645,7 @@ export class VelaWorkspace {
         this.pool.clear();
         for (const { id, ...cs } of st.charts) this.pool.set(id, cs);
         this.order = st.charts.map((c) => c.id); // the document's arrangement IS the order
-        const def = layoutDefinition(st.layout);
+        const def = ensureLayout(st.layout);
         if (def) this.def = def;
         this.cellBackend = this.backendFor(this.def);
         this.applyGrid();
@@ -802,7 +818,9 @@ export class VelaWorkspace {
     // ── internals ───────────────────────────────────────────────
     private resolveLayout(layout: string | LayoutDefinition): LayoutDefinition {
         if (typeof layout !== 'string') return layout;
-        const def = layoutDefinition(layout);
+        // Registered ids first, then the picker's self-describing dynamic ids
+        // (`g3x2`, `p3-2`) — those synthesize without touching the registry.
+        const def = ensureLayout(layout);
         if (!def) throw new Error(`[vela] unknown workspace layout "${layout}" — register it with registerLayout().`);
         return def;
     }
@@ -835,6 +853,9 @@ export class VelaWorkspace {
      *  `order[i]` — the identity/position decoupling in one line. */
     private applyGrid(): void {
         const { container, perCell } = gridStyles(this.def, this.trackSizes.get(this.def.id));
+        // The active-cell ring only exists on multi-cell grids (see the stylesheet).
+        if (this.def.cells.length > 1) this.gridEl.dataset.multi = '1';
+        else delete this.gridEl.dataset.multi;
         this.gridEl.style.gridTemplateColumns = container.gridTemplateColumns ?? '';
         this.gridEl.style.gridTemplateRows = container.gridTemplateRows ?? '';
         this.gridEl.style.gridTemplateAreas = container.gridTemplateAreas ?? '';
@@ -883,6 +904,9 @@ export class VelaWorkspace {
             });
             cell.host.style.gridArea = perCell[slot.id]?.gridArea ?? '';
             this.cellsById.set(id, cell);
+            // A REBUILT active cell (backend flip, pool round-trip) gets a fresh host —
+            // re-assert the highlight attribute setActiveCell put on the old one.
+            if (id === this.activeId) cell.host.dataset.active = '1';
             this.wireCell(cell);
             // The shared star set is a workspace pref — every newborn cell inherits it
             // silently (equal-set idempotence keeps the favorites event from echoing).
@@ -972,11 +996,14 @@ export class VelaWorkspace {
             if (setting && ![...this.cellsById.values()].some((c) => c.chart.renderer.supportsExternalCrosshair)) {
                 console.warn('[vela] crosshair sync: no cell renderer supports an external crosshair — nothing will show.');
             }
-            // Refresh the layout dropdown's toggle check (absent during constructor boot).
+            // Refresh the layout dropdown's switch state (absent during constructor boot).
             if (this.topbar && this.def) this.topbar.setLayout(this.def.id);
             this.markStateDirty();
             return; // no market/viewport alignment applies to a pointer link
         }
+        // Symbol/interval switches live in the layout dropdown too — keep an open
+        // panel truthful when the setting flips through the API.
+        if (this.topbar && this.def) this.topbar.setLayout(this.def.id);
         this.markStateDirty();
         if (align && setting && this.activeId) {
             if (kind === 'viewport') {

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -51,8 +51,6 @@ import {
     activeAfterLayout,
     ensureLayout,
     layoutForGrid,
-    layoutForColumns,
-    layoutForRows,
     layoutShape,
     occupancyGrid,
     type LayoutDefinition,
@@ -340,7 +338,6 @@ export class VelaWorkspace {
                 shape: () => layoutShape(this.def),
                 presets: () => layouts().filter((l) => layoutShape(l) === null).map((l) => ({ id: l.id, label: l.label })),
                 onSelectGrid: (rows, cols) => this.setLayout(layoutForGrid(rows, cols)),
-                onSelectStacks: (counts, axis) => this.setLayout(axis === 'rows' ? layoutForRows(counts) : layoutForColumns(counts)),
                 onSelectPreset: (id) => this.setLayout(id),
                 // The SYNC switches reflect the simple all-cells form; flipping one
                 // OVERRIDES a host-set group record with plain on/off (groups stay an
@@ -826,7 +823,7 @@ export class VelaWorkspace {
     private resolveLayout(layout: string | LayoutDefinition): LayoutDefinition {
         if (typeof layout !== 'string') return layout;
         // Registered ids first, then the picker's self-describing dynamic ids
-        // (`g3x2`, `p3-2`) — those synthesize without touching the registry.
+        // (`g3x2`) — those synthesize without touching the registry.
         const def = ensureLayout(layout);
         if (!def) throw new Error(`[vela] unknown workspace layout "${layout}" — register it with registerLayout().`);
         return def;

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -54,6 +54,7 @@ import {
     layoutForColumns,
     layoutForRows,
     layoutShape,
+    occupancyGrid,
     type LayoutDefinition,
     type TrackSizes,
 } from './layouts';
@@ -141,7 +142,12 @@ const CSS = `
     pointer-events: none;
     z-index: 10;
 }
-.vela-ws-splitter:hover { background: var(--vela-accent); opacity: 0.35; }
+/* Splitter hover mirrors the in-chart pane separator hover (CrosshairRenderer):
+   a soft band over the whole grab target + a solid 2px line on the seam center. */
+.vela-ws-splitter:hover { background: var(--vela-separator-hover-band); }
+.vela-ws-splitter:hover::after { content: ''; position: absolute; background: var(--vela-separator-hover-line); }
+.vela-ws-splitter[data-axis='cols']:hover::after { left: calc(50% - 1px); top: 0; width: 2px; height: 100%; }
+.vela-ws-splitter[data-axis='rows']:hover::after { top: calc(50% - 1px); left: 0; height: 2px; width: 100%; }
 `;
 
 /** Grid glyph for the topbar layout dropdown (stroke follows the button color). */
@@ -452,6 +458,7 @@ export class VelaWorkspace {
 
         this.splitters = new SplitterLayer(this.gridEl, {
             tracks: () => this.currentTracks(),
+            grid: () => occupancyGrid(this.def),
             apply: (axis, weights) => this.applyTracks(axis, weights),
             reset: (axis) => this.applyTracks(axis, evenTracks(this.currentTracks()[axis].length)),
             gapPx: () => GAP_PX,

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -240,8 +240,9 @@ export class VelaWorkspace {
     private drawingSyncBusy = false;
     /** LINKED drawings (the drawings sync): one map per synced set (cellId → that
      *  cell's drawing id), reachable from every member under its `cellId\0drawingId`
-     *  key — any member finds its peers to push edits/removals onto. Session-scoped:
-     *  a reload (or `applyState`) leaves previously synced drawings independent. */
+     *  key — any member finds its peers to push edits/removals onto. Survives a
+     *  toggle-off (propagation freezes while the setting is off; re-enabling resumes
+     *  edit/delete for these pairs). Cleared on reload / `applyState`. */
     private readonly drawingLinks = new Map<string, Map<string, string>>();
     private manifest: ResolvedIndicator[] = [];
     /** The shared manifest can no longer change instance sets — resolved, or no
@@ -1033,8 +1034,9 @@ export class VelaWorkspace {
         if (setting == null || setting === false) delete this.syncOpts[kind];
         else this.syncOpts[kind] = setting;
         if (kind === 'drawings') {
-            // Only FUTURE drawings follow the link — nothing to align retroactively,
-            // but any mirrored placement ghosts are stale under the new setting.
+            // Placement ghosts are stale under the new setting. Link pairs stay —
+            // turning off freezes propagation; turning on resumes edit/delete for
+            // drawings paired earlier (never copies unpaired ones onto peers).
             for (const cell of this.cellsById.values()) cell.chart.drawings.setExternalGhost(null);
             // The toggle lives on the shared drawing toolbar; keep it truthful.
             this.drawToolbar?.setDrawingsSyncMode(!!setting);

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -37,7 +37,7 @@ import { resolveIndicators, type IndicatorManifest, type ResolvedIndicator } fro
 import { DrawingToolbar } from '../renderers/native/drawings/DrawingToolbar';
 import { createAttributionMark, createCustomMark } from '../renderers/native/chrome/AttributionMark';
 import { rendererDefaults } from '../core/renderer-defaults';
-import { defaultToolbar, type DrawingTypeKey, type SnapMode } from '../core/drawings';
+import { defaultToolbar, type DrawingTypeKey, type SerializedDrawing, type SnapMode } from '../core/drawings';
 import { timeframeToMs } from '../data/timeframe';
 import { syncTargets, rangesWithin, type SyncKind, type SyncOptions, type SyncSetting } from './sync';
 import { encodeState, decodeState, sanitizeState, type WorkspaceState, type WorkspaceStorage } from './persist';
@@ -86,8 +86,10 @@ export interface VelaWorkspaceOptions extends Omit<VelaOptions, 'height'>, VelaS
     /** Sync links between cells: per kind, `true` = all cells, or a `{cellId: group}`
      *  record (only same-group cells follow each other). `crosshair` mirrors the
      *  pointer time as ghost crosshairs on the followers (also toggleable from the
-     *  layout dropdown). Default: everything off. Change at runtime via
-     *  `ws.sync.set(kind, setting)`. */
+     *  layout dropdown); `drawings` copies each newly created drawing onto the
+     *  followers and keeps the set linked — edits and removals follow (also
+     *  toggleable from the shared drawing toolbar). Default: everything off.
+     *  Change at runtime via `ws.sync.set(kind, setting)`. */
     sync?: SyncOptions;
     /** Above this many cells, EVERY cell uses the canvas2d backend (uniform look inside
      *  the browser's WebGL-context budget; glow is unavailable there). Default 8; an
@@ -233,6 +235,14 @@ export class VelaWorkspace {
     /** Re-entrance guard around one propagation tick: followers' synchronous echoes
      *  (their setVisibleRange re-emits viewport:changed) must not re-propagate. */
     private syncBusy = false;
+    /** Same guard for the drawings link: the propagated mutations' own `drawing:*`
+     *  events fire synchronously inside the propagation loop and must not fan out again. */
+    private drawingSyncBusy = false;
+    /** LINKED drawings (the drawings sync): one map per synced set (cellId → that
+     *  cell's drawing id), reachable from every member under its `cellId\0drawingId`
+     *  key — any member finds its peers to push edits/removals onto. Session-scoped:
+     *  a reload (or `applyState`) leaves previously synced drawings independent. */
+    private readonly drawingLinks = new Map<string, Map<string, string>>();
     private manifest: ResolvedIndicator[] = [];
     /** The shared manifest can no longer change instance sets — resolved, or no
      *  `indicators` option so nothing ever will. Gates the cells' ledger fallback. */
@@ -267,7 +277,7 @@ export class VelaWorkspace {
         this.timezone = boot?.timezone ?? opts.timezone ?? 'Etc/UTC';
         if (boot?.favorites) this.favs = [...boot.favorites];
         const sync = boot?.sync ?? opts.sync;
-        for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair'] as const) {
+        for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair', 'drawings'] as const) {
             this.applySyncSetting(kind, sync?.[kind]);
         }
         this.def = this.resolveLayout(boot?.layout && ensureLayout(boot.layout) ? boot.layout : (opts.layout ?? '4'));
@@ -433,11 +443,21 @@ export class VelaWorkspace {
                       this.active.chart.drawings.setStayMode(on);
                       this.refocusActive();
                   },
-                  { dock: 'static' },
+                  {
+                      dock: 'static',
+                      // Drawings sync is a WORKSPACE link (same model as the layout
+                      // dropdown's switches) — the bar only hosts its toggle.
+                      onDrawingsSync: (on) => {
+                          this.sync.set('drawings', on);
+                          this.refocusActive();
+                      },
+                  },
               )
             : null;
         this.drawToolbar?.setDefinition(defaultToolbar());
         this.drawToolbar?.setVisible(true);
+        // Sync settings applied before the bar existed (boot/persisted) — reflect now.
+        this.drawToolbar?.setDrawingsSyncMode(!!this.syncOpts.drawings);
 
         this.bottombar =
             opts.bottombar !== false
@@ -638,7 +658,7 @@ export class VelaWorkspace {
         if (st.favorites) this.favs = [...st.favorites]; // newborn cells inherit below (buildCells)
         // Absent in documents written before the dock existed — those leave the column closed.
         this.dock.applyState(st.panels);
-        for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair'] as const) this.applySyncSetting(kind, st.sync?.[kind]);
+        for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair', 'drawings'] as const) this.applySyncSetting(kind, st.sync?.[kind]);
         this.trackSizes.clear();
         if (st.trackSizes) for (const [id, ts] of Object.entries(st.trackSizes)) this.trackSizes.set(id, ts);
         // Full rebuild from the document — every current slot is replaced by the restored one.
@@ -648,6 +668,7 @@ export class VelaWorkspace {
             this.events.emit('cell:destroyed', { id });
         }
         this.pool.clear();
+        this.drawingLinks.clear(); // restored drawings carry new ids — old links are stale
         for (const { id, ...cs } of st.charts) this.pool.set(id, cs);
         this.order = st.charts.map((c) => c.id); // the document's arrangement IS the order
         const def = ensureLayout(st.layout);
@@ -962,9 +983,24 @@ export class VelaWorkspace {
         // as ghost markers. Leave already emits `time: null` — the clear rides along.
         chart.renderer.onCrosshairMove((e) => this.propagateCrosshair(cell.id, e.time));
         // Drawing edits are cell state (the per-slot drawings document) — persistable.
-        chart.on('drawing:created', () => this.markStateDirty());
-        chart.on('drawing:edited', () => this.markStateDirty());
-        chart.on('drawing:removed', () => this.markStateDirty());
+        // When the drawings link is on, a CREATED drawing copies onto the same-group
+        // cells and the set stays LINKED: edits and removals of any member follow
+        // (the guard stops the propagated mutations from fanning out again).
+        chart.on('drawing:created', ({ id }) => {
+            this.propagateDrawing(cell.id, id);
+            this.markStateDirty();
+        });
+        // Placement progress mirrors LIVE as ghosts on the same-group cells; the end of
+        // the placement carries `null`, which clears them (the created copy takes over).
+        chart.on('drawing:draft', ({ doc }) => this.propagateDraft(cell.id, doc));
+        chart.on('drawing:edited', ({ id }) => {
+            this.propagateDrawingEdit(cell.id, id);
+            this.markStateDirty();
+        });
+        chart.on('drawing:removed', ({ id }) => {
+            this.propagateDrawingRemoval(cell.id, id);
+            this.markStateDirty();
+        });
         // Tool/magnet/mode reflection (trigger ②): the ACTIVE cell's drawing state drives
         // the shared bar and the global mirrors — whatever the source (bar press, keymap,
         // API, a one-shot tool disarming itself after placement).
@@ -996,6 +1032,15 @@ export class VelaWorkspace {
     private applySyncSetting(kind: SyncKind, setting: SyncSetting | undefined, align = false): void {
         if (setting == null || setting === false) delete this.syncOpts[kind];
         else this.syncOpts[kind] = setting;
+        if (kind === 'drawings') {
+            // Only FUTURE drawings follow the link — nothing to align retroactively,
+            // but any mirrored placement ghosts are stale under the new setting.
+            for (const cell of this.cellsById.values()) cell.chart.drawings.setExternalGhost(null);
+            // The toggle lives on the shared drawing toolbar; keep it truthful.
+            this.drawToolbar?.setDrawingsSyncMode(!!setting);
+            this.markStateDirty();
+            return;
+        }
         if (kind === 'crosshair') {
             // Any setting change invalidates current ghosts — they rebuild on the next
             // pointer move under the NEW grouping (and vanish entirely when disabled).
@@ -1064,6 +1109,105 @@ export class VelaWorkspace {
             }
         } finally {
             this.syncBusy = false;
+        }
+    }
+
+    /**
+     * Copy a freshly created drawing onto the origin's same-group followers (fresh ids
+     * through `drawings.add` — anchors are time+price, so the copy lands at the same
+     * spot whatever the follower shows) and register the whole set as LINKED: edits
+     * and removals of any member follow while the link is on ({@link drawingLinks}).
+     * The busy guard stops the copies' own `drawing:created` events from fanning out.
+     */
+    private propagateDrawing(originId: string, drawingId: string): void {
+        if (this.drawingSyncBusy || this.destroyed) return;
+        const setting = this.syncOpts.drawings;
+        if (!setting) return;
+        const doc = this.cellsById.get(originId)?.chart.drawings.all().find((d) => d.id === drawingId);
+        if (!doc) return;
+        this.drawingSyncBusy = true;
+        try {
+            const group = new Map([[originId, drawingId]]);
+            for (const id of syncTargets(originId, setting, [...this.cellsById.keys()])) {
+                const copy = this.cellsById.get(id)?.chart.drawings.add(doc.type, {
+                    paneId: doc.paneId,
+                    anchors: doc.anchors,
+                    style: doc.style,
+                    text: doc.text,
+                    props: doc.props,
+                });
+                if (copy) group.set(id, copy.id);
+            }
+            if (group.size > 1) {
+                for (const [cellId, dId] of group) this.drawingLinks.set(`${cellId}\u0000${dId}`, group);
+            }
+        } finally {
+            this.drawingSyncBusy = false;
+        }
+    }
+
+    /** Mirror an in-progress placement (its current ghost, `null` = placement ended)
+     *  onto the origin's same-group followers — the live half of the drawings link;
+     *  the created copy replaces the ghosts when the placement completes. One-way by
+     *  contract (an external ghost never re-emits drafts), so no busy guard needed. */
+    private propagateDraft(originId: string, doc: SerializedDrawing | null): void {
+        if (this.destroyed) return;
+        const setting = this.syncOpts.drawings;
+        if (!setting) return;
+        for (const id of syncTargets(originId, setting, [...this.cellsById.keys()])) {
+            this.cellsById.get(id)?.chart.drawings.setExternalGhost(doc);
+        }
+    }
+
+    /** Push a linked drawing's edited CONTENT (anchors, style, text, per-type props)
+     *  onto its same-group peers — any member propagates, not just the original. */
+    private propagateDrawingEdit(originId: string, drawingId: string): void {
+        if (this.drawingSyncBusy || this.destroyed) return;
+        const setting = this.syncOpts.drawings;
+        if (!setting) return;
+        const group = this.drawingLinks.get(`${originId}\u0000${drawingId}`);
+        if (!group) return;
+        const doc = this.cellsById.get(originId)?.chart.drawings.all().find((d) => d.id === drawingId);
+        if (!doc) return;
+        this.drawingSyncBusy = true;
+        try {
+            for (const id of syncTargets(originId, setting, [...this.cellsById.keys()])) {
+                const peerId = group.get(id);
+                if (peerId == null) continue;
+                this.cellsById.get(id)?.chart.drawings.update(peerId, {
+                    anchors: doc.anchors,
+                    style: doc.style,
+                    text: doc.text,
+                    props: doc.props,
+                });
+            }
+        } finally {
+            this.drawingSyncBusy = false;
+        }
+    }
+
+    /** Remove a linked drawing's peers with it. The removed member always leaves its
+     *  link group (whatever the setting); peers are only deleted while the link is on.
+     *  A propagated peer removal re-enters here under the busy guard and just cleans
+     *  its own link key. */
+    private propagateDrawingRemoval(originId: string, drawingId: string): void {
+        if (this.destroyed) return;
+        const key = `${originId}\u0000${drawingId}`;
+        const group = this.drawingLinks.get(key);
+        if (!group) return;
+        this.drawingLinks.delete(key);
+        group.delete(originId);
+        if (this.drawingSyncBusy) return;
+        const setting = this.syncOpts.drawings;
+        if (!setting) return;
+        this.drawingSyncBusy = true;
+        try {
+            for (const id of syncTargets(originId, setting, [...this.cellsById.keys()])) {
+                const peerId = group.get(id);
+                if (peerId != null) this.cellsById.get(id)?.chart.drawings.remove(peerId);
+            }
+        } finally {
+            this.drawingSyncBusy = false;
         }
     }
 

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -14,8 +14,14 @@ export {
     registerBuiltinLayouts,
     gridStyles,
     activeAfterLayout,
+    layoutForGrid,
+    layoutForColumns,
+    layoutForRows,
+    ensureLayout,
+    layoutShape,
+    GRID_PICKER_MAX,
 } from './layouts';
-export type { LayoutDefinition, TrackSizes } from './layouts';
+export type { LayoutDefinition, LayoutShape, TrackSizes } from './layouts';
 export { evenTracks, resizeTracks, trackOffsets } from './splitters';
 export { syncTargets, rangesWithin } from './sync';
 export type { SyncKind, SyncSetting, SyncOptions } from './sync';

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -15,8 +15,6 @@ export {
     gridStyles,
     activeAfterLayout,
     layoutForGrid,
-    layoutForColumns,
-    layoutForRows,
     ensureLayout,
     layoutShape,
     GRID_PICKER_MAX,

--- a/src/workspace/layouts.ts
+++ b/src/workspace/layouts.ts
@@ -241,6 +241,18 @@ export function layoutShape(def: LayoutDefinition): LayoutShape | null {
     return null;
 }
 
+/**
+ * Which slot occupies each `[row][col]` track — PURE. Area layouts read their
+ * `grid-template-areas` rows; auto-flow layouts place `cells` row-major. The grid is
+ * what the splitter layer segments its strips against: a boundary is only a real seam
+ * where the two neighboring tracks hold DIFFERENT slots.
+ */
+export function occupancyGrid(def: LayoutDefinition): string[][] {
+    if (def.areas) return def.areas.map((row) => row.trim().split(/\s+/));
+    const cols = def.cols.length;
+    return def.rows.map((_, r) => def.cols.map((_, c) => def.cells[r * cols + c]?.id ?? `·${r}x${c}`));
+}
+
 /** Inline styles for the grid container + each cell — PURE (the workspace applies them). */
 export function gridStyles(
     def: LayoutDefinition,

--- a/src/workspace/layouts.ts
+++ b/src/workspace/layouts.ts
@@ -78,11 +78,10 @@ export function registerBuiltinLayouts(): void {
 
 // ── dynamic layouts (the topbar's grid picker) ──────────────────────────────
 //
-// The picker composes layouts on a bounded canvas instead of choosing from a fixed
-// list: a UNIFORM rows×cols grid (Grid mode) or per-column / per-row chart stacks
-// (Custom mode). Dynamic definitions are NOT registered — their ids are
-// self-describing (`g3x2`, `p3-2`, `r3-2`) and `ensureLayout` re-synthesizes them,
-// so persisted picks restore across boots without polluting the plugin registry.
+// The picker composes UNIFORM rows×cols grids on a bounded canvas instead of choosing
+// from a fixed list. Dynamic definitions are NOT registered — their ids are
+// self-describing (`g3x2`) and `ensureLayout` re-synthesizes them, so persisted picks
+// restore across boots without polluting the plugin registry.
 
 /** Picker canvas bound — dynamic layouts stay within a 4×4 grid (16 cells, the
  *  workspace's dormant-state pool capacity). */
@@ -120,116 +119,30 @@ export function layoutForGrid(rows: number, cols: number): LayoutDefinition {
     };
 }
 
-const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
-const lcm = (a: number, b: number): number => (a * b) / gcd(a, b);
-
-/**
- * The layout for per-column chart stacks (Custom picker mode): `counts[i]` charts
- * stacked in column i, every column filling the full height. Zero-count columns are
- * dropped; uniform counts collapse to the plain grid. Mixed counts use LCM row
- * tracks bound through `grid-template-areas` (e.g. `[3, 2]` → 6 tracks, the left
- * column's cells spanning 2 each, the right's spanning 3). Slots are column-major.
- */
-export function layoutForColumns(counts: readonly number[]): LayoutDefinition {
-    const stacks = normalizeStacks(counts);
-    if (stacks.length === 0) return layoutForGrid(1, 1);
-    if (stacks.every((n) => n === stacks[0])) return layoutForGrid(stacks[0]!, stacks.length);
-    const trackRows = stacks.reduce(lcm, 1);
-    const starts = stackStarts(stacks);
-    const areas = Array.from({ length: trackRows }, (_, r) =>
-        stacks.map((n, c) => `c${starts[c]! + Math.floor(r / (trackRows / n)) + 1}`).join(' '),
-    );
-    return {
-        id: `p${stacks.join('-')}`,
-        label: `Columns ${stacks.join('·')}`,
-        cols: stacks.map(() => 1),
-        rows: Array.from({ length: trackRows }, () => 1),
-        areas,
-        cells: stackCells(stacks),
-    };
-}
-
-/**
- * The row-based counterpart of `layoutForColumns`: `counts[i]` charts side by side
- * in row i, every row filling the full width. Mixed counts use LCM column tracks
- * (e.g. `[3, 2]` → 6 tracks, the top row's cells spanning 2 each, the bottom's
- * spanning 3). Slots are row-major; ids are `r3-2`-style.
- */
-export function layoutForRows(counts: readonly number[]): LayoutDefinition {
-    const stacks = normalizeStacks(counts);
-    if (stacks.length === 0) return layoutForGrid(1, 1);
-    if (stacks.every((n) => n === stacks[0])) return layoutForGrid(stacks.length, stacks[0]!);
-    const trackCols = stacks.reduce(lcm, 1);
-    const starts = stackStarts(stacks);
-    const areas = stacks.map((n, r) =>
-        Array.from({ length: trackCols }, (_, c) => `c${starts[r]! + Math.floor(c / (trackCols / n)) + 1}`).join(' '),
-    );
-    return {
-        id: `r${stacks.join('-')}`,
-        label: `Rows ${stacks.join('·')}`,
-        cols: Array.from({ length: trackCols }, () => 1),
-        rows: stacks.map(() => 1),
-        areas,
-        cells: stackCells(stacks),
-    };
-}
-
-function normalizeStacks(counts: readonly number[]): number[] {
-    return counts
-        .filter((n) => n > 0)
-        .slice(0, GRID_PICKER_MAX)
-        .map(clampTrack);
-}
-
-function stackStarts(stacks: readonly number[]): number[] {
-    const starts: number[] = [];
-    let total = 0;
-    for (const n of stacks) {
-        starts.push(total);
-        total += n;
-    }
-    return starts;
-}
-
-function stackCells(stacks: readonly number[]): Array<{ id: string; area: string }> {
-    const total = stacks.reduce((a, b) => a + b, 0);
-    return Array.from({ length: total }, (_, i) => ({ id: `c${i + 1}`, area: `c${i + 1}` }));
-}
-
 const GRID_ID_RE = /^g([1-4])x([1-4])$/;
-const COLUMNS_ID_RE = /^p([1-4](?:-[1-4]){0,3})$/;
-const ROWS_ID_RE = /^r([1-4](?:-[1-4]){0,3})$/;
 
 /**
  * Resolve a layout id to its definition, synthesizing the picker's dynamic ids
- * (`g<rows>x<cols>`, `p<count>-<count>…`, `r<count>-<count>…`) when they are not
- * registered — the boot path for persisted picks. Unknown ids stay undefined.
+ * (`g<rows>x<cols>`) when they are not registered — the boot path for persisted
+ * picks. Unknown ids stay undefined.
  */
 export function ensureLayout(id: string): LayoutDefinition | undefined {
     const registered = registry.get(id);
     if (registered) return registered;
     const g = GRID_ID_RE.exec(id);
     if (g) return layoutForGrid(Number(g[1]), Number(g[2]));
-    const p = COLUMNS_ID_RE.exec(id);
-    if (p) return layoutForColumns(p[1]!.split('-').map(Number));
-    const r = ROWS_ID_RE.exec(id);
-    if (r) return layoutForRows(r[1]!.split('-').map(Number));
     return undefined;
 }
 
 /** A layout's shape on the picker canvas. */
-export type LayoutShape = { rows: number; cols: number } | { counts: number[]; axis: 'columns' | 'rows' };
+export type LayoutShape = { rows: number; cols: number };
 
 /**
- * The picker-canvas shape of a layout: `{rows, cols}` for uniform grids,
- * `{counts, axis}` for column/row stacks, `null` when the layout is not expressible
- * on the canvas (bespoke plugin presets) — pickers list those as labeled rows instead.
+ * The picker-canvas shape of a layout: `{rows, cols}` for uniform grids, `null`
+ * when the layout is not expressible on the canvas (bespoke plugin presets) —
+ * pickers list those as labeled rows instead.
  */
 export function layoutShape(def: LayoutDefinition): LayoutShape | null {
-    const p = COLUMNS_ID_RE.exec(def.id);
-    if (p && def.areas) return { counts: p[1]!.split('-').map(Number), axis: 'columns' };
-    const r = ROWS_ID_RE.exec(def.id);
-    if (r && def.areas) return { counts: r[1]!.split('-').map(Number), axis: 'rows' };
     if (
         !def.areas &&
         def.rows.length <= GRID_PICKER_MAX &&

--- a/src/workspace/layouts.ts
+++ b/src/workspace/layouts.ts
@@ -194,3 +194,19 @@ export function activeAfterLayout(current: string | null, cellIds: readonly stri
     if (current != null && cellIds.includes(current)) return current;
     return cellIds[0] ?? null;
 }
+
+/**
+ * The identity order after a layout change: shrinking the grid must never pool the
+ * ACTIVE chart, so an active identity that would fall past the new slot count moves
+ * into the LAST surviving slot — every other identity keeps its relative order
+ * (the order reducer behind `setLayout`; pure for tests).
+ */
+export function orderAfterLayout(order: readonly string[], slots: number, active: string | null): string[] {
+    const next = [...order];
+    if (active == null || slots <= 0) return next;
+    const idx = next.indexOf(active);
+    if (idx < 0 || idx < slots) return next;
+    next.splice(idx, 1);
+    next.splice(slots - 1, 0, active);
+    return next;
+}

--- a/src/workspace/layouts.ts
+++ b/src/workspace/layouts.ts
@@ -76,6 +76,171 @@ export function registerBuiltinLayouts(): void {
     registerLayout({ id: '8', label: '8 grid', cols: [1, 1, 1, 1], rows: [1, 1], cells: slots(8) });
 }
 
+// ── dynamic layouts (the topbar's grid picker) ──────────────────────────────
+//
+// The picker composes layouts on a bounded canvas instead of choosing from a fixed
+// list: a UNIFORM rows×cols grid (Grid mode) or per-column / per-row chart stacks
+// (Custom mode). Dynamic definitions are NOT registered — their ids are
+// self-describing (`g3x2`, `p3-2`, `r3-2`) and `ensureLayout` re-synthesizes them,
+// so persisted picks restore across boots without polluting the plugin registry.
+
+/** Picker canvas bound — dynamic layouts stay within a 4×4 grid (16 cells, the
+ *  workspace's dormant-state pool capacity). */
+export const GRID_PICKER_MAX = 4;
+
+/** Classic preset ids by uniform geometry, so grid picks land on the builtins. */
+const GRID_BUILTIN_IDS: Record<string, string> = {
+    '1x1': '1',
+    '1x2': '2h',
+    '2x1': '2v',
+    '2x2': '4',
+    '2x4': '8',
+};
+
+const clampTrack = (n: number): number => Math.max(1, Math.min(GRID_PICKER_MAX, Math.round(n)));
+
+/**
+ * The layout for a UNIFORM rows×cols grid (Grid picker mode), clamped to the
+ * picker canvas. Geometry matching a registered classic preset returns that preset
+ * (id `'4'`, `'2h'`, …); anything else synthesizes a `g<rows>x<cols>` definition.
+ */
+export function layoutForGrid(rows: number, cols: number): LayoutDefinition {
+    const r = clampTrack(rows);
+    const c = clampTrack(cols);
+    const builtin = GRID_BUILTIN_IDS[`${r}x${c}`];
+    const registered = builtin ? registry.get(builtin) : undefined;
+    if (registered) return registered;
+    return {
+        id: `g${r}x${c}`,
+        // Width-first label — matches the picker's caption ("3 × 2" = 3 wide, 2 tall).
+        label: `${c} × ${r} grid`,
+        cols: Array.from({ length: c }, () => 1),
+        rows: Array.from({ length: r }, () => 1),
+        cells: slots(r * c),
+    };
+}
+
+const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
+const lcm = (a: number, b: number): number => (a * b) / gcd(a, b);
+
+/**
+ * The layout for per-column chart stacks (Custom picker mode): `counts[i]` charts
+ * stacked in column i, every column filling the full height. Zero-count columns are
+ * dropped; uniform counts collapse to the plain grid. Mixed counts use LCM row
+ * tracks bound through `grid-template-areas` (e.g. `[3, 2]` → 6 tracks, the left
+ * column's cells spanning 2 each, the right's spanning 3). Slots are column-major.
+ */
+export function layoutForColumns(counts: readonly number[]): LayoutDefinition {
+    const stacks = normalizeStacks(counts);
+    if (stacks.length === 0) return layoutForGrid(1, 1);
+    if (stacks.every((n) => n === stacks[0])) return layoutForGrid(stacks[0]!, stacks.length);
+    const trackRows = stacks.reduce(lcm, 1);
+    const starts = stackStarts(stacks);
+    const areas = Array.from({ length: trackRows }, (_, r) =>
+        stacks.map((n, c) => `c${starts[c]! + Math.floor(r / (trackRows / n)) + 1}`).join(' '),
+    );
+    return {
+        id: `p${stacks.join('-')}`,
+        label: `Columns ${stacks.join('·')}`,
+        cols: stacks.map(() => 1),
+        rows: Array.from({ length: trackRows }, () => 1),
+        areas,
+        cells: stackCells(stacks),
+    };
+}
+
+/**
+ * The row-based counterpart of `layoutForColumns`: `counts[i]` charts side by side
+ * in row i, every row filling the full width. Mixed counts use LCM column tracks
+ * (e.g. `[3, 2]` → 6 tracks, the top row's cells spanning 2 each, the bottom's
+ * spanning 3). Slots are row-major; ids are `r3-2`-style.
+ */
+export function layoutForRows(counts: readonly number[]): LayoutDefinition {
+    const stacks = normalizeStacks(counts);
+    if (stacks.length === 0) return layoutForGrid(1, 1);
+    if (stacks.every((n) => n === stacks[0])) return layoutForGrid(stacks.length, stacks[0]!);
+    const trackCols = stacks.reduce(lcm, 1);
+    const starts = stackStarts(stacks);
+    const areas = stacks.map((n, r) =>
+        Array.from({ length: trackCols }, (_, c) => `c${starts[r]! + Math.floor(c / (trackCols / n)) + 1}`).join(' '),
+    );
+    return {
+        id: `r${stacks.join('-')}`,
+        label: `Rows ${stacks.join('·')}`,
+        cols: Array.from({ length: trackCols }, () => 1),
+        rows: stacks.map(() => 1),
+        areas,
+        cells: stackCells(stacks),
+    };
+}
+
+function normalizeStacks(counts: readonly number[]): number[] {
+    return counts
+        .filter((n) => n > 0)
+        .slice(0, GRID_PICKER_MAX)
+        .map(clampTrack);
+}
+
+function stackStarts(stacks: readonly number[]): number[] {
+    const starts: number[] = [];
+    let total = 0;
+    for (const n of stacks) {
+        starts.push(total);
+        total += n;
+    }
+    return starts;
+}
+
+function stackCells(stacks: readonly number[]): Array<{ id: string; area: string }> {
+    const total = stacks.reduce((a, b) => a + b, 0);
+    return Array.from({ length: total }, (_, i) => ({ id: `c${i + 1}`, area: `c${i + 1}` }));
+}
+
+const GRID_ID_RE = /^g([1-4])x([1-4])$/;
+const COLUMNS_ID_RE = /^p([1-4](?:-[1-4]){0,3})$/;
+const ROWS_ID_RE = /^r([1-4](?:-[1-4]){0,3})$/;
+
+/**
+ * Resolve a layout id to its definition, synthesizing the picker's dynamic ids
+ * (`g<rows>x<cols>`, `p<count>-<count>…`, `r<count>-<count>…`) when they are not
+ * registered — the boot path for persisted picks. Unknown ids stay undefined.
+ */
+export function ensureLayout(id: string): LayoutDefinition | undefined {
+    const registered = registry.get(id);
+    if (registered) return registered;
+    const g = GRID_ID_RE.exec(id);
+    if (g) return layoutForGrid(Number(g[1]), Number(g[2]));
+    const p = COLUMNS_ID_RE.exec(id);
+    if (p) return layoutForColumns(p[1]!.split('-').map(Number));
+    const r = ROWS_ID_RE.exec(id);
+    if (r) return layoutForRows(r[1]!.split('-').map(Number));
+    return undefined;
+}
+
+/** A layout's shape on the picker canvas. */
+export type LayoutShape = { rows: number; cols: number } | { counts: number[]; axis: 'columns' | 'rows' };
+
+/**
+ * The picker-canvas shape of a layout: `{rows, cols}` for uniform grids,
+ * `{counts, axis}` for column/row stacks, `null` when the layout is not expressible
+ * on the canvas (bespoke plugin presets) — pickers list those as labeled rows instead.
+ */
+export function layoutShape(def: LayoutDefinition): LayoutShape | null {
+    const p = COLUMNS_ID_RE.exec(def.id);
+    if (p && def.areas) return { counts: p[1]!.split('-').map(Number), axis: 'columns' };
+    const r = ROWS_ID_RE.exec(def.id);
+    if (r && def.areas) return { counts: r[1]!.split('-').map(Number), axis: 'rows' };
+    if (
+        !def.areas &&
+        def.rows.length <= GRID_PICKER_MAX &&
+        def.cols.length <= GRID_PICKER_MAX &&
+        def.cells.length === def.rows.length * def.cols.length
+    ) {
+        return { rows: def.rows.length, cols: def.cols.length };
+    }
+    return null;
+}
+
 /** Inline styles for the grid container + each cell — PURE (the workspace applies them). */
 export function gridStyles(
     def: LayoutDefinition,

--- a/src/workspace/splitters.ts
+++ b/src/workspace/splitters.ts
@@ -48,10 +48,48 @@ export function trackOffsets(weights: readonly number[], sizePx: number, gapPx: 
     return out;
 }
 
+/**
+ * The stretches of one internal boundary that are REAL seams — PURE. `grid[r][c]` is
+ * the slot occupying that track (see `occupancyGrid`); a spanning cell makes the two
+ * neighboring tracks equal, and no strip may cover that stretch (it would sit on top
+ * of a chart, not between two). Returns inclusive track ranges along the boundary's
+ * own direction: rows for a `cols` boundary, columns for a `rows` one.
+ */
+export function seamSegments(grid: readonly (readonly string[])[], axis: 'cols' | 'rows', index: number): Array<[number, number]> {
+    const count = axis === 'cols' ? grid.length : (grid[0]?.length ?? 0);
+    const isSeam = (k: number): boolean =>
+        axis === 'cols' ? grid[k]?.[index] !== grid[k]?.[index + 1] : grid[index]?.[k] !== grid[index + 1]?.[k];
+    const out: Array<[number, number]> = [];
+    for (let k = 0; k < count; k += 1) {
+        if (!isSeam(k)) continue;
+        const last = out[out.length - 1];
+        if (last && last[1] === k - 1) last[1] = k;
+        else out.push([k, k]);
+    }
+    return out;
+}
+
+/**
+ * The pixel extent of tracks `from`…`to` (inclusive) along one axis — PURE. Interior
+ * ends extend halfway into the adjacent gap so strips meet cleanly at crossings;
+ * container ends run flush to the edge.
+ */
+export function segmentSpanPx(weights: readonly number[], sizePx: number, gapPx: number, from: number, to: number): { start: number; end: number } {
+    const total = weights.reduce((s, w) => s + w, 0);
+    if (total <= 0) return { start: 0, end: 0 };
+    const content = sizePx - gapPx * (weights.length - 1);
+    const startOf = (k: number): number => weights.slice(0, k).reduce((s, w) => s + (w / total) * content, 0) + gapPx * k;
+    const start = from === 0 ? 0 : startOf(from) - gapPx / 2;
+    const end = to === weights.length - 1 ? sizePx : startOf(to + 1) - gapPx / 2;
+    return { start, end };
+}
+
 /** What the layer needs from the workspace. */
 export interface SplitterDeps {
     /** Current track weights per axis. */
     tracks(): { cols: number[]; rows: number[] };
+    /** Slot occupancy by `[row][col]` track — where the strips find their real seams. */
+    grid(): string[][];
     /** Commit new weights for one axis (the workspace re-applies the grid template). */
     apply(axis: 'cols' | 'rows', weights: number[]): void;
     /** Reset one axis to an even split (double-click). */
@@ -63,10 +101,12 @@ export interface SplitterDeps {
 const HIT_PX = 8; // strip thickness (the visible seam is the grid gap; this is the grab target)
 
 /**
- * Owns the divider strips over a grid container: one strip per internal column/row
- * boundary, repositioned via {@link trackOffsets} whenever `layout()` is called
- * (layout change, container resize, drag). Dragging trades weight between the two
- * neighboring tracks; double-click evens the axis out.
+ * Owns the divider strips over a grid container: one strip per seam SEGMENT of each
+ * internal column/row boundary (never the boundary's full length — a cell spanning
+ * the boundary must keep receiving the pointer there), repositioned via
+ * {@link trackOffsets}/{@link seamSegments} whenever `layout()` is called (layout
+ * change, container resize, drag). Dragging trades weight between the two neighboring
+ * tracks; double-click evens the axis out.
  */
 export class SplitterLayer {
     private readonly strips: HTMLDivElement[] = [];
@@ -77,23 +117,36 @@ export class SplitterLayer {
         private readonly deps: SplitterDeps,
     ) {}
 
-    /** Rebuild + reposition the strips for the current tracks/size. */
+    /** Rebuild + reposition the strips for the current tracks/size/occupancy. */
     layout(): void {
         const { cols, rows } = this.deps.tracks();
+        const grid = this.deps.grid();
         const rect = this.container.getBoundingClientRect();
         const gap = this.deps.gapPx();
-        const wanted = Math.max(0, cols.length - 1) + Math.max(0, rows.length - 1);
-        while (this.strips.length > wanted) this.strips.pop()!.remove();
-        while (this.strips.length < wanted) this.strips.push(this.makeStrip());
-        let k = 0;
+        const placements: Array<{ axis: 'cols' | 'rows'; index: number; css: string }> = [];
         for (const [i, x] of trackOffsets(cols, rect.width, gap).entries()) {
-            this.place(this.strips[k]!, 'cols', i, `left:${Math.round(x - HIT_PX / 2)}px;top:0;width:${HIT_PX}px;height:100%;cursor:col-resize;`);
-            k += 1;
+            for (const [from, to] of seamSegments(grid, 'cols', i)) {
+                const { start, end } = segmentSpanPx(rows, rect.height, gap, from, to);
+                placements.push({
+                    axis: 'cols',
+                    index: i,
+                    css: `left:${Math.round(x - HIT_PX / 2)}px;top:${Math.round(start)}px;width:${HIT_PX}px;height:${Math.round(end - start)}px;cursor:col-resize;`,
+                });
+            }
         }
         for (const [i, y] of trackOffsets(rows, rect.height, gap).entries()) {
-            this.place(this.strips[k]!, 'rows', i, `left:0;top:${Math.round(y - HIT_PX / 2)}px;width:100%;height:${HIT_PX}px;cursor:row-resize;`);
-            k += 1;
+            for (const [from, to] of seamSegments(grid, 'rows', i)) {
+                const { start, end } = segmentSpanPx(cols, rect.width, gap, from, to);
+                placements.push({
+                    axis: 'rows',
+                    index: i,
+                    css: `left:${Math.round(start)}px;top:${Math.round(y - HIT_PX / 2)}px;width:${Math.round(end - start)}px;height:${HIT_PX}px;cursor:row-resize;`,
+                });
+            }
         }
+        while (this.strips.length > placements.length) this.strips.pop()!.remove();
+        while (this.strips.length < placements.length) this.strips.push(this.makeStrip());
+        for (const [k, p] of placements.entries()) this.place(this.strips[k]!, p.axis, p.index, p.css);
     }
 
     destroy(): void {

--- a/test/native-anim-settle.test.ts
+++ b/test/native-anim-settle.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+
+/**
+ * Animation SETTLING after a resize — regression guards for two workspace bugs.
+ *
+ * `clampViewport`'s bounds depend on the chart WIDTH, so a container resize (splitter
+ * drag, layout change) can strand the ease targets (`targetBarSpacing`, the
+ * scroll-to-latest glide) outside the reachable range. The ease then re-arms forever:
+ * a permanent rAF loop that repaints and emits `viewport:changed` every frame and
+ * visibly jitters `rightOffset` through the zoom anchor ("shaking" cells) until a
+ * pointerdown's freeze-on-touch happens to re-align the target. `animTick` must snap a
+ * target the clamp rejects onto the bound so the animation settles.
+ *
+ * And `syncSize` clears every canvas (the `canvas.width` assignments) before asking for
+ * a synchronous repaint — but `renderFrame` yields to the Animator while it runs, so a
+ * resize during an animation (live-bar ease, zoom glide) painted NOTHING until the next
+ * rAF tick: one blank frame per splitter move ("flashing" cells). While the animator is
+ * active, `syncSize` must paint synchronously itself.
+ *
+ * The vitest env is `node` (no DOM/canvas): the renderer is built unmounted, painting
+ * is stubbed, and the REAL coords/clamp/ease math is driven directly — the same
+ * technique as native-screenshot.test.ts.
+ */
+
+type AnyRenderer = Record<string, any>;
+
+/** An unmounted renderer whose paint layer is stubbed; coords carry `bars` bars at `width` px. */
+function setup(bars = 100, width = 800): { renderer: NativeRenderer; r: AnyRenderer; emits: () => number; paints: () => number } {
+    const renderer = new NativeRenderer();
+    const r = renderer as unknown as AnyRenderer;
+    let emits = 0;
+    let paints = 0;
+    r.coords.setSize(width, 200, 1);
+    r.coords.setBars(Array.from({ length: bars }, (_, i) => (i + 1) * 1000));
+    r.computeScales = () => {};
+    r.easeScales = () => false;
+    r.easeLiveBar = () => false;
+    r.paintData = () => { paints += 1; };
+    r.crosshairLayer = { render: () => {} };
+    r.externalCrossPx = () => null;
+    r.emitViewportChange = () => { emits += 1; };
+    return { renderer, r, emits: () => emits, paints: () => paints };
+}
+
+/** Drive animTick like the Animator would; the frame count until it reports settled. */
+function ticksToSettle(r: AnyRenderer, maxFrames = 300): number {
+    for (let i = 1; i <= maxFrames; i += 1) {
+        if (!(r.animTick(16) as boolean)) return i;
+    }
+    return Infinity;
+}
+
+describe('animTick settles when a resize strands its targets outside the clamp', () => {
+    it('zoom ease: a targetBarSpacing below the reachable minimum snaps to the bound', () => {
+        const { r } = setup(100, 800); // minBs = 800/(100+6) ≈ 7.55
+        r.coords.setViewport({ barSpacing: 10, rightOffset: 5 });
+        r.targetBarSpacing = 2; // stranded below minBs — as after a widening resize
+        expect(ticksToSettle(r)).toBeLessThan(10);
+        // Settled ON the clamp bound, target re-aligned so the loop stays down.
+        const vp = r.coords.getViewport();
+        expect(vp.barSpacing).toBeCloseTo(800 / 106, 3);
+        expect(r.targetBarSpacing).toBeCloseTo(vp.barSpacing, 6);
+    });
+
+    it('zoom ease: a targetBarSpacing above the reachable maximum snaps to the bound', () => {
+        const { r } = setup(100, 800); // maxBs = 800/2 = 400
+        r.coords.setViewport({ barSpacing: 100, rightOffset: 5 });
+        r.targetBarSpacing = 900; // stranded above maxBs — as after a narrowing resize
+        expect(ticksToSettle(r)).toBeLessThan(10);
+        expect(r.coords.getViewport().barSpacing).toBeCloseTo(400, 3);
+    });
+
+    it('an in-bounds zoom ease still glides (several frames) and lands on its target', () => {
+        const { r } = setup(100, 800);
+        r.coords.setViewport({ barSpacing: 10, rightOffset: 5 });
+        r.targetBarSpacing = 20;
+        const frames = ticksToSettle(r);
+        expect(frames).toBeGreaterThan(3); // it eased, not snapped
+        expect(frames).toBeLessThan(200);
+        expect(r.coords.getViewport().barSpacing).toBeCloseTo(20, 3);
+    });
+
+    it('scroll-to-latest glide: an unreachable rightOffset target settles on the pan bound', () => {
+        const { r } = setup(100, 800);
+        r.coords.setViewport({ barSpacing: 10, rightOffset: 5 });
+        r.targetBarSpacing = 10; // zoom already settled — isolate the scroll glide
+        r.scrollTargetRO = 9999; // beyond maxRo = visBars - (minVisible-1) = 79
+        expect(ticksToSettle(r)).toBeLessThan(200);
+        expect(r.scrollTargetRO).toBeNull(); // the glide ended
+        expect(r.coords.getViewport().rightOffset).toBeCloseTo(79, 2);
+    });
+
+    it('the settled loop stops emitting viewport changes', () => {
+        const { r, emits } = setup(100, 800);
+        r.coords.setViewport({ barSpacing: 10, rightOffset: 5 });
+        r.targetBarSpacing = 2;
+        ticksToSettle(r);
+        const settledEmits = emits();
+        for (let i = 0; i < 50; i += 1) r.animTick(16); // the Animator would have stopped; even direct ticks must not move anything
+        expect(emits()).toBe(settledEmits + 50); // ticks still report, but…
+        expect(r.animTick(16)).toBe(false); // …the loop keeps reporting settled (no re-arm)
+    });
+});
+
+describe('syncSize paints synchronously while the Animator owns the frame', () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    afterEach(() => { (globalThis as { window?: unknown }).window = originalWindow; });
+
+    function setupSized(animatorActive: boolean): { r: AnyRenderer; paints: () => number; flushes: () => number } {
+        (globalThis as { window?: unknown }).window = { devicePixelRatio: 1 };
+        const { r, paints } = setup();
+        let flushes = 0;
+        const canvas = () => ({ width: 0, height: 0 });
+        r.wrapper = { clientWidth: 400, clientHeight: 300 };
+        r.plot = { style: {} };
+        r.dataCanvas = canvas();
+        r.volumeCanvas = canvas();
+        r.vpvrCanvas = canvas();
+        r.chromeCanvas = canvas();
+        r.drawingsCanvas = canvas();
+        r.cursorCanvas = canvas();
+        r.extLayers = [];
+        r.layoutPanes = () => {};
+        r.repositionTables = () => {};
+        r.didInitialFit = true;
+        r.scheduler = { flushNow: () => { flushes += 1; } };
+        r.animator = { active: animatorActive };
+        return { r, paints, flushes: () => flushes };
+    }
+
+    it('animator active: the cleared canvases are repainted in the same task (no blank frame)', () => {
+        const { r, paints } = setupSized(true);
+        r.syncSize();
+        expect(paints()).toBe(1);
+    });
+
+    it('animator idle: the synchronous flush repaints as before', () => {
+        const { r, paints, flushes } = setupSized(false);
+        r.syncSize();
+        expect(flushes()).toBe(1);
+        expect(paints()).toBe(0); // the stub scheduler absorbs the flush — no double paint path
+    });
+});

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -14,6 +14,7 @@ import { avatarColor } from '../src/widget/symbol-picker';
 import { registerWidgetAction, unregisterWidgetAction, widgetActions, registerWidgetAttachment, unregisterWidgetAttachment, widgetAttachments, registerDefaultEngine, unregisterDefaultEngine, resolveEngines, registerLegendAction, unregisterLegendAction, legendActions, legendActionsProviderFor, type EngineFactory, type LegendIndicatorInfo } from '../src/widget/contributions';
 import type { ScriptingEngine } from '../src/core/ports/ScriptingEngine';
 import { loadPersisted, savePersisted, legacyWidgetState, type WidgetStorage } from '../src/widget/persist';
+import { watermarkFontPx } from '../src/widget/watermark';
 import { sanitizeState } from '../src/state/document';
 
 describe('parseTimeframe', () => {
@@ -563,5 +564,28 @@ describe('resolveIndicators — async loader form', () => {
 
     it('a rejecting loader behaves like a failing manifest URL (throws)', async () => {
         await expect(resolveIndicators(async () => Promise.reject(new Error('fs unavailable')))).rejects.toThrow('fs unavailable');
+    });
+});
+
+describe('watermarkFontPx — the mark fits the chart, not the viewport', () => {
+    it('keeps the cap when the text already fits with room to spare', () => {
+        // Text is 500px wide at the 72px cap; a 900px chart holds it (900*0.9 = 810 ≥ 500).
+        expect(watermarkFontPx(900, 500)).toBe(72);
+    });
+
+    it('shrinks proportionally when the chart is narrower than the text', () => {
+        // A 400px multichart cell: 72 * (400*0.9)/500 = 51.84 → floored.
+        expect(watermarkFontPx(400, 500)).toBe(51);
+        // Half the cell again → half the font.
+        expect(watermarkFontPx(200, 500)).toBe(25);
+    });
+
+    it('never drops below the floor nor exceeds the cap', () => {
+        expect(watermarkFontPx(30, 500)).toBe(12); // tiny cell → floor
+        expect(watermarkFontPx(100000, 10)).toBe(72); // huge chart → cap
+    });
+
+    it('an unmeasurable text (0 width) keeps the cap instead of dividing by zero', () => {
+        expect(watermarkFontPx(400, 0)).toBe(72);
     });
 });

--- a/test/workspace-core.test.ts
+++ b/test/workspace-core.test.ts
@@ -15,9 +15,10 @@ import {
     layoutForRows,
     ensureLayout,
     layoutShape,
+    occupancyGrid,
     type LayoutDefinition,
 } from '../src/workspace/layouts';
-import { evenTracks, resizeTracks, trackOffsets } from '../src/workspace/splitters';
+import { evenTracks, resizeTracks, trackOffsets, seamSegments, segmentSpanPx } from '../src/workspace/splitters';
 import { seedDefaults, cellChartDefaults, cellDrawings } from '../src/workspace/ChartCell';
 import { declaredOrder, nextAutoCellId } from '../src/workspace/VelaWorkspace';
 import { parseSymbol } from '../src/data/ProviderRegistry';
@@ -221,6 +222,69 @@ describe('splitter track math (pure)', () => {
         // Four even tracks, 800px, no gap: 200/400/600.
         expect(trackOffsets([1, 1, 1, 1], 800, 0)).toEqual([200, 400, 600]);
         expect(trackOffsets([1], 800, 4)).toEqual([]); // no internal boundary
+    });
+});
+
+describe('seam segmentation (strips never cross a spanning cell)', () => {
+    it('occupancyGrid reads area layouts and auto-flows plain grids', () => {
+        // Columns 3·2 (LCM 6 row tracks): the left stack spans 2 tracks each, the right 3.
+        const p32 = layoutForColumns([3, 2]);
+        const grid = occupancyGrid(p32);
+        expect(grid).toHaveLength(6);
+        expect(grid[0]).toEqual(['c1', 'c4']);
+        expect(grid[2]).toEqual(['c2', 'c4']);
+        expect(grid[5]).toEqual(['c3', 'c5']);
+        // Auto-flow 2×2 grid: row-major cells order.
+        expect(occupancyGrid(layoutDefinition('4')!)).toEqual([
+            ['c1', 'c2'],
+            ['c3', 'c4'],
+        ]);
+    });
+
+    it('a uniform grid boundary is one full-length seam', () => {
+        const grid = occupancyGrid(layoutDefinition('4')!);
+        expect(seamSegments(grid, 'cols', 0)).toEqual([[0, 1]]);
+        expect(seamSegments(grid, 'rows', 0)).toEqual([[0, 1]]);
+    });
+
+    it('a row boundary inside one stack never covers the neighboring spanning cell', () => {
+        // Columns 3·2: left column stacked 3 (c1..c3), right stacked 2 (c4, c5).
+        const grid = occupancyGrid(layoutForColumns([3, 2]));
+        // Row-track boundary 1 (between tracks 1|2) separates c1/c2 on the left ONLY —
+        // the right column's c4 spans it, so the seam stops at column 0.
+        expect(seamSegments(grid, 'rows', 1)).toEqual([[0, 0]]);
+        // Boundary 2 (tracks 2|3) is the right column's c4/c5 seam only.
+        expect(seamSegments(grid, 'rows', 2)).toEqual([[1, 1]]);
+        // Boundary 0 (tracks 0|1) crosses NO cell edge at all — no strip anywhere.
+        expect(seamSegments(grid, 'rows', 0)).toEqual([]);
+        // The single column boundary separates different cells over every row track.
+        expect(seamSegments(grid, 'cols', 0)).toEqual([[0, 5]]);
+    });
+
+    it('a spanning tall cell splits a boundary into disjoint segments', () => {
+        // ['a b', 'c b', 'd e']: the col boundary is a seam everywhere; row boundary 1
+        // (c|d and b|e) is full, row boundary 0 (a|c, b spans) is left-only.
+        const grid = [
+            ['a', 'b'],
+            ['c', 'b'],
+            ['d', 'e'],
+        ];
+        expect(seamSegments(grid, 'rows', 0)).toEqual([[0, 0]]);
+        expect(seamSegments(grid, 'rows', 1)).toEqual([[0, 1]]);
+        expect(seamSegments(grid, 'cols', 0)).toEqual([[0, 2]]);
+    });
+
+    it('segmentSpanPx runs flush at container edges and half a gap into interior gaps', () => {
+        // Six even tracks, 602px, 2px gap: content 592, each track 98.666…
+        const full = segmentSpanPx([1, 1, 1, 1, 1, 1], 602, 2, 0, 5);
+        expect(full.start).toBe(0);
+        expect(full.end).toBe(602);
+        const first = segmentSpanPx([1, 1, 1, 1, 1, 1], 602, 2, 0, 0);
+        expect(first.start).toBe(0);
+        expect(first.end).toBeCloseTo(98.666 + 1, 1); // track end + half the gap
+        const inner = segmentSpanPx([1, 1, 1, 1, 1, 1], 602, 2, 2, 3);
+        expect(inner.start).toBeCloseTo(2 * (98.666 + 2) - 1, 1);
+        expect(inner.end).toBeCloseTo(4 * (98.666 + 2) - 1, 1);
     });
 });
 

--- a/test/workspace-core.test.ts
+++ b/test/workspace-core.test.ts
@@ -10,6 +10,7 @@ import {
     layouts,
     gridStyles,
     activeAfterLayout,
+    orderAfterLayout,
     layoutForGrid,
     ensureLayout,
     layoutShape,
@@ -143,6 +144,23 @@ describe('activeAfterLayout (pure reducer)', () => {
         expect(activeAfterLayout('c3', ['c1', 'c2'])).toBe('c1'); // its slot left with the layout
         expect(activeAfterLayout(null, ['c1', 'c2'])).toBe('c1');
         expect(activeAfterLayout('c1', [])).toBe(null);
+    });
+});
+
+describe('orderAfterLayout (pure reducer)', () => {
+    it('moves an active identity that would pool into the last surviving slot', () => {
+        // 2×2 → single: the active chart becomes the one remaining chart.
+        expect(orderAfterLayout(['a', 'b', 'c', 'd'], 1, 'c')).toEqual(['c', 'a', 'b', 'd']);
+        // 2×2 → 2 side by side: the first chart keeps its slot, active takes the second.
+        expect(orderAfterLayout(['a', 'b', 'c', 'd'], 2, 'd')).toEqual(['a', 'd', 'b', 'c']);
+    });
+
+    it('leaves the order alone when the active chart already survives (or is unknown)', () => {
+        expect(orderAfterLayout(['a', 'b', 'c', 'd'], 2, 'b')).toEqual(['a', 'b', 'c', 'd']);
+        expect(orderAfterLayout(['a', 'b', 'c', 'd'], 8, 'd')).toEqual(['a', 'b', 'c', 'd']);
+        expect(orderAfterLayout(['a', 'b'], 1, null)).toEqual(['a', 'b']);
+        expect(orderAfterLayout(['a', 'b'], 1, 'nope')).toEqual(['a', 'b']);
+        expect(orderAfterLayout(['a', 'b'], 0, 'b')).toEqual(['a', 'b']);
     });
 });
 

--- a/test/workspace-core.test.ts
+++ b/test/workspace-core.test.ts
@@ -11,8 +11,6 @@ import {
     gridStyles,
     activeAfterLayout,
     layoutForGrid,
-    layoutForColumns,
-    layoutForRows,
     ensureLayout,
     layoutShape,
     occupancyGrid,
@@ -82,60 +80,17 @@ describe('dynamic picker layouts (pure)', () => {
         expect(layoutForGrid(4, 4).cells).toHaveLength(16);
     });
 
-    it('layoutForColumns: uniform stacks collapse to the plain grid', () => {
-        expect(layoutForColumns([2, 2]).id).toBe('4');
-        expect(layoutForColumns([3, 3]).id).toBe('g3x2');
-        expect(layoutForColumns([0, 2, 0]).id).toBe('2v'); // zero columns drop first
-        expect(layoutForColumns([]).id).toBe('1');
-    });
-
-    it('layoutForColumns: mixed stacks use LCM row tracks + column-major areas', () => {
-        const def = layoutForColumns([3, 2]);
-        expect(def.id).toBe('p3-2');
-        expect(def.cols).toEqual([1, 1]);
-        expect(def.rows).toHaveLength(6); // lcm(3, 2) tracks
-        expect(def.cells.map((c) => c.id)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5']);
-        // Left column stacks c1..c3 (2 tracks each); right stacks c4..c5 (3 each).
-        expect(def.areas).toEqual(['c1 c4', 'c1 c4', 'c2 c4', 'c2 c5', 'c3 c5', 'c3 c5']);
-        // The synthesized definition renders through the same pure grid math.
-        const { container, perCell } = gridStyles(def);
-        expect(container.gridTemplateRows).toBe('1fr 1fr 1fr 1fr 1fr 1fr');
-        expect(perCell.c4).toEqual({ gridArea: 'c4' });
-    });
-
-    it('layoutForRows: uniform stacks collapse; mixed stacks use LCM column tracks + row-major areas', () => {
-        expect(layoutForRows([2, 2]).id).toBe('4');
-        expect(layoutForRows([3, 3]).id).toBe('g2x3'); // 2 rows of 3
-        expect(layoutForRows([]).id).toBe('1');
-        const def = layoutForRows([3, 2]);
-        expect(def.id).toBe('r3-2');
-        expect(def.rows).toEqual([1, 1]);
-        expect(def.cols).toHaveLength(6); // lcm(3, 2) tracks
-        expect(def.cells.map((c) => c.id)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5']);
-        // Top row spreads c1..c3 (2 tracks each); bottom spreads c4..c5 (3 each).
-        expect(def.areas).toEqual(['c1 c1 c2 c2 c3 c3', 'c4 c4 c4 c5 c5 c5']);
-        const { container, perCell } = gridStyles(def);
-        expect(container.gridTemplateColumns).toBe('1fr 1fr 1fr 1fr 1fr 1fr');
-        expect(perCell.c4).toEqual({ gridArea: 'c4' });
-    });
-
     it('ensureLayout: registered ids win; dynamic ids re-synthesize; junk stays undefined', () => {
         expect(ensureLayout('4')).toBe(layoutDefinition('4'));
         expect(ensureLayout('g3x3')?.cells).toHaveLength(9);
-        expect(ensureLayout('p3-2')?.areas).toEqual(layoutForColumns([3, 2]).areas);
-        expect(ensureLayout('r3-2')?.areas).toEqual(layoutForRows([3, 2]).areas);
         expect(ensureLayout('g5x5')).toBeUndefined(); // beyond the canvas — not a picker id
-        expect(ensureLayout('p3-2-1-1-1')).toBeUndefined(); // more columns than the canvas
-        expect(ensureLayout('r3-2-1-1-1')).toBeUndefined(); // more rows than the canvas
         expect(ensureLayout('nope')).toBeUndefined();
     });
 
-    it('layoutShape reads grids and stacks back; bespoke areas stay null', () => {
+    it('layoutShape reads grids back; bespoke areas stay null', () => {
         expect(layoutShape(layoutDefinition('1')!)).toEqual({ rows: 1, cols: 1 });
         expect(layoutShape(layoutDefinition('8')!)).toEqual({ rows: 2, cols: 4 });
         expect(layoutShape(layoutForGrid(3, 2))).toEqual({ rows: 3, cols: 2 });
-        expect(layoutShape(layoutForColumns([3, 2]))).toEqual({ counts: [3, 2], axis: 'columns' });
-        expect(layoutShape(layoutForRows([3, 2]))).toEqual({ counts: [3, 2], axis: 'rows' });
         expect(
             layoutShape({
                 id: 'bespoke',
@@ -226,10 +181,19 @@ describe('splitter track math (pure)', () => {
 });
 
 describe('seam segmentation (strips never cross a spanning cell)', () => {
+    // An area layout with spanning cells: 3 charts stacked left, 2 stacked right,
+    // bound through 6 LCM row tracks (left cells span 2 each, right cells span 3).
+    const stacked32: LayoutDefinition = {
+        id: 'stacked-3-2',
+        label: 'Stacked 3·2',
+        cols: [1, 1],
+        rows: [1, 1, 1, 1, 1, 1],
+        areas: ['c1 c4', 'c1 c4', 'c2 c4', 'c2 c5', 'c3 c5', 'c3 c5'],
+        cells: Array.from({ length: 5 }, (_, i) => ({ id: `c${i + 1}`, area: `c${i + 1}` })),
+    };
+
     it('occupancyGrid reads area layouts and auto-flows plain grids', () => {
-        // Columns 3·2 (LCM 6 row tracks): the left stack spans 2 tracks each, the right 3.
-        const p32 = layoutForColumns([3, 2]);
-        const grid = occupancyGrid(p32);
+        const grid = occupancyGrid(stacked32);
         expect(grid).toHaveLength(6);
         expect(grid[0]).toEqual(['c1', 'c4']);
         expect(grid[2]).toEqual(['c2', 'c4']);
@@ -248,8 +212,8 @@ describe('seam segmentation (strips never cross a spanning cell)', () => {
     });
 
     it('a row boundary inside one stack never covers the neighboring spanning cell', () => {
-        // Columns 3·2: left column stacked 3 (c1..c3), right stacked 2 (c4, c5).
-        const grid = occupancyGrid(layoutForColumns([3, 2]));
+        // Stacked 3·2: left column stacked 3 (c1..c3), right stacked 2 (c4, c5).
+        const grid = occupancyGrid(stacked32);
         // Row-track boundary 1 (between tracks 1|2) separates c1/c2 on the left ONLY —
         // the right column's c4 spans it, so the seam stops at column 0.
         expect(seamSegments(grid, 'rows', 1)).toEqual([[0, 0]]);

--- a/test/workspace-core.test.ts
+++ b/test/workspace-core.test.ts
@@ -10,6 +10,11 @@ import {
     layouts,
     gridStyles,
     activeAfterLayout,
+    layoutForGrid,
+    layoutForColumns,
+    layoutForRows,
+    ensureLayout,
+    layoutShape,
     type LayoutDefinition,
 } from '../src/workspace/layouts';
 import { evenTracks, resizeTracks, trackOffsets } from '../src/workspace/splitters';
@@ -49,6 +54,97 @@ describe('layout registry + presets', () => {
         expect(layoutDefinition('custom-16')!.label).toBe('Sixteen'); // last registration wins
         unregisterLayout('custom-16');
         expect(layoutDefinition('custom-16')).toBeUndefined();
+    });
+});
+
+describe('dynamic picker layouts (pure)', () => {
+    it('layoutForGrid lands on the classic presets when the geometry matches', () => {
+        expect(layoutForGrid(1, 1).id).toBe('1');
+        expect(layoutForGrid(1, 2).id).toBe('2h');
+        expect(layoutForGrid(2, 1).id).toBe('2v');
+        expect(layoutForGrid(2, 2).id).toBe('4');
+        expect(layoutForGrid(2, 4).id).toBe('8');
+    });
+
+    it('layoutForGrid synthesizes other geometries WITHOUT registering them', () => {
+        const def = layoutForGrid(3, 2);
+        expect(def.id).toBe('g3x2');
+        expect(def.rows).toEqual([1, 1, 1]);
+        expect(def.cols).toEqual([1, 1]);
+        expect(def.areas).toBeUndefined();
+        expect(def.cells.map((c) => c.id)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
+        expect(layoutDefinition('g3x2')).toBeUndefined(); // the registry stays presets-only
+    });
+
+    it('layoutForGrid clamps to the picker canvas (1..4 per axis)', () => {
+        expect(layoutForGrid(9, 0).id).toBe('g4x1');
+        expect(layoutForGrid(4, 4).cells).toHaveLength(16);
+    });
+
+    it('layoutForColumns: uniform stacks collapse to the plain grid', () => {
+        expect(layoutForColumns([2, 2]).id).toBe('4');
+        expect(layoutForColumns([3, 3]).id).toBe('g3x2');
+        expect(layoutForColumns([0, 2, 0]).id).toBe('2v'); // zero columns drop first
+        expect(layoutForColumns([]).id).toBe('1');
+    });
+
+    it('layoutForColumns: mixed stacks use LCM row tracks + column-major areas', () => {
+        const def = layoutForColumns([3, 2]);
+        expect(def.id).toBe('p3-2');
+        expect(def.cols).toEqual([1, 1]);
+        expect(def.rows).toHaveLength(6); // lcm(3, 2) tracks
+        expect(def.cells.map((c) => c.id)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5']);
+        // Left column stacks c1..c3 (2 tracks each); right stacks c4..c5 (3 each).
+        expect(def.areas).toEqual(['c1 c4', 'c1 c4', 'c2 c4', 'c2 c5', 'c3 c5', 'c3 c5']);
+        // The synthesized definition renders through the same pure grid math.
+        const { container, perCell } = gridStyles(def);
+        expect(container.gridTemplateRows).toBe('1fr 1fr 1fr 1fr 1fr 1fr');
+        expect(perCell.c4).toEqual({ gridArea: 'c4' });
+    });
+
+    it('layoutForRows: uniform stacks collapse; mixed stacks use LCM column tracks + row-major areas', () => {
+        expect(layoutForRows([2, 2]).id).toBe('4');
+        expect(layoutForRows([3, 3]).id).toBe('g2x3'); // 2 rows of 3
+        expect(layoutForRows([]).id).toBe('1');
+        const def = layoutForRows([3, 2]);
+        expect(def.id).toBe('r3-2');
+        expect(def.rows).toEqual([1, 1]);
+        expect(def.cols).toHaveLength(6); // lcm(3, 2) tracks
+        expect(def.cells.map((c) => c.id)).toEqual(['c1', 'c2', 'c3', 'c4', 'c5']);
+        // Top row spreads c1..c3 (2 tracks each); bottom spreads c4..c5 (3 each).
+        expect(def.areas).toEqual(['c1 c1 c2 c2 c3 c3', 'c4 c4 c4 c5 c5 c5']);
+        const { container, perCell } = gridStyles(def);
+        expect(container.gridTemplateColumns).toBe('1fr 1fr 1fr 1fr 1fr 1fr');
+        expect(perCell.c4).toEqual({ gridArea: 'c4' });
+    });
+
+    it('ensureLayout: registered ids win; dynamic ids re-synthesize; junk stays undefined', () => {
+        expect(ensureLayout('4')).toBe(layoutDefinition('4'));
+        expect(ensureLayout('g3x3')?.cells).toHaveLength(9);
+        expect(ensureLayout('p3-2')?.areas).toEqual(layoutForColumns([3, 2]).areas);
+        expect(ensureLayout('r3-2')?.areas).toEqual(layoutForRows([3, 2]).areas);
+        expect(ensureLayout('g5x5')).toBeUndefined(); // beyond the canvas — not a picker id
+        expect(ensureLayout('p3-2-1-1-1')).toBeUndefined(); // more columns than the canvas
+        expect(ensureLayout('r3-2-1-1-1')).toBeUndefined(); // more rows than the canvas
+        expect(ensureLayout('nope')).toBeUndefined();
+    });
+
+    it('layoutShape reads grids and stacks back; bespoke areas stay null', () => {
+        expect(layoutShape(layoutDefinition('1')!)).toEqual({ rows: 1, cols: 1 });
+        expect(layoutShape(layoutDefinition('8')!)).toEqual({ rows: 2, cols: 4 });
+        expect(layoutShape(layoutForGrid(3, 2))).toEqual({ rows: 3, cols: 2 });
+        expect(layoutShape(layoutForColumns([3, 2]))).toEqual({ counts: [3, 2], axis: 'columns' });
+        expect(layoutShape(layoutForRows([3, 2]))).toEqual({ counts: [3, 2], axis: 'rows' });
+        expect(
+            layoutShape({
+                id: 'bespoke',
+                label: 'Bespoke',
+                cols: [2, 1],
+                rows: [1, 1],
+                areas: ['main a', 'main b'],
+                cells: [{ id: 'c1', area: 'main' }, { id: 'c2', area: 'a' }, { id: 'c3', area: 'b' }],
+            }),
+        ).toBeNull();
     });
 });
 

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { encodeState, decodeState, sanitizeState, memoryStorageAdapter, type WorkspaceState } from '../src/workspace/persist';
 import { localStorageAdapter } from '../src/widget/persist';
+import { ensureLayout, registerBuiltinLayouts } from '../src/workspace/layouts';
 
 const fullDoc: WorkspaceState = {
     version: 1,
@@ -35,6 +36,20 @@ const fullDoc: WorkspaceState = {
 describe('state codec round-trip', () => {
     it('decodeState(encodeState(doc)) preserves a full valid document', () => {
         expect(decodeState(encodeState(fullDoc))).toEqual(fullDoc);
+    });
+
+    it('a dynamic picker layout id survives the round-trip and resolves at boot', () => {
+        registerBuiltinLayouts();
+        // The picker's ids are never registered — the boot path re-synthesizes them
+        // (ensureLayout), so a persisted custom grid restores across sessions.
+        const doc: WorkspaceState = { ...fullDoc, layout: 'p3-2' };
+        const restored = decodeState(encodeState(doc));
+        expect(restored!.layout).toBe('p3-2');
+        expect(ensureLayout(restored!.layout)?.cells).toHaveLength(5);
+        const grid: WorkspaceState = { ...fullDoc, layout: 'g3x3' };
+        expect(ensureLayout(decodeState(encodeState(grid))!.layout)?.cells).toHaveLength(9);
+        const rows: WorkspaceState = { ...fullDoc, layout: 'r3-2' };
+        expect(ensureLayout(decodeState(encodeState(rows))!.layout)?.cells).toHaveLength(5);
     });
 
     it('rejects unusable payloads with null, never throws', () => {

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -13,7 +13,7 @@ const fullDoc: WorkspaceState = {
     activeCellId: 'c2',
     timezone: 'Europe/Paris',
     favorites: ['trendline', 'hline'],
-    sync: { viewport: true, symbol: { c1: 'a', c2: 'a' }, crosshair: true },
+    sync: { viewport: true, symbol: { c1: 'a', c2: 'a' }, crosshair: true, drawings: true },
     trackSizes: { '4': { cols: [1.4, 0.6], rows: [1, 1] } },
     charts: [
         {
@@ -42,14 +42,10 @@ describe('state codec round-trip', () => {
         registerBuiltinLayouts();
         // The picker's ids are never registered — the boot path re-synthesizes them
         // (ensureLayout), so a persisted custom grid restores across sessions.
-        const doc: WorkspaceState = { ...fullDoc, layout: 'p3-2' };
-        const restored = decodeState(encodeState(doc));
-        expect(restored!.layout).toBe('p3-2');
-        expect(ensureLayout(restored!.layout)?.cells).toHaveLength(5);
         const grid: WorkspaceState = { ...fullDoc, layout: 'g3x3' };
-        expect(ensureLayout(decodeState(encodeState(grid))!.layout)?.cells).toHaveLength(9);
-        const rows: WorkspaceState = { ...fullDoc, layout: 'r3-2' };
-        expect(ensureLayout(decodeState(encodeState(rows))!.layout)?.cells).toHaveLength(5);
+        const restored = decodeState(encodeState(grid));
+        expect(restored!.layout).toBe('g3x3');
+        expect(ensureLayout(restored!.layout)?.cells).toHaveLength(9);
     });
 
     it('rejects unusable payloads with null, never throws', () => {


### PR DESCRIPTION
Various fixes and features for multichart.

- Grid like multi chart selection
- Symbol and timeframe sync
- Drawing sync
- Active chart always stays during multi chart layout changes
- Fix shaking and reloading in multi charts
- Fix active chart highlighter appearing on single chart
- Minor style changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Drawings sync and linked-id maps touch persistence and cross-cell mutation paths; resize/animation fixes change native renderer timing but are regression-tested. Layout and splitter geometry changes affect workspace grid interaction broadly.
> 
> **Overview**
> **Workspace multi-chart** gets a **`drawings`** sync kind (`ws.sync.set('drawings', true)` plus a toolbar toggle): new drawings copy to same-group cells by time+price anchors, edits and deletes stay linked, and in-progress placement shows as reduced-opacity ghosts on followers via optional **`drawing:draft`** / **`setExternalGhost`** SDK seams (additive for custom renderers).
> 
> The topbar **layout dropdown** becomes a **4×4 grid canvas** (hover preview, click to apply); classic presets reuse builtin ids, other sizes use self-describing ids like `g3x2` via **`layoutForGrid`**. **Symbol**, **Interval**, and **Crosshair** sync switches sit in the same panel; drawings sync stays on the shared drawing toolbar.
> 
> **Layout shrink** no longer pools the **active** chart—it moves into the last surviving slot (**`orderAfterLayout`**). **Grid splitters** only cover real seams between cells (not full width across spanning layouts), with pane-style separator hover tokens.
> 
> **Watermarks** fit each cell’s plot using **`--vela-scale-gutter`** and chart-local sizing (**`watermarkFontPx`**). **Resize** during animation repaints synchronously (no blank flash) and **`animTick`** snaps stranded zoom/scroll targets to clamp bounds (stops shake and runaway rAF). The active-cell ring applies only when **`data-multi`** is set on the grid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ad6fcc1ad25b24c216c39f4e744b9f679ed6584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->