### PR TITLE
Feat: layer integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ All notable changes to Vela, newest first.
   type's settings tab can now include `heading` rows — group titles that organize a
   large tab into named sections.
 
+- **Settings tabs that show only what matters — and scale past one flat list.**
+  Chart-type settings stay pure data but gain structure. A row may carry a `when`
+  condition (`{ key, equals }` / `{ key, anyOf }`, or an AND-ed array) and is shown only
+  while the gate passes against the tab's current values — the dialog re-evaluates live
+  on every edit, so mode-specific colors or a manual-size input appear exactly when they
+  apply. A section may declare `instances` instead of flat rows: the pane opens with a
+  tab strip — one tab per present instance, a dashed `+` that turns the next one on, an
+  `×` on the active removable tab — with presence stored as a plain boolean
+  (`enableKey`) in the same per-type bag. Inside an instance (and inside the new
+  `subsections`, indented entries under the section's rail tab), `heading` rows become a
+  group TOC on the left of the pane that shows one group at a time. And
+  `placement: 'after-symbol'` puts a type's tab directly under Symbol. Two row forms
+  keep panes static where a conditional reveal would jump the layout: a toggle row may
+  carry inline color swatches (`colors` — edited on the toggle's own row, dimmed while
+  it is off), and a `range` row edits a min–max pair on one line (with an optional
+  `placeholder` naming the unset state, so a cleared input reads "Off" instead of a
+  magic 0). Select options may be `[value, label]` pairs so camelCase ids show as
+  human text. A subsection's `enableKey` soft-disables its other rows (visible but
+  grayed) while off, instead of hiding them. Hidden rows keep their stored values;
+  persistence and delivery are unchanged — consumers still receive one flat settings
+  object.
+
 - **A light theme that actually works — switchable live.** `theme: 'light'` now skins the
   whole product coherently: white surfaces with dark, readable text across the toolbar,
   menus, dialogs, legends, axes, and pane separators. The theme can be swapped at runtime —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **Candle settings for plugin chart types that draw candles.** A registered chart type
+  that keeps the candle series under its own layer (an order-flow style, for example) now
+  gets a Candles group in chart settings → Symbol while it is active: body, border, and
+  wick toggles with their up/down colors, plus the bar spacing. These cosmetics belong to
+  that chart type alone — changing them restyles its candles without touching the Candles
+  or Heikin Ashi styles, and any value left untouched keeps following the shared candle
+  settings. They persist and export with the rest of the chart config.
+
 - **Plugin layers can fade the chart under them and follow the pointer.** A renderer
   layer registered through the plugin SDK gains three quieter levers. It can now dim or
   slim the base painting gradually — its `modulateBase` hook returns per-frame candle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **Plugin layers can fade the chart under them and follow the pointer.** A renderer
+  layer registered through the plugin SDK gains three quieter levers. It can now dim or
+  slim the base painting gradually — its `modulateBase` hook returns per-frame candle
+  body width/opacity and grid opacity, the smooth counterpart of the all-or-nothing
+  `basePainting: 'none'` — so a style that reveals under the candles as you zoom in can
+  fade them down instead of switching them off. A layer that reacts to hovering
+  (tooltips, row highlights) can declare `repaintOnCursor` and is repainted whenever the
+  pointer moves, receiving the pointer position with its paint arguments. And a chart
+  type's settings tab can now include `heading` rows — group titles that organize a
+  large tab into named sections.
+
 - **A light theme that actually works — switchable live.** `theme: 'light'` now skins the
   whole product coherently: white surfaces with dark, readable text across the toolbar,
   menus, dialogs, legends, axes, and pane separators. The theme can be swapped at runtime —

--- a/docs/architecture/settings-rows.md
+++ b/docs/architecture/settings-rows.md
@@ -12,10 +12,14 @@ registerChartType({
                                 // active; 'always': shown whenever the type is registered
         rows: [
             { kind: 'heading', label: 'Levels' },   // key-less: an in-tab group title, stores nothing
-            { kind: 'toggle', key: 'imbalances', label: 'Imbalances', defval: true },
-            { kind: 'number', key: 'levels', label: 'Max levels', defval: 20, min: 5, max: 50, step: 1 },
+            { kind: 'toggle', key: 'highlights', label: 'Highlights', defval: true,
+              colors: [{ key: 'highlightColor', label: 'Highlight color', defval: '#e0b400' }] },
+            { kind: 'number', key: 'levels', label: 'Max levels', defval: 20, min: 5, max: 50, step: 1,
+              when: { key: 'highlights', equals: true } },   // shown only while the toggle is on
             { kind: 'color',  key: 'buyColor', label: 'Buy color', defval: '#089981' },
             { kind: 'select', key: 'mode', label: 'Display', options: ['bid-ask', 'delta'], defval: 'bid-ask' },
+            { kind: 'range',  label: 'Volume', minKey: 'minVolume', maxKey: 'maxVolume',
+              defval: 0, min: 0, max: 1e9, step: 1, placeholder: 'Off' },
         ],
     },
 });
@@ -44,6 +48,76 @@ delivery, and engine delivery.
 `number` / `string`). The `heading` variant is the exception: label only, no key and no
 stored value — it renders as a group title inside the tab, so a large section can be
 organized without splitting into multiple tabs.
+
+Two kinds bundle several values on one row, which keeps panes STATIC where a
+conditionally revealed row would jump the layout:
+
+- **`toggle` with `colors`** — inline color swatches on the toggle's row (each swatch a
+  `{ key, label, defval }`, the label its tooltip). The swatches dim and ignore input
+  while the toggle is off. Prefer this over a separate `color` row gated on the toggle
+  whenever the toggle governs one or two colors.
+- **`range`** — a min–max pair (`minKey`/`maxKey`, both seeded from the shared
+  `defval`). With `placeholder`, an input at the default renders empty showing it, and
+  clearing an input stores the default back — the placeholder names the unset state
+  (`'Off'` for 0-disables bounds).
+- **`select` options** may be bare strings (value = label) or `[value, label]` pairs
+  when the stored id differs from the display text (`['bidAskProfile', 'Bid × Ask Profile']`).
+- **Subsection `enableKey`** — while that bag boolean is false, every row except the
+  matching toggle stays visible but soft-disabled (grayed / non-interactive), so the
+  pane remains browseable with the feature off. Put the toggle inside a group (e.g.
+  Display), not above the TOC.
+
+### Conditions (`when`)
+
+Every row — headings included — may carry a **`when` gate**: a `SettingsRowCondition`
+(`{ key, equals }` or `{ key, anyOf: [...] }`) or a readonly array of them (AND-ed). The
+row is shown only while the gate passes against the section's **current values** (stored
+value, else that key's `defval`). The dialog re-evaluates gates live on every edit — no
+rebuild — so dependent rows appear exactly when they matter (e.g. a manual-size input
+only while `sizeMode` is `'manual'`, mode-specific colors only in that mode). The
+evaluation helper is exported as `settingsRowVisible(when, bag)`.
+
+Gated values are **still stored and delivered** — hiding a row never clears its value;
+consumers decide what a hidden-but-set value means (usually: the gating toggle already
+disables the feature).
+
+### Structured sections: instances, group TOC, subsections, placement
+
+A big section can go beyond the flat form. Instead of `rows`, declare **`instances`**:
+the pane then opens with an **instance tab strip** — one tab per *present* instance, a
+dashed `+` that turns on the next absent one, and an `×` on the active removable tab.
+Presence is the boolean at the instance's `enableKey` (in the same per-type bag); an
+instance without `enableKey` is always present and not removable (the base instance).
+
+```ts
+settings: {
+    title: 'My Type',
+    placement: 'after-symbol',            // rail position: right under Symbol ('end' = default)
+    instances: [
+        { label: 'Block 1', rows: block('') },                          // base — not removable
+        { label: 'Block 2', enableKey: 'b2Enabled', rows: block('b2') },  // '+' adds, '×' removes
+    ],
+    subsections: [
+        { title: 'Overlay', rows: overlayRows },   // indented rail entry under the tab
+    ],
+},
+```
+
+Inside an instance (and inside every subsection) the `heading` rows become a **group
+TOC** on the left of the pane: selecting an entry shows only that group's rows. Rows
+before the first heading form the *always block*, visible above every group (put an
+enable toggle there). A group whose rows are all gated out by `when` — or whose heading's
+own `when` fails — leaves the TOC; the TOC hides entirely when no group is live, which is
+how a subsection collapses to just its enable toggle while switched off.
+
+**`subsections`** add indented entries under the section's rail tab, each with its own
+pane of rows (same TOC treatment). **`placement: 'after-symbol'`** puts the tab (and its
+subsections) directly under Symbol instead of after the built-in tabs.
+
+Everything stays **one flat per-type bag**: instance and subsection keys are ordinary
+keys (use a prefix convention like `b2Size`), `+`/`×` just write the `enableKey` boolean,
+and consumers keep receiving a single object — the structured form is pure dialog
+presentation.
 
 ## Adding a NEW row kind
 

