### PR TITLE
Better settings header support

### DIFF
--- a/docs/architecture/settings-rows.md
+++ b/docs/architecture/settings-rows.md
@@ -11,9 +11,10 @@ registerChartType({
         visibility: 'active',   // 'active' (default): tab shown only while the style is
                                 // active; 'always': shown whenever the type is registered
         rows: [
-            { kind: 'heading', label: 'Levels' },   // key-less: an in-tab group title, stores nothing
+            { kind: 'heading', label: 'Levels' },   // key-less: TOC group (or flat in-tab title)
             { kind: 'toggle', key: 'highlights', label: 'Highlights', defval: true,
               colors: [{ key: 'highlightColor', label: 'Highlight color', defval: '#e0b400' }] },
+            { kind: 'header', label: 'Colors' },    // in-group subgroup title (not a TOC entry)
             { kind: 'number', key: 'levels', label: 'Max levels', defval: 20, min: 5, max: 50, step: 1,
               when: { key: 'highlights', equals: true } },   // shown only while the toggle is on
             { kind: 'color',  key: 'buyColor', label: 'Buy color', defval: '#089981' },
@@ -45,9 +46,13 @@ delivery, and engine delivery.
 `SettingsRowDescriptor` (in `src/chart-types/registry.ts`) is a **discriminated union on
 `kind`**. Each value variant carries its `key` (the storage key inside the type's bag), a
 `label`, its `defval`, and kind-specific fields. Values are stored as-is (`boolean` /
-`number` / `string`). The `heading` variant is the exception: label only, no key and no
-stored value — it renders as a group title inside the tab, so a large section can be
-organized without splitting into multiple tabs.
+`number` / `string`). Two key-less variants organize the pane without storing values:
+
+- **`heading`** — a GROUP title. Flat sections render it inline; structured
+  `instances`/`subsections` promote it to the left-hand group TOC.
+- **`header`** — an in-pane subgroup title (same visual as a flat heading). Inside a
+  structured pane it stays in the rows column so you can cluster rows *inside* a TOC
+  group (Colors / Values under Display) without adding another TOC entry.
 
 Two kinds bundle several values on one row, which keeps panes STATIC where a
 conditionally revealed row would jump the layout:
@@ -104,10 +109,11 @@ settings: {
 ```
 
 Inside an instance (and inside every subsection) the `heading` rows become a **group
-TOC** on the left of the pane: selecting an entry shows only that group's rows. Rows
-before the first heading form the *always block*, visible above every group (put an
-enable toggle there). A group whose rows are all gated out by `when` — or whose heading's
-own `when` fails — leaves the TOC; the TOC hides entirely when no group is live, which is
+TOC** on the left of the pane: selecting an entry shows only that group's rows. `header`
+rows stay in the rows column as subgroup titles within the active group. Rows before the
+first heading form the *always block*, visible above every group (put an enable toggle
+there). A group whose value rows are all gated out by `when` — or whose heading's own
+`when` fails — leaves the TOC; the TOC hides entirely when no group is live, which is
 how a subsection collapses to just its enable toggle while switched off.
 
 **`subsections`** add indented entries under the section's rail tab, each with its own

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -67,9 +67,9 @@ only while another key holds a value), a toggle row may carry inline color swatc
 (`colors`, dimmed while off), a `range` row edits a min–max pair on one line, and a
 section may go structured: an `instances` tab strip (repeated blocks with add/remove
 via an `enableKey` boolean), `subsections` as indented rail entries, a group TOC built
-from `heading` rows, and a `placement: 'after-symbol'` rail position — all pure data,
-evaluated live by the dialog. See
-[architecture/settings-rows.md](../architecture/settings-rows.md) for the row kinds,
+from `heading` rows (with optional in-group `header` subgroup titles), and a
+`placement: 'after-symbol'` rail position — all pure data, evaluated live by the dialog.
+See [architecture/settings-rows.md](../architecture/settings-rows.md) for the row kinds,
 conditions, the structured form, and how to add new ones.
 
 ## Renderer layers — `registerRendererLayer`

--- a/src/chart-types/registry.ts
+++ b/src/chart-types/registry.ts
@@ -115,8 +115,13 @@ export interface SettingsRowSwatch {
  * `heading` titles a GROUP of rows: the heading plus everything after it up to the next
  * heading. In a flat `rows` section headings render as inline group titles; inside
  * `instances`/`subsections` they become entries of the pane's group TOC (see
- * {@link ChartTypeSettingsSection}). Any row may carry `when` — it is shown only while
- * the condition holds.
+ * {@link ChartTypeSettingsSection}).
+ *
+ * `header` is an in-pane subgroup title: same visual as a flat heading, but inside a
+ * structured pane it stays in the rows column (does NOT become a TOC entry). Use it to
+ * cluster rows inside a TOC group (e.g. Colors / Values under Display).
+ *
+ * Any row may carry `when` — it is shown only while the condition holds.
  *
  * `range` is a min–max pair on one row (two number inputs storing under `minKey` /
  * `maxKey`, both seeded from the shared `defval`). When `placeholder` is given, an
@@ -132,6 +137,7 @@ export type SettingsSelectOption = string | readonly [value: string, label: stri
 
 export type SettingsRowDescriptor =
     | { kind: 'heading'; label: string; when?: SettingsRowWhen }
+    | { kind: 'header'; label: string; when?: SettingsRowWhen }
     | { kind: 'toggle'; key: string; label: string; defval: boolean; colors?: readonly SettingsRowSwatch[]; when?: SettingsRowWhen }
     | { kind: 'number'; key: string; label: string; defval: number; min?: number; max?: number; step?: number; when?: SettingsRowWhen }
     | { kind: 'color'; key: string; label: string; defval: string; when?: SettingsRowWhen }

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -608,7 +608,7 @@ export class SettingsDialog {
         };
         const seed = (rows: readonly SettingsRowDescriptor[]): void => {
             for (const r of rows) {
-                if (r.kind === 'heading') continue;
+                if (r.kind === 'heading' || r.kind === 'header') continue;
                 if (r.kind === 'range') {
                     seedKey(r.minKey, 'number', r.defval);
                     seedKey(r.maxKey, 'number', r.defval);
@@ -656,7 +656,7 @@ export class SettingsDialog {
     }
 
     /** The FLAT chart-type form: rows appended straight to the body (the pane grid wraps
-     *  them), headings as inline group titles, `when` gates refreshed live. */
+     *  them), headings/headers as inline group titles, `when` gates refreshed live. */
     private flatTypeRows(
         rows: readonly SettingsRowDescriptor[],
         bag: Record<string, unknown>,
@@ -666,7 +666,7 @@ export class SettingsDialog {
     ): void {
         const entries: Array<{ el: HTMLElement; when?: SettingsRowWhen }> = [];
         for (const r of rows) {
-            const el = r.kind === 'heading' ? this.sectionTitle(r.label) : this.typeRow(r, bag, put);
+            const el = r.kind === 'heading' || r.kind === 'header' ? this.sectionTitle(r.label) : this.typeRow(r, bag, put);
             entries.push({ el, when: r.when });
             body.append(el);
         }
@@ -679,7 +679,7 @@ export class SettingsDialog {
 
     /** One value row for a chart-type descriptor, writing through `put`. */
     private typeRow(
-        r: Exclude<SettingsRowDescriptor, { kind: 'heading' }>,
+        r: Exclude<SettingsRowDescriptor, { kind: 'heading' | 'header' }>,
         bag: Record<string, unknown>,
         put: (key: string, v: unknown) => void,
     ): HTMLElement {
@@ -824,9 +824,11 @@ export class SettingsDialog {
      * A GROUPED rows pane: a TOC column of the group labels (from `heading` rows) and
      * ONE rows host holding every row — the active group's rows show, the rest hide.
      * Rows BEFORE the first heading are the always block, visible above every group.
-     * A group whose rows are all gated out (or whose heading's own `when` fails) leaves
-     * the TOC; the whole TOC hides when no group is live. The rows host is tagged for
-     * `layoutSettingsGrids`, keeping one shared label column across all groups.
+     * `header` rows stay in the rows column as in-group subgroup titles (not TOC
+     * entries). A group whose value rows are all gated out (or whose heading's own
+     * `when` fails) leaves the TOC; the whole TOC hides when no group is live. The
+     * rows host is tagged for `layoutSettingsGrids`, keeping one shared label column
+     * across all groups.
      *
      * `enableKey` (optional): while that bag boolean is false, every row except the one
      * whose key matches is soft-disabled (visible but grayed / non-interactive) so the
@@ -849,7 +851,7 @@ export class SettingsDialog {
         rowsHost.style.cssText = 'flex:1 1 auto;min-width:0;';
         wrap.append(toc, rowsHost);
 
-        const entries: Array<{ el: HTMLElement; when?: SettingsRowWhen; group: number; key?: string }> = [];
+        const entries: Array<{ el: HTMLElement; when?: SettingsRowWhen; group: number; key?: string; header?: boolean }> = [];
         const groups: string[] = [];
         const groupWhens: Array<SettingsRowWhen | undefined> = [];
         let g = -1; // -1 = the always block before the first heading
@@ -860,6 +862,11 @@ export class SettingsDialog {
                 groupWhens.push(r.when);
                 continue; // headings live in the TOC, not the rows column
             }
+            if (r.kind === 'header') {
+                entries.push({ el: this.sectionTitle(r.label), when: r.when, group: g, header: true });
+                rowsHost.append(entries[entries.length - 1]!.el);
+                continue;
+            }
             const el = this.typeRow(r, bag, put);
             const key = r.kind === 'range' ? undefined : r.key;
             entries.push({ el, when: r.when, group: g, key });
@@ -867,9 +874,10 @@ export class SettingsDialog {
         }
 
         const refresh = (): void => {
+            // Headers don't keep a TOC group alive — only value rows do.
             const live = groups.map((_, gi) =>
                 settingsRowVisible(groupWhens[gi], bag)
-                && entries.some((e) => e.group === gi && settingsRowVisible(e.when, bag)));
+                && entries.some((e) => e.group === gi && !e.header && settingsRowVisible(e.when, bag)));
             let activeIdx = groups.indexOf(this.typeActiveGroup.get(paneKey) ?? '');
             if (activeIdx < 0 || !live[activeIdx]) activeIdx = live.findIndex(Boolean);
             if (activeIdx >= 0) this.typeActiveGroup.set(paneKey, groups[activeIdx]!);
@@ -892,8 +900,20 @@ export class SettingsDialog {
             wrap.classList.toggle('no-toc', !anyGroup);
 
             const enabled = !enableKey || bag[enableKey] === true;
-            for (const e of entries) {
-                const visible = (e.group === -1 || e.group === activeIdx) && settingsRowVisible(e.when, bag);
+            for (let i = 0; i < entries.length; i++) {
+                const e = entries[i]!;
+                let visible = (e.group === -1 || e.group === activeIdx) && settingsRowVisible(e.when, bag);
+                // A header with no visible content under it (until the next header /
+                // group end) collapses so empty subgroups don't leave orphan titles.
+                if (visible && e.header) {
+                    let hasContent = false;
+                    for (let j = i + 1; j < entries.length; j++) {
+                        const n = entries[j]!;
+                        if (n.group !== e.group || n.header) break;
+                        if (settingsRowVisible(n.when, bag)) { hasContent = true; break; }
+                    }
+                    visible = hasContent;
+                }
                 e.el.classList.toggle('vela-sd-hide', !visible);
                 // Soft-disable everything except the master toggle while the feature is off.
                 e.el.classList.toggle('vela-sd-soft', visible && !enabled && e.key !== enableKey);

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -451,7 +451,7 @@ export function factoryResetConfig(factory: ChartConfig): ChartConfig {
         const defaults: Record<string, unknown> = {};
         const addRows = (rows: readonly SettingsRowDescriptor[] | undefined): void => {
             for (const r of rows ?? []) {
-                if (r.kind === 'heading') continue;
+                if (r.kind === 'heading' || r.kind === 'header') continue;
                 if (r.kind === 'range') {
                     defaults[r.minKey] = r.defval;
                     defaults[r.maxKey] = r.defval;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only extension to declarative settings descriptors and dialog layout; no persistence or data-engine contract changes beyond ignoring key-less rows.
> 
> **Overview**
> Adds a new declarative settings row kind **`header`**, separate from **`heading`**: headings still define left-hand TOC groups in structured chart-type settings, while headers render as in-pane subgroup titles inside the active group (e.g. “Colors” under “Display”) without another TOC entry.
> 
> **SettingsDialog** treats headers like headings in flat tabs (inline section titles), seeds no bag keys for either, and in **groupedRows** keeps headers in the rows column, excludes them from TOC “group alive” checks, and hides a header when every value row under it is gated off by **`when`**. **factoryResetConfig** skips headers when building defaults. Docs and plugin-sdk notes describe **`heading` vs `header`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe5cfabc2afa67a2f0af24a0e0d4b4c921f737b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->