### PR TITLE
Feat: layer integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **Duplicate-keyed settings rows stay in sync.** Several `when`-gated chart-type
+  settings rows may now store under the same bag key(s) — the pattern for per-mode
+  rows over one shared state (each mode gets its own row label while the stored
+  toggle and colors stay one value). The settings dialog re-syncs every keyed
+  control (checkbox, color swatch, select) from the values bag on each edit, so a
+  hidden twin row never shows stale state when its gate brings it back.
+
 - **Inline line-width dropdown and number input on settings toggle rows.** A chart
   type's settings toggle row may now carry `width: { key, label, defval }` next to
   its `colors` swatches — a compact dropdown offering the drawing bar's classic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vela, newest first.
 
 ## [v0.5.0]
 
+### Fixed
+
+- **Chart-type data engines now receive stored settings on (re)creation.** A type's
+  data engine used to hear about its settings only through live dialog edits — a
+  persisted config restore or a market switch (which recreates engines) left the
+  fresh engine fetching on schema defaults until the user touched the dialog. The
+  orchestrator now remembers the last-seen per-type values and replays them into
+  every newly created engine just before `start()` (a pre-start `onSettings` is
+  pure configuration by contract).
+
 ### Added
 
 - **Duplicate-keyed settings rows stay in sync.** Several `when`-gated chart-type

--- a/docs/architecture/settings-rows.md
+++ b/docs/architecture/settings-rows.md
@@ -130,6 +130,13 @@ Gated values are **still stored and delivered** — hiding a row never clears it
 consumers decide what a hidden-but-set value means (usually: the gating toggle already
 disables the feature).
 