--- a/docs/architecture/settings-rows.md
+++ b/docs/architecture/settings-rows.md
@@ -11,6 +11,7 @@ registerChartType({
         visibility: 'active',   // 'active' (default): tab shown only while the style is
                                 // active; 'always': shown whenever the type is registered
         rows: [
+            { kind: 'heading', label: 'Levels' },   // key-less: an in-tab group title, stores nothing
             { kind: 'toggle', key: 'imbalances', label: 'Imbalances', defval: true },
             { kind: 'number', key: 'levels', label: 'Max levels', defval: 20, min: 5, max: 50, step: 1 },
             { kind: 'color',  key: 'buyColor', label: 'Buy color', defval: '#089981' },
@@ -38,9 +39,11 @@ delivery, and engine delivery.
 ## The row-kind contract
 
 `SettingsRowDescriptor` (in `src/chart-types/registry.ts`) is a **discriminated union on
-`kind`**. Each variant carries its `key` (the storage key inside the type's bag), a
+`kind`**. Each value variant carries its `key` (the storage key inside the type's bag), a
 `label`, its `defval`, and kind-specific fields. Values are stored as-is (`boolean` /
-`number` / `string`).
+`number` / `string`). The `heading` variant is the exception: label only, no key and no
+stored value — it renders as a group title inside the tab, so a large section can be
+organized without splitting into multiple tabs.
 
 ## Adding a NEW row kind
 

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -78,20 +78,37 @@ import { registerRendererLayer } from 'vela/plugin';
 registerRendererLayer({
     id: 'mytype',                    // = the `setNativeData` channel it receives
     placement: 'above-data',         // or 'below-data' (behind the candles)
+    repaintOnCursor: true,           // opt-in: pointer moves repaint this layer too
     create: () => ({
         mount(canvas) { /* keep the canvas reference */ },
-        render({ bars, data, pending, coords, scale, bounds, theme, priceStyle, nowMs }) {
+        render({ bars, data, pending, coords, scale, bounds, theme, priceStyle, nowMs, cursor }) {
             // Always clear + repaint your own canvas. Gate on `priceStyle` if the
             // layer belongs to a chart type. Key mappings:
             //   coords.logicalToX(i) / coords.timeToX(ms)  → x
             //   coords.priceToY(price, scale, bounds)      → y
             //   coords.width / coords.dpr                  → sizing
+            // `cursor` is the plot-relative pointer ({ x, y } | null) — hover
+            // hit-testing input for layers that set `repaintOnCursor`.
         },
         animating?: () => false,     // return true while a pulse/fade needs frames
+        modulateBase?: (args) => ({ candleBodyScale: 0.07, gridAlpha: 0 }),
         destroy?: () => {},
     }),
 });
 ```
+
+Two per-frame levers beyond the basic contract:
+
+- **`repaintOnCursor`** (definition): pointer moves normally repaint only the crosshair
+  overlay; a layer that hover-tests (tooltips, row highlights) sets this flag and is
+  repainted — its own canvas only — whenever the cursor moves, with `args.cursor` fresh.
+- **`modulateBase`** (instance): the gradual counterpart of the chart type's
+  all-or-nothing `basePainting: 'none'`. Called after `render`, only for the layer whose
+  id matches the ACTIVE price style; the returned `{ candleBodyScale?, candleBodyAlpha?,
+  gridAlpha? }` dims/slims the base painting for that same frame (values clamped to
+  [0..1]; omitted fields keep their defaults). Return null to leave the base painting
+  untouched — this is how a reveal-under style fades candles down as its own layer
+  fades in, instead of switching them off entirely.
 
 ## Native indicators — `registerNativeIndicator`
 

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -62,9 +62,15 @@ Two more levers for full-replacement types:
 A chart type may also declare a **settings section** (`settings: { title, rows,
 visibility }`) that the chart-settings dialog renders as its own tab — values persist in
 the renderer config, reach the type's renderer layer as `args.settings`, and its data
-engine via `onSettings(values)`. See
-[architecture/settings-rows.md](../architecture/settings-rows.md) for the row kinds and
-how to add new ones.
+engine via `onSettings(values)`. Rows may carry declarative `when` conditions (shown
+only while another key holds a value), a toggle row may carry inline color swatches
+(`colors`, dimmed while off), a `range` row edits a min–max pair on one line, and a
+section may go structured: an `instances` tab strip (repeated blocks with add/remove
+via an `enableKey` boolean), `subsections` as indented rail entries, a group TOC built
+from `heading` rows, and a `placement: 'after-symbol'` rail position — all pure data,
+evaluated live by the dialog. See
+[architecture/settings-rows.md](../architecture/settings-rows.md) for the row kinds,
+conditions, the structured form, and how to add new ones.
 
 ## Renderer layers — `registerRendererLayer`
 

--- a/src/chart-types/registry.ts
+++ b/src/chart-types/registry.ts
@@ -82,21 +82,129 @@ export interface ChartTypeDefinition {
     basePainting?: 'candles' | 'none';
 }
 
-/** One declarative settings row. To add a NEW kind, see docs/architecture/settings-rows.md. */
-export type SettingsRowDescriptor =
-    | { kind: 'heading'; label: string }
-    | { kind: 'toggle'; key: string; label: string; defval: boolean }
-    | { kind: 'number'; key: string; label: string; defval: number; min?: number; max?: number; step?: number }
-    | { kind: 'color'; key: string; label: string; defval: string }
-    | { kind: 'select'; key: string; label: string; options: readonly string[]; defval: string };
+/**
+ * A declarative visibility condition on another row's CURRENT value (stored value,
+ * or that row's `defval` while unset). Pure data — the dialog evaluates it live as
+ * the user edits, so dependent rows appear/disappear without a rebuild.
+ * `anyOf` wins over `equals` when both are given.
+ */
+export interface SettingsRowCondition {
+    key: string;
+    equals?: boolean | string | number;
+    anyOf?: readonly (boolean | string | number)[];
+}
 
+/** A row's visibility gate: one condition, or several AND-ed together. */
+export type SettingsRowWhen = SettingsRowCondition | readonly SettingsRowCondition[];
+
+/**
+ * An inline color swatch on a toggle row — the color(s) the toggle governs, edited
+ * right on the toggle's row (dimmed while the toggle is off) instead of a
+ * conditionally revealed row below. Each swatch stores under its own bag key.
+ */
+export interface SettingsRowSwatch {
+    key: string;
+    /** Names the color for the swatch's tooltip (`'Highlight color'`). */
+    label: string;
+    defval: string;
+}
+
+/**
+ * One declarative settings row. To add a NEW kind, see docs/architecture/settings-rows.md.
+ *
+ * `heading` titles a GROUP of rows: the heading plus everything after it up to the next
+ * heading. In a flat `rows` section headings render as inline group titles; inside
+ * `instances`/`subsections` they become entries of the pane's group TOC (see
+ * {@link ChartTypeSettingsSection}). Any row may carry `when` — it is shown only while
+ * the condition holds.
+ *
+ * `range` is a min–max pair on one row (two number inputs storing under `minKey` /
+ * `maxKey`, both seeded from the shared `defval`). When `placeholder` is given, an
+ * input holding the default value renders EMPTY showing the placeholder, and clearing
+ * an input stores the default back — so the placeholder names the "unset" state
+ * (`'Off'` for a 0-disables filter bound).
+ */
+/**
+ * A select option: a bare string (value = label) or a `[value, label]` pair when the
+ * stored id differs from the human-readable text (`['bidAskProfile', 'Bid × Ask Profile']`).
+ */
+export type SettingsSelectOption = string | readonly [value: string, label: string];
+
+export type SettingsRowDescriptor =
+    | { kind: 'heading'; label: string; when?: SettingsRowWhen }
+    | { kind: 'toggle'; key: string; label: string; defval: boolean; colors?: readonly SettingsRowSwatch[]; when?: SettingsRowWhen }
+    | { kind: 'number'; key: string; label: string; defval: number; min?: number; max?: number; step?: number; when?: SettingsRowWhen }
+    | { kind: 'color'; key: string; label: string; defval: string; when?: SettingsRowWhen }
+    | { kind: 'select'; key: string; label: string; options: readonly SettingsSelectOption[]; defval: string; when?: SettingsRowWhen }
+    | { kind: 'range'; label: string; minKey: string; maxKey: string; defval: number; min?: number; max?: number; step?: number; placeholder?: string; when?: SettingsRowWhen };
+
+/** Whether a row's `when` gate passes against the current values bag. */
+export function settingsRowVisible(when: SettingsRowWhen | undefined, bag: Record<string, unknown>): boolean {
+    if (!when) return true;
+    const conds: readonly SettingsRowCondition[] = Array.isArray(when) ? when : [when as SettingsRowCondition];
+    return conds.every((c) => (c.anyOf ? c.anyOf.some((x) => x === bag[c.key]) : bag[c.key] === c.equals));
+}
+
+/**
+ * One tab of a section's INSTANCE STRIP — a repeated block of settings (e.g. one of
+ * several overlays a style can paint). The dialog shows a tab per PRESENT instance,
+ * a dashed `+` that turns on the next absent one, and an `×` on the active removable
+ * tab that turns it off. Presence is the boolean at `enableKey` (stored in the same
+ * per-type bag as every other value); an instance without `enableKey` is always
+ * present and not removable — the base instance.
+ */
+export interface ChartTypeSettingsInstance {
+    /** Tab label in the strip (`'Footprint 1'`). */
+    label: string;
+    /** Boolean bag key controlling presence; omitted = always present, not removable. */
+    enableKey?: string;
+    rows: readonly SettingsRowDescriptor[];
+}
+
+/** An indented sub-entry under the section's rail tab, with its own pane of rows. */
+export interface ChartTypeSettingsSubsection {
+    title: string;
+    rows: readonly SettingsRowDescriptor[];
+    /**
+     * Boolean bag key that masters this pane. While it is false, every row EXCEPT the
+     * one whose `key` matches stays visible but grayed out (not hidden) — so users can
+     * still browse and preview settings with the feature off. The matching toggle is
+     * typically the first row of the Display group.
+     */
+    enableKey?: string;
+}
+
+/**
+ * A chart type's settings tab. Two forms:
+ *
+ * - **Flat**: `rows` only — rendered as one scrollable pane, `heading` rows as inline
+ *   group titles (the historical form).
+ * - **Structured**: `instances` (and optionally `subsections`) — the pane opens with an
+ *   instance TAB STRIP, and each instance's rows are organized by a GROUP TOC on the
+ *   left built from its `heading` rows (rows before the first heading always show above
+ *   the groups; selecting a TOC entry shows only that group's rows). `subsections` add
+ *   indented rail entries under the section's tab, each a pane with the same TOC
+ *   treatment. A TOC entry hides itself while every row of its group is hidden by
+ *   `when` gates.
+ *
+ * All values — every instance and subsection included — live in the ONE per-type bag
+ * (`config.chartTypes[<id>]`), so consumers keep receiving a single flat object.
+ */
 export interface ChartTypeSettingsSection {
     /** Section heading in the settings dialog. */
     title: string;
-    rows: readonly SettingsRowDescriptor[];
+    /** Flat form. Ignored when `instances` is declared. */
+    rows?: readonly SettingsRowDescriptor[];
+    /** Structured form: the pane's instance tab strip. */
+    instances?: readonly ChartTypeSettingsInstance[];
+    /** Indented sub-entries under this section's rail tab. */
+    subsections?: readonly ChartTypeSettingsSubsection[];
     /** `'active'` (default): shown only while this chart type is the active price style;
      *  `'always'`: shown whenever the type is registered. */
     visibility?: 'always' | 'active';
+    /** Rail position: `'end'` (default, after the built-in tabs) or `'after-symbol'`
+     *  (directly under the Symbol tab). Subsections follow their parent. */
+    placement?: 'after-symbol' | 'end';
 }
 
 const registry = new Map<string, ChartTypeDefinition>();

--- a/src/chart-types/registry.ts
+++ b/src/chart-types/registry.ts
@@ -84,6 +84,7 @@ export interface ChartTypeDefinition {
 
 /** One declarative settings row. To add a NEW kind, see docs/architecture/settings-rows.md. */
 export type SettingsRowDescriptor =
+    | { kind: 'heading'; label: string }
     | { kind: 'toggle'; key: string; label: string; defval: boolean }
     | { kind: 'number'; key: string; label: string; defval: number; min?: number; max?: number; step?: number }
     | { kind: 'color'; key: string; label: string; defval: string }

--- a/src/chart-types/registry.ts
+++ b/src/chart-types/registry.ts
@@ -154,7 +154,6 @@ export function settingsRowVisible(when: SettingsRowWhen | undefined, bag: Recor
  * present and not removable — the base instance.
  */
 export interface ChartTypeSettingsInstance {
-    /** Tab label in the strip (`'Footprint 1'`). */
     label: string;
     /** Boolean bag key controlling presence; omitted = always present, not removable. */
     enableKey?: string;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -22,7 +22,13 @@ export {
     tickerModifierIds,
     type ChartTypeDefinition,
     type ChartTypeSettingsSection,
+    type ChartTypeSettingsInstance,
+    type ChartTypeSettingsSubsection,
     type SettingsRowDescriptor,
+    type SettingsRowSwatch,
+    type SettingsSelectOption,
+    type SettingsRowCondition,
+    type SettingsRowWhen,
     type SeriesDataEngine,
     type SeriesDataEngineHost,
 } from './chart-types/registry';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,6 +46,7 @@ export {
     type RendererLayerDefinition,
     type RendererLayerInstance,
     type RendererLayerArgs,
+    type BasePaintingModulation,
 } from './renderers/native/layers';
 export {
     registerWidgetAction,

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -54,7 +54,7 @@ import { computePaneScale, expandScaleByPixels } from './core/autoscale';
 import { mergeTradeMarkersState, tradesPriceHints, type TradeMarkerHints } from '../shared/trade-markers';
 import { rescaleAround, shiftScale } from './core/manualScale';
 import { resizeSplit, type PaneSplit } from './core/paneResize';
-import { type ChartConfig, CHART_CONFIG_VERSION, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf, candleOverrideFor } from './core/chartConfig';
+import { type ChartConfig, CHART_CONFIG_VERSION, factoryResetConfig, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf, candleOverrideFor } from './core/chartConfig';
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
 import { rendererLayers, type RendererLayerArgs, type RendererLayerDefinition, type RendererLayerInstance } from './layers';
 import { applyAttributionMarkTheme, attributionMarkColor, createAttributionMark, createCustomMark } from './chrome/AttributionMark';
@@ -924,7 +924,7 @@ export class NativeRenderer implements IChartRenderer {
             (patch) => this.applyConfig(patch),
             (json) => this.applyConfig(json),
             () => {
-                if (this.factoryConfig) this.applyConfig(this.factoryConfig);
+                if (this.factoryConfig) this.applyConfig(factoryResetConfig(this.factoryConfig));
                 // Re-open so every control re-reads the restored values.
                 this.settingsDialog?.close();
                 this.openSettingsDialog();

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -31,7 +31,7 @@ import { PaneControls } from './chrome/PaneControls';
 import { TableOverlay } from '../shared/TableOverlay';
 import { NATIVE_CAPABILITIES, supportsWebGL2 } from './capabilities';
 import { WebGL2Backend } from './backend/WebGL2Backend';
-import { CoordinateSystem, type PriceScale } from './core/CoordinateSystem';
+import { CoordinateSystem, type PaneBounds, type PriceScale } from './core/CoordinateSystem';
 import { Scheduler, InvalidateLevel, repaintsData, repaintsChrome } from './core/Scheduler';
 import { Animator, easeToward } from './core/Animator';
 import { InputController } from './core/InputController';
@@ -56,7 +56,7 @@ import { rescaleAround, shiftScale } from './core/manualScale';
 import { resizeSplit, type PaneSplit } from './core/paneResize';
 import { type ChartConfig, CHART_CONFIG_VERSION, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf } from './core/chartConfig';
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
-import { rendererLayers, type RendererLayerDefinition, type RendererLayerInstance } from './layers';
+import { rendererLayers, type RendererLayerArgs, type RendererLayerDefinition, type RendererLayerInstance } from './layers';
 import { applyAttributionMarkTheme, attributionMarkColor, createAttributionMark, createCustomMark } from './chrome/AttributionMark';
 import type { HostSettingsSection } from './chrome/SettingsDialog';
 import { VpvrRenderer } from './vpvr/VpvrRenderer';
@@ -2625,6 +2625,38 @@ export class NativeRenderer implements IChartRenderer {
             this.chrome.render(this.scene, this.coords, this.theme, { background: this.surfaceBackground, textColor: this.surfaceTextColor });
         }
         this.crosshairLayer.render(this.scene, this.coords, this.theme, this.hoverSeparatorY, this.externalCrossPx()); // L2 crosshair
+        // Hover-testing SDK layers (repaintOnCursor) follow pointer moves too — each owns
+        // one transparent canvas, so this stays as cheap as the crosshair tier itself.
+        if (!repaintsData(level) && this.paintedData) this.repaintCursorLayers();
+    }
+
+    /** Repaint the SDK layers that opted into cursor tracking (their own canvas only). */
+    private repaintCursorLayers(): void {
+        const pane = this.scene.panes.get(PRICE_PANE_ID);
+        if (!pane) return;
+        const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        for (const l of this.extLayers) {
+            if (!l.def.repaintOnCursor) continue;
+            l.instance.render(this.extLayerArgs(l.def.id, pane.scale, pane.bounds, nowMs));
+            if (this.animZoom && l.instance.animating?.()) this.animator.start();
+        }
+    }
+
+    /** One frame's args for an SDK renderer layer (shared by the data + cursor paint paths). */
+    private extLayerArgs(id: string, scale: PriceScale, bounds: PaneBounds, nowMs: number): RendererLayerArgs {
+        return {
+            bars: this.scene.bars,
+            data: this.scene.nativeData.get(id),
+            settings: (this.scene.nativeData.get(`${id}-settings`) as Record<string, unknown> | undefined) ?? {},
+            pending: this.scene.nativePending.get(id) ?? [],
+            coords: this.coords,
+            scale,
+            bounds,
+            theme: this.theme,
+            priceStyle: this.scene.priceStyle,
+            nowMs,
+            cursor: this.lastPointer,
+        };
     }
 
     /** Paint the below-data (L-1) + geometry (L0) + chrome (L1) layers from the current scene/coords. */
@@ -2661,18 +2693,19 @@ export class NativeRenderer implements IChartRenderer {
             // SDK renderer layers: shared paint cycle, own channel data, own canvas.
             const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
             for (const l of this.extLayers) {
-                l.instance.render({
-                    bars: this.scene.bars,
-                    data: this.scene.nativeData.get(l.def.id),
-                settings: (this.scene.nativeData.get(`${l.def.id}-settings`) as Record<string, unknown> | undefined) ?? {},
-                    pending: this.scene.nativePending.get(l.def.id) ?? [],
-                    coords: this.coords,
-                    scale: pane.scale,
-                    bounds: pane.bounds,
-                    theme: this.theme,
-                    priceStyle: this.scene.priceStyle,
-                    nowMs,
-                });
+                const args = this.extLayerArgs(l.def.id, pane.scale, pane.bounds, nowMs);
+                l.instance.render(args);
+                // The active style's layer may dim/slim the base painting under it (a
+                // gradual counterpart of basePainting 'none') — applied this same frame,
+                // before the backend paints.
+                if (l.def.id === this.scene.priceStyle && l.instance.modulateBase) {
+                    const mod = l.instance.modulateBase(args);
+                    if (mod) {
+                        if (mod.candleBodyScale != null) this.backend.candleBodyScale = clamp01(mod.candleBodyScale) || 0.01;
+                        if (mod.candleBodyAlpha != null) this.backend.candleBodyAlpha = clamp01(mod.candleBodyAlpha) * this.candleBodyAlpha;
+                        if (mod.gridAlpha != null) this.backend.gridAlpha = clamp01(mod.gridAlpha);
+                    }
+                }
                 // A pulsing/fading layer keeps the animator alive; it stops itself when done.
                 if (this.animZoom && l.instance.animating?.()) this.animator.start();
             }
@@ -3380,6 +3413,10 @@ function sanitizeHighlights(value: unknown): HighlightArea[] {
 }
 
 /** Whether a value is one of the supported price-series styles (built-ins + SDK-registered). */
+function clamp01(v: number): number {
+    return Math.max(0, Math.min(1, v));
+}
+
 function isPriceStyle(v: unknown): v is PriceStyle {
     return typeof v === 'string' && (priceStyleIds() as readonly string[]).includes(v);
 }

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -54,7 +54,7 @@ import { computePaneScale, expandScaleByPixels } from './core/autoscale';
 import { mergeTradeMarkersState, tradesPriceHints, type TradeMarkerHints } from '../shared/trade-markers';
 import { rescaleAround, shiftScale } from './core/manualScale';
 import { resizeSplit, type PaneSplit } from './core/paneResize';
-import { type ChartConfig, CHART_CONFIG_VERSION, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf } from './core/chartConfig';
+import { type ChartConfig, CHART_CONFIG_VERSION, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf, candleOverrideFor } from './core/chartConfig';
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
 import { rendererLayers, type RendererLayerArgs, type RendererLayerDefinition, type RendererLayerInstance } from './layers';
 import { applyAttributionMarkTheme, attributionMarkColor, createAttributionMark, createCustomMark } from './chrome/AttributionMark';
@@ -290,6 +290,7 @@ export class NativeRenderer implements IChartRenderer {
             this.candleDown = opts.downColor;
             this.scene.priceStyle = opts.priceStyle;
             this.scene.basePainting = basePaintingOf(opts.priceStyle);
+            this.scene.candleOverride = candleOverrideFor(opts.priceStyle, this.scene.style.chartTypes);
         }
         // Seed a theme so getConfig()/applyConfig() work before mount (mount overwrites
         // it with the real, Vela-resolved theme). Candle colors follow opts.
@@ -796,6 +797,10 @@ export class NativeRenderer implements IChartRenderer {
         };
         // series
         this.setPriceStyle(next.series.style);
+        // Re-read the active style's candle override: setPriceStyle no-ops when the style
+        // did not change, but the per-type bag (candle* keys) may have — this is the live
+        // path behind the Symbol tab's Candles group for plugin styles.
+        this.scene.candleOverride = candleOverrideFor(this.scene.priceStyle, s.chartTypes);
         this.scene.baselineValue = next.series.baseline;
         // Spacing multiplier: widens the center-to-center pitch (and crosshair step) without
         // touching body width. Re-clamp because it changes how many bars fit → the zoom/pan limits.
@@ -1912,6 +1917,7 @@ export class NativeRenderer implements IChartRenderer {
         if (style === this.scene.priceStyle) return;
         this.scene.priceStyle = style;
         this.scene.basePainting = basePaintingOf(style);
+        this.scene.candleOverride = candleOverrideFor(style, this.scene.style.chartTypes);
         for (const cb of this.priceStyleCbs) cb(style);
     }
 

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -10,7 +10,7 @@ import { paneAxisTicks, timeTicks } from '../chrome/ticks';
 import { percentScaleFor } from '../core/SceneGraph';
 import { tzOffsetMs } from '../chrome/tz';
 import { candleTier, wickWidth, candleGeometry } from './candle-lod';
-import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha } from '../core/chartConfig';
+import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, effectiveCandlePaint } from '../core/chartConfig';
 import type { IRenderBackend } from './IRenderBackend';
 
 /**
@@ -401,12 +401,15 @@ export class Canvas2dBackend implements IRenderBackend {
     ): void {
         const spacing = coords.bodySpacing();
         const tier = candleTier(spacing);
+        // A candle-based plugin style paints with its OWN cosmetics (unset keys inherit
+        // the shared candles block); built-ins pass through untouched.
+        const paint = effectiveCandlePaint(scene.style.candle, scene.candleOverride, theme.upColor, theme.downColor);
         if (tier === 'aggregate') {
-            this.drawCandlesAggregated(ctx, bars, i0, i1, coords, pane, theme.upColor, theme.downColor, barColors);
+            this.drawCandlesAggregated(ctx, bars, i0, i1, coords, pane, paint.up, paint.down, barColors);
             return;
         }
         const drawBody = tier === 'full';
-        const cs = scene.style.candle;
+        const cs = paint.candle;
         // When a fading style drops the body below the structure, draw a body outline even
         // if no border is configured — so the candle keeps a visible (hollow) skeleton.
         const fading = this.candleStructureAlpha > this.candleBodyAlpha + 0.001;
@@ -418,7 +421,7 @@ export class Canvas2dBackend implements IRenderBackend {
             const g = candleGeometry(coords.logicalToX(i), spacing, coords.dpr, this.candleBodyScale);
             const x = g.center;
             const up = b.close >= b.open;
-            const dir = up ? theme.upColor : theme.downColor;
+            const dir = up ? paint.up : paint.down;
             const bc = barColors.get(b.time);
             const color = bc ?? dir;
             // Body geometry up front so the wick can be clipped to it when the body is hollow.

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -10,7 +10,7 @@ import { paneAxisTicks, timeTicks } from '../chrome/ticks';
 import { percentScaleFor } from '../core/SceneGraph';
 import { tzOffsetMs } from '../chrome/tz';
 import { candleTier, wickWidth, candleGeometry } from './candle-lod';
-import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha as cssWithAlpha } from '../core/chartConfig';
+import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha as cssWithAlpha, effectiveCandlePaint } from '../core/chartConfig';
 import type { IRenderBackend } from './IRenderBackend';
 import { Batch, type RGBA } from './gl/Batch';
 import { parseColor } from './gl/color';
@@ -878,14 +878,17 @@ export class WebGL2Backend implements IRenderBackend {
     private emitCandles(b: Batch, scene: SceneGraph, bars: OHLCV[], i0: number, i1: number, coords: CoordinateSystem, pane: PaneNode, theme: VelaTheme, barColors: ReadonlyMap<number, string>): void {
         const spacing = coords.bodySpacing();
         const tier = candleTier(spacing);
+        // A candle-based plugin style paints with its OWN cosmetics (unset keys inherit
+        // the shared candles block); built-ins pass through untouched.
+        const paint = effectiveCandlePaint(scene.style.candle, scene.candleOverride, theme.upColor, theme.downColor);
         if (tier === 'aggregate') {
-            this.emitCandlesAggregated(b, bars, i0, i1, coords, pane, theme.upColor, theme.downColor, barColors);
+            this.emitCandlesAggregated(b, bars, i0, i1, coords, pane, paint.up, paint.down, barColors);
             return;
         }
         const drawBody = tier === 'full';
-        const up = theme.upColor;
-        const down = theme.downColor;
-        const cs = scene.style.candle;
+        const up = paint.up;
+        const down = paint.down;
+        const cs = paint.candle;
         // When a fading style drops the body below the structure, draw a body outline even
         // if no border is configured — so the candle keeps a visible (hollow) skeleton.
         const fading = this.candleStructureAlpha > this.candleBodyAlpha + 0.001;

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -396,6 +396,10 @@ export class SettingsDialog {
             body.append(marker);
             const values = config.chartTypes[def.id] ?? {};
             for (const r of typeSettings.rows) {
+                if (r.kind === 'heading') {
+                    body.append(this.sectionTitle(r.label));
+                    continue;
+                }
                 const current = values[r.key];
                 if (r.kind === 'toggle') {
                     body.append(this.boolRow(r.label, typeof current === 'boolean' ? current : r.defval, (v) => this.emitType(def.id, r.key, v)));

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -1,7 +1,17 @@
 import type { VelaTheme, ThemeName } from '../../../core/options';
 import type { ChartConfig } from '../core/chartConfig';
-import { chartType, chartTypes } from '../../../chart-types/registry';
+import {
+    chartType,
+    chartTypes,
+    settingsRowVisible,
+    type ChartTypeSettingsInstance,
+    type ChartTypeSettingsSection,
+    type SettingsRowDescriptor,
+    type SettingsRowWhen,
+    type SettingsSelectOption,
+} from '../../../chart-types/registry';
 import { toHex6, withAlpha } from '../../../core/color';
+import { CATEGORICAL } from '../../../core/palette';
 import { iconAt } from '../../../core/icons';
 import { TIMEZONES, tzMenuLabel, normalizeTimezone } from '../../../core/timezones';
 import { colorField, closeColorPopover } from './ColorField';
@@ -53,6 +63,9 @@ function styleLabel(id: string): string {
 
 const SD_STYLE_ID = 'vela-settings-controls';
 
+/** Accent dots for instance-strip tabs (by instance index) — decoration, not data. */
+const INSTANCE_DOT_COLORS = CATEGORICAL;
+
 /**
  * The dialog's surface palette. It follows the STABLE chrome surface (the tokens written on
  * the chart container), not the live plot background: recoloring the plot must not repaint
@@ -99,6 +112,38 @@ function ensureControlStyles(): void {
 .vela-sd-btn:hover{background:var(--vela-hover);border-color:var(--vela-border-strong);color:var(--vela-fg-bright);}
 .vela-sd-close{cursor:pointer;display:inline-flex;align-items:center;justify-content:center;background:transparent;border:none;color:var(--vela-fg-muted);line-height:0;width:30px;height:30px;border-radius:var(--vela-radius-sm);transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
 .vela-sd-close:hover{background:var(--vela-hover);color:var(--vela-fg-bright);}
+/* Rows/blocks gated away by chart-type conditions, TOC filters, or the instance strip.
+   !important: the pane grid rewrites inline display ('contents') AFTER the initial
+   visibility pass, so a class must win. */
+.vela-sd-hide{display:none !important;}
+/* Indented rail sub-entry (a chart-type section's subsection tab). */
+.vela-sd-tab-sub{padding-left:28px;font-weight:600;font-size:12px;}
+/* Instance strip: a tab per present instance (accent dot + label, ✕ on the active
+   removable one) and a dashed + that turns on the next absent instance. The rule
+   under it separates the strip from the instance's TOC + rows area. */
+.vela-sd-itabs{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:14px 0 0;padding-bottom:12px;border-bottom:1px solid var(--vela-border);}
+.vela-sd-itab{display:inline-flex;align-items:center;gap:7px;height:30px;padding:0 11px;background:transparent;border:1px solid var(--vela-border);border-radius:var(--vela-radius-md);color:var(--vela-fg-muted);font-family:inherit;font-size:var(--vela-font-size-md);font-weight:600;cursor:pointer;transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease,border-color var(--vela-dur-fast) ease;}
+.vela-sd-itab:hover{background:var(--vela-hover);color:var(--vela-fg-bright);}
+.vela-sd-itab.on{background:var(--vela-active);color:var(--vela-fg-bright);border-color:var(--vela-border-strong);}
+.vela-sd-idot{width:7px;height:7px;border-radius:50%;flex:none;}
+.vela-sd-ix{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;margin-right:-4px;border-radius:var(--vela-radius-sm);color:var(--vela-fg-muted);font-size:10px;line-height:1;}
+.vela-sd-ix:hover{background:var(--vela-hover);color:var(--vela-fg-bright);}
+.vela-sd-itab-add{border-style:dashed;min-width:30px;justify-content:center;padding:0;}
+/* Structured pane: group TOC column + rows column, TOP-ALIGNED (the shared padding-top
+   lives on the wrap, never on one column). The TOC sticks while the pane scrolls; the
+   vertical rule sits on the rows column so it spans the full content height. When every
+   group gates out the TOC hides and .no-toc drops the rule with it. */
+.vela-sd-struct{display:flex;align-items:flex-start;padding-top:14px;}
+.vela-sd-toc{position:sticky;top:0;flex:0 0 auto;min-width:104px;display:flex;flex-direction:column;gap:2px;padding:2px 14px 0 0;}
+.vela-sd-struct>[data-sd-rows-host]{border-left:1px solid var(--vela-border);padding-left:18px;}
+.vela-sd-struct.no-toc>[data-sd-rows-host]{border-left:none;padding-left:0;}
+.vela-sd-toc-btn{text-align:left;padding:6px 10px;background:transparent;border:none;border-radius:var(--vela-radius-sm);color:var(--vela-fg-muted);font-family:inherit;font-size:12px;font-weight:600;cursor:pointer;transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
+.vela-sd-toc-btn:hover{background:var(--vela-hover);color:var(--vela-fg-bright);}
+.vela-sd-toc-btn.on{background:var(--vela-active);color:var(--vela-fg-bright);}
+/* Soft-disable: a subsection's enableKey is off — rows stay visible (browseable) but
+   muted and non-interactive. Applied to each row's children so it survives display:contents;
+   !important beats the inline opacity on labels. */
+.vela-sd-soft>*{opacity:0.4 !important;pointer-events:none !important;}
 `;
     document.head.appendChild(st);
 }
@@ -117,6 +162,10 @@ export class SettingsDialog {
     private themeControl: { current: ThemeName; onSelect: (name: ThemeName) => void } | null = null;
     /** The built tabs, by title — how `showSection` reaches a pane while the dialog is open. */
     private tabs: Array<{ title: string; show: () => void }> = [];
+    /** Active instance-strip tab per chart type — remembered across dialog rebuilds. */
+    private readonly typeActiveInstance = new Map<string, number>();
+    /** Active TOC group per structured pane (`<typeId>/<pane>` → group label). */
+    private readonly typeActiveGroup = new Map<string, string>();
     /** The tab currently shown, so a theme change (which rebuilds) lands back on it. */
     private activeSection: string | null = null;
 
@@ -335,9 +384,27 @@ export class SettingsDialog {
                 }
             }
         };
+        // ══ CHART-TYPE SDK SECTIONS — each registered type's declarative settings tab.
+        //    visibility 'active' (default) shows the tab only while the style is active;
+        //    'always' keeps it visible. Values persist under config.chartTypes[<id>] and
+        //    are pushed to the `<id>-settings` channel by the renderer's applyConfig.
+        //    placement 'after-symbol' puts the tab (and its subsections) right under
+        //    Symbol; 'end' (default) keeps the historical position after the built-ins.
+        const renderChartTypeSections = (placement: 'after-symbol' | 'end'): void => {
+            for (const def of chartTypes()) {
+                const typeSettings = def.settings;
+                if (!typeSettings) continue;
+                if ((typeSettings.placement ?? 'end') !== placement) continue;
+                this.chartTypeSection(def.id, typeSettings, config, body);
+            }
+        };
+
         // 'symbol' rows FIRST — they must land before any host TAB marker, or the
         // split walker files them into that tab's pane instead of Symbol's.
+        // Chart-type 'after-symbol' tabs precede host ones: an active style's own tab
+        // sits DIRECTLY under Symbol.
         renderHostSections('symbol');
+        renderChartTypeSections('after-symbol');
         renderHostSections('after-symbol');
 
         // ══ SCALES AND LINES — price scale + crosshair (the reference tab) ══
@@ -383,35 +450,7 @@ export class SettingsDialog {
             body.append(this.selectRow('Color theme', tc.current === 'dark' ? 'Dark' : 'Light', ['Dark', 'Light'], (v) => tc.onSelect(v === 'Dark' ? 'dark' : 'light')));
         }
 
-        // ══ CHART-TYPE SDK SECTIONS — each registered type's declarative settings tab.
-        //    visibility 'active' (default) shows the tab only while the style is active;
-        //    'always' keeps it visible. Values persist under config.chartTypes[<id>] and
-        //    are pushed to the `<id>-settings` channel by the renderer's applyConfig.
-        for (const def of chartTypes()) {
-            const typeSettings = def.settings;
-            if (!typeSettings) continue;
-            const marker = this.section(typeSettings.title);
-            marker.dataset.sdStyle = def.id;
-            marker.dataset.sdVisibility = typeSettings.visibility ?? 'active';
-            body.append(marker);
-            const values = config.chartTypes[def.id] ?? {};
-            for (const r of typeSettings.rows) {
-                if (r.kind === 'heading') {
-                    body.append(this.sectionTitle(r.label));
-                    continue;
-                }
-                const current = values[r.key];
-                if (r.kind === 'toggle') {
-                    body.append(this.boolRow(r.label, typeof current === 'boolean' ? current : r.defval, (v) => this.emitType(def.id, r.key, v)));
-                } else if (r.kind === 'number') {
-                    body.append(this.numberRow(r.label, typeof current === 'number' ? current : r.defval, r.min ?? 0, r.max ?? 1_000_000, r.step ?? 1, (v) => this.emitType(def.id, r.key, v)));
-                } else if (r.kind === 'color') {
-                    body.append(this.colorRow(r.label, typeof current === 'string' ? current : r.defval, (v) => this.emitType(def.id, r.key, v)));
-                } else {
-                    body.append(this.selectRow(r.label, typeof current === 'string' ? current : r.defval, [...r.options], (v) => this.emitType(def.id, r.key, v)));
-                }
-            }
-        }
+        renderChartTypeSections('end');
 
         renderHostSections('end');
 
@@ -434,7 +473,7 @@ export class SettingsDialog {
                 const tab = document.createElement('button');
                 tab.type = 'button';
                 tab.textContent = title;
-                tab.className = 'vela-sd-tab';
+                tab.className = 'vela-sd-tab' + (child.dataset.sdSub !== undefined ? ' vela-sd-tab-sub' : '');
                 panes.push({ title, el, tab, style: child.dataset.sdStyle, visibility: child.dataset.sdVisibility });
                 current = el;
                 child.remove();
@@ -480,7 +519,16 @@ export class SettingsDialog {
         this.root = scrim;
         // Pane-wide label column — must run after mount so label clones can be measured
         // against the live dialog (detached/`display:none` trees report width 0).
-        for (const p of panes) this.layoutSettingsGrids(p.el, dlg);
+        // Structured chart-type panes (instance strip / group TOC) own their layout and
+        // tag their rows hosts instead; each host gets its own grid.
+        for (const p of panes) {
+            const hosts = [...p.el.querySelectorAll('[data-sd-rows-host]')] as HTMLElement[];
+            if (hosts.length === 0) {
+                this.layoutSettingsGrids(p.el, dlg);
+                continue;
+            }
+            for (const h of hosts) this.layoutSettingsGrids(h, dlg);
+        }
     }
 
     close(): void {
@@ -514,6 +562,325 @@ export class SettingsDialog {
         el.style.cssText = 'margin:24px 0 0;padding-bottom:8px;font-size:var(--vela-font-size-sm);font-weight:700;letter-spacing:0.05em;text-transform:uppercase;color:var(--vela-fg-muted);';
         el.textContent = text;
         return el;
+    }
+
+    /**
+     * One chart type's settings tab (and its subsection tabs), appended to the linear
+     * `body` for the pane splitter to file. One live values BAG serves the whole section
+     * — instances and subsections share the per-type store, so a `when` gate anywhere
+     * can reference a key edited anywhere else; every edit runs every registered
+     * refresher.
+     */
+    private chartTypeSection(typeId: string, section: ChartTypeSettingsSection, config: ChartConfig, body: HTMLElement): void {
+        const marker = this.section(section.title);
+        marker.dataset.sdStyle = typeId;
+        marker.dataset.sdVisibility = section.visibility ?? 'active';
+        body.append(marker);
+
+        const values = config.chartTypes[typeId] ?? {};
+        const bag: Record<string, unknown> = {};
+        const seedKey = (key: string, want: 'boolean' | 'number' | 'string', defval: unknown): void => {
+            const v = values[key];
+            bag[key] = typeof v === want ? v : defval;
+        };
+        const seed = (rows: readonly SettingsRowDescriptor[]): void => {
+            for (const r of rows) {
+                if (r.kind === 'heading') continue;
+                if (r.kind === 'range') {
+                    seedKey(r.minKey, 'number', r.defval);
+                    seedKey(r.maxKey, 'number', r.defval);
+                    continue;
+                }
+                seedKey(r.key, r.kind === 'toggle' ? 'boolean' : r.kind === 'number' ? 'number' : 'string', r.defval);
+                if (r.kind === 'toggle') for (const c of r.colors ?? []) seedKey(c.key, 'string', c.defval);
+            }
+        };
+        if (section.rows) seed(section.rows);
+        for (const inst of section.instances ?? []) seed(inst.rows);
+        for (const sub of section.subsections ?? []) seed(sub.rows);
+        // Instance / subsection presence keys may have no row of their own — absent means OFF.
+        for (const inst of section.instances ?? []) {
+            if (!inst.enableKey || inst.enableKey in bag) continue;
+            bag[inst.enableKey] = values[inst.enableKey] === true;
+        }
+        for (const sub of section.subsections ?? []) {
+            if (!sub.enableKey || sub.enableKey in bag) continue;
+            bag[sub.enableKey] = values[sub.enableKey] === true;
+        }
+
+        const refreshers: Array<() => void> = [];
+        const put = (key: string, v: unknown): void => {
+            bag[key] = v;
+            this.emitType(typeId, key, v);
+            for (const r of refreshers) r();
+        };
+
+        if (section.instances && section.instances.length > 0) {
+            body.append(this.instancesBlock(typeId, section.instances, bag, put, refreshers));
+        } else if (section.rows) {
+            this.flatTypeRows(section.rows, bag, put, refreshers, body);
+        }
+
+        for (const sub of section.subsections ?? []) {
+            const subMarker = this.section(sub.title);
+            subMarker.dataset.sdStyle = typeId;
+            subMarker.dataset.sdVisibility = section.visibility ?? 'active';
+            subMarker.dataset.sdSub = '1';
+            body.append(subMarker);
+            body.append(this.groupedRows(`${typeId}/${sub.title}`, sub.rows, bag, put, refreshers, sub.enableKey));
+        }
+        for (const r of refreshers) r();
+    }
+
+    /** The FLAT chart-type form: rows appended straight to the body (the pane grid wraps
+     *  them), headings as inline group titles, `when` gates refreshed live. */
+    private flatTypeRows(
+        rows: readonly SettingsRowDescriptor[],
+        bag: Record<string, unknown>,
+        put: (key: string, v: unknown) => void,
+        refreshers: Array<() => void>,
+        body: HTMLElement,
+    ): void {
+        const entries: Array<{ el: HTMLElement; when?: SettingsRowWhen }> = [];
+        for (const r of rows) {
+            const el = r.kind === 'heading' ? this.sectionTitle(r.label) : this.typeRow(r, bag, put);
+            entries.push({ el, when: r.when });
+            body.append(el);
+        }
+        refreshers.push(() => {
+            // A class, not inline display: the pane grid dissolves rows into
+            // display:contents AFTER the first pass, which would wipe inline 'none'.
+            for (const e of entries) e.el.classList.toggle('vela-sd-hide', !settingsRowVisible(e.when, bag));
+        });
+    }
+
+    /** One value row for a chart-type descriptor, writing through `put`. */
+    private typeRow(
+        r: Exclude<SettingsRowDescriptor, { kind: 'heading' }>,
+        bag: Record<string, unknown>,
+        put: (key: string, v: unknown) => void,
+    ): HTMLElement {
+        if (r.kind === 'toggle') {
+            const swatches = (r.colors ?? []).map((c) => {
+                const sw = this.swatch(bag[c.key] as string, (v) => put(c.key, v));
+                sw.title = c.label;
+                return sw;
+            });
+            return this.toggleRow(r.label, bag[r.key] as boolean, (v) => put(r.key, v), swatches);
+        }
+        if (r.kind === 'number') return this.numberRow(r.label, bag[r.key] as number, r.min ?? 0, r.max ?? 1_000_000, r.step ?? 1, (v) => put(r.key, v));
+        if (r.kind === 'color') return this.colorRow(r.label, bag[r.key] as string, (v) => put(r.key, v));
+        if (r.kind === 'range') return this.rangeRow(r, bag, put);
+        return this.selectRowLabeled(r.label, bag[r.key] as string, normalizeSelectOptions(r.options), (v) => put(r.key, v));
+    }
+
+    /**
+     * A MIN–MAX row: two number inputs on one row (stored under the descriptor's
+     * `minKey`/`maxKey`). With a `placeholder`, an input at the DEFAULT value renders
+     * empty showing it, and clearing an input stores the default back — the
+     * placeholder names the unset state ('Off' for 0-disables bounds).
+     */
+    private rangeRow(
+        r: Extract<SettingsRowDescriptor, { kind: 'range' }>,
+        bag: Record<string, unknown>,
+        put: (key: string, v: unknown) => void,
+    ): HTMLElement {
+        const { wrap } = this.row(r.label);
+        const input = (key: string, title: string): HTMLInputElement => {
+            const ni = document.createElement('input');
+            ni.type = 'number';
+            ni.className = 'vela-sd-number';
+            ni.min = String(r.min ?? 0);
+            ni.max = String(r.max ?? 1_000_000);
+            ni.step = String(r.step ?? 1);
+            ni.title = title;
+            const current = bag[key] as number;
+            if (r.placeholder !== undefined) {
+                ni.placeholder = r.placeholder;
+                if (current !== r.defval) ni.value = String(current);
+            } else {
+                ni.value = String(current);
+            }
+            // 'change' (commit), not 'input': an empty field means "default" only once
+            // the user is done, never while they are mid-edit.
+            ni.addEventListener('change', () => {
+                const raw = ni.value.trim() === '' ? r.defval : Number(ni.value);
+                const v = Number.isFinite(raw) ? Math.min(r.max ?? Infinity, Math.max(r.min ?? -Infinity, raw)) : r.defval;
+                ni.value = r.placeholder !== undefined && v === r.defval ? '' : String(v);
+                put(key, v);
+            });
+            return ni;
+        };
+        const box = document.createElement('div');
+        box.style.cssText = 'display:flex;align-items:center;gap:6px;flex:0 0 auto;';
+        const dash = document.createElement('span');
+        dash.textContent = '–';
+        dash.style.cssText = 'color:var(--vela-fg-muted);';
+        box.append(input(r.minKey, `${r.label} — min`), dash, input(r.maxKey, `${r.label} — max`));
+        wrap.appendChild(box);
+        return wrap;
+    }
+
+    /**
+     * The INSTANCE STRIP block: a tab per present instance (dot + label, `×` on the
+     * active removable one), a dashed `+` while an instance is still absent, and one
+     * grouped-rows content per instance below — only the active tab's content shows.
+     * Presence is the boolean at each instance's `enableKey`; the strip rebuilds on
+     * every section edit, so gates elsewhere stay coherent.
+     */
+    private instancesBlock(
+        typeId: string,
+        instances: readonly ChartTypeSettingsInstance[],
+        bag: Record<string, unknown>,
+        put: (key: string, v: unknown) => void,
+        refreshers: Array<() => void>,
+    ): HTMLElement {
+        const wrap = document.createElement('div');
+        const strip = document.createElement('div');
+        strip.className = 'vela-sd-itabs';
+        wrap.append(strip);
+        const contents = instances.map((inst, i) => {
+            const content = this.groupedRows(`${typeId}/#${i}`, inst.rows, bag, put, refreshers);
+            wrap.append(content);
+            return content;
+        });
+
+        const present = (inst: ChartTypeSettingsInstance): boolean => !inst.enableKey || bag[inst.enableKey] === true;
+        const refresh = (): void => {
+            let active = this.typeActiveInstance.get(typeId) ?? 0;
+            if (!present(instances[active] ?? instances[0]!)) active = 0;
+            this.typeActiveInstance.set(typeId, active);
+
+            strip.replaceChildren();
+            instances.forEach((inst, i) => {
+                if (!present(inst)) return;
+                const tab = document.createElement('button');
+                tab.type = 'button';
+                tab.className = 'vela-sd-itab' + (i === active ? ' on' : '');
+                const dot = document.createElement('span');
+                dot.className = 'vela-sd-idot';
+                dot.style.background = INSTANCE_DOT_COLORS[i % INSTANCE_DOT_COLORS.length]!;
+                const lbl = document.createElement('span');
+                lbl.textContent = inst.label;
+                tab.append(dot, lbl);
+                if (i === active && inst.enableKey) {
+                    const x = document.createElement('span');
+                    x.className = 'vela-sd-ix';
+                    x.textContent = '✕';
+                    x.title = `Remove ${inst.label}`;
+                    x.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        this.typeActiveInstance.set(typeId, 0);
+                        put(inst.enableKey!, false); // put() re-runs every refresher, this one included
+                    });
+                    tab.append(x);
+                }
+                tab.addEventListener('click', () => {
+                    this.typeActiveInstance.set(typeId, i);
+                    refresh();
+                });
+                strip.append(tab);
+            });
+            const absent = instances.findIndex((inst) => !present(inst));
+            if (absent >= 0) {
+                const add = document.createElement('button');
+                add.type = 'button';
+                add.className = 'vela-sd-itab vela-sd-itab-add';
+                add.textContent = '+';
+                add.title = `Add ${instances[absent]!.label}`;
+                add.addEventListener('click', () => {
+                    this.typeActiveInstance.set(typeId, absent);
+                    put(instances[absent]!.enableKey!, true);
+                });
+                strip.append(add);
+            }
+            contents.forEach((c, i) => c.classList.toggle('vela-sd-hide', i !== active));
+        };
+        refreshers.push(refresh);
+        return wrap;
+    }
+
+    /**
+     * A GROUPED rows pane: a TOC column of the group labels (from `heading` rows) and
+     * ONE rows host holding every row — the active group's rows show, the rest hide.
+     * Rows BEFORE the first heading are the always block, visible above every group.
+     * A group whose rows are all gated out (or whose heading's own `when` fails) leaves
+     * the TOC; the whole TOC hides when no group is live. The rows host is tagged for
+     * `layoutSettingsGrids`, keeping one shared label column across all groups.
+     *
+     * `enableKey` (optional): while that bag boolean is false, every row except the one
+     * whose key matches is soft-disabled (visible but grayed / non-interactive) so the
+     * pane stays browseable with the feature off.
+     */
+    private groupedRows(
+        paneKey: string,
+        rows: readonly SettingsRowDescriptor[],
+        bag: Record<string, unknown>,
+        put: (key: string, v: unknown) => void,
+        refreshers: Array<() => void>,
+        enableKey?: string,
+    ): HTMLElement {
+        const wrap = document.createElement('div');
+        wrap.className = 'vela-sd-struct';
+        const toc = document.createElement('div');
+        toc.className = 'vela-sd-toc';
+        const rowsHost = document.createElement('div');
+        rowsHost.dataset.sdRowsHost = '1';
+        rowsHost.style.cssText = 'flex:1 1 auto;min-width:0;';
+        wrap.append(toc, rowsHost);
+
+        const entries: Array<{ el: HTMLElement; when?: SettingsRowWhen; group: number; key?: string }> = [];
+        const groups: string[] = [];
+        const groupWhens: Array<SettingsRowWhen | undefined> = [];
+        let g = -1; // -1 = the always block before the first heading
+        for (const r of rows) {
+            if (r.kind === 'heading') {
+                g = groups.length;
+                groups.push(r.label);
+                groupWhens.push(r.when);
+                continue; // headings live in the TOC, not the rows column
+            }
+            const el = this.typeRow(r, bag, put);
+            const key = r.kind === 'range' ? undefined : r.key;
+            entries.push({ el, when: r.when, group: g, key });
+            rowsHost.append(el);
+        }
+
+        const refresh = (): void => {
+            const live = groups.map((_, gi) =>
+                settingsRowVisible(groupWhens[gi], bag)
+                && entries.some((e) => e.group === gi && settingsRowVisible(e.when, bag)));
+            let activeIdx = groups.indexOf(this.typeActiveGroup.get(paneKey) ?? '');
+            if (activeIdx < 0 || !live[activeIdx]) activeIdx = live.findIndex(Boolean);
+            if (activeIdx >= 0) this.typeActiveGroup.set(paneKey, groups[activeIdx]!);
+
+            toc.replaceChildren();
+            groups.forEach((label, gi) => {
+                if (!live[gi]) return;
+                const b = document.createElement('button');
+                b.type = 'button';
+                b.className = 'vela-sd-toc-btn' + (gi === activeIdx ? ' on' : '');
+                b.textContent = label;
+                b.addEventListener('click', () => {
+                    this.typeActiveGroup.set(paneKey, label);
+                    refresh();
+                });
+                toc.append(b);
+            });
+            const anyGroup = live.some(Boolean);
+            toc.classList.toggle('vela-sd-hide', !anyGroup);
+            wrap.classList.toggle('no-toc', !anyGroup);
+
+            const enabled = !enableKey || bag[enableKey] === true;
+            for (const e of entries) {
+                const visible = (e.group === -1 || e.group === activeIdx) && settingsRowVisible(e.when, bag);
+                e.el.classList.toggle('vela-sd-hide', !visible);
+                // Soft-disable everything except the master toggle while the feature is off.
+                e.el.classList.toggle('vela-sd-soft', visible && !enabled && e.key !== enableKey);
+            }
+        };
+        refreshers.push(refresh);
+        return wrap;
     }
 
     /** Vertical breathing space between row clusters — grouping reads from whitespace,
@@ -798,7 +1165,7 @@ export class SettingsDialog {
         const { wrap } = this.row(label);
         const sel = document.createElement('select');
         sel.className = 'vela-sd-select';
-        sel.style.cssText = 'max-width:140px;flex:0 0 auto;';
+        sel.style.cssText = 'max-width:200px;flex:0 0 auto;';
         for (const [val, lbl] of options) {
             const o = document.createElement('option');
             o.value = val;
@@ -815,7 +1182,7 @@ export class SettingsDialog {
         const { wrap } = this.row(label);
         const sel = document.createElement('select');
         sel.className = 'vela-sd-select';
-        sel.style.cssText = 'max-width:140px;flex:0 0 auto;';
+        sel.style.cssText = 'max-width:200px;flex:0 0 auto;';
         for (const opt of options) {
             const o = document.createElement('option');
             o.value = opt;
@@ -858,6 +1225,11 @@ export class SettingsDialog {
 }
 
 const AUTO_MANUAL_OPTS: readonly (readonly [string, string])[] = [['auto', 'Auto'], ['manual', 'Manual']];
+
+/** Normalize a select descriptor's options to `[value, label]` pairs. */
+function normalizeSelectOptions(options: readonly SettingsSelectOption[]): readonly (readonly [string, string])[] {
+    return options.map((o) => (typeof o === 'string' ? [o, o] as const : o));
+}
 
 const FONT_FAMILIES = ['sans-serif', 'serif', 'monospace', 'Arial', 'Helvetica', 'Georgia', 'Courier New', '-apple-system, Segoe UI, sans-serif'];
 const LINE_STYLES = ['solid', 'dashed', 'dotted'];

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -11,11 +11,10 @@ import {
     type SettingsSelectOption,
 } from '../../../chart-types/registry';
 import { toHex6, withAlpha } from '../../../core/color';
-import { CATEGORICAL } from '../../../core/palette';
 import { iconAt } from '../../../core/icons';
 import { TIMEZONES, tzMenuLabel, normalizeTimezone } from '../../../core/timezones';
 import { colorField, closeColorPopover } from './ColorField';
-import { priceStyleIds } from '../core/chartConfig';
+import { priceStyleIds, hasOwnCandlePaint } from '../core/chartConfig';
 
 /** A nested partial of `ChartConfig` — what a single control edit emits. */
 type ConfigPatch = Record<string, unknown>;
@@ -62,9 +61,6 @@ function styleLabel(id: string): string {
 }
 
 const SD_STYLE_ID = 'vela-settings-controls';
-
-/** Accent dots for instance-strip tabs (by instance index) — decoration, not data. */
-const INSTANCE_DOT_COLORS = CATEGORICAL;
 
 /**
  * The dialog's surface palette. It follows the STABLE chrome surface (the tokens written on
@@ -118,14 +114,13 @@ function ensureControlStyles(): void {
 .vela-sd-hide{display:none !important;}
 /* Indented rail sub-entry (a chart-type section's subsection tab). */
 .vela-sd-tab-sub{padding-left:28px;font-weight:600;font-size:12px;}
-/* Instance strip: a tab per present instance (accent dot + label, ✕ on the active
-   removable one) and a dashed + that turns on the next absent instance. The rule
-   under it separates the strip from the instance's TOC + rows area. */
+/* Instance strip: a tab per present instance (label, ✕ on the active removable one)
+   and a dashed + that turns on the next absent instance. The rule under it separates
+   the strip from the instance's TOC + rows area. */
 .vela-sd-itabs{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:14px 0 0;padding-bottom:12px;border-bottom:1px solid var(--vela-border);}
 .vela-sd-itab{display:inline-flex;align-items:center;gap:7px;height:30px;padding:0 11px;background:transparent;border:1px solid var(--vela-border);border-radius:var(--vela-radius-md);color:var(--vela-fg-muted);font-family:inherit;font-size:var(--vela-font-size-md);font-weight:600;cursor:pointer;transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease,border-color var(--vela-dur-fast) ease;}
 .vela-sd-itab:hover{background:var(--vela-hover);color:var(--vela-fg-bright);}
 .vela-sd-itab.on{background:var(--vela-active);color:var(--vela-fg-bright);border-color:var(--vela-border-strong);}
-.vela-sd-idot{width:7px;height:7px;border-radius:50%;flex:none;}
 .vela-sd-ix{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;margin-right:-4px;border-radius:var(--vela-radius-sm);color:var(--vela-fg-muted);font-size:10px;line-height:1;}
 .vela-sd-ix:hover{background:var(--vela-hover);color:var(--vela-fg-bright);}
 .vela-sd-itab-add{border-style:dashed;min-width:30px;justify-content:center;padding:0;}
@@ -366,6 +361,34 @@ export class SettingsDialog {
         baseline.append(this.numberRow('Width', config.baseline.width, 1, 10, 1, (v) => this.emit({ baseline: { width: v } })));
         groups.baseline = baseline;
         body.append(baseline);
+
+        // Candle-based PLUGIN styles (an order-flow type keeps candles under its layer):
+        // the same candle rows, but stored in the type's OWN bag (chartTypes.<id>.candle*)
+        // so edits style THAT type's candles without touching the shared candles block the
+        // candles/heikin-ashi styles paint with. Unset keys inherit the shared values.
+        for (const def of chartTypes()) {
+            if (!hasOwnCandlePaint(def.id)) continue;
+            const bag = config.chartTypes[def.id] ?? {};
+            const colorOf = (key: string, shared: string): string => (typeof bag[key] === 'string' && bag[key] !== '' ? bag[key] as string : shared);
+            const boolOf = (key: string, shared: boolean): boolean => (typeof bag[key] === 'boolean' ? bag[key] as boolean : shared);
+            const g = this.group();
+            g.append(this.sectionTitle('Candles'));
+            g.append(this.toggleRow('Body', boolOf('candleBodyVisible', config.candles.bodyVisible), (v) => this.emitType(def.id, 'candleBodyVisible', v), [
+                this.swatch(colorOf('candleUpColor', config.candles.upColor), (v) => this.emitType(def.id, 'candleUpColor', v)),
+                this.swatch(colorOf('candleDownColor', config.candles.downColor), (v) => this.emitType(def.id, 'candleDownColor', v)),
+            ]));
+            g.append(this.toggleRow('Borders', boolOf('candleBorderVisible', config.candles.borderVisible), (v) => this.emitType(def.id, 'candleBorderVisible', v), [
+                this.swatch(colorOf('candleBorderUpColor', config.candles.borderUpColor), (v) => this.emitType(def.id, 'candleBorderUpColor', v)),
+                this.swatch(colorOf('candleBorderDownColor', config.candles.borderDownColor), (v) => this.emitType(def.id, 'candleBorderDownColor', v)),
+            ]));
+            g.append(this.toggleRow('Wick', boolOf('candleWickVisible', config.candles.wickVisible), (v) => this.emitType(def.id, 'candleWickVisible', v), [
+                this.swatch(colorOf('candleWickUpColor', config.candles.wickUpColor), (v) => this.emitType(def.id, 'candleWickUpColor', v)),
+                this.swatch(colorOf('candleWickDownColor', config.candles.wickDownColor), (v) => this.emitType(def.id, 'candleWickDownColor', v)),
+            ]));
+            g.append(this.numberRow('Spacing', config.series.spacing, 0.1, 10, 0.1, (v) => this.emit({ series: { spacing: v } })));
+            groups[def.id] = g;
+            body.append(g);
+        }
         showActive(config.series.style);
 
         body.append(this.sectionTitle('Time zone'));
@@ -722,8 +745,8 @@ export class SettingsDialog {
     }
 
     /**
-     * The INSTANCE STRIP block: a tab per present instance (dot + label, `×` on the
-     * active removable one), a dashed `+` while an instance is still absent, and one
+     * The INSTANCE STRIP block: a tab per present instance (label, `×` on the active
+     * removable one), a dashed `+` while an instance is still absent, and one
      * grouped-rows content per instance below — only the active tab's content shows.
      * Presence is the boolean at each instance's `enableKey`; the strip rebuilds on
      * every section edit, so gates elsewhere stay coherent.
@@ -757,12 +780,9 @@ export class SettingsDialog {
                 const tab = document.createElement('button');
                 tab.type = 'button';
                 tab.className = 'vela-sd-itab' + (i === active ? ' on' : '');
-                const dot = document.createElement('span');
-                dot.className = 'vela-sd-idot';
-                dot.style.background = INSTANCE_DOT_COLORS[i % INSTANCE_DOT_COLORS.length]!;
                 const lbl = document.createElement('span');
                 lbl.textContent = inst.label;
-                tab.append(dot, lbl);
+                tab.append(lbl);
                 if (i === active && inst.enableKey) {
                     const x = document.createElement('span');
                     x.className = 'vela-sd-ix';

--- a/src/renderers/native/core/SceneGraph.ts
+++ b/src/renderers/native/core/SceneGraph.ts
@@ -5,7 +5,7 @@ import type { PaneKind } from '../../../core/model/scene';
 import type { IndicatorModel } from '../../../core/model/indicator';
 import type { PriceStyle } from '../../../core/options';
 import type { PriceScale, PaneBounds } from './CoordinateSystem';
-import { type ChartStyle, defaultChartStyle } from './chartConfig';
+import { type CandlePaintOverride, type ChartStyle, defaultChartStyle } from './chartConfig';
 import { defaultTradeMarkersState, type TradeMarkersState } from '../../shared/trade-markers';
 
 /** A user-defined shaded time band spanning the full plot height (all panes) — the
@@ -123,6 +123,9 @@ export class SceneGraph {
     priceStyle: PriceStyle = 'candles';
     /** Price-series base painting for the ACTIVE style (see ChartTypeDefinition.basePainting). */
     basePainting: 'candles' | 'none' = 'candles';
+    /** The ACTIVE style's own candle cosmetics (`chartTypes.<id>.candle*`) when it is a
+     *  candle-based plugin type; null ⇒ paint with the shared `style.candle` block. */
+    candleOverride: CandlePaintOverride | null = null;
     /** Explicit baseline reference price for `priceStyle:'baseline'`; when null the
      *  baseline follows `style.baseline.baselineLevel` as a percent of the visible pane
      *  range (resolved per frame via `baselinePriceFor`). */

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -292,6 +292,79 @@ export function basePaintingOf(style: PriceStyle): 'candles' | 'none' {
     return 'candles';
 }
 
+/**
+ * Candle cosmetics a candle-based PLUGIN style stores in its own per-type bag
+ * (`chartTypes.<id>.candle*` — reserved keys, edited by the Symbol tab's Candles
+ * group while that style is active). Per-key: `null` inherits the shared `candles`
+ * block, so an untouched plugin style paints exactly like before — and edits never
+ * leak back into the candles/heikin-ashi styles.
+ */
+export interface CandlePaintOverride {
+    upColor: string | null;
+    downColor: string | null;
+    bodyVisible: boolean | null;
+    borderVisible: boolean | null;
+    borderUpColor: string | null;
+    borderDownColor: string | null;
+    wickVisible: boolean | null;
+    wickUpColor: string | null;
+    wickDownColor: string | null;
+}
+
+/** Whether a style carries its OWN candle cosmetics: a registered plugin type whose
+ *  base painting is candles. Built-ins — heikin-ashi included — share the `candles`
+ *  block instead. */
+export function hasOwnCandlePaint(style: PriceStyle): boolean {
+    if ((BUILTIN_PRICE_STYLES as readonly string[]).includes(style)) return false;
+    for (const t of chartTypes()) if (t.id === style) return (t.basePainting ?? 'candles') === 'candles';
+    return false;
+}
+
+/** The candle override for a style, read from the per-type bags — null for built-ins
+ *  and for `basePainting: 'none'` types (nothing of theirs is candle-painted). */
+export function candleOverrideFor(style: PriceStyle, bags: Record<string, Record<string, unknown>>): CandlePaintOverride | null {
+    if (!hasOwnCandlePaint(style)) return null;
+    const bag = bags[style] ?? {};
+    const color = (v: unknown): string | null => (isColor(v) ? v : null);
+    const bool = (v: unknown): boolean | null => (isBool(v) ? v : null);
+    return {
+        upColor: color(bag.candleUpColor),
+        downColor: color(bag.candleDownColor),
+        bodyVisible: bool(bag.candleBodyVisible),
+        borderVisible: bool(bag.candleBorderVisible),
+        borderUpColor: color(bag.candleBorderUpColor),
+        borderDownColor: color(bag.candleBorderDownColor),
+        wickVisible: bool(bag.candleWickVisible),
+        wickUpColor: color(bag.candleWickUpColor),
+        wickDownColor: color(bag.candleWickDownColor),
+    };
+}
+
+/** The candle cosmetics to PAINT: the shared block overridden per-key by the active
+ *  style's override; body colors default to the theme's up/down (shared by both
+ *  backends, so their candle paths stay pixel-identical). */
+export function effectiveCandlePaint(
+    base: CandleStyle,
+    override: CandlePaintOverride | null,
+    themeUp: string,
+    themeDown: string,
+): { up: string; down: string; candle: CandleStyle } {
+    if (!override) return { up: themeUp, down: themeDown, candle: base };
+    return {
+        up: override.upColor ?? themeUp,
+        down: override.downColor ?? themeDown,
+        candle: {
+            bodyVisible: override.bodyVisible ?? base.bodyVisible,
+            borderVisible: override.borderVisible ?? base.borderVisible,
+            borderUpColor: override.borderUpColor ?? base.borderUpColor,
+            borderDownColor: override.borderDownColor ?? base.borderDownColor,
+            wickVisible: override.wickVisible ?? base.wickVisible,
+            wickUpColor: override.wickUpColor ?? base.wickUpColor,
+            wickDownColor: override.wickDownColor ?? base.wickDownColor,
+        },
+    };
+}
+
 /** Every valid price-style id RIGHT NOW: the built-ins plus SDK-registered chart types. */
 export function priceStyleIds(): PriceStyle[] {
     const out: PriceStyle[] = [...BUILTIN_PRICE_STYLES];

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -1,5 +1,5 @@
 import type { LineStyle } from '../../../core/model/series';
-import { chartTypes } from '../../../chart-types/registry';
+import { chartTypes, type SettingsRowDescriptor } from '../../../chart-types/registry';
 import { withAlpha } from '../../../core/color';
 import { BEARISH, BULLISH, CROSSHAIR, SERIES_LINE, SLATE } from '../../../core/palette';
 import type { PriceStyle } from '../../../core/options';
@@ -433,6 +433,53 @@ function nullableBound(v: unknown, base: number | null): number | null {
     return isNum(v) ? (v < 0 ? 0 : v) : base;
 }
 
+
+/**
+ * The document "Reset defaults" applies. `mergeConfig` is deliberately ADDITIVE for
+ * `chartTypes` (a patch only touches the type ids it names), so the factory snapshot
+ * alone cannot undo SDK settings edited after mount — the reset document must name
+ * every registered type at its registry-declared row defaults, covering EVERY key the
+ * section can store (instances, subsections, range min/max, toggle swatches). The
+ * registry is read at call time (types may register after mount), and values the
+ * snapshot itself pinned win over the defvals — they ARE the first-run state.
+ */
+export function factoryResetConfig(factory: ChartConfig): ChartConfig {
+    const bag: Record<string, Record<string, unknown>> = {};
+    for (const t of chartTypes()) {
+        const section = t.settings;
+        if (!section) continue;
+        const defaults: Record<string, unknown> = {};
+        const addRows = (rows: readonly SettingsRowDescriptor[] | undefined): void => {
+            for (const r of rows ?? []) {
+                if (r.kind === 'heading') continue;
+                if (r.kind === 'range') {
+                    defaults[r.minKey] = r.defval;
+                    defaults[r.maxKey] = r.defval;
+                    continue;
+                }
+                defaults[r.key] = r.defval;
+                if (r.kind === 'toggle') for (const c of r.colors ?? []) defaults[c.key] = c.defval;
+            }
+        };
+        // An absent enable key means OFF — seed it explicitly so an instance the user
+        // turned on cannot survive the additive merge; a row that declares the same key
+        // (a subsection's master toggle) overrides it with its own defval via addRows.
+        for (const inst of section.instances ?? []) {
+            if (inst.enableKey) defaults[inst.enableKey] = false;
+            addRows(inst.rows);
+        }
+        for (const sub of section.subsections ?? []) {
+            if (sub.enableKey) defaults[sub.enableKey] = false;
+            addRows(sub.rows);
+        }
+        if (!section.instances) addRows(section.rows);
+        bag[t.id] = defaults;
+    }
+    for (const [typeId, vals] of Object.entries(factory.chartTypes)) {
+        bag[typeId] = { ...(bag[typeId] ?? {}), ...vals };
+    }
+    return { ...factory, chartTypes: bag };
+}
 
 /**
  * Deep-merge an untrusted partial `patch` onto a known-good `base`, validating every

--- a/src/renderers/native/layers.ts
+++ b/src/renderers/native/layers.ts
@@ -31,6 +31,21 @@ export interface RendererLayerArgs {
     priceStyle: string;
     /** Frame clock (ms) for pulses/fades; monotonic within a session. */
     nowMs: number;
+    /** Plot-relative pointer position, or null when the pointer is off the plot. Layers
+     *  that hover-test set `repaintOnCursor` on their definition so pointer moves repaint
+     *  them (only data-tier frames repaint layers otherwise). */
+    cursor: { x: number; y: number } | null;
+}
+
+/** How the active style's layer dims/slims the BASE painting under it (see
+ *  {@link RendererLayerInstance.modulateBase}). Omitted fields keep their defaults. */
+export interface BasePaintingModulation {
+    /** Candle body width multiplier, (0..1] (1 = full width). */
+    candleBodyScale?: number;
+    /** Candle body-fill opacity, [0..1] (wick + border keep their own opacity). */
+    candleBodyAlpha?: number;
+    /** Gridline opacity, [0..1] (fade the grid as a reveal-under layer opens). */
+    gridAlpha?: number;
 }
 
 /** One live layer instance (per mounted renderer). */
@@ -41,6 +56,14 @@ export interface RendererLayerInstance {
     render(args: RendererLayerArgs): void;
     /** Return true while the layer needs CONTINUOUS frames (a pulse/fade) — keeps the animator alive. */
     animating?(): boolean;
+    /**
+     * How the base painting (candles, grid) should be dimmed/slimmed under this layer for
+     * the CURRENT frame — a gradual counterpart of the chart type's all-or-nothing
+     * `basePainting: 'none'`. Called after `render`, only for the layer whose id matches
+     * the active price style; returning null (or omitting the method) leaves the base
+     * painting untouched. Values are clamped by the renderer.
+     */
+    modulateBase?(args: RendererLayerArgs): BasePaintingModulation | null;
     /** The renderer unmounted — release everything (the canvas itself is removed by the renderer). */
     destroy?(): void;
 }
@@ -52,6 +75,9 @@ export interface RendererLayerDefinition {
     /** Stacking: `'below-data'` = behind the candles (reveal-under styles); `'above-data'` =
      *  over the candles, under the chrome/axes. Default `'above-data'`. */
     placement?: 'below-data' | 'above-data';
+    /** Repaint this layer when the pointer moves (hover hit-testing UIs). Off by default:
+     *  pointer moves normally repaint only the crosshair overlay, not the layers. */
+    repaintOnCursor?: boolean;
     /** Instance factory — called once per mounted renderer. */
     create(): RendererLayerInstance;
 }

--- a/test/chart-type-registry.test.ts
+++ b/test/chart-type-registry.test.ts
@@ -2,7 +2,7 @@
 // extended-ticker modifiers, and the dynamic price-style id list the renderer validates
 // against. Heikin Ashi is registered through the SAME public API (builtins.ts).
 import { describe, it, expect, afterEach } from 'vitest';
-import { registerChartType, unregisterChartType, chartType, chartTypes, tickerModifierIds } from '../src/chart-types/registry';
+import { registerChartType, unregisterChartType, chartType, chartTypes, tickerModifierIds, settingsRowVisible } from '../src/chart-types/registry';
 import { basePaintingOf } from '../src/renderers/native/core/chartConfig';
 import { registerBuiltinChartTypes } from '../src/chart-types/builtins';
 import { barTransformFor, parseExtendedTicker } from '../src/core/price-styles/BarTransform';
@@ -62,6 +62,78 @@ describe('chart-type registry', () => {
         expect(priceStyleIds()).toContain('renko-like');
         unregisterChartType('renko-like');
         expect(priceStyleIds()).not.toContain('renko-like');
+    });
+});
+
+describe('structured settings sections (instances + subsections)', () => {
+    it('a section may declare an instance strip, subsections, and rail placement', () => {
+        registerChartType({
+            id: 'renko-like',
+            settings: {
+                title: 'Renko-like',
+                placement: 'after-symbol',
+                instances: [
+                    { label: 'Block 1', rows: [{ kind: 'heading', label: 'Display' }, { kind: 'number', key: 'size', label: 'Size', defval: 4 }] },
+                    { label: 'Block 2', enableKey: 'b2Enabled', rows: [{ kind: 'number', key: 'b2Size', label: 'Size', defval: 4 }] },
+                ],
+                subsections: [
+                    { title: 'Overlay', rows: [{ kind: 'toggle', key: 'overlay', label: 'Show overlay', defval: false }] },
+                ],
+            },
+        });
+        const def = chartType('renko-like')!;
+        expect(def.settings?.placement).toBe('after-symbol');
+        expect(def.settings?.instances?.[1]?.enableKey).toBe('b2Enabled');
+        expect(def.settings?.subsections?.[0]?.title).toBe('Overlay');
+        unregisterChartType('renko-like');
+    });
+
+    it('toggle rows may carry inline swatches; range rows edit a min–max pair', () => {
+        registerChartType({
+            id: 'renko-like',
+            settings: {
+                title: 'Renko-like',
+                rows: [
+                    { kind: 'toggle', key: 'hl', label: 'Highlights', defval: false, colors: [
+                        { key: 'hlAskColor', label: 'Ask color', defval: '#e0b400' },
+                        { key: 'hlBidColor', label: 'Bid color', defval: '#e0b400' },
+                    ] },
+                    { kind: 'range', label: 'Volume', minKey: 'minVolume', maxKey: 'maxVolume', defval: 0, min: 0, max: 1e9, step: 1, placeholder: 'Off' },
+                ],
+            },
+        });
+        const rows = chartType('renko-like')!.settings!.rows!;
+        const toggle = rows[0]!;
+        const range = rows[1]!;
+        expect(toggle.kind === 'toggle' && toggle.colors?.[1]?.key).toBe('hlBidColor');
+        expect(range.kind === 'range' && range.placeholder).toBe('Off');
+        unregisterChartType('renko-like');
+    });
+});
+
+describe('settings row `when` conditions (settingsRowVisible)', () => {
+    it('no gate is always visible', () => {
+        expect(settingsRowVisible(undefined, {})).toBe(true);
+    });
+
+    it('equals matches the bag value strictly', () => {
+        expect(settingsRowVisible({ key: 'mode', equals: 'volume' }, { mode: 'volume' })).toBe(true);
+        expect(settingsRowVisible({ key: 'mode', equals: 'volume' }, { mode: 'delta' })).toBe(false);
+        expect(settingsRowVisible({ key: 'on', equals: true }, { on: false })).toBe(false);
+        expect(settingsRowVisible({ key: 'on', equals: true }, {})).toBe(false); // unset never matches
+    });
+
+    it('anyOf wins over equals and matches membership', () => {
+        const when = { key: 'mode', equals: 'x', anyOf: ['delta', 'deltaAbs'] } as const;
+        expect(settingsRowVisible(when, { mode: 'delta' })).toBe(true);
+        expect(settingsRowVisible(when, { mode: 'x' })).toBe(false);
+    });
+
+    it('an array of conditions ANDs them', () => {
+        const when = [{ key: 'mode', equals: 'volume' }, { key: 'dual', equals: false }] as const;
+        expect(settingsRowVisible(when, { mode: 'volume', dual: false })).toBe(true);
+        expect(settingsRowVisible(when, { mode: 'volume', dual: true })).toBe(false);
+        expect(settingsRowVisible(when, { mode: 'delta', dual: false })).toBe(false);
     });
 });
 

--- a/test/native-candle-override.test.ts
+++ b/test/native-candle-override.test.ts
@@ -1,0 +1,125 @@
+// Per-type candle cosmetics for candle-based PLUGIN styles (chartTypes.<id>.candle*):
+// the resolution helpers plus the renderer wiring that keeps scene.candleOverride in
+// sync with the active style and its bag. The painted pixels are exercised in the
+// browser/oracle suites; the unit-testable part is the override resolution.
+import { describe, it, expect, afterEach } from 'vitest';
+import { registerChartType, unregisterChartType } from '../src/chart-types/registry';
+import {
+    candleOverrideFor,
+    effectiveCandlePaint,
+    hasOwnCandlePaint,
+    type CandleStyle,
+} from '../src/renderers/native/core/chartConfig';
+import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+import type { SceneGraph } from '../src/renderers/native/core/SceneGraph';
+
+afterEach(() => {
+    unregisterChartType('fauxflow');
+    unregisterChartType('bricks');
+});
+
+describe('hasOwnCandlePaint', () => {
+    it('is false for every built-in (heikin-ashi shares the candles block)', () => {
+        for (const s of ['candles', 'bars', 'line', 'area', 'baseline', 'heikinashi']) {
+            expect(hasOwnCandlePaint(s)).toBe(false);
+        }
+    });
+
+    it('is true for a registered candle-based plugin type, false for basePainting none', () => {
+        registerChartType({ id: 'fauxflow' }); // basePainting defaults to 'candles'
+        registerChartType({ id: 'bricks', basePainting: 'none' });
+        expect(hasOwnCandlePaint('fauxflow')).toBe(true);
+        expect(hasOwnCandlePaint('bricks')).toBe(false);
+        expect(hasOwnCandlePaint('unregistered')).toBe(false);
+    });
+});
+
+describe('candleOverrideFor', () => {
+    it('reads the candle* keys from the type bag, dropping malformed values to null', () => {
+        registerChartType({ id: 'fauxflow' });
+        const ov = candleOverrideFor('fauxflow', {
+            fauxflow: {
+                candleUpColor: '#112233',
+                candleDownColor: 42, // wrong type → inherit
+                candleBodyVisible: false,
+                candleWickVisible: 'yes', // wrong type → inherit
+            },
+        });
+        expect(ov).not.toBeNull();
+        expect(ov!.upColor).toBe('#112233');
+        expect(ov!.downColor).toBeNull();
+        expect(ov!.bodyVisible).toBe(false);
+        expect(ov!.wickVisible).toBeNull();
+        expect(ov!.borderVisible).toBeNull();
+    });
+
+    it('is null for built-ins even when their id has a bag entry', () => {
+        expect(candleOverrideFor('heikinashi', { heikinashi: { candleUpColor: '#fff' } })).toBeNull();
+        expect(candleOverrideFor('candles', {})).toBeNull();
+    });
+});
+
+describe('effectiveCandlePaint', () => {
+    const base: CandleStyle = {
+        bodyVisible: true,
+        borderVisible: false,
+        borderUpColor: null,
+        borderDownColor: null,
+        wickVisible: true,
+        wickUpColor: '#aaa',
+        wickDownColor: '#bbb',
+    };
+
+    it('passes the shared cosmetics through when there is no override', () => {
+        const p = effectiveCandlePaint(base, null, '#up', '#down');
+        expect(p.up).toBe('#up');
+        expect(p.down).toBe('#down');
+        expect(p.candle).toBe(base);
+    });
+
+    it('wins per-key, inheriting the shared value for unset keys', () => {
+        const p = effectiveCandlePaint(
+            base,
+            {
+                upColor: '#123',
+                downColor: null,
+                bodyVisible: null,
+                borderVisible: true,
+                borderUpColor: null,
+                borderDownColor: null,
+                wickVisible: false,
+                wickUpColor: null,
+                wickDownColor: '#ccc',
+            },
+            '#up',
+            '#down',
+        );
+        expect(p.up).toBe('#123'); // overridden
+        expect(p.down).toBe('#down'); // inherited
+        expect(p.candle.bodyVisible).toBe(true); // inherited
+        expect(p.candle.borderVisible).toBe(true); // overridden
+        expect(p.candle.wickVisible).toBe(false); // overridden
+        expect(p.candle.wickUpColor).toBe('#aaa'); // inherited
+        expect(p.candle.wickDownColor).toBe('#ccc'); // overridden
+    });
+});
+
+describe('NativeRenderer wiring', () => {
+    it('tracks the active style and its bag; built-ins never carry an override', () => {
+        registerChartType({ id: 'fauxflow' });
+        const r = new NativeRenderer();
+        const scene = (r as unknown as { scene: SceneGraph }).scene;
+        expect(scene.candleOverride).toBeNull(); // candles
+
+        r.applyConfig({ series: { style: 'fauxflow' }, chartTypes: { fauxflow: { candleUpColor: '#123456' } } });
+        expect(scene.candleOverride?.upColor).toBe('#123456');
+
+        // A bag edit WITHOUT a style change (the Symbol tab's live path) re-resolves.
+        r.applyConfig({ chartTypes: { fauxflow: { candleDownColor: '#654321' } } });
+        expect(scene.candleOverride?.downColor).toBe('#654321');
+
+        // Back to a built-in: the override drops, the shared candles block paints again.
+        r.applyConfig({ series: { style: 'heikinashi' } });
+        expect(scene.candleOverride).toBeNull();
+    });
+});

--- a/test/native-chart-config.test.ts
+++ b/test/native-chart-config.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
-import { CHART_CONFIG_VERSION, defaultChartStyle, mergeConfig, type ChartConfig } from '../src/renderers/native/core/chartConfig';
+import { registerChartType, unregisterChartType } from '../src/chart-types/registry';
+import { CHART_CONFIG_VERSION, defaultChartStyle, factoryResetConfig, mergeConfig, type ChartConfig } from '../src/renderers/native/core/chartConfig';
 
 /** A known-good baseline config for the pure mergeConfig tests. */
 function baseConfig(): ChartConfig {
@@ -238,6 +239,110 @@ describe('NativeRenderer.applyConfig — applies + syncs the live scene fields',
         expect(cfg.stacking.candles).toBe(2);
         expect(cfg.stacking.series['ind-1']).toBe(3); // held for the indicator's (later) mount
         expect(r.readFeature('candleZOrder')).toBe(2);
+    });
+});
+
+describe('factoryResetConfig — "Reset defaults" restores chart-type SDK settings', () => {
+    afterEach(() => unregisterChartType('sdktype'));
+
+    function registerSdkType(): void {
+        registerChartType({
+            id: 'sdktype',
+            settings: {
+                title: 'SDK Type',
+                rows: [
+                    { kind: 'number', key: 'rows', label: 'Rows', defval: 10 },
+                    { kind: 'toggle', key: 'shade', label: 'Shade', defval: true },
+                ],
+            },
+        });
+    }
+
+    it('the factory snapshot alone cannot undo SDK settings (additive chartTypes merge)', () => {
+        registerSdkType();
+        const r = new NativeRenderer();
+        const factory = r.getConfig();
+        expect(factory.chartTypes).toEqual({}); // nothing stored until a value is edited
+        r.applyConfig({ chartTypes: { sdktype: { rows: 25, shade: false } } });
+        r.applyConfig(factory); // the raw snapshot names no type ids → values survive
+        expect(r.getConfig().chartTypes.sdktype).toEqual({ rows: 25, shade: false });
+    });
+
+    it('names every registered type at its registry-declared row defaults', () => {
+        registerSdkType();
+        const r = new NativeRenderer();
+        const factory = r.getConfig();
+        r.applyConfig({ chartTypes: { sdktype: { rows: 25, shade: false } } });
+        const pushed: Array<[string, Record<string, unknown>]> = [];
+        r.onChartTypeSettingsChange((typeId, values) => pushed.push([typeId, values]));
+        r.applyConfig(factoryResetConfig(factory));
+        expect(r.getConfig().chartTypes.sdktype).toEqual({ rows: 10, shade: true });
+        // the change is announced (settings channel + data engine), not just stored
+        expect(pushed).toContainEqual(['sdktype', { rows: 10, shade: true }]);
+    });
+
+    it('keeps values the factory snapshot itself pinned (pre-mount edits win over defvals)', () => {
+        registerSdkType();
+        const r = new NativeRenderer();
+        r.applyConfig({ chartTypes: { sdktype: { rows: 40 } } });
+        const factory = r.getConfig(); // snapshot taken AFTER a value was stored
+        r.applyConfig({ chartTypes: { sdktype: { rows: 99, shade: false } } });
+        r.applyConfig(factoryResetConfig(factory));
+        expect(r.getConfig().chartTypes.sdktype).toEqual({ rows: 40, shade: true });
+    });
+
+    it('covers a type registered after the snapshot was taken', () => {
+        const r = new NativeRenderer();
+        const factory = r.getConfig(); // 'sdktype' not registered yet
+        registerSdkType();
+        r.applyConfig({ chartTypes: { sdktype: { rows: 25 } } });
+        r.applyConfig(factoryResetConfig(factory)); // registry is read at reset time
+        expect(r.getConfig().chartTypes.sdktype).toEqual({ rows: 10, shade: true });
+    });
+
+    it('covers structured sections: instances, subsections, ranges, and toggle swatches', () => {
+        registerChartType({
+            id: 'sdktype',
+            settings: {
+                title: 'SDK Type',
+                instances: [
+                    { label: 'One', rows: [{ kind: 'number', key: 'size', label: 'Size', defval: 5 }] },
+                    {
+                        label: 'Two',
+                        enableKey: 'twoEnabled',
+                        rows: [
+                            { kind: 'toggle', key: 'shade', label: 'Shade', defval: false, colors: [{ key: 'shadeColor', label: 'Shade color', defval: '#111111' }] },
+                            { kind: 'range', label: 'Filter', minKey: 'filterMin', maxKey: 'filterMax', defval: 0 },
+                        ],
+                    },
+                ],
+                subsections: [
+                    {
+                        title: 'Extra',
+                        enableKey: 'extraOn',
+                        rows: [
+                            { kind: 'toggle', key: 'extraOn', label: 'Extra', defval: true },
+                            { kind: 'heading', label: 'Group' },
+                            { kind: 'select', key: 'flavor', label: 'Flavor', options: ['a', 'b'], defval: 'a' },
+                        ],
+                    },
+                ],
+            },
+        });
+        const r = new NativeRenderer();
+        const factory = r.getConfig();
+        r.applyConfig({ chartTypes: { sdktype: { size: 9, twoEnabled: true, shade: true, shadeColor: '#ff0000', filterMin: 3, filterMax: 8, extraOn: false, flavor: 'b' } } });
+        r.applyConfig(factoryResetConfig(factory));
+        expect(r.getConfig().chartTypes.sdktype).toEqual({
+            size: 5,
+            twoEnabled: false, // enable key without a row — instance presence resets to off
+            shade: false,
+            shadeColor: '#111111',
+            filterMin: 0,
+            filterMax: 0,
+            extraOn: true, // enable key WITH a row — the row's defval wins over the off seed
+            flavor: 'a',
+        });
     });
 });
 

