### PR TITLE
feat: indicator legends changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,18 @@ All notable changes to Vela, newest first.
 
 ## [v0.5.0]
 
-### Fixed
-
-- **Chart-type data engines now receive stored settings on (re)creation.** A type's
-  data engine used to hear about its settings only through live dialog edits — a
-  persisted config restore or a market switch (which recreates engines) left the
-  fresh engine fetching on schema defaults until the user touched the dialog. The
-  orchestrator now remembers the last-seen per-type values and replays them into
-  every newly created engine just before `start()` (a pre-start `onSettings` is
-  pure configuration by contract).
-
 ### Added
+
+- **Indicator legends show their plot values.** Each indicator's legend row now
+  displays the current value of every plot to the right of its title, colored like
+  the plot itself. The values follow the crosshair — hover a bar and they read that
+  bar; move off the chart and they rest on the latest bar, ticking with live data.
+  Hovering the legend row itself sets the values aside while its controls (eye, gear,
+  ✕…) are out, so the row never crowds. Right-clicking a legend row opens a small
+  menu whose "Indicator values" entry shows or hides that indicator's values, and
+  chart settings → Status line → Indicators gains a "Values" toggle that shows or
+  hides them for every indicator at once. The chart-wide choice persists with the
+  rest of the chart state.
 
 - **Duplicate-keyed settings rows stay in sync.** Several `when`-gated chart-type
   settings rows may now store under the same bag key(s) — the pattern for per-mode
@@ -149,6 +150,10 @@ All notable changes to Vela, newest first.
 
 ### Changed
 
+- **An indicator that is fetching shows quiet load dots in its legend.** While an
+  indicator's data is in flight, its legend row now ends with three small pulsing
+  dots — the same load affordance the chart itself shows while bars load — at the
+  row's right end. The old circular spinner to the left of the title is gone.
 - **Scripting engines report a strategy's state in neutral terms.** An engine that simulates
   order execution now describes it with the same vocabulary whatever language it runs, so one
   dashboard reads them all. Engines are also expected to report a script's variables under
@@ -174,6 +179,20 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Chart-type data engines now receive stored settings on (re)creation.** A type's
+  data engine used to hear about its settings only through live dialog edits — a
+  persisted config restore or a market switch (which recreates engines) left the
+  fresh engine fetching on schema defaults until the user touched the dialog. The
+  orchestrator now remembers the last-seen per-type values and replays them into
+  every newly created engine just before `start()` (a pre-start `onSettings` is
+  pure configuration by contract).
+- **Tooltips in the indicator settings dialog no longer hide behind it.** The ⓘ input
+  hints and the dialog's own control tips opened underneath the dialog card, where they
+  were unreadable; they now stack above it like every other tooltip.
+- **Opening the Indicators dialog closes an open indicator-settings dialog.** The two
+  dialogs used to stack — the topbar picker never counted as a click outside the
+  in-chart dialog. It now dismisses it on open, the same way the symbol search already
+  did, in the widget and in every workspace cell.
 - **Undo steps back exactly one action when drawings and indicators mix.** With a drawing
   and an indicator change both in the history, one Ctrl+Z over the chart used to revert
   both at once — the drawing layer and the app history each answered the shortcut. A single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,13 @@ All notable changes to Vela, newest first.
   orchestrator now remembers the last-seen per-type values and replays them into
   every newly created engine just before `start()` (a pre-start `onSettings` is
   pure configuration by contract).
+- **The fixed-range volume profile emphasizes its value area.** The default fills were
+  inverted — the value area rendered more transparent than the tails around it. The value
+  area is now the opaque region and the outside rows recede. Its POC line also stops
+  defaulting to the accent blue: until you pick a color for it, the POC draws in the
+  active theme's contrast ink — white on a dark chart, black on a light one — and follows
+  a theme switch immediately. A POC color you picked yourself, and profiles already
+  saved, are left untouched.
 - **Tooltips in the indicator settings dialog no longer hide behind it.** The ⓘ input
   hints and the dialog's own control tips opened underneath the dialog card, where they
   were unreadable; they now stack above it like every other tooltip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,11 @@ All notable changes to Vela, newest first.
 
 ### Changed
 
+- **Visible Range Volume Profile is named in full.** The built-in volume profile of
+  the visible range now appears in the indicator picker as "Visible Range Volume
+  Profile", with the short legend label "VRVP" (it was previously titled "VPVR"
+  everywhere). Native indicators may also declare an optional `shortTitle` so the
+  legend stays compact while the picker and settings dialog keep the full name.
 - **An indicator that is fetching shows quiet load dots in its legend.** While an
   indicator's data is in flight, its legend row now ends with three small pulsing
   dots — the same load affordance the chart itself shows while bars load — at the