+**Duplicate keys across gated rows are supported.** Several `when`-gated rows may store
+under the same key(s) — the pattern for per-mode rows over one shared state (each mode
+gets its own row label, e.g. "Volume gradient" / "Delta gradient", while the gradient
+toggle and colors stay one stored value). The dialog re-syncs every keyed control from
+the values bag on each edit, so the hidden twins never show stale state when they come
+back. Keep at most one such row visible at a time (mutually exclusive gates).
+
 ### Structured sections: instances, group TOC, subsections, placement
 
 A big section can go beyond the flat form. The lightest upgrade is **`layout:

--- a/src/chart-types/registry.ts
+++ b/src/chart-types/registry.ts
@@ -46,7 +46,11 @@ export interface SeriesDataEngine {
     stop(): void;
     /** The visible range changed (pan/zoom) while the style is active. */
     onViewport?(range: { from: number; to: number }): void;
-    /** New settings values from the chart-settings dialog (the type's SDK section). */
+    /** New settings values from the chart-settings dialog (the type's SDK section).
+     *  Also delivered once just BEFORE `start()` whenever stored values exist (a
+     *  persisted config, a market switch recreating the engine) — an engine must
+     *  accept a pre-start call as pure configuration, so it never fetches on
+     *  schema defaults the user has edited away. */
     onSettings?(values: Record<string, unknown>): void;
 }
 

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -117,6 +117,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
     private barTransform: BarTransform | null = null;
     // ── chart-type data engines (SDK): one lazily-created engine per style id ──
     private readonly typeEngines = new Map<string, SeriesDataEngine>();
+    /** Last-seen chart-type settings per type id (dialog edits + persisted restores) —
+     *  replayed into a data engine whenever one is (re)created. */
+    private readonly typeSettings = new Map<string, Record<string, unknown>>();
     /** The style id whose data engine is currently ACTIVE (drives suspend/resume + pokes). */
     private activeEngineStyle: string | null = null;
     /** The chart's current price style (tracked from the renderer's change events + initial read). */
@@ -181,8 +184,17 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         // pane's indicators; the rest are already applied by the renderer — this keeps the
         // `chart.panes` view + collapse/maximize mirror in sync).
         this.paneActionUnsub = this.renderer.onPaneAction?.((a) => this.handlePaneAction(a)) ?? null;
-        // Chart-type SDK settings edited in the renderer's dialog → the type's data engine.
-        this.renderer.onChartTypeSettingsChange?.((typeId, values) => this.typeEngines.get(typeId)?.onSettings?.(values));
+        // Chart-type SDK settings edited in the renderer's dialog (or replayed by
+        // applyConfig on a persisted restore) → remember them AND forward to the
+        // type's data engine. The cache matters: the engine may not exist yet (a
+        // restored config lands before the style's first activation) or may be
+        // recreated later (a market switch) — `startChartTypeEngine` replays the
+        // last-seen values into every fresh engine, so one never fetches on schema
+        // defaults the user has edited away.
+        this.renderer.onChartTypeSettingsChange?.((typeId, values) => {
+            this.typeSettings.set(typeId, values);
+            this.typeEngines.get(typeId)?.onSettings?.(values);
+        });
         // The renderer's legend "Move to" menu / row drag reports a move here → route it.
         this.renderer.onMoveIndicator?.((id, target) => this.moveIndicator(id, target));
         // The renderer's in-chart theme control (settings dialog Canvas → Theme) reports a
@@ -814,6 +826,11 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         if (!def?.dataEngine) return;
         const engine = def.dataEngine();
         this.typeEngines.set(id, engine);
+        // Seed the stored settings BEFORE start (a pre-start onSettings is pure
+        // configuration by contract), so the engine's first fetch already runs on
+        // the user's values — never on schema defaults they edited away.
+        const stored = this.typeSettings.get(id);
+        if (stored) engine.onSettings?.(stored);
         engine.start({
             symbol: this.config.market.symbol ?? 'TEST',
             timeframe: this.config.market.timeframe ?? '60',

--- a/src/renderers/native/chrome/ColorField.ts
+++ b/src/renderers/native/chrome/ColorField.ts
@@ -62,6 +62,10 @@ export function colorField(theme: VelaTheme, getVal: () => string, onVal: (v: st
         swatch.style.background = `linear-gradient(${v}, ${v}), ${CHECKER}`;
     };
     paint();
+    // External re-sync: when the value behind `getVal` changes outside this field (a
+    // duplicate-keyed settings row, a reset), the owner dispatches 'vela-sync' on the
+    // trigger and the preview repaints from the getter.
+    trigger.addEventListener('vela-sync', paint);
 
     trigger.addEventListener('click', (e) => {
         e.stopPropagation();

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -704,6 +704,10 @@ export class SettingsDialog {
         const controls: HTMLElement[] = [];
         for (const c of n.controls) {
             const el = this.inlineControl(c, bag, put, n.toggle !== undefined);
+            // Keyed controls re-read the bag on every refresh ('vela-sync') — several
+            // `when`-gated rows may share one key (a per-mode row set over one stored
+            // state), and the hidden twins must not go stale when the visible one edits.
+            if (c.kind !== 'hint') refreshers.push(() => el.dispatchEvent(new Event('vela-sync')));
             if (c.kind !== 'hint' && c.when) {
                 el.dataset.sdSelfGated = '1';
                 const when = c.when;
@@ -715,7 +719,9 @@ export class SettingsDialog {
         }
         if (n.toggle) {
             const t = n.toggle;
-            return this.toggleRow(n.label, bag[t.key] as boolean, (v) => put(t.key, v), controls);
+            const el = this.toggleRow(n.label, bag[t.key] as boolean, (v) => put(t.key, v), controls, () => bag[t.key] === true);
+            refreshers.push(() => el.dispatchEvent(new Event('vela-sync')));
+            return el;
         }
         return this.rowWith(n.label, controls);
     }
@@ -738,7 +744,7 @@ export class SettingsDialog {
             return s;
         }
         if (c.kind === 'color') {
-            const sw = this.swatch(bag[c.key] as string, (v) => put(c.key, v));
+            const sw = this.swatch(bag[c.key] as string, (v) => put(c.key, v), () => bag[c.key] as string);
             sw.title = c.label;
             return sw;
         }
@@ -765,6 +771,9 @@ export class SettingsDialog {
                 sel.appendChild(o);
             }
             sel.addEventListener('change', () => put(c.key, sel.value));
+            sel.addEventListener('vela-sync', () => {
+                sel.value = typeof bag[c.key] === 'string' ? (bag[c.key] as string) : c.defval;
+            });
             return sel;
         }
         // number
@@ -1052,9 +1061,11 @@ export class SettingsDialog {
     }
 
     /** A bare color swatch input (for toggle-row right groups / swatch pairs). */
-    private swatch(value: string, onChange: (v: string) => void): HTMLElement {
+    /** With `get`, the field reads its value live (and repaints on 'vela-sync') —
+     *  duplicate-keyed rows stay honest when another row edits the shared key. */
+    private swatch(value: string, onChange: (v: string) => void, get?: () => string): HTMLElement {
         let current = value;
-        return colorField(this.theme, () => current, (v) => { current = v; onChange(v); });
+        return colorField(this.theme, () => (get ? get() : current), (v) => { current = v; onChange(v); });
     }
 
     /** A label row with arbitrary controls in the shared control column (no toggle). */
@@ -1112,8 +1123,11 @@ export class SettingsDialog {
 
     /** An enable row: checkbox + label in the label column, dependent controls in the
      *  shared control column; the control group dims and ignores input while the toggle
-     *  is off. With no controls it reads like a plain toggle row (full-width in the grid). */
-    private toggleRow(label: string, value: boolean, onToggle: (v: boolean) => void, controls: HTMLElement[]): HTMLElement {
+     *  is off. With no controls it reads like a plain toggle row (full-width in the grid).
+     *  With `get`, the row re-reads its state on a 'vela-sync' event — the seam that
+     *  keeps DUPLICATE-KEYED rows honest (several `when`-gated rows over one bag key,
+     *  only one visible at a time; see `typeRow`). */
+    private toggleRow(label: string, value: boolean, onToggle: (v: boolean) => void, controls: HTMLElement[], get?: () => boolean): HTMLElement {
         const wrap = document.createElement('div');
         // No cursor on the row itself: only the checkbox is clickable, so a row-wide
         // pointer would promise a click target that isn't there.
@@ -1135,6 +1149,12 @@ export class SettingsDialog {
             wrap.style.cssText = 'display:flex;align-items:center;gap:8px;min-height:22px;';
             wrap.append(cb, lbl);
             cb.addEventListener('click', () => onToggle(cbToggle()));
+            if (get) {
+                wrap.addEventListener('vela-sync', () => {
+                    checked = get();
+                    cb.classList.toggle('on', checked);
+                });
+            }
             return wrap;
         }
         wrap.className = 'vela-sd-row';
@@ -1155,6 +1175,13 @@ export class SettingsDialog {
         };
         syncDim(value);
         cb.addEventListener('click', () => { const v = cbToggle(); onToggle(v); syncDim(v); });
+        if (get) {
+            wrap.addEventListener('vela-sync', () => {
+                checked = get();
+                cb.classList.toggle('on', checked);
+                syncDim(checked);
+            });
+        }
         wrap.append(left, box);
         return wrap;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches chart-type engine lifecycle and settings persistence—incorrect replay could cause wrong fetches on restore or market switch, but changes are localized and contract-documented.
> 
> **Overview**
> **Chart-type data engines** now get persisted or restored settings before their first `start()`, not only when the user edits the dialog. The orchestrator caches last-seen per-type values and replays them into every newly created engine via `onSettings` immediately before `start()`; the `SeriesDataEngine` contract documents that pre-start `onSettings` is configuration-only.
> 
> **Settings dialog** keeps duplicate-keyed `when`-gated rows honest: several rows can share the same bag keys (per-mode labels over one stored toggle/colors). On each edit, keyed controls refresh from the values bag through a `vela-sync` path on toggles, color fields, selects, and inline controls—hidden twin rows no longer show stale UI when their gate brings them back.
> 
> Docs and **CHANGELOG** describe both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc1ceecfe1a724191dcde52c7e206fe6eb7528a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->