--- a/test/renderer-layers.test.ts
+++ b/test/renderer-layers.test.ts
@@ -2,7 +2,7 @@
 // generic native-data channel routing on the renderer (unmounted — mounted painting is
 // exercised in the browser playground; the channel/scene plumbing is the unit-testable part).
 import { describe, it, expect, afterEach } from 'vitest';
-import { registerRendererLayer, unregisterRendererLayer, rendererLayers } from '../src/renderers/native/layers';
+import { registerRendererLayer, unregisterRendererLayer, rendererLayers, type RendererLayerArgs, type RendererLayerInstance } from '../src/renderers/native/layers';
 import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
 import { SceneGraph } from '../src/renderers/native/core/SceneGraph';
 
@@ -17,6 +17,29 @@ describe('renderer-layer registry', () => {
         expect(rendererLayers().find((d) => d.id === 'demo')?.placement).toBe('below-data'); // last wins
         unregisterRendererLayer('demo');
         expect(rendererLayers().some((d) => d.id === 'demo')).toBe(false);
+    });
+
+    it('carries the cursor-repaint opt-in on the definition', () => {
+        registerRendererLayer({ id: 'demo', repaintOnCursor: true, create: () => ({ mount() {}, render() {} }) });
+        expect(rendererLayers().find((d) => d.id === 'demo')?.repaintOnCursor).toBe(true);
+    });
+
+    it('accepts a base-painting-modulating, cursor-reading instance (contract shape)', () => {
+        // Compile-time + shape check for the modulation seam: a layer may read args.cursor
+        // and return partial modulation values; the mounted paint path (clamping + backend
+        // application) is exercised in the browser/oracle suites.
+        const instance: RendererLayerInstance = {
+            mount() {},
+            render(args: RendererLayerArgs) {
+                void args.cursor; // { x, y } | null — hover hit-testing input
+            },
+            modulateBase(args: RendererLayerArgs) {
+                return args.priceStyle === 'demo' ? { candleBodyScale: 0.07, gridAlpha: 0 } : null;
+            },
+        };
+        registerRendererLayer({ id: 'demo', create: () => instance });
+        const mod = rendererLayers().find((d) => d.id === 'demo')!.create().modulateBase?.({ priceStyle: 'demo' } as RendererLayerArgs);
+        expect(mod).toEqual({ candleBodyScale: 0.07, gridAlpha: 0 });
     });
 });
 


