### PR TITLE
feat: add volume indicator readout for series-less native model

### DIFF
--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -2625,6 +2625,9 @@ export class NativeRenderer implements IChartRenderer {
 
     /** One indicator's readout at bar `idx`: a row per drawable plot, formatted on its pane's scale. */
     private dataWindowRowsFor(model: IndicatorModel, idx: number, pricePane: PaneNode | null): DataWindowRow[] {
+        // The volume native draws through its bespoke layer and mounts a series-less model, so
+        // its readout comes straight from the bar's volume instead of iterating `model.series`.
+        if (model.native?.type === 'volume') return this.volumeReadoutRows(model, idx);
         const pane = (model.paneId ? this.scene.panes.get(model.paneId) : null) ?? pricePane;
         const off = this.scene.offsetOf(model.id);
         const rows: DataWindowRow[] = [];
@@ -2645,6 +2648,19 @@ export class NativeRenderer implements IChartRenderer {
             rows.push({ label: s.title || model.title, value: this.dataWindowFmt(value, pane), color });
         }
         return rows;
+    }
+
+    /** The volume indicator's readout: the bar's volume, tinted with the layer's own direction
+     *  colors. Hiding volume keeps its model in the scene (only the layer is suppressed — see
+     *  `setIndicatorVisible`), so the hidden flag is checked here rather than by model absence. */
+    private volumeReadoutRows(model: IndicatorModel, idx: number): DataWindowRow[] {
+        if (this.volumeHidden) return [];
+        const bar = this.bars[idx];
+        const vol = bar?.volume;
+        if (bar == null || vol == null || !Number.isFinite(vol)) return [];
+        const cfg = this.scene.volumeLayer;
+        const color = bar.close >= bar.open ? (cfg?.upColor ?? this.theme.upColor) : (cfg?.downColor ?? this.theme.downColor);
+        return [{ label: model.title, value: formatVolume(vol), color }];
     }
 
     /** Refresh the plot values beside every legend title — the same readout the data window

--- a/test/data-window-readout.test.ts
+++ b/test/data-window-readout.test.ts
@@ -73,6 +73,39 @@ describe('NativeRenderer.getDataWindowReadout', () => {
     it('no longer exposes a floating data-window feature — the readout is the only seam', () => {
         expect(new NativeRenderer().features).not.toContain('dataWindow');
     });
+
+    describe('volume indicator readout (series-less native model)', () => {
+        /** Mount a volume-shaped model + layer config straight into the scene (the layer draws
+         *  outside the model, so the readout must synthesize its row from the bar's volume). */
+        function withVolume(withVol = true): { r: NativeRenderer; anyR: any } {
+            const { r, anyR } = makeRenderer();
+            r.setBars(bars([100, 101, 105], withVol));
+            anyR.scene.indicators.set('vol1', { id: 'vol1', title: 'Volume', series: [], native: { type: 'volume' } });
+            anyR.scene.volumeLayer = { upColor: '#11aa11', downColor: '#aa1111', heightFrac: 0.2 };
+            anyR.volumeActive = true;
+            return { r, anyR };
+        }
+
+        it('reads the bar volume, abbreviated, tinted with the layer direction color', () => {
+            const { r } = withVolume();
+            const group = r.getDataWindowReadout().groups.find((g) => g.name === 'Volume');
+            expect(group?.rows).toEqual([{ label: 'Volume', value: '1.23K', color: '#11aa11' }]); // latest bar is up
+        });
+
+        it('uses the down color on a down bar', () => {
+            const { r } = withVolume();
+            r.setBars([...bars([100, 101], true), { time: 1_700_000_000_000 + 2 * HOUR, open: 110, high: 111, low: 98, close: 99, volume: 1234 }]);
+            const group = r.getDataWindowReadout().groups.find((g) => g.name === 'Volume');
+            expect(group?.rows[0]?.color).toBe('#aa1111');
+        });
+
+        it('yields no row without bar volume, and none while the indicator is hidden', () => {
+            expect(withVolume(false).r.getDataWindowReadout().groups).toEqual([]);
+            const hidden = withVolume();
+            hidden.anyR.volumeHidden = true; // hiding suppresses the layer but keeps the model
+            expect(hidden.r.getDataWindowReadout().groups).toEqual([]);
+        });
+    });
 });
 
 describe('indicatorValues feature (legend plot values)', () => {


### PR DESCRIPTION
- Implemented a new method to handle volume readouts directly from the bar's volume for the volume indicator.
- Added logic to return the appropriate color based on the bar's direction.
- Updated tests to verify the correct behavior of the volume readout, including cases for hidden indicators and bars without volume.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Readout-only change on an existing volume hide path; no paint or data pipeline changes.
> 
> **Overview**
> The **data window** and **legend plot values** now include the Volume indicator even though its native layer draws from chart bars and the mounted model has **no series**.
> 
> `dataWindowRowsFor` delegates volume natives to **`volumeReadoutRows`**, which builds one row from the bar’s volume (abbreviated via `formatVolume`), tints it with the volume layer’s up/down colors, and returns nothing when the bar has no volume or when volume is hidden via the legend eye (`volumeHidden` — the model stays in the scene while only the layer is suppressed).
> 
> Tests cover abbreviated values, direction colors, missing volume, and the hidden state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a250a21f0a71be734665f634bd7316a22949540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->