--- a/src/core/drawings/types/FixedRangeVolumeProfile.ts
+++ b/src/core/drawings/types/FixedRangeVolumeProfile.ts
@@ -66,7 +66,9 @@ export interface FrvpStyle {
     valColor: string;
     valStyle: LineStyle;
     showPoc: boolean;
-    pocColor: string;
+    /** `undefined` ⇒ the theme's contrast ink (white on dark, black on light), resolved at
+     *  paint time so it follows theme switches live; a set color always wins. */
+    pocColor?: string;
     pocStyle: LineStyle;
     showDevelopingPoc: boolean;
     developingPocColor: string;
@@ -76,11 +78,12 @@ export interface FrvpStyle {
     developingVaStyle: LineStyle;
 }
 
-/** Outside-VA fills at 25% transparency; value-area fills at 60% transparency. */
-const OUTSIDE_UP = `${BULLISH}BF`;
-const OUTSIDE_DOWN = `${BEARISH}BF`;
-const VA_UP = `${BULLISH}66`;
-const VA_DOWN = `${BEARISH}66`;
+/** Value-area fills at 25% transparency; outside-VA fills at 60% transparency — the value
+ *  area is the profile's emphasized region, the tails around it recede. */
+const OUTSIDE_UP = `${BULLISH}66`;
+const OUTSIDE_DOWN = `${BEARISH}66`;
+const VA_UP = `${BULLISH}BF`;
+const VA_DOWN = `${BEARISH}BF`;
 
 function defaultFrvpStyle(): FrvpStyle {
     return {
@@ -99,7 +102,7 @@ function defaultFrvpStyle(): FrvpStyle {
         valColor: NEUTRAL,
         valStyle: 'solid',
         showPoc: true,
-        pocColor: ACCENT,
+        pocColor: undefined, // theme contrast ink until the user picks a color
         pocStyle: 'solid',
         showDevelopingPoc: false,
         developingPocColor: ACCENT,

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1399,6 +1399,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         return {
             id: record.id,
             title: record.title,
+            ...(d.shortTitle ? { shorttitle: d.shortTitle } : {}),
             overlay: d.overlay,
             paneHint: d.paneHint,
             native: { type: record.native!.type },

--- a/src/core/model/indicator.ts
+++ b/src/core/model/indicator.ts
@@ -24,7 +24,13 @@ export type PaneHint = 'price' | 'new';
 export interface IndicatorModel {
     /** Per-instance id (stable). */
     id: string;
+    /** Full display name (settings dialog, object tree, inspect). */
     title: string;
+    /**
+     * Compact legend label when the full {@link title} is too long for the chip.
+     * Absent ⇒ the legend uses {@link title}. Mirrors Pine `indicator(..., shorttitle=)`.
+     */
+    shorttitle?: string;
     overlay: boolean;
     paneHint: PaneHint;
     /**

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -76,7 +76,13 @@ export interface NativeIndicator {
  */
 export interface NativeIndicatorDescriptor {
     readonly type: string;
+    /** Full display name (picker, settings header, handle title). */
     readonly title: string;
+    /**
+     * Compact name for the on-chart legend chip. Absent ⇒ {@link title}. The picker and
+     * settings dialog keep the full title either way.
+     */
+    readonly shortTitle?: string;
     readonly paneHint: 'price' | 'new';
     readonly overlay: boolean;
     /** Whether instances react to viewport changes (drives the orchestrator's viewport poke). */

--- a/src/core/native-indicators/vpvr/VpvrIndicator.ts
+++ b/src/core/native-indicators/vpvr/VpvrIndicator.ts
@@ -72,10 +72,11 @@ class VpvrIndicator implements NativeIndicator {
     stop(): void {}
 }
 
-/** Descriptor for the built-in VPVR indicator. Bar volume needs no capability probe. */
+/** Descriptor for the built-in visible-range volume profile. Bar volume needs no capability probe. */
 export const vpvrDescriptor: NativeIndicatorDescriptor = {
     type: 'vpvr',
-    title: 'VPVR',
+    title: 'Visible Range Volume Profile',
+    shortTitle: 'VRVP',
     paneHint: 'price',
     overlay: true,
     inputsSchema: (): InputSchema[] => [

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1806,7 +1806,11 @@ export class NativeRenderer implements IChartRenderer {
         this.scene.indicators.set(model.id, model);
         this.refreshAnchorOffset(model);
         this.scene.assignIndicatorZ(model.id); // default z = mount order (later ⇒ in front)
-        this.inputsUI.upsert(model.id, model.title, model.inputs, model.inputValues, model.paneId, { native: !!model.native });
+        // Legend chip prefers the compact shorttitle; the settings dialog keeps the full title.
+        this.inputsUI.upsert(model.id, model.shorttitle ?? model.title, model.inputs, model.inputValues, model.paneId, {
+            native: !!model.native,
+            ...(model.shorttitle ? { settingsTitle: model.title } : {}),
+        });
         this.syncTables(model);
         if (model.native?.type === 'volume') {
             this.volumeActive = true; // the volume layer follows the indicator's presence

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -26,7 +26,7 @@ import type { InputValue, SymbolPickerFn } from '../../core/model/inputs';
 import type { RendererDisplayOptions, NativeBackend, PriceStyle, MoveTarget, ThemeName } from '../../core/options';
 import type { Unsubscribe } from '../../core/util/types';
 import { isLineLikeSeries } from '../../core/model/series';
-import { InputsUI } from '../shared/InputsUI';
+import { InputsUI, type LegendPlotValue } from '../shared/InputsUI';
 import { PaneControls } from './chrome/PaneControls';
 import { TableOverlay } from '../shared/TableOverlay';
 import { NATIVE_CAPABILITIES, supportsWebGL2 } from './capabilities';
@@ -167,6 +167,8 @@ export class NativeRenderer implements IChartRenderer {
     private symbolPicker: SymbolPickerFn | null = null;
     /** Indicator titles (the legend rows) shown — held here so a remount re-applies it. */
     private indicatorTitlesOn = true;
+    /** Plot values beside the legend titles shown — held here so a remount re-applies it. */
+    private indicatorValuesOn = true;
     /** Host-contributed legend actions — held here so a rebuild of the legend re-wires them. */
     private legendActionsProvider: ((indicatorId: string) => LegendActionView[]) | null = null;
     // ── keyboard navigation / accessibility (item 11) ──
@@ -298,7 +300,7 @@ export class NativeRenderer implements IChartRenderer {
     }
 
     readonly name = 'native';
-    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles'];
+    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles', 'indicatorValues'];
 
     /** Apply a render feature live — mutate the field + invalidate, no engine re-run. */
     applyFeature(key: string, value: unknown): void {
@@ -433,6 +435,12 @@ export class NativeRenderer implements IChartRenderer {
                 this.indicatorTitlesOn = value !== false;
                 this.inputsUI?.setTitlesVisible(this.indicatorTitlesOn);
                 return; // own DOM, no repaint needed
+            case 'indicatorValues':
+                // Show/hide the plot values beside every legend title (the settings dialog's
+                // Indicators → Values toggle); clears any per-row context-menu overrides.
+                this.indicatorValuesOn = value !== false;
+                this.inputsUI?.setValuesVisible(this.indicatorValuesOn);
+                return; // own DOM, no repaint needed
             case 'attribution':
                 // `false` hides it, `true` restores the built-in mark, a non-empty STRING
                 // puts the host's own mark in that corner (see the NOTICE).
@@ -501,6 +509,7 @@ export class NativeRenderer implements IChartRenderer {
             case 'historyChords': return this.historyChordsEnabled;
             case 'settings': return this.settingsEnabled;
             case 'indicatorTitles': return this.indicatorTitlesOn;
+            case 'indicatorValues': return this.indicatorValuesOn;
             case 'attribution': return this.attributionHtml ?? this.attributionEnabled;
             case 'dialogHost': return this.dialogHost ?? undefined;
             default: return undefined;
@@ -1321,6 +1330,7 @@ export class NativeRenderer implements IChartRenderer {
 
         this.inputsUI = new InputsUI(this.plot, theme, (paneId) => this.paneBoundsFor(paneId));
         this.inputsUI.setTitlesVisible(this.indicatorTitlesOn); // a remount keeps the toggle state
+        this.inputsUI.setValuesVisible(this.indicatorValuesOn);
         this.inputsUI.setDialogHost(this.dialogHost);
         this.inputsUI.setSymbolPicker(this.symbolPicker);
         this.inputsUI.setLegendActions(this.legendActionsProvider);
@@ -2121,6 +2131,7 @@ export class NativeRenderer implements IChartRenderer {
         this.skeletonClockMs += dtMs; // drives the loading-skeleton pulse (harmless when none show)
         this.paintData();
         this.crosshairLayer.render(this.scene, this.coords, this.theme, this.hoverSeparatorY, this.externalCrossPx());
+        this.updateLegendValues(); // the animator owns the frame — renderFrame won't run
         this.emitViewportChange();
         return active;
     }
@@ -2585,28 +2596,51 @@ export class NativeRenderer implements IChartRenderer {
     private dataWindowGroups(idx: number, pricePane: PaneNode | null): DataWindowGroup[] {
         const groups: DataWindowGroup[] = [];
         for (const model of this.scene.indicators.values()) {
-            const pane = (model.paneId ? this.scene.panes.get(model.paneId) : null) ?? pricePane;
-            const off = this.scene.offsetOf(model.id);
-            const rows: DataWindowRow[] = [];
-            for (const s of model.series) {
-                let value: number | null | undefined;
-                let color: string;
-                if (s.kind === 'candle' || s.kind === 'bar') {
-                    value = s.bars[idx - off]?.close;
-                    color = s.style?.up ?? this.theme.upColor;
-                } else if (isLineLikeSeries(s)) {
-                    if (s.visible === false) continue;
-                    value = s.points[idx - off]?.value;
-                    color = s.points[idx - off]?.color ?? s.style.color;
-                } else {
-                    continue; // markers carry no scalar readout
-                }
-                if (value == null || !Number.isFinite(value)) continue;
-                rows.push({ label: s.title || model.title, value: this.dataWindowFmt(value, pane), color });
-            }
+            const rows = this.dataWindowRowsFor(model, idx, pricePane);
             if (rows.length) groups.push({ name: model.title, rows });
         }
         return groups;
+    }
+
+    /** One indicator's readout at bar `idx`: a row per drawable plot, formatted on its pane's scale. */
+    private dataWindowRowsFor(model: IndicatorModel, idx: number, pricePane: PaneNode | null): DataWindowRow[] {
+        const pane = (model.paneId ? this.scene.panes.get(model.paneId) : null) ?? pricePane;
+        const off = this.scene.offsetOf(model.id);
+        const rows: DataWindowRow[] = [];
+        for (const s of model.series) {
+            let value: number | null | undefined;
+            let color: string;
+            if (s.kind === 'candle' || s.kind === 'bar') {
+                value = s.bars[idx - off]?.close;
+                color = s.style?.up ?? this.theme.upColor;
+            } else if (isLineLikeSeries(s)) {
+                if (s.visible === false) continue;
+                value = s.points[idx - off]?.value;
+                color = s.points[idx - off]?.color ?? s.style.color;
+            } else {
+                continue; // markers carry no scalar readout
+            }
+            if (value == null || !Number.isFinite(value)) continue;
+            rows.push({ label: s.title || model.title, value: this.dataWindowFmt(value, pane), color });
+        }
+        return rows;
+    }
+
+    /** Refresh the plot values beside every legend title — the same readout the data window
+     *  shows (crosshair bar, else the latest bar), pushed per paint. A hidden indicator has
+     *  no scene model, so its row is absent from the map and its readout clears. */
+    private updateLegendValues(): void {
+        if (!this.inputsUI) return;
+        const n = this.bars.length;
+        const values = new Map<string, LegendPlotValue[]>();
+        if (n > 0) {
+            const idx = this.hoverLogical != null ? this.hoverLogical : n - 1;
+            const pricePane = this.dataWindowPricePane();
+            for (const model of this.scene.indicators.values()) {
+                values.set(model.id, this.dataWindowRowsFor(model, idx, pricePane).map((r) => ({ value: r.value, color: r.color })));
+            }
+        }
+        this.inputsUI.setPlotValues(values);
     }
 
     private renderFrame(level: InvalidateLevel): void {
@@ -2634,6 +2668,9 @@ export class NativeRenderer implements IChartRenderer {
         // Hover-testing SDK layers (repaintOnCursor) follow pointer moves too — each owns
         // one transparent canvas, so this stays as cheap as the crosshair tier itself.
         if (!repaintsData(level) && this.paintedData) this.repaintCursorLayers();
+        // Legend values follow the same tiers (hover moves the read bar, data changes the
+        // value); the push diffs per row, so an unchanged frame touches no DOM.
+        this.updateLegendValues();
     }
 
     /** Repaint the SDK layers that opted into cursor tracking (their own canvas only). */

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -237,7 +237,7 @@ export class DrawingPainter {
             return;
         }
         if (d instanceof FixedRangeVolumeProfile) {
-            this.paintFixedRangeVp(ctx, d, proj);
+            this.paintFixedRangeVp(ctx, d, proj, theme);
             this.paintLabel(ctx, d, proj, theme);
             return;
         }
@@ -755,7 +755,7 @@ export class DrawingPainter {
     /** Paint a fixed-range volume profile: horizontal histogram rows (up/down split) anchored to
      *  the left or right of the time span, optional VAH / VAL / POC levels across the range, and
      *  optional developing POC / VA polylines. Recomputes from the two anchors on every paint. */
-    private paintFixedRangeVp(ctx: CanvasRenderingContext2D, d: FixedRangeVolumeProfile, proj: Projector): void {
+    private paintFixedRangeVp(ctx: CanvasRenderingContext2D, d: FixedRangeVolumeProfile, proj: Projector, theme: VelaTheme): void {
         const L = d.layout(proj);
         if (!L) return;
         const s = d.frvp;
@@ -797,7 +797,9 @@ export class DrawingPainter {
         };
         hLine(s.showVah, s.vahColor, s.vahStyle, L.vahY);
         hLine(s.showVal, s.valColor, s.valStyle, L.valY);
-        hLine(s.showPoc, s.pocColor, s.pocStyle, L.pocY);
+        // No explicit POC ink ⇒ the theme's contrast color, resolved per paint so the line
+        // follows theme switches live (white on dark, black on light).
+        hLine(s.showPoc, s.pocColor ?? contrastColor(theme.background), s.pocStyle, L.pocY);
 
         // Developing levels sit on top of the histogram so they stay readable.
         const devW = Math.max(1, w);

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../core/drawings';
 import { icon, svg24, svg24Solid } from '../../../core/icons';
 import { applyChromeTokens } from '../../shared/theme-tokens';
+import { contrastColor } from '../../shared/drawing-geometry';
 import { buildColorPicker } from './colorPicker';
 
 /** A `{ path: value }` patch emitted as the user edits a control. */
@@ -690,14 +691,16 @@ export class DrawingSettingsPopup {
             const chk = document.createElement('input');
             chk.type = 'checkbox';
             chk.checked = Boolean(s[showPath]);
-            chk.style.cssText = `accent-color:${s[colorPath] as string};width:15px;height:15px;flex:none;cursor:pointer;`;
+            // An unset color (the POC's themed default) shows as the ink actually painted.
+            const current = (s[colorPath] as string | undefined) ?? contrastColor(t.background);
+            chk.style.cssText = `accent-color:${current};width:15px;height:15px;flex:none;cursor:pointer;`;
             chk.addEventListener('change', () => actions.patch({ [`frvp.${showPath}`]: chk.checked }));
             const lbl = document.createElement('span');
             lbl.textContent = label;
             lbl.style.cssText = 'flex:1;min-width:0;opacity:0.9;';
             const col = document.createElement('button');
             col.type = 'button';
-            let cur = s[colorPath] as string;
+            let cur = current;
             col.style.cssText = `width:18px;height:18px;flex:none;border:1px solid var(--vela-border);border-radius:0;cursor:pointer;background:${cur};padding:0;`;
             col.addEventListener('pointerdown', (e) => e.stopPropagation());
             col.addEventListener('click', (e) => {

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -29,6 +29,12 @@ export interface InputsUIChange {
     value: InputValue;
 }
 
+/** One plot's current value as shown beside the legend title (pre-formatted, plot-colored). */
+export interface LegendPlotValue {
+    value: string;
+    color: string;
+}
+
 interface LegendRow {
     id: string;
     title: string;
@@ -37,6 +43,16 @@ interface LegendRow {
     el: HTMLElement;
     titleEl: HTMLElement;
     statusEl: HTMLElement;
+    /** The plot-values readout beside the title (one colored span per drawable plot). */
+    valuesEl: HTMLElement;
+    /** Latest plot values pushed by the renderer (kept so visibility toggles re-render). */
+    plotValues: LegendPlotValue[];
+    /** Cheap change key of {@link plotValues} — skips DOM writes on unchanged frames. */
+    plotValuesKey: string;
+    /** Per-row override from the row's context menu; null ⇒ follow the chart-wide setting. */
+    showValues: boolean | null;
+    /** Hovered/selected (outline + controls visible) — the values readout yields to the controls. */
+    highlighted: boolean;
     paneId: string;
     hidden: boolean;
     eyeEl: HTMLButtonElement | null;
@@ -48,9 +64,10 @@ interface LegendRow {
 }
 
 const SOURCES = ['close', 'open', 'high', 'low', 'hl2', 'hlc3', 'ohlc4', 'volume'];
-/** Keyframes for the legend-row status affordances (spinner + live pulse), injected once into the document. */
+/** Keyframes for the legend-row live pulse, injected once into the document (the load
+ *  dots animate through the Web Animations API and need no stylesheet). */
 const STATUS_KEYFRAMES =
-    '@keyframes vela-ind-spin{to{transform:rotate(360deg)}}@keyframes vela-ind-pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.3;transform:scale(.6)}}';
+    '@keyframes vela-ind-pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.3;transform:scale(.6)}}';
 
 /** Legend glyph size — the row's own font belongs to the indicator title beside them. */
 const LEGEND_ICON_PX = 13;
@@ -109,6 +126,11 @@ export class InputsUI {
     /** Titles switched off entirely (a settings toggle): every pane's legend container
      *  hides — rows, fold chevron and all — unlike the fold, which leaves its chip. */
     private titlesVisible = true;
+    /** Plot values shown beside the titles chart-wide (a settings toggle); a row's own
+     *  context-menu choice ({@link LegendRow.showValues}) overrides it per indicator. */
+    private valuesVisible = true;
+    /** Open legend-row context menu (kept so it can be torn down). */
+    private rowMenu: HTMLElement | null = null;
     /** The single fold toggle, on the price-pane legend: a bordered ^ chevron under the
      *  rows, or the bordered "˅ N" chip (N counts every pane's indicators) when folded. */
     private foldToggle: HTMLButtonElement | null = null;
@@ -244,6 +266,58 @@ export class InputsUI {
         this.reposition(); // positionLegend applies the flag per pane
     }
 
+    /**
+     * Show/hide the plot values chart-wide (the settings dialog's Indicators → Values
+     * toggle). "All" is meant literally: per-row context-menu overrides are cleared, so
+     * every legend follows the new state.
+     */
+    setValuesVisible(visible: boolean): void {
+        this.valuesVisible = visible;
+        for (const row of this.rows.values()) {
+            row.showValues = null;
+            this.renderRowValues(row);
+        }
+    }
+
+    /**
+     * Push the current plot values of every indicator at once (the renderer calls this per
+     * paint). Rows absent from the map (e.g. a hidden indicator) show no values. Cheap on
+     * unchanged frames: each row diffs against its last rendered values before touching DOM.
+     */
+    setPlotValues(values: ReadonlyMap<string, LegendPlotValue[]>): void {
+        for (const row of this.rows.values()) {
+            const next = values.get(row.id) ?? [];
+            const key = next.map((v) => `${v.value}|${v.color}`).join('\u0000');
+            if (key === row.plotValuesKey) continue;
+            row.plotValues = next;
+            row.plotValuesKey = key;
+            this.renderRowValues(row);
+        }
+    }
+
+    /** Whether a row currently shows its values: its own override, else the chart-wide flag. */
+    private rowValuesShown(row: LegendRow): boolean {
+        return row.showValues ?? this.valuesVisible;
+    }
+
+    /** (Re)build one row's values readout from its stored plot values + visibility. A
+     *  highlighted (hovered/selected) row shows only the title + controls — no values. */
+    private renderRowValues(row: LegendRow): void {
+        if (!this.rowValuesShown(row) || row.plotValues.length === 0 || row.highlighted) {
+            row.valuesEl.style.display = 'none';
+            row.valuesEl.replaceChildren();
+            return;
+        }
+        row.valuesEl.style.display = 'inline-flex';
+        row.valuesEl.replaceChildren();
+        for (const v of row.plotValues) {
+            const span = document.createElement('span');
+            span.textContent = v.value;
+            span.style.color = v.color;
+            row.valuesEl.appendChild(span);
+        }
+    }
+
     // ── legend move/merge (menu + drag) ─────────────────────────────────────
 
     /** Open the "Move to" menu for a row, anchored under its move button. */
@@ -307,6 +381,58 @@ export class InputsUI {
         if (typeof document !== 'undefined') document.removeEventListener('pointerdown', this.onMoveMenuOutside, true);
         this.moveMenu?.remove();
         this.moveMenu = null;
+    }
+
+    // ── legend row context menu (right-click) ───────────────────────────────
+
+    /** Open the row's action menu at the pointer. One entry today: the values toggle. */
+    private openRowMenu(id: string, x: number, y: number): void {
+        this.closeRowMenu();
+        this.closeMoveMenu();
+        const row = this.rows.get(id);
+        if (!row) return;
+        const menu = document.createElement('div');
+        menu.style.cssText = `position:fixed;z-index:var(--vela-z-tooltip);min-width:170px;padding:4px;border-radius:var(--vela-radius-md);background:var(--vela-surface-elev);color:${this.theme.textColor};border:1px solid var(--vela-border);box-shadow:var(--vela-shadow);font-size:var(--vela-font-size-md);`;
+        applyChromeTokens(menu, this.theme);
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'vela-ind-menuitem';
+        item.style.cssText = 'display:flex;align-items:center;gap:8px;width:100%;text-align:left;padding:6px 10px;border:none;border-radius:var(--vela-radius-sm);color:inherit;cursor:pointer;white-space:nowrap;';
+        // A fixed-width check slot keeps the label aligned in both states.
+        const check = document.createElement('span');
+        check.style.cssText = 'display:inline-flex;align-items:center;justify-content:center;width:14px;flex:none;line-height:0;';
+        check.innerHTML = this.rowValuesShown(row) ? CHECK_SVG : '';
+        const label = document.createElement('span');
+        label.textContent = 'Indicator values';
+        item.append(check, label);
+        item.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.closeRowMenu();
+            row.showValues = !this.rowValuesShown(row);
+            this.renderRowValues(row);
+        });
+        menu.appendChild(item);
+        document.body.appendChild(menu);
+        // Clamp within the viewport so a bottom/right-edge row's menu stays visible.
+        const mw = menu.offsetWidth || 180;
+        const mh = menu.offsetHeight || 40;
+        menu.style.left = `${Math.min(x, window.innerWidth - mw - 6)}px`;
+        menu.style.top = `${Math.min(y, window.innerHeight - mh - 6)}px`;
+        this.rowMenu = menu;
+        // Close on the next outside click (deferred so this same gesture doesn't immediately close it).
+        setTimeout(() => {
+            if (typeof document !== 'undefined') document.addEventListener('pointerdown', this.onRowMenuOutside, true);
+        }, 0);
+    }
+
+    private readonly onRowMenuOutside = (e: Event): void => {
+        if (this.rowMenu && !this.rowMenu.contains(e.target as Node)) this.closeRowMenu();
+    };
+
+    private closeRowMenu(): void {
+        if (typeof document !== 'undefined') document.removeEventListener('pointerdown', this.onRowMenuOutside, true);
+        this.rowMenu?.remove();
+        this.rowMenu = null;
     }
 
     /** Move a legend row to another pane (indicator merged/moved), tidying an emptied container. */
@@ -483,10 +609,17 @@ export class InputsUI {
             e.preventDefault();
             this.onRemove?.(id);
         });
-        // Status indicator (left of the title): a spinner while fetching, a pulse while live, hidden when idle.
+        // Right-click opens the row's own action menu — swallowed here so the host's
+        // chart-body context menu (bound higher up the tree) doesn't open over it.
+        el.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.openRowMenu(id, e.clientX, e.clientY);
+        });
+        // Status indicator (appended at the row's right end, below): pulsing load dots while
+        // fetching, a pulse while live, hidden when idle.
         const statusEl = document.createElement('span');
         statusEl.style.cssText = 'display:none;box-sizing:border-box;flex:none;';
-        el.appendChild(statusEl);
         // Title (+ optional "beta" exponent) wrapped so the superscript stays glued to the label and
         // survives title-text updates (which only touch the inner span).
         const titleWrap = document.createElement('span');
@@ -504,6 +637,11 @@ export class InputsUI {
             titleWrap.appendChild(beta);
         }
         el.appendChild(titleWrap);
+        // Plot values readout, right of the title — filled by setPlotValues, hidden until
+        // values arrive (or while the values toggle is off for this row).
+        const valuesEl = document.createElement('span');
+        valuesEl.style.cssText = 'display:none;align-items:center;gap:5px;white-space:nowrap;font-variant-numeric:tabular-nums;';
+        el.appendChild(valuesEl);
         // Hide/show (eye) — revealed on hover/selection like the other controls, but ALSO kept
         // visible while the indicator is hidden (so its "show" toggle stays reachable without
         // hovering). It sits outside `controlsEl` so it can outlive the collapse. Only present when
@@ -567,9 +705,10 @@ export class InputsUI {
         close.addEventListener('click', () => this.onRemove?.(id));
         controlsEl.appendChild(close);
         el.appendChild(controlsEl);
+        el.appendChild(statusEl); // status sits at the row's right end, after values and controls
 
         this.attach(this.legendFor(paneId), el, !!opts.native);
-        this.rows.set(id, { id, title, inputs, values: { ...values }, el, titleEl, statusEl, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
+        this.rows.set(id, { id, title, inputs, values: { ...values }, el, titleEl, statusEl, valuesEl, plotValues: [], plotValuesKey: '', showValues: null, highlighted: false, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
         this.syncFoldToggle(); // 2+ indicators grow the fold chevron; a folded legend hides the new row too
     }
 
@@ -586,30 +725,35 @@ export class InputsUI {
     }
 
     /**
-     * Reflect an indicator's live status in its legend row: `'loading'` shows a spinner (a fetch is
-     * in flight), `'live'` a pulsing dot (live-updating), `'idle'` nothing. Rendered left of the title.
+     * Reflect an indicator's live status in its legend row: `'loading'` shows three pulsing
+     * dots (a fetch is in flight — the same load affordance as the chart's own bar-load dots,
+     * at legend scale), `'live'` a pulsing dot, `'idle'` nothing. Rendered at the row's right end.
      */
     setStatus(id: string, status: 'idle' | 'loading' | 'live'): void {
         const row = this.rows.get(id);
         if (!row) return;
         const el = row.statusEl;
+        el.replaceChildren(); // the load dots (and their Web Animations) die with the children
         if (status === 'idle') {
-            el.style.display = 'none';
-            el.style.animation = 'none';
+            el.style.cssText = 'display:none;box-sizing:border-box;flex:none;';
             return;
         }
-        this.ensureStatusKeyframes();
         if (status === 'loading') {
-            el.style.cssText =
-                `display:inline-block;box-sizing:border-box;flex:none;width:11px;height:11px;border-radius:50%;` +
-                `border:2px solid var(--vela-border-strong);border-top-color:var(--vela-fg-bright);` +
-                `animation:vela-ind-spin .7s linear infinite;`;
-        } else {
-            // live — a pulsing filled dot
-            el.style.cssText =
-                `display:inline-block;box-sizing:border-box;flex:none;width:8px;height:8px;border-radius:50%;` +
-                `background:${this.theme.upColor};animation:vela-ind-pulse 1.2s ease-in-out infinite;`;
+            el.style.cssText = 'display:inline-flex;align-items:center;gap:3px;box-sizing:border-box;flex:none;';
+            for (let i = 0; i < 3; i += 1) {
+                const dot = document.createElement('span');
+                dot.style.cssText = 'width:4px;height:4px;border-radius:50%;background:currentColor;opacity:0.15;flex:none;';
+                // Staggered phases via negative delays — every dot animates from the first frame.
+                dot.animate?.([{ opacity: 0.12 }, { opacity: 0.55 }], { duration: 800, iterations: Infinity, direction: 'alternate', easing: 'ease-in-out', delay: -i * 260 });
+                el.appendChild(dot);
+            }
+            return;
         }
+        // live — a pulsing filled dot
+        this.ensureStatusKeyframes();
+        el.style.cssText =
+            `display:inline-block;box-sizing:border-box;flex:none;width:8px;height:8px;border-radius:50%;` +
+            `background:${this.theme.upColor};animation:vela-ind-pulse 1.2s ease-in-out infinite;`;
     }
 
     /** Inject the status keyframes once (idempotent). */
@@ -655,6 +799,8 @@ export class InputsUI {
     private setRowHighlighted(id: string, highlighted: boolean): void {
         const row = this.rows.get(id);
         if (!row) return;
+        row.highlighted = highlighted;
+        this.renderRowValues(row); // values step aside while the controls are out
         row.el.style.boxShadow = highlighted ? `inset 0 0 0 1px ${this.neutralBorder()}` : 'none';
         // The solid fill exists only while the row is open — an idle row is a translucent
         // title-sized chip that lets the plot show through while keeping the label legible.
@@ -689,6 +835,7 @@ export class InputsUI {
     destroy(): void {
         this.closeDialog();
         this.closeMoveMenu();
+        this.closeRowMenu();
         for (const id of [...this.rowTips.keys()]) this.disposeTips(this.rowTips, id);
         for (const id of [...this.extrasTips.keys()]) this.disposeTips(this.extrasTips, id);
         for (const lg of this.legends.values()) lg.remove();

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -37,7 +37,10 @@ export interface LegendPlotValue {
 
 interface LegendRow {
     id: string;
+    /** Legend chip text (may be a compact shorttitle). */
     title: string;
+    /** Settings-dialog header; falls back to {@link title} when unset. */
+    settingsTitle: string;
     inputs: InputSchema[];
     values: Record<string, InputValue>;
     el: HTMLElement;
@@ -559,10 +562,12 @@ export class InputsUI {
     }
 
     /** Create or update an indicator's legend row (in the legend for its pane). */
-    upsert(id: string, title: string, inputs: InputSchema[], values: Record<string, InputValue>, paneId = 'price', opts: { native?: boolean; beta?: boolean } = {}): void {
+    upsert(id: string, title: string, inputs: InputSchema[], values: Record<string, InputValue>, paneId = 'price', opts: { native?: boolean; beta?: boolean; settingsTitle?: string } = {}): void {
+        const settingsTitle = opts.settingsTitle ?? title;
         const existing = this.rows.get(id);
         if (existing) {
             existing.title = title;
+            existing.settingsTitle = settingsTitle;
             existing.inputs = inputs;
             existing.values = { ...values };
             existing.titleEl.textContent = title;
@@ -708,7 +713,7 @@ export class InputsUI {
         el.appendChild(statusEl); // status sits at the row's right end, after values and controls
 
         this.attach(this.legendFor(paneId), el, !!opts.native);
-        this.rows.set(id, { id, title, inputs, values: { ...values }, el, titleEl, statusEl, valuesEl, plotValues: [], plotValuesKey: '', showValues: null, highlighted: false, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
+        this.rows.set(id, { id, title, settingsTitle, inputs, values: { ...values }, el, titleEl, statusEl, valuesEl, plotValues: [], plotValuesKey: '', showValues: null, highlighted: false, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
         this.syncFoldToggle(); // 2+ indicators grow the fold chevron; a folded legend hides the new row too
     }
 
@@ -913,7 +918,7 @@ export class InputsUI {
         const header = document.createElement('div');
         header.style.cssText = 'display:flex;justify-content:space-between;align-items:flex-start;gap:12px;padding:16px 20px 12px;flex:0 0 auto;';
         const hTitle = document.createElement('span');
-        hTitle.textContent = row.title;
+        hTitle.textContent = row.settingsTitle;
         hTitle.style.cssText = 'font-weight:600;font-size:16px;line-height:1.3;';
         const closeBtn = document.createElement('button');
         closeBtn.type = 'button';

--- a/src/renderers/shared/chrome-tooltip.ts
+++ b/src/renderers/shared/chrome-tooltip.ts
@@ -46,8 +46,10 @@ export function attachChromeTooltip(anchor: HTMLElement, opts: ChromeTooltipOpti
         const doc = anchor.ownerDocument;
         tip = doc.createElement('div');
         tip.textContent = text;
+        // The tooltip layer token (60) keeps tips above the in-chart dialogs (40) — the
+        // settings dialog's own control tips used to open BEHIND its card at a fixed 25.
         tip.style.cssText =
-            'position:absolute;z-index:25;pointer-events:none;' +
+            'position:absolute;z-index:var(--vela-z-tooltip);pointer-events:none;' +
             'background:var(--vela-bg);border:1px solid var(--vela-border);color:var(--vela-fg);' +
             'border-radius:var(--vela-radius-md);padding:4px 9px;box-shadow:var(--vela-shadow);' +
             'font:var(--vela-font-size-md) var(--vela-font);' +

--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -61,6 +61,8 @@ export interface CellState {
     watermark?: boolean;
     /** Indicator titles (the in-chart legend rows) visibility — a per-chart display pref. */
     indicatorTitles?: boolean;
+    /** Plot values beside the legend titles visibility — a per-chart display pref. */
+    indicatorValues?: boolean;
     /** The renderer's cosmetic config document (`renderer.getConfig()`). */
     rendererConfig?: unknown;
     /** The user-drawings document (`drawings.toJSON()`). */
@@ -171,6 +173,7 @@ function sanitizeCell(raw: unknown): CellState | null {
     if (typeof c.bars === 'number' && Number.isFinite(c.bars) && c.bars > 0) out.bars = c.bars;
     if (typeof c.watermark === 'boolean') out.watermark = c.watermark;
     if (typeof c.indicatorTitles === 'boolean') out.indicatorTitles = c.indicatorTitles;
+    if (typeof c.indicatorValues === 'boolean') out.indicatorValues = c.indicatorValues;
     if (c.rendererConfig != null && typeof c.rendererConfig === 'object') out.rendererConfig = c.rendererConfig;
     if (c.drawings != null && typeof c.drawings === 'object') out.drawings = c.drawings;
     const ind = c.indicators as Record<string, unknown> | undefined;

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -98,6 +98,8 @@ export class VelaWidget {
     private watermarkOn: boolean;
     /** Indicator titles (the in-chart legend rows) shown — reapplied across rebuilds. */
     private indicatorTitlesOn = true;
+    /** Plot values beside the legend titles shown — reapplied across rebuilds. */
+    private indicatorValuesOn = true;
     private pendingRange: RangePreset | null = null;
     /** Symbol already reported as unservable (the core re-reports on every index settle). */
     private unresolvedToasted: string | null = null;
@@ -176,6 +178,7 @@ export class VelaWidget {
         this.bars = Number(fromUrl.bars ?? bootCell?.bars ?? opts.bars ?? 1000);
         this.watermarkOn = bootCell?.watermark !== undefined ? bootCell.watermark : opts.watermark !== false;
         this.indicatorTitlesOn = bootCell?.indicatorTitles ?? true;
+        this.indicatorValuesOn = bootCell?.indicatorValues ?? true;
         this.favs = boot?.favorites ? [...boot.favorites] : [];
         this.savedConfig = bootCell?.rendererConfig ?? null;
         this.savedDrawings = bootCell?.drawings ?? null;
@@ -226,7 +229,12 @@ export class VelaWidget {
                 if (i < present.length) this.removeNative(present[i]!.type);
                 else this.removeInstance(i - present.length);
             },
-            onOpenChange: (open) => this.trackDialog(open),
+            onOpenChange: (open) => {
+                // Same rule as the symbol search: the renderer's in-chart dialogs never see
+                // an outside-dismiss from a topbar dialog — close them explicitly.
+                if (open) this.inner?.renderer.closeDialogs();
+                this.trackDialog(open);
+            },
         });
         this.tfQuick = new TimeframeQuick({
             host: this.root,
@@ -515,6 +523,7 @@ export class VelaWidget {
         if (this.bars > 0) cell.bars = this.bars;
         cell.watermark = this.watermarkOn;
         cell.indicatorTitles = this.indicatorTitlesOn;
+        cell.indicatorValues = this.indicatorValuesOn;
         if (this.inner) {
             cell.rendererConfig = this.inner.renderer.getConfig();
             cell.drawings = this.inner.drawings.toJSON();
@@ -566,6 +575,7 @@ export class VelaWidget {
             if (style && style !== this.priceStyle) this.setPriceStyle(style);
             if (cell.watermark !== undefined && cell.watermark !== this.watermarkOn) this.setWatermarkVisible(cell.watermark);
             if (cell.indicatorTitles !== undefined && cell.indicatorTitles !== this.indicatorTitlesOn) this.setIndicatorTitlesVisible(cell.indicatorTitles);
+            if (cell.indicatorValues !== undefined && cell.indicatorValues !== this.indicatorValuesOn) this.setIndicatorValuesVisible(cell.indicatorValues);
             if (cell.rendererConfig != null) {
                 this.savedConfig = cell.rendererConfig;
                 this.inner?.renderer.applyConfig(cell.rendererConfig);
@@ -676,6 +686,13 @@ export class VelaWidget {
     setIndicatorTitlesVisible(visible: boolean): void {
         this.indicatorTitlesOn = visible;
         this.inner?.renderer.set('indicatorTitles', visible);
+        this.markStateDirty();
+    }
+
+    /** Show/hide the plot values beside every indicator's legend title (persisted). */
+    setIndicatorValuesVisible(visible: boolean): void {
+        this.indicatorValuesOn = visible;
+        this.inner?.renderer.set('indicatorValues', visible);
         this.markStateDirty();
     }
 
@@ -962,6 +979,7 @@ export class VelaWidget {
         if (this.priceStyle !== 'candles') chart.renderer.set('priceStyle', this.priceStyle);
         if (this.timezone !== 'Etc/UTC') chart.renderer.set('timezone', this.timezone);
         if (!this.indicatorTitlesOn) chart.renderer.set('indicatorTitles', false);
+        if (!this.indicatorValuesOn) chart.renderer.set('indicatorValues', false);
         // The renderer's settings dialog owns a Time zone row too (it commits through
         // applyConfig) — mirror it back so the bottom-bar clock/label and the persisted
         // state never disagree with the axis. `renderer.set` is a feature write, not an
@@ -1023,6 +1041,12 @@ export class VelaWidget {
                             label: 'Titles',
                             get: () => this.indicatorTitlesOn,
                             set: (v: boolean) => this.setIndicatorTitlesVisible(v),
+                        },
+                        {
+                            kind: 'toggle',
+                            label: 'Values',
+                            get: () => this.indicatorValuesOn,
+                            set: (v: boolean) => this.setIndicatorValuesVisible(v),
                         },
                     ],
                 },

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -181,6 +181,8 @@ export class ChartCell {
     private watermarkOn: boolean;
     /** Indicator titles (this cell's in-chart legend rows) shown. */
     private indicatorTitlesOn = true;
+    /** Plot values beside this cell's legend titles shown. */
+    private indicatorValuesOn = true;
     private destroyed = false;
 
     constructor(
@@ -286,6 +288,8 @@ export class ChartCell {
 
         this.indicatorTitlesOn = seed.indicatorTitles ?? true;
         if (!this.indicatorTitlesOn) this.inner.renderer.set('indicatorTitles', false);
+        this.indicatorValuesOn = seed.indicatorValues ?? true;
+        if (!this.indicatorValuesOn) this.inner.renderer.set('indicatorValues', false);
         this.watermarkOn = seed.watermark ?? deps.watermark;
         this.watermark = deps.watermark ? new Watermark(this.host, symbol ?? '', seed.timeframe ?? '60') : null;
         if (!this.watermarkOn) this.watermark?.setVisible(false);
@@ -409,6 +413,12 @@ export class ChartCell {
                             get: () => this.indicatorTitlesOn,
                             set: (v: boolean) => this.setIndicatorTitlesVisible(v),
                         },
+                        {
+                            kind: 'toggle',
+                            label: 'Values',
+                            get: () => this.indicatorValuesOn,
+                            set: (v: boolean) => this.setIndicatorValuesVisible(v),
+                        },
                     ],
                 },
                 advanced,
@@ -445,6 +455,13 @@ export class ChartCell {
     setIndicatorTitlesVisible(visible: boolean): void {
         this.indicatorTitlesOn = visible;
         this.inner?.renderer.set('indicatorTitles', visible);
+        this.deps.onStateDirty();
+    }
+
+    /** Show/hide the plot values beside this cell's legend titles (persisted per cell). */
+    setIndicatorValuesVisible(visible: boolean): void {
+        this.indicatorValuesOn = visible;
+        this.inner?.renderer.set('indicatorValues', visible);
         this.deps.onStateDirty();
     }
 
@@ -715,6 +732,7 @@ export class ChartCell {
             priceStyle: this.priceStyle,
             watermark: this.watermarkOn,
             indicatorTitles: this.indicatorTitlesOn,
+            indicatorValues: this.indicatorValuesOn,
             rendererConfig: this.inner?.renderer.getConfig() ?? undefined,
             drawings: this.inner ? this.inner.drawings.toJSON() : undefined,
             // Natives from the chart's SYNC registry read — an async catalog mirror here

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -301,7 +301,12 @@ export class VelaWorkspace {
             onChart: () => this.active.onChartRows(),
             onAdd: (i) => this.active.addFromLibrary(i),
             onRemove: (i) => this.active.removeFromChart(i),
-            onOpenChange: (open) => this.trackDialog(open),
+            onOpenChange: (open) => {
+                // Same rule as the symbol search: the renderer's in-chart dialogs never see
+                // an outside-dismiss from a topbar dialog — close them on every cell.
+                if (open) for (const cell of this.cells()) cell.chart.renderer.closeDialogs();
+                this.trackDialog(open);
+            },
         });
         this.tfQuick = new TimeframeQuick({
             host: this.root,

--- a/test/data-window-readout.test.ts
+++ b/test/data-window-readout.test.ts
@@ -75,6 +75,18 @@ describe('NativeRenderer.getDataWindowReadout', () => {
     });
 });
 
+describe('indicatorValues feature (legend plot values)', () => {
+    it('is a supported feature, on by default, and round-trips through apply/read', () => {
+        const { r } = makeRenderer();
+        expect(r.features).toContain('indicatorValues');
+        expect(r.readFeature('indicatorValues')).toBe(true);
+        r.applyFeature('indicatorValues', false);
+        expect(r.readFeature('indicatorValues')).toBe(false);
+        r.applyFeature('indicatorValues', true);
+        expect(r.readFeature('indicatorValues')).toBe(true);
+    });
+});
+
 describe('RendererControl.dataWindowReadout', () => {
     const readout: DataWindowReadout = { date: '2023-11-14', time: '22:13', ohlc: null, groups: [] };
 

--- a/test/drawings-frvp.test.ts
+++ b/test/drawings-frvp.test.ts
@@ -124,14 +124,16 @@ describe('drawings/FixedRangeVolumeProfile', () => {
         expect(d.frvp.valueAreaPct).toBe(70);
         expect(d.frvp.widthPct).toBe(35);
         expect(d.frvp.anchor).toBe('left');
-        // Defaults come from the shared semantic palette, never from local literals.
-        expect(d.frvp.upColor).toBe(`${BULLISH}BF`);
-        expect(d.frvp.downColor).toBe(`${BEARISH}BF`);
-        expect(d.frvp.vaUpColor).toBe(`${BULLISH}66`);
-        expect(d.frvp.vaDownColor).toBe(`${BEARISH}66`);
+        // Defaults come from the shared semantic palette, never from local literals — and
+        // the value area is the emphasized (more opaque) region, the outside tails recede.
+        expect(d.frvp.upColor).toBe(`${BULLISH}66`);
+        expect(d.frvp.downColor).toBe(`${BEARISH}66`);
+        expect(d.frvp.vaUpColor).toBe(`${BULLISH}BF`);
+        expect(d.frvp.vaDownColor).toBe(`${BEARISH}BF`);
         expect(d.frvp.vahColor).toBe(NEUTRAL);
         expect(d.frvp.valColor).toBe(NEUTRAL);
-        expect(d.frvp.pocColor).toBe(ACCENT);
+        // Unset POC ink ⇒ the painter resolves the theme's contrast color per paint.
+        expect(d.frvp.pocColor).toBeUndefined();
         expect(d.frvp.developingPocStyle).toBe('dotted');
         expect(d.frvp.developingVaStyle).toBe('dotted');
         expect(d.frvp.developingPocColor).toBe(ACCENT);

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1331,6 +1331,8 @@ describe('EngineOrchestrator — built-in volume native indicators', () => {
         await flush();
         const model = renderer.mountedModels.find((m) => m.native?.type === 'vpvr');
         expect(model).toBeDefined();
+        expect(model!.title).toBe('Visible Range Volume Profile');
+        expect(model!.shorttitle).toBe('VRVP');
         expect(model!.series).toHaveLength(0);
         expect(model!.paneId).toBe('price');
         expect(renderer.vpvrPushes).toEqual([

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -24,6 +24,7 @@ const fullDoc: WorkspaceState = {
             bars: 500,
             watermark: false,
             indicatorTitles: false,
+            indicatorValues: false,
             rendererConfig: { theme: 'dark', nested: { any: ['shape'] } },
             drawings: { version: 1, items: [{ type: 'trendline' }] },
             indicators: { manifest: ['EMA 20'], natives: ['volume'] },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly legend DOM, renderer features, and visual defaults for one drawing tool; persistence adds an optional boolean with safe defaults. No auth, data, or payment paths touched.
> 
> **Overview**
> **Indicator legends now show live plot values** beside each title (plot-colored, crosshair bar or latest bar). Values hide while a row is highlighted for controls; legend right-click toggles values per indicator; chart settings → Indicators adds a persisted **Values** toggle (widget and workspace cells). The native renderer exposes a new `indicatorValues` feature and pushes readouts each paint via shared data-window formatting.
> 
> **Legend UX tweaks:** fetching indicators use three pulsing dots at the row’s right end instead of a left spinner; native indicators can declare `shortTitle` so the chip stays short while picker/settings keep the full name — built-in VPVR is now **Visible Range Volume Profile** with legend label **VRVP**.
> 
> **Fixed-range volume profile (drawing):** default fills emphasize the value area (tails more transparent); unset POC color resolves to theme contrast ink at paint time (settings UI matches).
> 
> **Dialog stacking:** opening the topbar Indicators picker closes an open in-chart indicator-settings dialog (widget + workspace); indicator-settings tooltips use the shared tooltip z-index so they sit above the dialog card.
> 
> **Orchestrator:** last-seen chart-type settings are replayed into newly created data engines before `start()` so restored config and market switches don’t leave engines on schema defaults until the user edits settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e26986d5ea0e81911d1e24b96f1645d0e826b96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->