### PR DESCRIPTION
- Extend chart settings manipulation
- Adjust config reset
- Preserve candle settings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the native renderer paint loop, settings dialog, and persisted `chartTypes` shape—high-touch UI/config paths—but behavior is mostly additive SDK surface with unit tests; risk is integration regressions in settings visibility and candle painting rather than security or data handling.
> 
> **Overview**
> Extends the **plugin chart-type** and **renderer layer** surfaces so order-flow–style types can own their UI and paint behavior without touching built-in candle styles.
> 
> **Per-type candle cosmetics** — Candle-based plugin types (`basePainting: 'candles'`) get a **Candles** group under Symbol while active. Body, border, wick toggles and colors live in `chartTypes.<id>.candle*`; unset keys inherit the shared `candles` block. `effectiveCandlePaint` applies overrides in both Canvas2d and WebGL2 backends; `scene.candleOverride` updates on style and bag edits.
> 
> **Renderer layers** — Layers can opt into **`repaintOnCursor`** (pointer moves repaint only that layer’s canvas) with **`cursor`** on `RendererLayerArgs`. The active style’s layer may **`modulateBase`** per frame (`candleBodyScale`, `candleBodyAlpha`, `gridAlpha`) as a gradual alternative to `basePainting: 'none'`.
> 
> **Declarative settings** — Chart-type settings gain **`when`** gates (`settingsRowVisible`), **`heading`**, **`range`**, toggle inline **`colors`**, **`instances`** (add/remove via `enableKey`), **`subsections`**, group TOC from headings, and **`placement: 'after-symbol'`**. Values still land in one flat per-type bag; the dialog is the only structured layer.
> 
> **Reset defaults** — **`factoryResetConfig`** rebuilds every registered type’s bag from registry `defval`s (instances, ranges, swatches) so additive `mergeConfig` on `chartTypes` no longer leaves SDK edits after “Reset defaults”.
> 
> Docs, changelog, and tests cover registry helpers, candle override resolution, factory reset, and layer contract shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6a960fbb596120ad94638389cceeff0b6114f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->