### PR TITLE
feat: mobile version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,69 @@ All notable changes to Vela, newest first.
 
 ## [v0.5.1]
 
+### Changed
+
+- **Mobile chrome polish.** The timeframe sheet labels its date-range chips and
+  timeframe grid with matching white section headers (no divider between them), and
+  highlights the active chip in white. In the drawings sheet the search field and
+  group tabs stay pinned while the tool list scrolls. The in-chart status line drops
+  the O/H/L/C block on mobile and stacks the bar change under an aligned
+  logo / symbol / timeframe / market-status row. The scroll-to-latest control is
+  smaller and only appears when the latest bars are off-screen. Time zone moved out
+  of the three-dots sheet onto a long-press of the time axis; a long-press on the
+  price scale opens a price-scale sheet. The LuxAlgo attribution mark keeps its
+  desktop size and is only slightly smaller on mobile; the faded symbol watermark
+  caps at a quieter size.
+
 ### Added
+
+- **A mobile chrome for the widget.** In a narrow container — or on a touch-first
+  device, or forced with the new `layoutMode` shell option (`'auto' | 'mobile' |
+  'desktop'`) — the widget swaps its desktop bars for one touch-sized bottom bar:
+  symbol search, timeframe, indicators, drawings, a three-dots drawer, and chart
+  settings. The timeframe entry opens a bottom sheet with the date-range presets and
+  the timeframe grid; the drawings entry opens a searchable, tabbed tool sheet with
+  favorite stars, and an armed tool shows a floating pill over the chart with the
+  magnet, stay-in-drawing-mode and eraser controls; the three-dots sheet carries
+  undo/redo, screenshot, chart type, the side panels (which open full-screen on
+  mobile), alerts, and any contributed actions. A long-press on the time axis opens
+  the time-zone sheet; a long-press on the price scale opens scale settings. Symbol
+  search, the indicator picker, chart settings and indicator settings all present
+  full-screen; in chart settings the section list sits behind a burger button, a
+  section's groups become scrollable tabs, and multi-instance strips (like a
+  footprint's) scroll sideways. The chart itself gains the touch gestures the chrome
+  assumes: one-finger pan with inertia, two-finger pinch zoom, a long-press that
+  inspects with the crosshair without moving the view, and a double-tap that mirrors
+  the desktop double-click — on the price or time axis it resets that scale's view,
+  and inside the plot it maximizes/restores the tapped pane. The button that jumps
+  back to the most recent bar appears when those bars are off-screen. Desktop
+  behavior is unchanged, and the mode follows the container live — resizing across
+  the breakpoint swaps the chrome in place.
+- **The workspace shares the mobile chrome.** `VelaWorkspace` honors the same
+  `layoutMode` option and auto-detection: on mobile the shared topbar, desktop
+  bottombar and the docked drawing-toolbar column give way to the same touch-first
+  bottom bar, sheets and full-screen pickers, all acting on the active cell. The
+  three-dots sheet additionally carries the multi-chart **Layout** picker — the same
+  tap-to-apply grid canvas as the desktop topbar's layout dropdown, its non-grid
+  preset rows, and the symbol/interval/crosshair sync switches. The grid-wide
+  attribution mark also picks up the smaller mobile lockup the widget uses.
+  Multi-cell grids keep each cell's status line on ONE row — segments that don't fit
+  the cell hide instead of wrapping (bar change first, then the venue/timeframe, then
+  the market badge; the logo + ticker always stay). On mobile the indicator legend is
+  **collapsed by default** behind its count chip, and in a multi-cell grid the chip
+  routes to the **object tree** instead of unfolding in place — whose indicator action
+  menu gains an **"Indicator settings"** entry (the legend gear's twin).
+- **Plugin SDK: two per-indicator chrome seams on the renderer port.**
+  `IChartRenderer.setLegendOverviewAction?(action)` lets a host shell replace the
+  indicator legend's fold toggle with its own overview entry point (the workspace
+  routes it to the object tree on mobile grids), and
+  `IChartRenderer.openIndicatorSettings?(indicatorId)` opens one indicator's settings
+  dialog programmatically — the legend gear's twin, surfaced on `chart.renderer` as
+  `setLegendOverviewAction` / `openIndicatorSettings` (+ `supportsIndicatorSettings`).
+  Both are additive and optional: a renderer without them keeps today's behavior.
+- **`vela/ui` gains a `Drawer`.** A bottom sheet with a grab handle, drag-to-dismiss
+  and a dimmed backdrop — the primitive the mobile chrome's sheets are built on,
+  exported for building your own.
 
 - **Drawings sync across a workspace grid.** A new `drawings` sync kind
   (`ws.sync.set('drawings', true)`, also a toggle on the shared drawing toolbar) links

--- a/docs/contributing/adding-a-renderer.md
+++ b/docs/contributing/adding-a-renderer.md
@@ -106,6 +106,8 @@ The descriptor covers these fields. Some are tri-state (for example `native` / `
 | Trade markers (`trades` flag) | no | optional — inside the **Drawings** tier family: paints `IndicatorModel.trades` (order-fill arrows + labels + fill-price ticks on the price pane) and honors the `tradeMarkers` feature; absent/false ⇒ the channel is carried but never painted |
 | Inputs UI (you provide the in-chart settings dialog) | no | optional — **Inputs UI** tier |
 | Contributed legend actions (`setLegendActions?`) | no | optional — inside the **Inputs UI** tier: the shells wire `registerLegendAction` through it; without it those buttons simply never show |
+| Legend overview override (`setLegendOverviewAction?`) | no | optional — inside the **Inputs UI** tier: a multi-chart shell replaces the legend's fold toggle with its own indicator-overview entry point; without it the inline fold stays |
+| Per-indicator settings opener (`openIndicatorSettings?`) | no | optional — inside the **Inputs UI** tier: host chrome (the object tree's action menu) opens one indicator's settings dialog programmatically; without it that menu entry never shows |
 
 The optional-tier rows line up one-to-one with the optional tiers in the [conformance ladder](#a-conformance-ladder): a flag stays off until its tier lands.
 

--- a/docs/user/widget.md
+++ b/docs/user/widget.md
@@ -39,7 +39,8 @@ the surface it shares, name for name and meaning for meaning, with
 | `indicators` | manifest \| URL string | — | The indicator manifest — inline JSON or a URL returning it (see below). |
 | `timeframes` | `string[]` | `['1','5','15','60','240','D','W']` | The topbar timeframe presets. |
 | `timezone` | IANA string | `'Etc/UTC'` | Initial display timezone; changed live from the bottom bar. |
-| `statusline` / `watermark` / `bottombar` | boolean | `true` | Chrome toggles. |
+| `statusline` / `watermark` / `bottombar` | boolean | `true` | Chrome toggles (`bottombar` governs the mobile bottom bar too). |
+| `layoutMode` | `'auto'` \| `'mobile'` \| `'desktop'` | `'auto'` | The chrome size class. `'auto'` follows the **container** width (plus a coarse-pointer heuristic for tablets) and re-evaluates live; the explicit values pin it. See [Mobile](#mobile). |
 | `autofocus` | boolean | `false` | Focus the chart on mount so keyboard shortcuts work from the first keystroke. Off by default: an embedded chart should not steal the page's focus. |
 | `persist` | boolean \| string | `false` | Bring the chart back as you left it — the widget persists its FULL state (the unified `getState()` document: market, prefs, renderer config, user drawings, indicators) and restores it at construction (`true` = key `'vela-widget'`; a string is the key). Old three-key payloads migrate transparently. |
 | `storage` | `VelaStorage` | localStorage | The persistence backend — inject a custom adapter (see below); one contract for both shells. |
@@ -132,6 +133,48 @@ work from the very first keystroke, before any click.
   for the display timezone. Every pane's price scale has its own menu, so a study pane's scale
   is independent of the main one. Each menu's settings entry opens the settings dialog on the
   tab that belongs to it — Canvas from the chart body, Scales and lines from either axis.
+
+## Mobile
+
+In a container narrower than ~640px (or up to ~920px with a coarse pointer — a
+tablet), the widget switches to its **mobile chrome**; `layoutMode: 'mobile'` or
+`'desktop'` pins the choice. The mode is container-driven and live: resizing across
+the breakpoint swaps the chrome in place, closing whatever was open in the other
+presentation.
+
+What changes on mobile:
+
+- **One bottom bar replaces both desktop bars**, left to right: the symbol button
+  (full-screen symbol search), the timeframe button (a bottom sheet with the date-range
+  presets on top and the timeframe grid below), indicators (the full-screen picker),
+  drawings (a bottom sheet with a search bar, the tool groups as scrollable tabs, and
+  favorite stars), a three-dots sheet (undo/redo, screenshot, chart type, the side
+  panels, time zone, alerts, and contributed topbar actions), and chart settings.
+- **The docked drawing toolbar hides.** Picking a tool from the drawings sheet arms it
+  and shows a floating pill over the chart — the armed tool's icon, the magnet cycle,
+  stay-in-drawing-mode, the eraser, and ✕ to disarm. Favorites keep working (stars in
+  the sheet), so a radial-wheel-style picker built on them keeps its data.
+- **Dialogs go full-screen** — symbol search, the indicator picker, indicator settings,
+  and chart settings, where the section rail sits behind a burger button, a section's
+  group list becomes scrollable tabs at the top, and instance strips scroll sideways.
+- **Side panels** (data window, object tree, contributed) open over the chart instead
+  of docking a column beside it.
+- **The indicator legend starts collapsed** behind its count chip (tap to unfold) — a
+  phone-width plot has no room for the rows. The object tree's per-indicator action
+  menu carries an "Indicator settings" entry, so settings stay reachable without the
+  legend gear.
+- **Touch gestures**: one-finger pan (with the usual fling), two-finger pinch zoom
+  anchored between the fingers, and a **long-press** that inspects with the crosshair —
+  the view stays put while the finger drives the readout; lifting clears it. A
+  **double-tap** mirrors the desktop double-click: on the price axis it resets that
+  pane's scale to auto, on the time axis it fits the view to content, and inside the
+  plot it maximizes the tapped pane (price or indicator) — a second double-tap
+  restores the split. The price/time axis strips still drag-rescale, and the button
+  that jumps back to the most recent bar stays visible whenever the chart has data.
+
+Embedders need nothing special: the mode also reaches the renderer's own chrome, and a
+chart in a phone-sized *container on a desktop page* gets the same treatment — the
+widget's own bounds, not the viewport, are what count.
 
 ## Widget state — the same surface as the workspace
 
@@ -236,5 +279,5 @@ Three levels, shallow to deep:
 3. **Contributed actions** — plugins and hosts add topbar buttons and context-menu items
    as data descriptors via
    [`registerWidgetAction`](../contributing/plugin-sdk.md#widget-actions--registerwidgetaction);
-   the kit's primitives (`Dialog`, `Menu`, `Tooltip`, `KeymapManager`) are exported from
-   `vela/ui` for building your own panels against the headless core.
+   the kit's primitives (`Dialog`, `Drawer`, `Menu`, `Tooltip`, `KeymapManager`) are
+   exported from `vela/ui` for building your own panels against the headless core.

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -256,8 +256,25 @@ silently reorder them).
 | `timeframes` | presets | Topbar timeframe presets. |
 | `timezone` | `'Etc/UTC'` | Display timezone (every cell). |
 | `statusline` / `watermark` / `bottombar` | `true` | Chrome toggles. |
+| `layoutMode` | `'auto'` | Chrome size class — see [the widget's Mobile section](./widget.md#mobile); the workspace behaves the same. |
 | `autofocus` | `false` | Focus the active chart on mount (off: an embedded workspace should not steal the page's focus). |
 | `persist` / `storage` | off / localStorage | State persistence (see above). |
+
+**Mobile.** The workspace follows the same mobile rules as the widget (narrow container
+or coarse pointer, or a pinned `layoutMode`): the shared topbar, the desktop bottombar
+and the docked drawing-toolbar column give way to one touch-first bottom bar whose
+sheets and full-screen pickers act on the **active cell**, and every cell's chart gains
+the touch gestures. The one workspace-specific addition sits in the three-dots sheet: a
+**Layout** entry opening the same tap-to-apply grid canvas as the desktop topbar's
+layout dropdown (plus its non-grid preset rows), with the symbol/interval/crosshair
+sync switches below it.
+
+In **multi-cell grids** each cell's status line stays on one row — segments that don't
+fit the cell hide instead of wrapping (bar change first, then venue/timeframe, then the
+market badge; the logo + ticker always stay) — and on mobile the indicator legend's
+count chip opens the **object tree** instead of unfolding rows in place; its
+per-indicator action menu carries an "Indicator settings" entry, so everything the
+legend rows offered stays one tap away.
 
 **Workspace options** (the grid's own):
 
@@ -267,7 +284,6 @@ silently reorder them).
 | `cells` | — | Per-cell overrides, keyed by FREE-FORM name = the cell's durable identity; declaration order fills the layout's slots (see above). |
 | `sync` | off | Initial sync links (see above). |
 | `drawingToolbar` | `true` | The one shared drawing toolbar (acts on the active cell). |
-| `maxWebglCells` | `8` | Above this many cells, every cell renders canvas2d (WebGL-context budget). |
 | `maxWebglCells` | `8` | Above this many cells, every cell uses canvas2d (uniform look inside the browser's WebGL budget; `glow` unavailable there). |
 
 Contributed actions/attachments (`vela/plugin`) work unchanged — `ctx.chart` resolves

--- a/src/core/RendererControl.ts
+++ b/src/core/RendererControl.ts
@@ -1,4 +1,4 @@
-import type { CrosshairEvent, DataWindowReadout, IChartRenderer, LegendActionView, RendererCapabilities } from './ports/IChartRenderer';
+import type { AxisLongPressEvent, CrosshairEvent, DataWindowReadout, IChartRenderer, LegendActionView, RendererCapabilities } from './ports/IChartRenderer';
 import type { Unsubscribe } from './util/types';
 import type { SymbolPickerFn } from './model/inputs';
 
@@ -57,6 +57,31 @@ export class RendererControl {
     }
 
     /**
+     * Replace the indicator legend's fold toggle with a host action (or restore it with
+     * `null`) — multi-chart shells point the chip at their indicator overview instead of
+     * unfolding rows in place. Silent no-op on a renderer without a foldable legend.
+     */
+    setLegendOverviewAction(action: (() => void) | null): this {
+        this.renderer.setLegendOverviewAction?.(action);
+        return this;
+    }
+
+    /** Whether the active renderer can open a per-indicator settings dialog. */
+    get supportsIndicatorSettings(): boolean {
+        return typeof this.renderer.openIndicatorSettings === 'function';
+    }
+
+    /**
+     * Open one indicator's settings dialog — the programmatic twin of the legend gear
+     * (see {@link supportsIndicatorSettings}). Silent no-op without the seam or for an
+     * unknown id.
+     */
+    openIndicatorSettings(indicatorId: string): this {
+        this.renderer.openIndicatorSettings?.(indicatorId);
+        return this;
+    }
+
+    /**
      * Export the current chart as a PNG data URL, or null if the active renderer
      * doesn't support it (warns). DOM overlays (tables, legend) are not included.
      */
@@ -105,6 +130,11 @@ export class RendererControl {
      */
     onCrosshairMove(cb: (e: CrosshairEvent) => void): Unsubscribe {
         return this.renderer.onCrosshairMove(cb);
+    }
+
+    /** Touch long-press on a price or time axis strip — silent no-op without the seam. */
+    onAxisLongPress(cb: (e: AxisLongPressEvent) => void): Unsubscribe {
+        return this.renderer.onAxisLongPress?.(cb) ?? (() => undefined);
     }
 
     /**
@@ -177,6 +207,14 @@ export class RendererControl {
      *  e.g. the widget's Status line toggles. Silent no-op without a dialog. */
     setSettingsSections(sections: ReadonlyArray<{ title: string; rows: readonly unknown[] }>): this {
         this.renderer.setSettingsSections?.(sections);
+        return this;
+    }
+
+    /** Tell the renderer's own chrome which size class the host shell is in —
+     *  `'mobile'` switches its dialogs/toolbars to the touch-first presentation.
+     *  Silent no-op on a renderer without adaptive chrome. */
+    setLayoutMode(mode: 'mobile' | 'desktop'): this {
+        this.renderer.setLayoutMode?.(mode);
         return this;
     }
 }

--- a/src/core/icons.ts
+++ b/src/core/icons.ts
@@ -120,6 +120,7 @@ registerIcon(
 
 // ── disclosure, row actions and menu verbs (side panels, nested menus) ──
 registerIcon('chevron-right', S('<path d="m6 3.5 4.5 4.5L6 12.5"/>'));
+registerIcon('chevron-left', S('<path d="M10 3.5 5.5 8l4.5 4.5"/>'));
 registerIcon('chevron-down', S('<path d="M3.5 6 8 10.5 12.5 6"/>'));
 registerIcon('chevron-up', S('<path d="M3.5 10 8 5.5 12.5 10"/>'));
 registerIcon('chevrons-right', S('<path d="m4 3.5 4.5 4.5L4 12.5"/><path d="m8.5 3.5 4.5 4.5-4.5 4.5"/>'));
@@ -150,6 +151,7 @@ registerIcon('star', S('<path d="M8 2.2l1.75 3.55 3.9.55-2.8 2.75.65 3.9L8 11.1l
 registerIcon('star-filled', S('<path d="M8 2.2l1.75 3.55 3.9.55-2.8 2.75.65 3.9L8 11.1l-3.5 1.85.65-3.9-2.8-2.75 3.9-.55z"/>', 'fill="currentColor"'));
 registerIcon('grip', S('<circle cx="6" cy="3.5" r="1"/><circle cx="10" cy="3.5" r="1"/><circle cx="6" cy="8" r="1"/><circle cx="10" cy="8" r="1"/><circle cx="6" cy="12.5" r="1"/><circle cx="10" cy="12.5" r="1"/>', 'fill="currentColor" stroke="none"'));
 registerIcon('kebab', S('<circle cx="8" cy="3.2" r="1.2"/><circle cx="8" cy="8" r="1.2"/><circle cx="8" cy="12.8" r="1.2"/>', 'fill="currentColor" stroke="none"'));
+registerIcon('burger', S('<path d="M2.5 4.5h11M2.5 8h11M2.5 11.5h11"/>'));
 registerIcon('reset', S('<rect x="6" y="6" width="4" height="4" rx="0.8"/><path d="M2.2 8a5.8 5.8 0 1 0 1.9-4.3L2.2 5.3"/><path d="M2.2 2.2v3.1h3.1"/>'));
 
 // ── pane chrome (stack order, collapse, maximize) ──

--- a/src/core/ports/IChartRenderer.ts
+++ b/src/core/ports/IChartRenderer.ts
@@ -88,6 +88,14 @@ export interface ClickEvent {
     price: number | null;
 }
 
+/** A touch long-press on an axis strip — the mobile substitute for a right-click menu. */
+export interface AxisLongPressEvent {
+    axis: 'price' | 'time';
+    /** Plot-local pixel of the press (y maps a multi-pane price scale to its pane). */
+    x: number;
+    y: number;
+}
+
 /** One indicator plot's readout line in the data window. */
 export interface DataWindowRow {
     label: string;
@@ -265,6 +273,24 @@ export interface IChartRenderer {
     setLegendActions?(provider: ((indicatorId: string) => LegendActionView[]) | null): void;
 
     /**
+     * Replace the indicator legend's fold toggle with a HOST action (or restore it with
+     * null): the chip stays — a list glyph plus the indicator count — but pressing it
+     * runs the action instead of unfolding the rows, which stay hidden while the
+     * override is in force. Multi-chart shells route it to their indicator overview
+     * (e.g. an object-tree panel), where per-indicator controls live instead. Optional —
+     * a renderer without a foldable legend omits it.
+     */
+    setLegendOverviewAction?(action: (() => void) | null): void;
+
+    /**
+     * Open the settings dialog of one mounted indicator — the programmatic twin of the
+     * legend row's gear button, for host chrome that reaches indicators outside the
+     * legend (an object tree's action menu). Silent no-op for an unknown id. Optional —
+     * a renderer without per-indicator settings UI omits it.
+     */
+    openIndicatorSettings?(indicatorId: string): void;
+
+    /**
      * Hide (`false`) or show (`true`) a mounted indicator's visuals while keeping its legend row
      * (marked hidden). Optional — a renderer that can't suppress an indicator omits it (and the
      * core's hide still works for resource suspension; only the in-chart legend eye is unavailable).
@@ -289,6 +315,9 @@ export interface IChartRenderer {
     onToggleIndicatorVisible?(cb: (id: string, visible: boolean) => void): Unsubscribe;
     onCrosshairMove(cb: (e: CrosshairEvent) => void): Unsubscribe;
     onClick(cb: (e: ClickEvent) => void): Unsubscribe;
+    /** Touch long-press on a price or time axis strip. Optional — a renderer without
+     *  touch axis gestures omits it; host chrome (timezone / price-scale sheets) keys off it. */
+    onAxisLongPress?(cb: (e: AxisLongPressEvent) => void): Unsubscribe;
 
     /**
      * Display an EXTERNAL crosshair at a data-space position — a ghost marker driven by
@@ -381,6 +410,14 @@ export interface IChartRenderer {
     onChartTypeSettingsChange?(cb: (typeId: string, values: Record<string, unknown>) => void): Unsubscribe;
     /** Host-app settings tabs (callback rows) shown by the renderer's settings dialog. */
     setSettingsSections?(sections: ReadonlyArray<{ title: string; rows: readonly unknown[] }>): void;
+
+    /**
+     * The host shell's chrome size class. `'mobile'` asks the renderer's own chrome
+     * (dialogs, toolbars, buttons) for its touch-first presentation — fullscreen
+     * dialogs, no hover-gated affordances; `'desktop'` (the default) keeps the
+     * pointer-first one. Optional — a renderer without adaptive chrome omits it.
+     */
+    setLayoutMode?(mode: 'mobile' | 'desktop'): void;
 
     /**
      * Interactive user-drawings surface. Present iff `capabilities.userDrawings`.

--- a/src/core/timezones.ts
+++ b/src/core/timezones.ts
@@ -92,14 +92,9 @@ export function tzMenuLabel(zone: string, location: string): string {
     return `(${tzOffset(zone)}) ${location}`;
 }
 
-/** A zone's display location: the catalog label, else its IANA city segment. */
-function tzLocation(zone: string): string {
-    const entry = TIMEZONES.find((t) => t.value === normalizeTimezone(zone));
-    return entry?.label ?? (zone.split('/').pop() ?? zone).replace(/_/g, ' ');
-}
-
-/** Compact label for the bottom-bar button ("UTC", "UTC+2 Paris"). */
+/** Compact label for the bottom-bar button — just the offset ("UTC", "UTC+2", "UTC-9:30"). */
 export function tzButtonLabel(zone: string): string {
+    // Some ICU builds format Etc/UTC as "GMT+0" — fold that back to the bare "UTC".
     if (normalizeTimezone(zone) === 'Etc/UTC') return 'UTC';
-    return `${tzOffset(zone)} ${tzLocation(zone)}`;
+    return tzOffset(zone);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export type {
     IndicatorRenderHandle,
     CrosshairEvent,
     ClickEvent,
+    AxisLongPressEvent,
     InputChangeEvent,
     VisibleRange,
     DataWindowReadout,

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -5,6 +5,7 @@ import type {
     CrosshairEvent,
     CrosshairOHLC,
     ClickEvent,
+    AxisLongPressEvent,
     InputChangeEvent,
     VisibleRange,
     IndicatorStatus,
@@ -80,12 +81,13 @@ const TIME_AXIS_H = 22; // px reserved at the bottom for the time axis
 // ── "scroll to most recent bar" affordance (bottom-right, shown only when the latest bar is off-screen and the cursor is nearby) ──
 // Size/border match the playground drawing-toolbar collapse toggle (`.toolbar-toggle`).
 const SCROLL_BTN_SIZE = 26; // px — width & height (`.toolbar-toggle`)
+const SCROLL_BTN_SIZE_TOUCH = 24; // px — the mobile variant; a hair under the desktop affordance
 const SCROLL_BTN_RADIUS = 5; // px — border-radius (`.toolbar-toggle`)
 const SCROLL_BTN_SHADOW = '0 2px 8px rgba(0,0,0,0.4)'; // box-shadow (`.toolbar-toggle`)
 const SCROLL_BTN_ICON_PX = 12; // px — icon box (`.toolbar-toggle` font-size / FA glyph size)
-const SCROLL_BTN_RIGHT_INSET = 25; // px the button sits left of the price-axis gutter's inner edge
+const SCROLL_BTN_RIGHT_INSET = 12; // px the button sits left of the price-axis gutter's inner edge
 const SCROLL_BTN_RIGHT = RIGHT_AXIS_W + SCROLL_BTN_RIGHT_INSET; // initial offset (single-column scale); widened at runtime for merged scales
-const SCROLL_BTN_BOTTOM = TIME_AXIS_H + 30; // px from the plot's bottom edge — a row above the settings gear so they never overlap
+const SCROLL_BTN_BOTTOM = TIME_AXIS_H + 14; // px from the plot's bottom edge — the corner slot also used by the opt-in `settings` gear (off by default)
 const SCROLL_BTN_PROXIMITY_PX = 120; // the button reveals only while the cursor is within this radius of its center
 const MIN_VISIBLE_BARS = 2; // never zoom/pan so far that fewer than this many candles stay on screen (the only pan limit)
 const ZOOM_OUT_MARGIN_BARS = 6; // breathing room at max zoom-out: all bars + this margin fill the width (no thin strip)
@@ -171,6 +173,8 @@ export class NativeRenderer implements IChartRenderer {
     private indicatorValuesOn = true;
     /** Host-contributed legend actions — held here so a rebuild of the legend re-wires them. */
     private legendActionsProvider: ((indicatorId: string) => LegendActionView[]) | null = null;
+    /** Host override of the legend's fold toggle — held here so a remount re-applies it. */
+    private legendOverviewAction: (() => void) | null = null;
     // ── keyboard navigation / accessibility (item 11) ──
     private keyboard: KeyboardController | null = null;
     private keyboardEnabled = true;
@@ -263,6 +267,9 @@ export class NativeRenderer implements IChartRenderer {
     // pane carries merged (own-scale) columns; the constant only clears a single-column scale.
     private scrollBtnRightPx = SCROLL_BTN_RIGHT;
 
+    // ── chrome size class (pushed by the host shell; see IChartRenderer.setLayoutMode) ──
+    private layoutMode: 'mobile' | 'desktop' = 'desktop';
+
     private readonly viewportCbs = new Set<(r: VisibleRange) => void>();
     private readonly crosshairCbs = new Set<(e: CrosshairEvent) => void>();
     private readonly chartTypeSettingsCbs = new Set<(typeId: string, values: Record<string, unknown>) => void>();
@@ -273,6 +280,7 @@ export class NativeRenderer implements IChartRenderer {
     private factoryConfig: ChartConfig | null = null;
     private hostSettingsSections: HostSettingsSection[] = [];
     private readonly clickCbs = new Set<(e: ClickEvent) => void>();
+    private readonly axisLongPressCbs = new Set<(e: AxisLongPressEvent) => void>();
     private readonly inputChangeCbs = new Set<(e: InputChangeEvent) => void>();
     private readonly removeIndicatorCbs = new Set<(id: string) => void>();
     private readonly toggleVisibleCbs = new Set<(id: string, visible: boolean) => void>();
@@ -903,7 +911,10 @@ export class NativeRenderer implements IChartRenderer {
     /** Port surface: hosts (bottom-bar / chrome buttons) open the same dialog as the
      *  in-chart gear — created on demand, independent of the gear feature being enabled. */
     openSettingsDialog(section?: string): void {
-        if (!this.settingsDialog && this.plot) this.settingsDialog = new SettingsDialog(this.dialogHost ?? this.plot, this.theme);
+        if (!this.settingsDialog && this.plot) {
+            this.settingsDialog = new SettingsDialog(this.dialogHost ?? this.plot, this.theme);
+            this.settingsDialog.setLayoutMode(this.layoutMode);
+        }
         this.toggleSettingsDialog(section);
     }
 
@@ -1022,11 +1033,18 @@ export class NativeRenderer implements IChartRenderer {
         this.updateScrollToRealtimeButton();
     };
 
-    /** Show the button only when the latest bar is scrolled off the right edge AND the cursor is nearby. */
+    /** Show the button only when the latest bar is scrolled off the right edge. On desktop the
+     *  cursor must also be nearby (hover reveal); on mobile — no hovering cursor — the button
+     *  appears whenever the latest bars are off-screen and hides again once the view is back
+     *  at the right edge. */
     private updateScrollToRealtimeButton(): void {
         const btn = this.scrollButton;
         if (!btn) return;
         const latestOffScreen = this.coords.barCount > 0 && this.coords.getViewport().rightOffset < 0;
+        if (this.layoutMode === 'mobile') {
+            btn.style.display = latestOffScreen ? 'flex' : 'none';
+            return;
+        }
         btn.style.display = latestOffScreen && this.pointerNearScrollBtn ? 'flex' : 'none';
     }
 
@@ -1267,6 +1285,9 @@ export class NativeRenderer implements IChartRenderer {
             fling: (v) => this.fling(v),
             onPointerMove: (x, y) => this.handlePointerMove(x, y),
             onClick: (x) => this.handleClick(x),
+            onAxisLongPress: (axis, x, y) => {
+                for (const cb of this.axisLongPressCbs) cb({ axis, x, y });
+            },
             beginPriceScale: (x, y) => this.beginPriceScale(x, y),
             priceScaleBy: (dy) => this.priceScaleBy(dy),
             beginPricePan: (y) => this.beginPricePan(y),
@@ -1322,6 +1343,15 @@ export class NativeRenderer implements IChartRenderer {
             setToolbarGutter: (px) => this.setToolbarGutter(px),
         });
         this.userDrawings.historyChords = this.historyChordsEnabled; // may be set before init()
+        // Honor a layout mode pushed before mount (the shell may set it ahead of the chart build).
+        if (this.layoutMode === 'mobile') {
+            this.mountContainer?.setAttribute('data-vela-layout', this.layoutMode);
+            this.userDrawings.setLayoutMode(this.layoutMode);
+            if (this.scrollButton) {
+                this.scrollButton.style.width = `${SCROLL_BTN_SIZE_TOUCH}px`;
+                this.scrollButton.style.height = `${SCROLL_BTN_SIZE_TOUCH}px`;
+            }
+        }
 
         this.keyboard = new KeyboardController({
             panByBars: (bars) => this.panByBars(bars),
@@ -1336,11 +1366,13 @@ export class NativeRenderer implements IChartRenderer {
         this.setKeyboardEnabled(this.keyboardEnabled); // accessible by default; wires focus + ARIA
 
         this.inputsUI = new InputsUI(this.plot, theme, (paneId) => this.paneBoundsFor(paneId));
+        this.inputsUI.setLayoutMode(this.layoutMode);
         this.inputsUI.setTitlesVisible(this.indicatorTitlesOn); // a remount keeps the toggle state
         this.inputsUI.setValuesVisible(this.indicatorValuesOn);
         this.inputsUI.setDialogHost(this.dialogHost);
         this.inputsUI.setSymbolPicker(this.symbolPicker);
         this.inputsUI.setLegendActions(this.legendActionsProvider);
+        this.inputsUI.setLegendOverviewAction(this.legendOverviewAction);
         this.inputsUI.setOnChange((c) => {
             for (const cb of this.inputChangeCbs) cb({ indicatorId: c.indicatorId, key: c.key, value: c.value });
         });
@@ -1888,6 +1920,15 @@ export class NativeRenderer implements IChartRenderer {
         this.inputsUI?.setLegendActions(provider);
     }
 
+    setLegendOverviewAction(action: (() => void) | null): void {
+        this.legendOverviewAction = action;
+        this.inputsUI?.setLegendOverviewAction(action);
+    }
+
+    openIndicatorSettings(indicatorId: string): void {
+        this.inputsUI?.openSettingsFor(indicatorId);
+    }
+
     /**
      * Hide/show a mounted indicator. Hiding drops its model from the scene (so every paint path —
      * series, fills, drawings, tables, glow, data window — skips it) while keeping its z key and its
@@ -1949,6 +1990,26 @@ export class NativeRenderer implements IChartRenderer {
         return () => this.removeIndicatorCbs.delete(cb);
     }
 
+    /** Port surface: the host shell's chrome size class. Mobile switches the renderer
+     *  chrome to its touch-first presentation — fullscreen dialogs, no docked drawing
+     *  toolbar (the shell provides its own picker), the scroll-to-latest button shown
+     *  whenever the latest bars are off-screen (touch has no cursor proximity). */
+    setLayoutMode(mode: 'mobile' | 'desktop'): void {
+        if (mode === this.layoutMode) return;
+        this.layoutMode = mode;
+        this.mountContainer?.setAttribute('data-vela-layout', mode);
+        this.userDrawings?.setLayoutMode(mode);
+        this.settingsDialog?.setLayoutMode(mode);
+        this.inputsUI?.setLayoutMode(mode);
+        if (this.scrollButton) {
+            // A finger needs a larger target than a cursor.
+            const px = mode === 'mobile' ? SCROLL_BTN_SIZE_TOUCH : SCROLL_BTN_SIZE;
+            this.scrollButton.style.width = `${px}px`;
+            this.scrollButton.style.height = `${px}px`;
+        }
+        this.updateScrollToRealtimeButton();
+    }
+
     setSettingsSections(sections: HostSettingsSection[]): void {
         this.hostSettingsSections = sections;
         this.settingsDialog?.setHostSections(sections);
@@ -1977,6 +2038,11 @@ export class NativeRenderer implements IChartRenderer {
     onClick(cb: (e: ClickEvent) => void): Unsubscribe {
         this.clickCbs.add(cb);
         return () => this.clickCbs.delete(cb);
+    }
+
+    onAxisLongPress(cb: (e: AxisLongPressEvent) => void): Unsubscribe {
+        this.axisLongPressCbs.add(cb);
+        return () => this.axisLongPressCbs.delete(cb);
     }
 
     onViewportChange(cb: (range: VisibleRange) => void): Unsubscribe {

--- a/src/renderers/native/chrome/AttributionMark.ts
+++ b/src/renderers/native/chrome/AttributionMark.ts
@@ -56,7 +56,23 @@ const CSS = `
     max-width: 240px;
     opacity: 1;
     transform: translateX(0);
-}`;
+}
+/* Mobile: a hair smaller so the mark doesn't dominate a phone-width plot. Keyed on the
+   renderer's own container attribute (data-vela-layout) AND the shell root's
+   (data-layout): the workspace's single grid-wide mark lives OUTSIDE any renderer
+   container, so only the shell attribute reaches it. */
+[data-vela-layout='mobile'] .vela-attribution .vela-attr-symbol svg,
+[data-layout='mobile'] .vela-attribution .vela-attr-symbol svg { height: 22px; }
+[data-vela-layout='mobile'] .vela-attribution .vela-attr-wordmark,
+[data-layout='mobile'] .vela-attribution .vela-attr-wordmark {
+    top: 2px;
+    transform: translateX(-6px);
+}
+[data-vela-layout='mobile'] .vela-attribution .vela-attr-wordmark svg,
+[data-layout='mobile'] .vela-attribution .vela-attr-wordmark svg { height: 21px; }
+[data-vela-layout='mobile'] .vela-attribution:hover .vela-attr-wordmark,
+[data-layout='mobile'] .vela-attribution:hover .vela-attr-wordmark { transform: translateX(0); }
+`;
 
 function ensureStyles(doc: Document): void {
     let s = doc.getElementById(STYLE_ID) as HTMLStyleElement | null;

--- a/src/renderers/native/chrome/ChromeRenderer.ts
+++ b/src/renderers/native/chrome/ChromeRenderer.ts
@@ -397,11 +397,29 @@ export class ChromeRenderer {
         const y = dataH + (fullH - dataH) / 2;
         const tr = coords.visibleTimeRange();
         const offset = tzOffsetMs((tr.from + tr.to) / 2, scene.timezone);
-        for (const tick of timeTicks(tr.from, tr.to, 8, offset)) {
-            const x = coords.timeToX(tick.time);
-            if (x < 20 || x > dataW - 20) continue;
-            ctx.fillText(tick.label, x, y);
-        }
+        // Width-adaptive density so a narrow surface — a phone, a multi-chart cell —
+        // asks for fewer ticks instead of cramming the default eight. The floor of 3
+        // keeps a narrow axis populated (a too-small target snaps the ladder to a huge
+        // step whose few ticks can all miss the frame); the collision pass below is
+        // what actually prevents overlap.
+        const target = Math.max(3, Math.min(8, Math.floor(dataW / 64)));
+        const ticks = timeTicks(tr.from, tr.to, target, offset)
+            .map((tick) => ({ ...tick, x: coords.timeToX(tick.time), half: ctx.measureText(tick.label).width / 2 }))
+            .filter((tick) => tick.x >= 20 && tick.x <= dataW - 20);
+        // Measured collision pass on top: label pitch in PIXELS isn't uniform (bar-index
+        // mapping, session gaps), so overlapping labels are SKIPPED, majors placed first
+        // (a date beats the 12:00 beside it).
+        const GAP = 12; // min px between neighboring labels
+        const placed: Array<{ l: number; r: number }> = [];
+        const put = (tick: { x: number; half: number; label: string }): void => {
+            const l = tick.x - tick.half;
+            const r = tick.x + tick.half;
+            if (!placed.every((p) => r + GAP <= p.l || l - GAP >= p.r)) return;
+            placed.push({ l, r });
+            ctx.fillText(tick.label, tick.x, y);
+        };
+        for (const tick of ticks) if (tick.major) put(tick);
+        for (const tick of ticks) if (!tick.major) put(tick);
         ctx.textAlign = 'start';
     }
 }

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -143,6 +143,30 @@ function ensureControlStyles(): void {
    muted and non-interactive. Applied to each row's children so it survives display:contents;
    !important beats the inline opacity on labels. */
 .vela-sd-soft>*{opacity:0.4 !important;pointer-events:none !important;}
+/* ── mobile presentation (.vela-sd-mobile on the scrim; structural sizes are inline in open()) ──
+   The tab rail becomes a burger-opened overlay sidebar; the group TOC becomes a sticky
+   row of horizontally scrollable tabs; the instance strip scrolls instead of wrapping;
+   controls grow to touch size and labels may wrap (the grid gives them a flexible track). */
+.vela-sd-mobile .vela-sd-burger{cursor:pointer;display:inline-flex;align-items:center;justify-content:center;background:transparent;border:none;color:var(--vela-fg);line-height:0;width:36px;height:36px;border-radius:var(--vela-radius-sm);margin-right:2px;}
+.vela-sd-mobile .vela-sd-burger:active{background:var(--vela-hover);}
+.vela-sd-mobile .vela-sd-railscrim{position:absolute;inset:0;z-index:2;background:var(--vela-backdrop);display:none;}
+.vela-sd-mobile .vela-sd-railscrim.open{display:block;}
+.vela-sd-mobile .vela-sd-rail{position:absolute;left:0;top:0;bottom:0;z-index:3;width:min(240px,80%);box-sizing:border-box;background:var(--vela-surface);border-right:1px solid var(--vela-border);box-shadow:var(--vela-shadow-dialog);transform:translateX(-105%);transition:transform var(--vela-dur-med) var(--vela-ease);}
+.vela-sd-mobile .vela-sd-rail.open{transform:translateX(0);}
+.vela-sd-mobile .vela-sd-tab{padding:12px;}
+.vela-sd-mobile .vela-sd-struct{flex-direction:column;padding-top:8px;}
+.vela-sd-mobile .vela-sd-toc{position:sticky;top:0;z-index:1;background:var(--vela-surface);flex-direction:row;overflow-x:auto;scrollbar-width:none;min-width:0;width:100%;box-sizing:border-box;gap:4px;padding:2px 0 8px;}
+.vela-sd-mobile .vela-sd-toc::-webkit-scrollbar{display:none;}
+.vela-sd-mobile .vela-sd-toc-btn{flex:none;padding:8px 12px;font-size:13px;}
+.vela-sd-mobile .vela-sd-struct>[data-sd-rows-host]{border-left:none;padding-left:0;width:100%;}
+.vela-sd-mobile .vela-sd-itabs{flex-wrap:nowrap;overflow-x:auto;scrollbar-width:none;}
+.vela-sd-mobile .vela-sd-itabs::-webkit-scrollbar{display:none;}
+.vela-sd-mobile .vela-sd-itab{height:36px;flex:none;}
+.vela-sd-mobile .vela-sd-check{width:22px;height:22px;}
+.vela-sd-mobile .vela-sd-select,.vela-sd-mobile .vela-sd-number{height:34px;}
+.vela-sd-mobile .vela-sd-close{width:40px;height:40px;}
+.vela-sd-mobile .vela-sd-btn{height:38px;}
+.vela-sd-mobile .vela-sd-row span,.vela-sd-mobile .vela-sd-bool span{white-space:normal !important;}
 `;
     document.head.appendChild(st);
 }
@@ -167,6 +191,8 @@ export class SettingsDialog {
     private readonly typeActiveGroup = new Map<string, string>();
     /** The tab currently shown, so a theme change (which rebuilds) lands back on it. */
     private activeSection: string | null = null;
+    /** Mobile chrome: fullscreen card, burger-opened section sidebar, TOC as top tabs. */
+    private mobileLayout = false;
 
     /** Host-app sections (e.g. the widget's Status line tab) — re-shown on next open. */
     setHostSections(sections: HostSettingsSection[]): void {
@@ -194,15 +220,29 @@ export class SettingsDialog {
 
     setTheme(theme: VelaTheme): void {
         this.theme = theme;
-        if (this.root) {
-            const cfg = this.config;
-            const oc = this.onChange;
-            const oi = this.onImport;
-            const orst = this.onReset;
-            const section = this.activeSection;
-            this.close();
-            if (cfg && oc) this.open(cfg, oc, oi ?? undefined, orst ?? undefined, section ?? undefined);
-        }
+        this.reopenIfLive();
+    }
+
+    /** The host shell's chrome size class — mobile presents the dialog fullscreen with
+     *  the tab rail behind a burger sidebar and the TOC as top tabs. An open dialog
+     *  re-presents in place, on the same tab. */
+    setLayoutMode(mode: 'mobile' | 'desktop'): void {
+        const mobile = mode === 'mobile';
+        if (mobile === this.mobileLayout) return;
+        this.mobileLayout = mobile;
+        this.reopenIfLive();
+    }
+
+    /** Rebuild an open dialog in place (theme swap, layout-mode flip) on the same tab. */
+    private reopenIfLive(): void {
+        if (!this.root) return;
+        const cfg = this.config;
+        const oc = this.onChange;
+        const oi = this.onImport;
+        const orst = this.onReset;
+        const section = this.activeSection;
+        this.close();
+        if (cfg && oc) this.open(cfg, oc, oi ?? undefined, orst ?? undefined, section ?? undefined);
     }
 
     isOpen(): boolean {
@@ -234,8 +274,15 @@ export class SettingsDialog {
         // remain fully readable while its settings are edited live; the scrim only exists
         // to catch the click-outside-to-close.
         ensureControlStyles();
+        const mobile = this.mobileLayout;
         const scrim = document.createElement('div');
         scrim.style.cssText = 'position:absolute;inset:0;z-index:21;display:flex;align-items:flex-start;justify-content:center;background:transparent;padding-top:8vh;pointer-events:auto;';
+        if (mobile) {
+            // Fullscreen presentation: the card fills the chart area edge to edge.
+            scrim.classList.add('vela-sd-mobile');
+            scrim.style.paddingTop = '0';
+            scrim.style.alignItems = 'stretch';
+        }
         scrim.addEventListener('mousedown', (e) => {
             if (e.target === scrim) this.close();
         });
@@ -247,12 +294,27 @@ export class SettingsDialog {
         // as wide as the rail + widest visible pane content needs, between a floor that keeps
         // sparse tabs from looking cramped and the old 720px cap.
         dlg.style.cssText = `width:fit-content;min-width:min(560px,94vw);max-width:min(720px,94vw);max-height:70vh;display:flex;flex-direction:column;background:${SETTINGS_SURFACE};border:1px solid ${SETTINGS_BORDER};border-radius:var(--vela-radius-lg);box-shadow:var(--vela-shadow-dialog);color:${SETTINGS_TEXT};font:13px var(--vela-font);overflow:hidden;cursor:default;`;
+        if (mobile) dlg.style.cssText += 'width:100%;min-width:0;max-width:none;max-height:none;flex:1 1 auto;border:none;border-radius:0;';
 
         const header = document.createElement('div');
         header.style.cssText = `display:flex;justify-content:space-between;align-items:center;padding:9px 9px 9px 16px;border-bottom:1px solid ${SETTINGS_BORDER};flex:0 0 auto;user-select:none;`;
+        if (mobile) header.style.paddingLeft = '8px';
         const hTitle = document.createElement('span');
         hTitle.textContent = 'Chart settings';
         hTitle.style.cssText = 'font-size:17px;font-weight:600;letter-spacing:0.2px;';
+        if (mobile) hTitle.style.cssText += 'flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+        // Mobile: the tab rail hides behind a burger-opened sidebar (there is no room for
+        // a permanent 170px column); the button lives left of the title, iOS-nav style.
+        let toggleRail: ((open?: boolean) => void) | null = null;
+        if (mobile) {
+            const burger = document.createElement('button');
+            burger.type = 'button';
+            burger.className = 'vela-sd-burger';
+            burger.innerHTML = iconAt('burger', 16);
+            burger.title = 'Sections';
+            burger.addEventListener('click', () => toggleRail?.());
+            header.append(burger);
+        }
         const closeBtn = document.createElement('button');
         closeBtn.type = 'button';
         closeBtn.innerHTML = iconAt('close', 15);
@@ -260,8 +322,10 @@ export class SettingsDialog {
         closeBtn.className = 'vela-sd-close';
         closeBtn.addEventListener('click', () => this.close());
         header.append(hTitle, closeBtn);
-        header.style.cursor = 'move';
-        {
+        if (!mobile) {
+            // Header dragging is a pointer affordance — a fullscreen mobile card has
+            // nowhere to move.
+            header.style.cursor = 'move';
             let sx = 0, sy = 0, ox = 0, oy = 0, dragging = false;
             header.addEventListener('pointerdown', (e) => {
                 // ANCESTRY, not identity: the button holds an SVG icon, so a press on the ✕
@@ -483,12 +547,30 @@ export class SettingsDialog {
 
         // ── Split the linear sections into a left tab rail + one pane per section ──
         const shell = document.createElement('div');
-        shell.style.cssText = 'display:flex;min-height:360px;max-height:calc(70vh - 100px);flex:1 1 auto;';
+        shell.style.cssText = mobile
+            ? 'display:flex;min-height:0;flex:1 1 auto;position:relative;overflow:hidden;'
+            : 'display:flex;min-height:360px;max-height:calc(70vh - 100px);flex:1 1 auto;';
         const rail = document.createElement('div');
-        rail.style.cssText = `flex:0 0 170px;display:flex;flex-direction:column;gap:2px;padding:10px 8px;border-right:1px solid ${SETTINGS_BORDER};overflow-y:auto;`;
+        rail.className = 'vela-sd-rail';
+        // Mobile: the class rules turn the rail into the slide-in sidebar; the inline
+        // styles here carry only its inner layout. Desktop keeps the fixed column.
+        rail.style.cssText = mobile
+            ? 'display:flex;flex-direction:column;gap:2px;padding:10px 8px;overflow-y:auto;'
+            : `flex:0 0 170px;display:flex;flex-direction:column;gap:2px;padding:10px 8px;border-right:1px solid ${SETTINGS_BORDER};overflow-y:auto;`;
+        let railScrim: HTMLElement | null = null;
+        if (mobile) {
+            railScrim = document.createElement('div');
+            railScrim.className = 'vela-sd-railscrim';
+            railScrim.addEventListener('click', () => toggleRail?.());
+            toggleRail = (open?: boolean) => {
+                const on = open ?? !rail.classList.contains('open');
+                rail.classList.toggle('open', on);
+                railScrim?.classList.toggle('open', on);
+            };
+        }
         const paneHost = document.createElement('div');
         paneHost.className = 'vela-sd-pane';
-        paneHost.style.cssText = 'flex:1;overflow-y:auto;padding:6px 18px 14px;';
+        paneHost.style.cssText = mobile ? 'flex:1;min-width:0;overflow-y:auto;padding:6px 14px calc(14px + env(safe-area-inset-bottom, 0px));' : 'flex:1;overflow-y:auto;padding:6px 18px 14px;';
 
         const panes: Array<{ title: string; el: HTMLElement; tab: HTMLButtonElement; style?: string; visibility?: string }> = [];
         let current: HTMLElement | null = null;
@@ -526,6 +608,11 @@ export class SettingsDialog {
                 p.tab.classList.toggle('on', i === idx);
             });
             this.activeSection = panes[idx]?.title ?? null;
+            if (mobile) {
+                // The header names the section (the rail is hidden); picking one closes the sidebar.
+                hTitle.textContent = panes[idx]?.title ?? 'Chart settings';
+                toggleRail?.(false);
+            }
         };
         panes.forEach((p, i) => {
             p.tab.addEventListener('click', () => activate(i));
@@ -544,6 +631,7 @@ export class SettingsDialog {
         this.syncTypeTabs?.(config.series.style);
 
         shell.append(rail, paneHost);
+        if (railScrim) shell.append(railScrim);
         dlg.appendChild(shell);
         dlg.appendChild(this.footer(config));
 
@@ -1011,6 +1099,17 @@ export class SettingsDialog {
      */
     private layoutSettingsGrids(pane: HTMLElement, measureHost: HTMLElement): void {
         if (pane.childElementCount === 0) return;
+        // Mobile: no measured label track — a fixed widest-label column would overflow a
+        // phone width. Labels get the flexible track (and may wrap), controls hug the
+        // right edge; no probe pass needed.
+        if (this.mobileLayout) {
+            const grid = document.createElement('div');
+            grid.style.cssText = 'display:grid;grid-template-columns:minmax(0,1fr) max-content;align-items:center;column-gap:12px;row-gap:16px;';
+            while (pane.firstChild) grid.appendChild(pane.firstChild);
+            pane.appendChild(grid);
+            this.prepareGridItems(grid);
+            return;
+        }
         const rows = [...pane.querySelectorAll('.vela-sd-row')] as HTMLElement[];
 
         // Clone labels into a visible host so hidden price-style groups still contribute

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -41,6 +41,9 @@ export interface InputControllerDeps {
     resetPaneSize(y: number): void;
     /** Double-click the time axis → fit the view to content (same as keyboard `0`). */
     resetView(): void;
+    /** Touch long-press on the price or time axis strip (the mobile substitute for a
+     *  right-click menu — host chrome opens a timezone / price-scale sheet). */
+    onAxisLongPress?(axis: 'price' | 'time', x: number, y: number): void;
 
     // ── user drawings (optional) — let the drawings layer claim a gesture before pan ──
     /** True when a press at (x,y) belongs to the drawings layer (armed tool, or over a drawing). */
@@ -70,6 +73,16 @@ export interface InputControllerDeps {
 const FLING_MIN_SPEED = 0.04; // px/ms below which a release is treated as a stop (no fling)
 const FLING_STALE_MS = 60; // if the last move is older than this at release, don't fling
 const DRAG_SLOP = 2; // px of motion before a press counts as a drag (vs a click)
+// ── touch gestures ──
+const LONG_PRESS_MS = 350; // touch hold before a data-area press becomes crosshair-inspect mode
+// A resting finger wobbles far more than a mouse: within this radius a hold still counts
+// as stationary (long-press keeps arming), beyond it the gesture is a pan.
+const TOUCH_SLOP = 8;
+// Two clean taps this close together (time and space) are a double-tap — the touch
+// dblclick. The browser never synthesizes dblclick here (the controller owns the touch
+// stream via touch-action:none), so the pairing is detected by hand.
+const DOUBLE_TAP_MS = 300;
+const DOUBLE_TAP_SLOP = 30;
 // Time-axis horizontal-zoom sensitivity: dragging left zooms in (e^(Δpx·k)). Kept low so
 // the zoom takes a deliberate, sizeable drag (~2× over ~170px) rather than a twitch.
 const TIME_SCALE_K = 0.004;
@@ -78,8 +91,10 @@ const TIME_SCALE_K = 0.004;
 const WHEEL_ZOOM_K = 0.0025;
 
 /** Which strip a gesture started over — the data plot, the right price axis, the bottom
- *  time axis, or a sub-pane separator (drag to resize the panes above/below it). */
-type DragRegion = 'data' | 'price' | 'time' | 'separator' | 'drawing';
+ *  time axis, a sub-pane separator (drag to resize the panes above/below it), or one of
+ *  the touch-only modes: a two-finger pinch, long-press crosshair inspection, or a
+ *  long-press that opened an axis sheet (no further drag for that gesture). */
+type DragRegion = 'data' | 'price' | 'time' | 'separator' | 'drawing' | 'pinch' | 'crosshair' | 'axis-sheet';
 
 /**
  * The logical bar + its pixel that a wheel-zoom keeps pinned. `right` (the default)
@@ -132,6 +147,23 @@ export function effectiveSnapMode(momentaryOverride: boolean, sticky: SnapMode):
     return momentaryOverride ? 'strong' : sticky;
 }
 
+/** The barSpacing a pinch has reached: the start spacing scaled by the finger-distance
+ *  ratio, clamped to the viewport's zoom bounds. `startDist` is floored at 1px so a
+ *  degenerate two-fingers-on-one-point start cannot divide by zero. */
+export function pinchBarSpacing(startBarSpacing: number, startDist: number, dist: number): number {
+    return clampBarSpacing(startBarSpacing * (dist / Math.max(1, startDist)));
+}
+
+/**
+ * The rightOffset that pins logical index `anchorLogical` at pixel `x` for a given
+ * effective pitch (barSpacing × spacing multiplier) — inverse of `logicalToX`. Pinning
+ * the pinch's start-midpoint logical at the LIVE midpoint x makes the bars track the
+ * fingers exactly: spread to zoom, drag both to pan, in one gesture.
+ */
+export function pinchPinnedRightOffset(anchorLogical: number, barCount: number, width: number, x: number, pxPerBar: number): number {
+    return anchorLogical - (barCount - 1) + (width - x) / pxPerBar;
+}
+
 /**
  * Translates pointer/wheel gestures into ViewportState + scale changes. A press in
  * the data area pans (`rightOffset`, instant) and — in manual-scale mode — also pans
@@ -169,15 +201,37 @@ export class InputController {
     // press/release re-shape the drawings preview with the pointer stationary.
     private cursorX = NaN;
     private cursorY = NaN;
+    // ── touch state ──
+    /** Live touch contacts (local coords) — two entries drive a pinch; extras are ignored. */
+    private readonly touches = new Map<number, { x: number; y: number }>();
+    private lpTimer: ReturnType<typeof setTimeout> | null = null;
+    private pinchStartDist = 1;
+    private pinchStartBarSpacing = 0;
+    private pinchAnchorLogical = 0;
+    // Last clean touch tap (for double-tap pairing). Time 0 = no pending first tap.
+    private lastTapT = 0;
+    private lastTapX = 0;
+    private lastTapY = 0;
 
     constructor(private readonly deps: InputControllerDeps) {}
 
     attach(el: HTMLElement): void {
         this.el = el;
+        // Own the touch stream: without this the browser converts a drag into page
+        // scroll (and a pinch into page zoom) before the chart sees coherent pointer
+        // events. Selection/callout off — a long-press means crosshair here. Guarded:
+        // headless fakes (unit tests) attach without a style object.
+        if (el.style !== undefined) {
+            el.style.touchAction = 'none';
+            el.style.userSelect = 'none';
+            el.style.setProperty('-webkit-user-select', 'none');
+            el.style.setProperty('-webkit-touch-callout', 'none');
+        }
         el.addEventListener('pointerdown', this.onDown);
         el.addEventListener('pointermove', this.onMove);
         el.addEventListener('pointerup', this.onUp);
         el.addEventListener('pointerleave', this.onLeave);
+        el.addEventListener('pointercancel', this.onCancel);
         el.addEventListener('dblclick', this.onDblClick);
         el.addEventListener('wheel', this.onWheel, { passive: false });
         // Middle-press companions: autoscroll starts on mousedown and Linux paste on
@@ -192,6 +246,10 @@ export class InputController {
         const win = el.ownerDocument?.defaultView;
         win?.addEventListener('keydown', this.onModifier);
         win?.addEventListener('keyup', this.onModifier);
+        // A touch long-press must never open a context menu over the chart (the hold
+        // means crosshair): swallow the synthesized event at the window capture phase,
+        // BEFORE any host/plugin contextmenu listener, while a touch gesture is live.
+        win?.addEventListener('contextmenu', this.onTouchContextMenu, true);
     }
 
     detach(): void {
@@ -200,16 +258,27 @@ export class InputController {
         const win = el.ownerDocument?.defaultView;
         win?.removeEventListener('keydown', this.onModifier);
         win?.removeEventListener('keyup', this.onModifier);
+        win?.removeEventListener('contextmenu', this.onTouchContextMenu, true);
         el.removeEventListener('pointerdown', this.onDown);
         el.removeEventListener('pointermove', this.onMove);
         el.removeEventListener('pointerup', this.onUp);
         el.removeEventListener('pointerleave', this.onLeave);
+        el.removeEventListener('pointercancel', this.onCancel);
         el.removeEventListener('dblclick', this.onDblClick);
         el.removeEventListener('wheel', this.onWheel);
         el.removeEventListener('mousedown', this.onMiddleGuard);
         el.removeEventListener('auxclick', this.onMiddleGuard);
+        this.cancelLongPress();
+        this.touches.clear();
         this.el = null;
     }
+
+    private readonly onTouchContextMenu = (e: MouseEvent): void => {
+        if (this.touches.size === 0) return;
+        if (!(e.target instanceof Node) || !this.el?.contains(e.target)) return;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+    };
 
     private readonly onMiddleGuard = (e: MouseEvent): void => {
         if (e.button === 1 && this.middleDeleted) e.preventDefault();
@@ -260,6 +329,18 @@ export class InputController {
         }
         if (e.button !== 0) return;
         const { x, y } = this.local(e);
+        if (e.pointerType === 'touch') {
+            // A second finger during a pan (or long-press crosshair) escalates to a
+            // pinch; during a claimed drawing/axis gesture — and beyond two contacts —
+            // extra fingers are ignored so they can't corrupt the gesture in flight.
+            if (this.touches.size === 1 && this.dragging && (this.region === 'data' || this.region === 'crosshair')) {
+                this.touches.set(e.pointerId, { x, y });
+                this.beginPinch(e);
+                return;
+            }
+            if (this.touches.size >= 1) return;
+            this.touches.set(e.pointerId, { x, y });
+        }
         this.deps.drawingsClearTransient?.(); // a finished ruler vanishes on the next press (pan still proceeds)
         this.dragging = true;
         this.moved = false;
@@ -290,11 +371,78 @@ export class InputController {
         if (this.region === 'price') this.deps.beginPriceScale(x, y);
         else if (this.region === 'separator') this.deps.beginPaneResize(y);
         else if (this.region === 'data') this.verticalPan = this.deps.beginPricePan(y);
+        // A stationary touch hold in the plot becomes crosshair inspection — the touch
+        // substitute for hovering (a finger can't hover, and a pan would move the view).
+        // On an axis strip the same hold opens the host's timezone / price-scale sheet
+        // (the mobile substitute for a right-click), unless the finger moves into a drag.
+        if (e.pointerType === 'touch' && (this.region === 'data' || this.region === 'price' || this.region === 'time')) {
+            this.startLongPress(x, y, this.region);
+        }
         this.lastX = x;
         this.lastT = e.timeStamp;
         this.vx = 0;
         this.capture(e.pointerId);
     };
+
+    /** Arm the long-press timer for a data-area → crosshair or axis → sheet hold;
+     *  movement past TOUCH_SLOP or a second finger cancels it. */
+    private startLongPress(x: number, y: number, region: 'data' | 'price' | 'time'): void {
+        this.cancelLongPress();
+        this.lpTimer = setTimeout(() => {
+            this.lpTimer = null;
+            if (!this.dragging || this.region !== region) return;
+            if (region === 'data') {
+                this.region = 'crosshair';
+                this.deps.onPointerMove(x, y);
+                return;
+            }
+            // Axis sheet: freeze the gesture so a later wobble cannot rescale/zoom.
+            this.region = 'axis-sheet';
+            this.moved = true; // not a click / not a pending drag
+            this.deps.onAxisLongPress?.(region, x, y);
+        }, LONG_PRESS_MS);
+    }
+
+    private cancelLongPress(): void {
+        if (this.lpTimer !== null) clearTimeout(this.lpTimer);
+        this.lpTimer = null;
+    }
+
+    /** Two fingers down: freeze the view and re-base the gesture as an anchored pinch. */
+    private beginPinch(e: PointerEvent): void {
+        this.cancelLongPress();
+        if (this.region === 'crosshair') this.deps.onPointerMove(null, null); // inspection ends; the pinch owns the gesture
+        const coords = this.deps.getCoords();
+        const vp = coords.getViewport();
+        this.deps.apply(vp); // freeze any in-flight fling/zoom before grabbing
+        const [a, b] = [...this.touches.values()] as [{ x: number; y: number }, { x: number; y: number }];
+        this.pinchStartDist = Math.max(1, Math.hypot(a.x - b.x, a.y - b.y));
+        this.pinchStartBarSpacing = vp.barSpacing;
+        this.pinchAnchorLogical = coords.xToLogical((a.x + b.x) / 2);
+        this.region = 'pinch';
+        this.dragging = true;
+        this.moved = true; // a pinch is never a click
+        this.vx = 0;
+        this.capture(e.pointerId);
+    }
+
+    /** Track both fingers: distance ratio zooms, the live midpoint pans (anchor pinned under it). */
+    private applyPinch(): void {
+        const coords = this.deps.getCoords();
+        const pts = [...this.touches.values()];
+        if (pts.length < 2) return;
+        const [a, b] = pts as [{ x: number; y: number }, { x: number; y: number }];
+        const barSpacing = pinchBarSpacing(this.pinchStartBarSpacing, this.pinchStartDist, Math.hypot(a.x - b.x, a.y - b.y));
+        // The spacing multiplier is constant through the gesture; derive it from the live
+        // effective pitch so the pin math matches logicalToX exactly.
+        const vp = coords.getViewport();
+        const pitchScale = vp.barSpacing > 0 ? coords.pxPerBar() / vp.barSpacing : 1;
+        const midX = (a.x + b.x) / 2;
+        this.deps.apply({
+            barSpacing,
+            rightOffset: pinchPinnedRightOffset(this.pinchAnchorLogical, coords.barCount, coords.width, midX, barSpacing * pitchScale),
+        });
+    }
 
     /** Capture defensively: a synthetic/already-released pointer can't be captured, and
      *  the move/up pair still routes through the element listeners without it. */
@@ -310,6 +458,20 @@ export class InputController {
         const { x, y } = this.local(e);
         this.cursorX = x;
         this.cursorY = y;
+        if (e.pointerType === 'touch' && this.touches.has(e.pointerId)) this.touches.set(e.pointerId, { x, y });
+        if (this.dragging && this.region === 'pinch') {
+            this.applyPinch();
+            return; // no crosshair while pinching — two fingers name no single point
+        }
+        if (this.dragging && this.region === 'crosshair') {
+            this.deps.onPointerMove(x, y); // inspect: the finger drives the crosshair, the view stays put
+            return;
+        }
+        if (this.dragging && this.region === 'axis-sheet') {
+            return; // sheet already opened — ignore further motion for this gesture
+        }
+        // Once a touch travels past the wobble slop it is a pan, not a nascent long-press.
+        if (this.lpTimer !== null && Math.hypot(x - this.startX, y - this.startY) > TOUCH_SLOP) this.cancelLongPress();
         if (this.dragging) {
             if (this.region === 'price') {
                 if (Math.abs(y - this.startY) > DRAG_SLOP) this.moved = true;
@@ -361,6 +523,37 @@ export class InputController {
     };
 
     private readonly onUp = (e: PointerEvent): void => {
+        if (e.pointerType === 'touch') this.touches.delete(e.pointerId);
+        this.cancelLongPress();
+        if (this.dragging && this.region === 'pinch') {
+            if (this.touches.size === 1) {
+                // One finger lifted: the survivor continues as a plain pan, re-based at
+                // its current position so the view doesn't jump.
+                const rest = [...this.touches.values()][0]!;
+                const vp = this.deps.getCoords().getViewport();
+                this.region = 'data';
+                this.verticalPan = false;
+                this.startX = rest.x;
+                this.startY = rest.y;
+                this.startRightOffset = vp.rightOffset;
+                this.startBarSpacing = vp.barSpacing;
+                this.lastX = rest.x;
+                this.lastT = e.timeStamp;
+                this.vx = 0;
+                return; // still dragging with the remaining finger
+            }
+            this.endGesture(e);
+            return;
+        }
+        if (this.dragging && this.region === 'crosshair') {
+            this.deps.onPointerMove(null, null); // no hover on touch — lifting the finger ends the readout
+            this.endGesture(e);
+            return;
+        }
+        if (this.dragging && this.region === 'axis-sheet') {
+            this.endGesture(e);
+            return;
+        }
         if (this.dragging && this.region === 'drawing') {
             const { x, y } = this.local(e);
             this.deps.drawingsPointerUp?.(x, y);
@@ -374,12 +567,51 @@ export class InputController {
                 this.deps.fling(-this.vx / pitch); // rightOffset velocity (logical/ms)
             }
         }
+        const wasTouch = e.pointerType === 'touch';
+        // A stationary touch release is a tap — feed the double-tap pairing (touch has
+        // no native dblclick here). Checked before endGesture clears the flags.
+        const wasTap = wasTouch && this.dragging && !this.moved;
+        this.endGesture(e);
+        // A finger leaves no resting cursor behind — clear the crosshair a pan/tap drew.
+        if (wasTouch) this.deps.onPointerMove(null, null);
+        if (wasTap) {
+            const { x, y } = this.local(e);
+            this.registerTap(e.timeStamp, x, y);
+        }
+    };
+
+    /** Pair clean taps into a double-tap — the touch equivalent of dblclick (same
+     *  routing: axis taps reset that axis' view, a plot tap toggles pane maximize). */
+    private registerTap(t: number, x: number, y: number): void {
+        const paired = this.lastTapT > 0 && t - this.lastTapT <= DOUBLE_TAP_MS && Math.hypot(x - this.lastTapX, y - this.lastTapY) <= DOUBLE_TAP_SLOP;
+        if (paired) {
+            this.lastTapT = 0; // a triple tap starts a fresh pair, not two doubles
+            this.doubleActivate(x, y);
+            return;
+        }
+        this.lastTapT = t;
+        this.lastTapX = x;
+        this.lastTapY = y;
+    }
+
+    private endGesture(e: PointerEvent): void {
         this.dragging = false;
         try {
             this.el?.releasePointerCapture(e.pointerId);
         } catch {
             // never captured (see capture()) or the pointer vanished — nothing to release
         }
+    }
+
+    /** The browser took the pointer back (system gesture, palm rejection, tab switch):
+     *  drop the gesture where it is — no click, no fling, no stuck `dragging`. */
+    private readonly onCancel = (e: PointerEvent): void => {
+        if (e.pointerType === 'touch') this.touches.delete(e.pointerId);
+        this.cancelLongPress();
+        if (!this.dragging) return;
+        if (this.region === 'drawing' && !Number.isNaN(this.cursorX)) this.deps.drawingsPointerUp?.(this.cursorX, this.cursorY);
+        if (this.region === 'crosshair' || e.pointerType === 'touch') this.deps.onPointerMove(null, null);
+        this.endGesture(e);
     };
 
     private readonly onLeave = (): void => {
@@ -390,6 +622,11 @@ export class InputController {
 
     private readonly onDblClick = (e: MouseEvent): void => {
         const { x, y } = this.local(e);
+        this.doubleActivate(x, y);
+    };
+
+    /** Shared double-click / double-tap routing, by the region under the point. */
+    private doubleActivate(x: number, y: number): void {
         // A drawing double-click opens its settings — suppress the view/scale reset.
         if (this.deps.drawingsDblClick?.(x, y)) return;
         const region = this.regionAt(x, y);
@@ -397,7 +634,7 @@ export class InputController {
         else if (region === 'separator') this.deps.resetPaneSize(y);
         else if (region === 'time') this.deps.resetView(); // fit-to-content on the time axis
         else this.deps.dataDblClick(x, y);
-    };
+    }
 
     private readonly onWheel = (e: WheelEvent): void => {
         e.preventDefault();

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -109,6 +109,9 @@ export class UserDrawingController implements IDrawingsRendererPort {
     private readonly measure = new MeasureOverlay(); // transient ruler — not a persistent drawing
     private toolbarVisible = false; // mirrors showToolbar (drives the gutter reservation)
     private toolbarCollapsed = false; // the bar is a slim expand-strip (narrower gutter)
+    /** Mobile chrome: the docked bar is suppressed (the shell provides its own tool
+     *  picker) while `toolbarVisible` keeps the host's INTENT for a later desktop flip. */
+    private mobileLayout = false;
     /** Self-serve Ctrl+Z / Ctrl+Y as drawing undo/redo. A host that owns a UNIFIED
      *  history (drawings + app ops in one timeline) turns this off so the chords
      *  bubble to its keymap instead — see the renderer's `historyChords` feature. */
@@ -177,13 +180,23 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     showToolbar(visible: boolean): void {
         this.toolbarVisible = visible;
-        this.toolbar.setVisible(visible);
+        this.toolbar.setVisible(visible && !this.mobileLayout);
         this.syncToolbarGutter(); // reserve/release the left gutter so the bar never overlaps the plot
+    }
+
+    /** Mobile suppresses the docked toolbar (hover flyouts don't work with touch; the
+     *  shell's own drawer picks tools instead) and releases its gutter; flipping back
+     *  to desktop restores whatever `showToolbar` last asked for. */
+    setLayoutMode(mode: 'mobile' | 'desktop'): void {
+        this.mobileLayout = mode === 'mobile';
+        this.toolbar.setVisible(this.toolbarVisible && !this.mobileLayout);
+        this.syncToolbarGutter();
     }
 
     /** The gutter follows the bar's current footprint: hidden 0, collapsed a slim strip, else full width. */
     private syncToolbarGutter(): void {
-        this.deps.setToolbarGutter(this.toolbarVisible ? (this.toolbarCollapsed ? TOOLBAR_COLLAPSED_WIDTH : TOOLBAR_WIDTH) : 0);
+        const shown = this.toolbarVisible && !this.mobileLayout;
+        this.deps.setToolbarGutter(shown ? (this.toolbarCollapsed ? TOOLBAR_COLLAPSED_WIDTH : TOOLBAR_WIDTH) : 0);
     }
 
     /** Core push: mirror (or clear) another chart's in-progress placement as a ghost. */

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -80,6 +80,7 @@ const GEAR_SVG = iconAt('gear', LEGEND_ICON_PX);
 const CLOSE_SVG = iconAt('close', 11);
 const FOLD_SVG = iconAt('chevron-up', LEGEND_ICON_PX);
 const UNFOLD_SVG = iconAt('chevron-down', LEGEND_ICON_PX);
+const OVERVIEW_SVG = iconAt('objects', LEGEND_ICON_PX);
 
 /**
  * Chart-style inputs UI built on top of lightweight-charts (which has no
@@ -108,6 +109,8 @@ export class InputsUI {
     private onToggleVisible: ((id: string, visible: boolean) => void) | null = null;
     /** Host symbol picker for `input.symbol`; when set the control opens the host's ticker UI. */
     private symbolPicker: SymbolPickerFn | null = null;
+    /** Mobile chrome: the inputs dialog opens fullscreen and the legends render compact. */
+    private mobileLayout = false;
     /** Pane move/merge hook — when set, rows get a "Move to" menu + become drag-to-pane sources. */
     private moveApi: LegendMoveApi | null = null;
     /** Host-contributed legend actions, resolved PER ROW at render time (see setLegendActions). */
@@ -137,6 +140,10 @@ export class InputsUI {
     /** The single fold toggle, on the price-pane legend: a bordered ^ chevron under the
      *  rows, or the bordered "˅ N" chip (N counts every pane's indicators) when folded. */
     private foldToggle: HTMLButtonElement | null = null;
+    /** Host-provided replacement for the fold toggle (multi-chart shells route it to
+     *  their indicator overview, e.g. an object tree). While set, the legend stays
+     *  folded and the chip runs this instead of unfolding inline. */
+    private overviewAction: (() => void) | null = null;
     /** Esc-to-close for the settings modal (bound so focus can sit anywhere). */
     private readonly onDialogKey = (e: KeyboardEvent): void => {
         if (e.key === 'Escape') {
@@ -171,6 +178,41 @@ export class InputsUI {
     ) {
         if (!container.style.position) container.style.position = 'relative';
         if (typeof document !== 'undefined') document.addEventListener('click', this.onDocClick);
+    }
+
+    /** The host shell's chrome size class — mobile makes the inputs dialog fullscreen
+     *  (an open dialog re-presents on the flip) and folds the legend behind its chip by
+     *  default (a phone-width plot has no room for the rows). */
+    setLayoutMode(mode: 'mobile' | 'desktop'): void {
+        const mobile = mode === 'mobile';
+        if (mobile === this.mobileLayout) return;
+        this.mobileLayout = mobile;
+        // The fold resets to the mode's presentation default on a flip — it is chrome
+        // presentation, not user state (an overview override keeps it folded either way).
+        if (this.overviewAction === null) this.legendFolded = mobile;
+        this.syncFoldToggle();
+        if (this.openId !== null) {
+            const id = this.openId;
+            this.closeOpenDialog();
+            this.openDialog(id);
+        }
+    }
+
+    /** Replace the fold toggle's behavior with a HOST action (or restore it with null):
+     *  the chip stays — objects icon + indicator count — but a press runs the action
+     *  (a multi-chart shell opens its indicator overview) instead of unfolding the rows,
+     *  which stay hidden while the override is in force. */
+    setLegendOverviewAction(action: (() => void) | null): void {
+        if (action === this.overviewAction) return;
+        this.overviewAction = action;
+        this.legendFolded = action !== null ? true : this.mobileLayout;
+        this.syncFoldToggle();
+    }
+
+    /** Open the settings dialog of one indicator (the legend gear's programmatic twin) —
+     *  no-op for an unknown id. */
+    openSettingsFor(id: string): void {
+        if (this.rows.has(id)) this.openDialog(id);
     }
 
     /** Attach a themed chrome tooltip to a control, recording its disposer under `id`. */
@@ -513,15 +555,21 @@ export class InputsUI {
      */
     private syncFoldToggle(): void {
         const count = this.rows.size;
-        if (count < 2) {
+        // Desktop earns the chevron at 2+ rows; mobile folds even a lone row behind the
+        // chip (the legend is collapsed by default there), and a host overview override
+        // needs the chip from the first row — it is the list's only entry point.
+        const minRows = this.overviewAction !== null || this.mobileLayout ? 1 : 2;
+        if (count < minRows) {
             const wasFolded = this.legendFolded;
-            this.legendFolded = false;
+            // Never strand a surviving row hidden behind a toggle that just disappeared;
+            // with no rows at all the fold keeps its default for the next indicator.
+            if (count > 0) this.legendFolded = false;
             if (this.foldToggle) {
                 this.foldToggle.remove();
                 this.foldToggle = null;
                 this.disposeTips(this.rowTips, 'fold');
             }
-            if (wasFolded) this.reposition(); // unhide the surviving row(s)
+            if (wasFolded && count > 0) this.reposition(); // unhide the surviving row(s)
             return;
         }
         let btn = this.foldToggle;
@@ -529,15 +577,19 @@ export class InputsUI {
             btn = document.createElement('button');
             btn.type = 'button';
             btn.className = 'vela-ind-fold';
-            this.tip(this.rowTips, 'fold', btn, () => (this.legendFolded ? 'Show indicator legend' : 'Hide indicator legend'));
+            this.tip(this.rowTips, 'fold', btn, () => (this.overviewAction !== null ? 'Indicators' : this.legendFolded ? 'Show indicator legend' : 'Hide indicator legend'));
             btn.addEventListener('click', () => {
+                if (this.overviewAction !== null) {
+                    this.overviewAction();
+                    return;
+                }
                 this.legendFolded = !this.legendFolded;
                 this.syncFoldToggle();
             });
             this.foldToggle = btn;
         }
         const folded = this.legendFolded;
-        btn.setAttribute('aria-label', folded ? 'Show indicator legend' : 'Hide indicator legend');
+        btn.setAttribute('aria-label', this.overviewAction !== null ? 'Indicators' : folded ? 'Show indicator legend' : 'Hide indicator legend');
         // Bordered chip in both states; folded shows chevron then the count to its right
         // (reference: "˅ 12"), expanded is just the up chevron that folds the list away.
         // Border uses the shared chrome token (same as menus/dialogs) — `--vela-fg-muted`
@@ -547,7 +599,9 @@ export class InputsUI {
         btn.replaceChildren();
         const icon = document.createElement('span');
         icon.style.cssText = 'display:inline-flex;align-items:center;line-height:0;';
-        icon.innerHTML = folded ? UNFOLD_SVG : FOLD_SVG;
+        // The overview override wears the list glyph — the chip opens the host's
+        // indicator overview rather than unfolding rows in place.
+        icon.innerHTML = this.overviewAction !== null ? OVERVIEW_SVG : folded ? UNFOLD_SVG : FOLD_SVG;
         btn.appendChild(icon);
         if (folded) {
             const label = document.createElement('span');
@@ -909,6 +963,8 @@ export class InputsUI {
         // the card is only as wide as the widest input row needs — no fixed width stretching the
         // full-width text area — while the cap + min keep it a sensible size.
         card.style.cssText = `display:flex;flex-direction:column;width:fit-content;min-width:min(360px,90%);max-width:min(640px,94%);max-height:82%;background:${t.background};border:1px solid ${border};border-radius:var(--vela-radius-lg);box-shadow:var(--vela-shadow-dialog);color:${fg};color-scheme:${scheme};font:13px ${font};overflow:hidden;`;
+        // Mobile: fullscreen, edge to edge — a floating card is unusable at phone widths.
+        if (this.mobileLayout) card.style.cssText += 'width:100%;min-width:0;max-width:none;height:100%;max-height:none;border:none;border-radius:0;';
         applyChromeTokens(card, t);
         // Keystrokes (typing in a field) must not reach the chart; let Esc bubble to the
         // document handler so it closes even when focus sits in an input.
@@ -930,7 +986,8 @@ export class InputsUI {
         closeBtn.addEventListener('click', () => this.closeDialog());
         header.append(hTitle, closeBtn);
         card.appendChild(header);
-        makeDialogDraggable(card, header, { closeSelector: 'button' });
+        // Dragging is a pointer affordance; a fullscreen mobile card has nowhere to go.
+        if (!this.mobileLayout) makeDialogDraggable(card, header, { closeSelector: 'button' });
 
         // ── Tab strip (Inputs) — full-width underline with the active tab underlined. ──
         const tabs = document.createElement('div');
@@ -954,7 +1011,11 @@ export class InputsUI {
                 section.appendChild(gh);
             }
             const grid = document.createElement('div');
-            grid.style.cssText = 'display:grid;grid-template-columns:minmax(140px,auto) auto auto 1fr;align-items:center;column-gap:12px;row-gap:22px;';
+            // Mobile keeps the same four tracks (row builders span across them) but gives
+            // the label the flexible, shrinkable one so nothing overflows a phone width.
+            grid.style.cssText = this.mobileLayout
+                ? 'display:grid;grid-template-columns:minmax(0,1fr) auto auto max-content;align-items:center;column-gap:12px;row-gap:22px;'
+                : 'display:grid;grid-template-columns:minmax(140px,auto) auto auto 1fr;align-items:center;column-gap:12px;row-gap:22px;';
             for (const inputRow of group.rows) this.buildInputRow(grid, inputRow, row);
             section.appendChild(grid);
             body.appendChild(section);

--- a/src/ui/components/dialog/styles.ts
+++ b/src/ui/components/dialog/styles.ts
@@ -68,4 +68,27 @@ export const DIALOG_CSS = `
     border: 2px solid transparent;
     background-clip: padding-box;
 }
+/* ── mobile chrome: dialogs fill the shell ─────────────────────────────────────────
+   Inside a shell in the mobile size class ([data-layout='mobile'] on the widget root,
+   which is position:relative) every kit dialog presents fullscreen: desktop cards are
+   unusable at phone widths, and the shell's bounds — not the viewport — are the honest
+   "screen" for an embedded chart. */
+[data-layout='mobile'] .vela-dialog-backdrop { position: absolute; }
+[data-layout='mobile'] .vela-dialog-positioner {
+    position: absolute;
+    padding: 0;
+    align-items: stretch;
+}
+[data-layout='mobile'] .vela-dialog {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    max-height: none;
+    flex: 1 1 auto;
+    border: none;
+    border-radius: 0;
+    transform: none !important; /* a desktop drag offset must not survive the flip */
+}
+[data-layout='mobile'] .vela-dialog-close { width: 40px; height: 40px; }
+[data-layout='mobile'] .vela-dialog-body { padding-bottom: calc(var(--vela-space-4) + env(safe-area-inset-bottom, 0px)); }
 `;

--- a/src/ui/components/drawer/controller.ts
+++ b/src/ui/components/drawer/controller.ts
@@ -1,0 +1,35 @@
+// Drawer CONTROLLER — a bottom sheet is a dialog with a different presentation, so it
+// rides the Zag dialog machine (focus trap, dismiss, ARIA) with drawer defaults: a
+// backdrop tap dismisses (the touch idiom the component exists for).
+import * as dialog from '@zag-js/dialog';
+import { nextUid, normalizeProps } from '../../zag';
+
+export interface DrawerControllerOptions {
+    closeOnEscape?: boolean;
+    /** Tap outside (on the backdrop) dismisses — default true. */
+    closeOnInteractOutside?: boolean;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export type DrawerService = dialog.Service;
+export type DrawerApi = dialog.Api;
+
+export interface DrawerController {
+    machine: typeof dialog.machine;
+    props: Partial<dialog.Props>;
+    connect(service: DrawerService): DrawerApi;
+}
+
+export function drawerController(opts: DrawerControllerOptions = {}): DrawerController {
+    return {
+        machine: dialog.machine,
+        props: {
+            id: nextUid('vela-drawer'),
+            modal: true,
+            closeOnEscape: opts.closeOnEscape ?? true,
+            closeOnInteractOutside: opts.closeOnInteractOutside ?? true,
+            onOpenChange: (d: dialog.OpenChangeDetails) => opts.onOpenChange?.(d.open),
+        } satisfies Partial<dialog.Props>,
+        connect: (service: DrawerService): DrawerApi => dialog.connect(service, normalizeProps),
+    };
+}

--- a/src/ui/components/drawer/index.ts
+++ b/src/ui/components/drawer/index.ts
@@ -1,0 +1,2 @@
+export { Drawer, type DrawerOptions } from './view';
+export { drawerController, type DrawerControllerOptions, type DrawerApi, type DrawerService } from './controller';

--- a/src/ui/components/drawer/styles.ts
+++ b/src/ui/components/drawer/styles.ts
@@ -1,0 +1,85 @@
+export const DRAWER_STYLE_ID = 'vela-ui-drawer';
+
+export const DRAWER_CSS = `
+.vela-drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--vela-backdrop);
+    z-index: var(--vela-z-dialog);
+}
+.vela-drawer-positioner {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    z-index: var(--vela-z-dialog);
+}
+/* Inside a shell that declares a size class, the sheet scopes to the SHELL's bounds
+   (the widget root is position:relative) instead of the whole viewport — an embedded
+   chart must not curtain the host page. */
+[data-layout] .vela-drawer-backdrop, [data-layout] .vela-drawer-positioner { position: absolute; }
+.vela-drawer {
+    background: var(--vela-surface);
+    color: var(--vela-fg);
+    border: 1px solid var(--vela-border-strong);
+    border-bottom: none;
+    border-radius: 14px 14px 0 0;
+    box-shadow: var(--vela-shadow-dialog);
+    font-size: 13px;
+    width: 100%;
+    max-height: 85%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    outline: none;
+}
+.vela-drawer[data-state='open'] { animation: vela-drawer-in var(--vela-dur-med) var(--vela-ease); }
+@keyframes vela-drawer-in {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
+}
+/* The grab zone owns its touches (drag-to-dismiss), so the browser must not scroll it. */
+.vela-drawer-grab {
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 0 6px;
+    cursor: grab;
+    touch-action: none;
+    user-select: none;
+}
+.vela-drawer-grab::before {
+    content: '';
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--vela-border-strong);
+}
+.vela-drawer-title {
+    flex: none;
+    padding: 0 16px 10px;
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    color: var(--vela-fg-bright);
+    user-select: none;
+}
+.vela-drawer-title:empty { display: none; }
+.vela-drawer-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    padding: 0 var(--vela-space-3) calc(var(--vela-space-3) + env(safe-area-inset-bottom, 0px));
+}
+.vela-drawer-body::-webkit-scrollbar { width: 8px; }
+.vela-drawer-body::-webkit-scrollbar-thumb {
+    background: var(--vela-scroll);
+    border-radius: 4px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+}
+`;

--- a/src/ui/components/drawer/view.ts
+++ b/src/ui/components/drawer/view.ts
@@ -1,0 +1,124 @@
+// Drawer VIEW — a bottom sheet: dimmed backdrop, a panel that slides up from the host's
+// bottom edge, a grab handle with drag-to-dismiss. The body is caller-owned. Built for
+// the mobile chrome, but host-agnostic like every kit component.
+import { runMachine, spreadProps, type HandleOf } from '../../zag';
+import { injectStyles } from '../../styles';
+import { drawerController, type DrawerControllerOptions } from './controller';
+import { DRAWER_CSS, DRAWER_STYLE_ID } from './styles';
+import * as zagDialog from '@zag-js/dialog';
+
+/** Drag past this fraction of the sheet's height (or this many px, whichever is
+ *  smaller) and the release dismisses; anything less springs back. */
+const DISMISS_FRACTION = 0.33;
+const DISMISS_PX = 96;
+
+export interface DrawerOptions extends DrawerControllerOptions {
+    title?: string;
+    content?: Node | ((body: HTMLElement) => void);
+    host?: HTMLElement;
+}
+
+export class Drawer {
+    /** Caller-owned content area — append your rows/lists here. */
+    readonly body: HTMLElement;
+    private readonly backdrop: HTMLElement;
+    private readonly positioner: HTMLElement;
+    private readonly panel: HTMLElement;
+    private readonly titleEl: HTMLElement;
+    private readonly handle: HandleOf<typeof zagDialog.machine>;
+    private readonly ctrl: ReturnType<typeof drawerController>;
+
+    constructor(opts: DrawerOptions = {}) {
+        const doc = (opts.host ?? document.body).ownerDocument;
+        injectStyles(DRAWER_STYLE_ID, DRAWER_CSS, doc);
+        const host = opts.host ?? doc.body;
+
+        this.backdrop = doc.createElement('div');
+        this.backdrop.className = 'vela-drawer-backdrop vela-ui-layer';
+        this.positioner = doc.createElement('div');
+        this.positioner.className = 'vela-drawer-positioner vela-ui-layer';
+        this.panel = doc.createElement('div');
+        this.panel.className = 'vela-drawer';
+
+        const grab = doc.createElement('div');
+        grab.className = 'vela-drawer-grab';
+        this.titleEl = doc.createElement('div');
+        this.titleEl.className = 'vela-drawer-title';
+        this.titleEl.textContent = opts.title ?? '';
+
+        this.body = doc.createElement('div');
+        this.body.className = 'vela-drawer-body';
+        if (opts.content instanceof Node) this.body.appendChild(opts.content);
+        else if (typeof opts.content === 'function') opts.content(this.body);
+
+        this.panel.append(grab, this.titleEl, this.body);
+        this.positioner.appendChild(this.panel);
+        host.append(this.backdrop, this.positioner);
+        this.wireDragToDismiss(grab);
+
+        this.ctrl = drawerController(opts);
+        const mid = String(this.ctrl.props.id);
+        this.handle = runMachine(this.ctrl.machine, this.ctrl.props, (service) => {
+            const api = this.ctrl.connect(service);
+            spreadProps(this.backdrop, api.getBackdropProps(), mid);
+            spreadProps(this.positioner, api.getPositionerProps(), mid);
+            spreadProps(this.panel, api.getContentProps(), mid);
+            spreadProps(this.titleEl, api.getTitleProps(), mid);
+            // Dialog-family machines expect conditional rendering (no `hidden` in the
+            // props) — the view toggles visibility from `api.open` itself.
+            this.backdrop.style.display = api.open ? '' : 'none';
+            this.positioner.style.display = api.open ? '' : 'none';
+        });
+    }
+
+    /** Pull the sheet down by its handle; past the threshold the release dismisses. */
+    private wireDragToDismiss(grab: HTMLElement): void {
+        let startY = 0;
+        let dy = 0;
+        let dragging = false;
+        grab.addEventListener('pointerdown', (e) => {
+            dragging = true;
+            startY = e.clientY;
+            dy = 0;
+            this.panel.style.transition = 'none';
+            grab.setPointerCapture(e.pointerId);
+        });
+        grab.addEventListener('pointermove', (e) => {
+            if (!dragging) return;
+            dy = Math.max(0, e.clientY - startY);
+            this.panel.style.transform = dy > 0 ? `translateY(${dy}px)` : '';
+        });
+        const settle = (): void => {
+            if (!dragging) return;
+            dragging = false;
+            this.panel.style.transition = '';
+            this.panel.style.transform = '';
+            const threshold = Math.min(DISMISS_PX, this.panel.getBoundingClientRect().height * DISMISS_FRACTION);
+            if (dy >= threshold) this.hide();
+        };
+        grab.addEventListener('pointerup', settle);
+        grab.addEventListener('pointercancel', settle);
+    }
+
+    setTitle(title: string): void {
+        this.titleEl.textContent = title;
+    }
+
+    get open(): boolean {
+        return this.ctrl.connect(this.handle.service).open;
+    }
+
+    show(): void {
+        this.ctrl.connect(this.handle.service).setOpen(true);
+    }
+
+    hide(): void {
+        this.ctrl.connect(this.handle.service).setOpen(false);
+    }
+
+    destroy(): void {
+        this.handle.stop();
+        this.backdrop.remove();
+        this.positioner.remove();
+    }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -9,3 +9,4 @@ export { KeymapManager, type KeyBindingDescriptor, type ResolvedBinding, type Ke
 export * from './components/tooltip';
 export * from './components/menu';
 export * from './components/dialog';
+export * from './components/drawer';

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -16,17 +16,28 @@ import { isEditableTarget, KeymapManager } from '../ui/keymap';
 import { Topbar } from './topbar';
 import { Statusline, statuslineInkOf } from './statusline';
 import { Watermark } from './watermark';
-import { Bottombar, type RangePreset } from './bottombar';
+import { Bottombar, RANGE_PRESETS, type RangePreset } from './bottombar';
 import { SymbolPicker } from './symbol-picker';
 import { ObjectTree } from './object-tree';
 import { DataWindow } from './data-window';
 import { PanelDock } from './panel-dock';
 import { ShortcutsHelp } from './shortcuts-help';
 import { ChartContextMenu } from './context-menu';
-import { widgetAttachments, resolveEngines, legendActionsProviderFor, type WidgetContext } from './contributions';
+import { widgetAttachments, widgetActions, resolveEngines, legendActionsProviderFor, type WidgetContext } from './contributions';
 import { IndicatorPicker } from './indicator-picker';
 import { TimeframeQuick } from './timeframe-quick';
 import { parsePersisted, legacyWidgetState, localStorageAdapter, type VelaStorage } from './persist';
+import { LayoutModeController, type LayoutMode } from './layout-mode';
+import { MobileBar } from './mobile-bar';
+import { TimeframeDrawer } from './timeframe-drawer';
+import { DrawingsDrawer } from './drawings-drawer';
+import { MoreDrawer } from './more-drawer';
+import { TimezoneDrawer } from './timezone-drawer';
+import { PriceScaleDrawer } from './price-scale-drawer';
+import { DrawingPill } from './drawing-pill';
+import { buildToolbar } from '../core/drawings/toolbar';
+import { priceStyleLabel, priceStyleIcon } from './topbar';
+import { priceStyleIds } from '../renderers/native/core/chartConfig';
 import type { VelaShellOptions } from './shell-options';
 import { encodeState, decodeState, sanitizeState, prefixedSymbol, type WorkspaceState, type CellState } from '../state/document';
 import { parseSymbol } from '../data/ProviderRegistry';
@@ -52,8 +63,8 @@ const DEFAULT_TIMEFRAMES = ['1', '5', '15', '60', '240', 'D', 'W'];
 // workspace reusing the component gets them too); only the widget SHELL layout stays here.
 const WIDGET_STYLE_ID = 'vela-widget';
 const WIDGET_CSS = `
-.vela-widget { display: flex; flex-direction: column; width: 100%; height: 100%; background: var(--vela-bg); }
-.vela-widget-main { display: flex; flex-direction: row; flex: 1 1 auto; min-height: 0; }
+.vela-widget { position: relative; display: flex; flex-direction: column; width: 100%; height: 100%; background: var(--vela-bg); }
+.vela-widget-main { position: relative; display: flex; flex-direction: row; flex: 1 1 auto; min-height: 0; }
 .vela-widget-chart { position: relative; flex: 1 1 auto; min-width: 0; }
 `;
 
@@ -143,6 +154,21 @@ export class VelaWidget {
     private indicatorsPromise: Promise<ResolvedIndicator[]> | null = null;
     private destroyed = false;
     private buildSeq = 0;
+    /** The chrome size class — writes `data-layout` on the root (all mobile CSS keys
+     *  off it) and pushes the mode into the renderer chrome on every change/rebuild. */
+    private layoutCtl!: LayoutModeController;
+    // ── mobile chrome (CSS-gated on data-layout; the drawers build lazily on first open) ──
+    private readonly mobileBar: MobileBar | null;
+    private readonly drawingPill: DrawingPill;
+    private tfDrawer: TimeframeDrawer | null = null;
+    private drawingsDrawer: DrawingsDrawer | null = null;
+    private moreDrawer: MoreDrawer | null = null;
+    private timezoneDrawer: TimezoneDrawer | null = null;
+    private priceScaleDrawer: PriceScaleDrawer | null = null;
+    /** Plot-local y of the last price-axis long-press (targets the pane under the finger). */
+    private priceScalePressY = 0;
+    /** The active range chip id (both bottom bars + the timeframe drawer mirror it). */
+    private activeRangeId: string | null = null;
 
     constructor(container: HTMLElement | string, opts: VelaWidgetOptions) {
         const hostEl = typeof container === 'string' ? document.querySelector<HTMLElement>(container) : container;
@@ -300,8 +326,28 @@ export class VelaWidget {
                       onSettingsClick: () => this.inner?.renderer.openSettings(),
                   })
                 : null;
+        // The mobile bar is the bottom bar of the mobile size class — the same chrome
+        // toggle governs both; CSS (data-layout) decides which one is visible.
+        this.mobileBar =
+            opts.bottombar !== false
+                ? new MobileBar(this.root, {
+                      symbol: this.symbol,
+                      timeframe: this.timeframe,
+                      onSymbolClick: () => this.symbolPicker.open(),
+                      onTimeframeClick: () => this.openTimeframeDrawer(),
+                      onIndicatorsClick: () => this.indicatorPicker.open(),
+                      onDrawingsClick: () => this.openDrawingsDrawer(),
+                      onMoreClick: () => this.openMoreDrawer(),
+                      onSettingsClick: () => this.inner?.renderer.openSettings(),
+                  })
+                : null;
+        this.drawingPill = new DrawingPill(this.chartHost);
 
         hostEl.appendChild(this.root);
+
+        // Measured AFTER the root is in the DOM so the first evaluation sees a real width.
+        this.layoutCtl = new LayoutModeController(this.root, opts.layoutMode ?? 'auto');
+        this.layoutCtl.onChange((mode) => this.onLayoutModeChange(mode));
 
         this.keymap = new KeymapManager();
         this.keymap.attach(this.root);
@@ -375,6 +421,91 @@ export class VelaWidget {
         if (opts.autofocus) this.inner?.renderer.focus();
     }
 
+    /** The mode flipped (container resized across the breakpoint, or a coarse-pointer
+     *  change). Close the open surfaces — a desktop card must not linger over the
+     *  mobile chrome (and vice versa) — and re-present the renderer's own chrome. */
+    private onLayoutModeChange(mode: LayoutMode): void {
+        this.symbolPicker.close();
+        this.indicatorPicker.close();
+        this.tfDrawer?.close();
+        this.drawingsDrawer?.close();
+        this.moreDrawer?.close();
+        this.timezoneDrawer?.close();
+        this.priceScaleDrawer?.close();
+        this.inner?.renderer.closeDialogs();
+        this.inner?.renderer.setLayoutMode(mode);
+    }
+
+    // ── mobile drawers (built on first open; every list is read live at open time) ──
+
+    private openTimeframeDrawer(): void {
+        this.tfDrawer ??= new TimeframeDrawer({
+            host: this.root,
+            timeframes: this.opts.timeframes ?? DEFAULT_TIMEFRAMES,
+            ranges: RANGE_PRESETS,
+            currentTimeframe: () => this.timeframe,
+            activeRange: () => this.activeRangeId,
+            onTimeframe: (tf) => this.setTimeframe(tf),
+            onRange: (preset) => this.applyRange(preset),
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.tfDrawer.open();
+    }
+
+    private openDrawingsDrawer(): void {
+        this.drawingsDrawer ??= new DrawingsDrawer({
+            host: this.root,
+            toolbar: () => buildToolbar(this.opts.drawings).definition,
+            currentTool: () => this.inner?.drawings.getTool() ?? null,
+            isFavorite: (type) => this.inner?.drawings.isFavorite(type) ?? false,
+            onFavorite: (type, on) => this.inner?.drawings.setFavorite(type, on),
+            onSelect: (type) => this.inner?.drawings.setTool(type),
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.drawingsDrawer.open();
+    }
+
+    private openMoreDrawer(): void {
+        this.moreDrawer ??= new MoreDrawer({
+            host: this.root,
+            onUndo: () => this.history.undo(),
+            onRedo: () => this.history.redo(),
+            onScreenshot: () => this.downloadScreenshot(),
+            canUndo: () => this.history.canUndo,
+            canRedo: () => this.history.canRedo,
+            priceStyles: () => priceStyleIds().map((id) => ({ id, label: priceStyleLabel(id), icon: priceStyleIcon(id) })),
+            priceStyle: () => this.priceStyle,
+            onPriceStyle: (id) => this.setPriceStyle(id),
+            panels: () => [...this.dock.list()],
+            onTogglePanel: (id) => this.dock.toggle(id),
+            alerts: () => this.alerts,
+            actions: () => widgetActions('topbar', this.context()).map((a) => ({ label: a.label, icon: a.icon, run: () => a.run(this.context()) })),
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.moreDrawer.open();
+    }
+
+    private openTimezoneDrawer(): void {
+        this.timezoneDrawer ??= new TimezoneDrawer({
+            host: this.root,
+            timezone: () => this.timezone,
+            onTimezone: (zone) => this.setTimezone(zone),
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.timezoneDrawer.open();
+    }
+
+    private openPriceScaleDrawer(y: number): void {
+        this.priceScalePressY = y;
+        this.priceScaleDrawer ??= new PriceScaleDrawer({
+            host: this.root,
+            chart: () => this.inner,
+            pressY: () => this.priceScalePressY,
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.priceScaleDrawer.open();
+    }
+
     /** Mount registered attachments not yet mounted on this widget (idempotent per id). */
     private mountAttachments(): void {
         for (const att of widgetAttachments()) {
@@ -446,6 +577,7 @@ export class VelaWidget {
     private syncTimeframeChrome(tf: string): void {
         this.timeframe = tf;
         this.topbar.setTimeframe(tf);
+        this.mobileBar?.setTimeframe(tf);
         this.watermark?.update(this.symbol, tf);
         this.statusline?.setMeta(tf, this.providerLabel());
     }
@@ -465,6 +597,7 @@ export class VelaWidget {
         // Leaving range mode: drop the chip highlight AND its fetch budget (back to the
         // user's own `bars`). Done HERE so every path — menu, quick entry, keyboard,
         // public API, plugins — behaves the same.
+        this.activeRangeId = null;
         this.bottombar?.setActiveRange(null);
         this.rangeBars = 0;
         this.syncTimeframeChrome(tf);
@@ -487,6 +620,7 @@ export class VelaWidget {
         this.unresolvedToasted = null; // a new symbol gets a fresh verdict
         this.symbol = symbol;
         this.topbar.setSymbol(symbol);
+        this.mobileBar?.setSymbol(symbol);
         this.statusline?.setSymbol(symbol);
         this.objectTree.setSymbol(symbol);
         this.watermark?.update(symbol, this.timeframe);
@@ -747,6 +881,10 @@ export class VelaWidget {
      */
     applyRange(preset: RangePreset): void {
         if (this.destroyed) return;
+        // Every entry path (desktop chips, the timeframe drawer, host code) records the
+        // active chip here, so both bars and the drawer highlight the same one.
+        this.activeRangeId = preset.id;
+        this.bottombar?.setActiveRange(preset.id);
         this.pendingRange = preset;
         const tfChanged = preset.tf !== this.timeframe;
         const deeper = preset.bars > Math.max(this.bars, this.rangeBars);
@@ -797,11 +935,19 @@ export class VelaWidget {
         this.statusline?.destroy();
         this.watermark?.destroy();
         this.bottombar?.destroy();
+        this.mobileBar?.destroy();
+        this.drawingPill.destroy();
+        this.tfDrawer?.destroy();
+        this.drawingsDrawer?.destroy();
+        this.moreDrawer?.destroy();
+        this.timezoneDrawer?.destroy();
+        this.priceScaleDrawer?.destroy();
         this.toast?.destroy();
         this.alertsMenu?.destroy();
         this.glider.stop();
         this.history.destroy();
         this.keymap.destroy();
+        this.layoutCtl.destroy();
         this.root.remove();
     }
 
@@ -825,6 +971,7 @@ export class VelaWidget {
             statusline: _statusline,
             watermark: _watermark,
             bottombar: _bottombar,
+            layoutMode: _layoutMode,
             ...chartOpts
         } = this.opts;
         const chart = new Vela(this.chartHost, {
@@ -841,6 +988,9 @@ export class VelaWidget {
         this.inner = chart;
 
         this.symbolPicker.setSource(() => chart.data.symbols());
+        // A fresh renderer starts desktop — push the live mode (constructor-time builds
+        // run before layoutCtl exists; the controller's first evaluation covers them).
+        if (this.layoutCtl !== undefined) chart.renderer.setLayoutMode(this.layoutCtl.current);
         this.objectTree.setSymbol(this.symbol);
         // Contributed legend-row actions (registerLegendAction) — resolved per row, per click.
         chart.renderer.setLegendActions(legendActionsProviderFor(chart, () => this.context()));
@@ -852,6 +1002,13 @@ export class VelaWidget {
         if (chart.renderer.supports('historyChords')) chart.renderer.set('historyChords', false);
         this.dock.onChart(chart); // every docked panel rebinds, contributed ones included
         this.contextMenu.onChart(chart);
+        // Mobile: long-press an axis strip → timezone / price-scale sheet (desktop keeps
+        // the right-click menu; the gesture is touch-only inside the renderer).
+        chart.renderer.onAxisLongPress((e) => {
+            if (this.layoutCtl.current !== 'mobile') return;
+            if (e.axis === 'time') this.openTimezoneDrawer();
+            else this.openPriceScaleDrawer(e.y);
+        });
         this.refreshNativeCatalog();
         chart.on('indicator:added', () => {
             this.syncPresentNatives();
@@ -933,6 +1090,7 @@ export class VelaWidget {
             if (symbol !== this.symbol) {
                 this.symbol = symbol;
                 this.topbar.setSymbol(symbol);
+                this.mobileBar?.setSymbol(symbol);
                 this.statusline?.setSymbol(symbol);
                 this.objectTree.setSymbol(symbol);
                 this.watermark?.update(symbol, this.timeframe);
@@ -994,6 +1152,7 @@ export class VelaWidget {
         });
         this.syncPlotOverlayTokens();
         this.statusline?.onChart(chart);
+        this.drawingPill.onChart(chart);
         this.syncStatuslineColors();
         const advanced = {
             title: 'Advanced',

--- a/src/widget/drawing-pill.ts
+++ b/src/widget/drawing-pill.ts
@@ -1,0 +1,160 @@
+// Floating drawing pill (mobile) — the on-chart remnant of the hidden drawing toolbar.
+// While a tool is armed (or the eraser is on) it floats over the plot with the armed
+// tool's glyph, the magnet cycle, stay-in-drawing-mode, the eraser, and a ✕ to disarm.
+// Widget chrome over the PUBLIC drawings facade only: it drives `chart.drawings` and
+// follows the drawing:* events, so any path that arms/disarms a tool (drawer, keyboard
+// shortcut, API) keeps it truthful. Only shown in the mobile size class — desktop keeps
+// the docked toolbar.
+import type { Vela } from '../Vela';
+import { iconEl, iconMarkup } from '../ui/icons';
+import { injectStyles } from '../ui/styles';
+import { getDrawingType, type SnapMode } from '../core/drawings';
+
+const STYLE_ID = 'vela-widget-drawing-pill';
+const CSS = `
+.vela-drawpill { display: none; }
+[data-layout='mobile'] .vela-drawpill {
+    position: absolute;
+    left: 50%;
+    bottom: 10px;
+    transform: translateX(-50%);
+    z-index: 7;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    padding: 4px;
+    border: 1px solid var(--vela-border-strong);
+    border-radius: 999px;
+    background: var(--vela-surface);
+    box-shadow: var(--vela-shadow-dialog);
+    color: var(--vela-fg);
+}
+[data-layout='mobile'] .vela-drawpill[hidden] { display: none !important; }
+.vela-drawpill-tool {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+    background: var(--vela-hover);
+    color: var(--vela-accent);
+}
+.vela-drawpill-tool svg { width: 22px; height: 22px; }
+.vela-drawpill-btn {
+    all: unset;
+    width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    color: var(--vela-fg-muted);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    position: relative;
+}
+.vela-drawpill-btn:active { background: var(--vela-hover); }
+.vela-drawpill-btn[data-on='1'] { color: var(--vela-accent); background: var(--vela-hover); }
+.vela-drawpill-btn .vela-icon { font-size: 17px; width: 17px; height: 17px; }
+.vela-drawpill-badge {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    font-size: 8px;
+    font-weight: 700;
+    color: var(--vela-accent);
+}
+`;
+
+export class DrawingPill {
+    private readonly el: HTMLElement;
+    private readonly toolGlyph: HTMLElement;
+    private readonly magnetBtn: HTMLButtonElement;
+    private readonly magnetBadge: HTMLElement;
+    private readonly stayBtn: HTMLButtonElement;
+    private readonly eraserBtn: HTMLButtonElement;
+    private chart: Vela | null = null;
+
+    constructor(host: HTMLElement) {
+        const doc = host.ownerDocument;
+        injectStyles(STYLE_ID, CSS, doc);
+        this.el = doc.createElement('div');
+        this.el.className = 'vela-drawpill';
+        this.el.hidden = true;
+
+        this.toolGlyph = doc.createElement('span');
+        this.toolGlyph.className = 'vela-drawpill-tool';
+
+        const btn = (icon: string, label: string, onClick: () => void): HTMLButtonElement => {
+            const b = doc.createElement('button');
+            b.className = 'vela-drawpill-btn';
+            b.setAttribute('aria-label', label);
+            b.appendChild(iconEl(icon, doc));
+            b.addEventListener('click', onClick);
+            return b;
+        };
+
+        this.magnetBtn = btn('magnet', 'Magnet snap', () => {
+            const order: SnapMode[] = ['off', 'weak', 'strong'];
+            const cur = this.chart?.drawings.getSnapMode() ?? 'off';
+            this.chart?.drawings.setSnapMode(order[(order.indexOf(cur) + 1) % order.length]!);
+        });
+        this.magnetBadge = doc.createElement('span');
+        this.magnetBadge.className = 'vela-drawpill-badge';
+        this.magnetBtn.appendChild(this.magnetBadge);
+        this.stayBtn = btn(iconMarkup('pen-lock') ? 'pen-lock' : 'pen', 'Stay in drawing mode', () => {
+            this.chart?.drawings.setStayMode(!this.chart.drawings.getStayMode());
+        });
+        this.eraserBtn = btn('eraser', 'Eraser', () => {
+            this.chart?.drawings.setMode(this.chart.drawings.getMode() === 'eraser' ? null : 'eraser');
+        });
+        const close = btn('close', 'Exit drawing mode', () => {
+            this.chart?.drawings.setTool(null);
+            this.chart?.drawings.setMode(null);
+        });
+
+        this.el.append(this.toolGlyph, this.magnetBtn, this.stayBtn, this.eraserBtn, close);
+        host.appendChild(this.el);
+    }
+
+    private chartSubs: Array<() => void> = [];
+
+    /** Rebind to another chart (a rebuild, or the workspace's active cell changing) —
+     *  the previous chart's subscriptions are dropped so only one chart drives the pill. */
+    onChart(chart: Vela): void {
+        for (const off of this.chartSubs) off();
+        this.chart = chart;
+        this.chartSubs = [
+            chart.on('drawing:tool', () => this.sync()),
+            chart.on('drawing:snap', () => this.sync()),
+            chart.on('drawing:stay', () => this.sync()),
+            chart.on('drawing:mode', () => this.sync()),
+        ];
+        this.sync();
+    }
+
+    private sync(): void {
+        const drawings = this.chart?.drawings;
+        if (!drawings || !drawings.supported) {
+            this.el.hidden = true;
+            return;
+        }
+        const tool = drawings.getTool();
+        const eraser = drawings.getMode() === 'eraser';
+        this.el.hidden = tool === null && !eraser;
+        if (this.el.hidden) return;
+        this.toolGlyph.innerHTML = tool !== null ? (getDrawingType(tool)?.icon ?? '') : (iconMarkup('eraser') ?? '');
+        const snap = drawings.getSnapMode();
+        this.magnetBtn.dataset.on = snap !== 'off' ? '1' : '';
+        this.magnetBadge.textContent = snap === 'weak' ? 'W' : snap === 'strong' ? 'S' : '';
+        this.stayBtn.dataset.on = drawings.getStayMode() ? '1' : '';
+        this.eraserBtn.dataset.on = eraser ? '1' : '';
+    }
+
+    destroy(): void {
+        for (const off of this.chartSubs) off();
+        this.chartSubs = [];
+        this.el.remove();
+    }
+}

--- a/src/widget/drawings-drawer.ts
+++ b/src/widget/drawings-drawer.ts
@@ -1,0 +1,264 @@
+// Drawings drawer (mobile) — the bottom-sheet counterpart of the docked drawing
+// toolbar: a search bar, the tool groups as horizontally scrollable tabs, and the
+// active group's tools as a touch-sized list with favorite stars. Searching flattens
+// every group into one filtered list. Data comes from the same DOM-free toolbar model
+// the docked bar paints (`ToolbarDefinition`), so custom `options.drawings` sets and
+// plugin-registered types appear here automatically.
+import { Drawer } from '../ui/components/drawer';
+import { iconEl } from '../ui/icons';
+import { injectStyles } from '../ui/styles';
+import type { ToolbarDefinition, ToolDefinition } from '../core/drawings/toolbar';
+import type { DrawingTypeKey } from '../core/drawings/Drawing';
+
+const STYLE_ID = 'vela-widget-drawings-drawer';
+const CSS = `
+/* Search + tabs stay pinned while the tool list scrolls underneath. */
+.vela-dd-sticky {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--vela-surface);
+    padding-top: 2px;
+}
+.vela-dd-search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    margin: 0 2px 8px;
+    border: 1px solid var(--vela-border);
+    border-radius: 8px;
+    color: var(--vela-fg-muted);
+    background: var(--vela-surface);
+}
+.vela-dd-search input {
+    all: unset;
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 14px;
+    color: var(--vela-fg-bright);
+}
+.vela-dd-tabs {
+    display: flex;
+    gap: 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    padding: 0 2px 8px;
+    border-bottom: 1px solid var(--vela-border);
+    background: var(--vela-surface);
+}
+.vela-dd-tabs::-webkit-scrollbar { display: none; }
+.vela-dd-tab {
+    all: unset;
+    flex: none;
+    min-height: 36px;
+    padding: 0 12px;
+    display: inline-flex;
+    align-items: center;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--vela-fg-muted);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-dd-tab[data-active='1'] { color: var(--vela-fg-bright); background: var(--vela-hover); }
+.vela-dd-list { padding: 6px 0 4px; }
+.vela-dd-section {
+    padding: 10px 2px 6px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    color: var(--vela-fg-muted);
+}
+.vela-dd-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-height: 44px;
+    padding: 0 2px;
+    border-radius: 8px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-dd-row:active { background: var(--vela-hover); }
+.vela-dd-row[data-active='1'] { background: var(--vela-hover); }
+.vela-dd-row[data-active='1'] .vela-dd-label { color: var(--vela-accent); }
+.vela-dd-glyph { flex: none; width: 24px; height: 24px; color: var(--vela-fg); }
+.vela-dd-glyph svg { width: 24px; height: 24px; }
+.vela-dd-label { flex: 1 1 auto; min-width: 0; font-size: 14px; color: var(--vela-fg-bright); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.vela-dd-star {
+    all: unset;
+    flex: none;
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    color: var(--vela-fg-muted);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-dd-star[data-on='1'] { color: var(--vela-accent); }
+.vela-dd-empty { padding: 18px 2px; color: var(--vela-fg-muted); font-size: 13px; }
+`;
+
+export interface DrawingsDrawerOptions {
+    host: HTMLElement;
+    /** Read live at open — the toolbar model (custom sets / late-registered types apply). */
+    toolbar: () => ToolbarDefinition;
+    currentTool: () => DrawingTypeKey | null;
+    isFavorite: (type: DrawingTypeKey) => boolean;
+    onFavorite: (type: DrawingTypeKey, on: boolean) => void;
+    onSelect: (type: DrawingTypeKey) => void;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export class DrawingsDrawer {
+    private readonly drawer: Drawer;
+    private readonly input: HTMLInputElement;
+    private readonly tabs: HTMLElement;
+    private readonly list: HTMLElement;
+    private definition: ToolbarDefinition = { groups: [] };
+    private activeGroup = '';
+
+    constructor(private readonly opts: DrawingsDrawerOptions) {
+        const doc = opts.host.ownerDocument;
+        injectStyles(STYLE_ID, CSS, doc);
+        this.drawer = new Drawer({ host: opts.host, title: 'Drawings', onOpenChange: opts.onOpenChange });
+
+        const sticky = doc.createElement('div');
+        sticky.className = 'vela-dd-sticky';
+
+        const search = doc.createElement('div');
+        search.className = 'vela-dd-search';
+        search.appendChild(iconEl('search', doc));
+        this.input = doc.createElement('input');
+        this.input.type = 'text';
+        this.input.placeholder = 'Search tools…';
+        this.input.addEventListener('input', () => this.renderList());
+        search.appendChild(this.input);
+
+        this.tabs = doc.createElement('div');
+        this.tabs.className = 'vela-dd-tabs';
+        sticky.append(search, this.tabs);
+
+        this.list = doc.createElement('div');
+        this.list.className = 'vela-dd-list';
+
+        this.drawer.body.append(sticky, this.list);
+    }
+
+    open(): void {
+        this.definition = this.opts.toolbar();
+        if (!this.definition.groups.some((g) => g.id === this.activeGroup)) this.activeGroup = this.definition.groups[0]?.id ?? '';
+        this.input.value = '';
+        this.renderTabs();
+        this.renderList();
+        this.drawer.show();
+    }
+
+    close(): void {
+        this.drawer.hide();
+    }
+
+    destroy(): void {
+        this.drawer.destroy();
+    }
+
+    private renderTabs(): void {
+        const doc = this.tabs.ownerDocument;
+        this.tabs.replaceChildren();
+        for (const group of this.definition.groups) {
+            const tab = doc.createElement('button');
+            tab.className = 'vela-dd-tab';
+            tab.textContent = group.label;
+            if (group.id === this.activeGroup) tab.dataset.active = '1';
+            tab.addEventListener('click', () => {
+                this.activeGroup = group.id;
+                this.input.value = ''; // picking a tab leaves search mode
+                this.renderTabs();
+                this.renderList();
+            });
+            this.tabs.appendChild(tab);
+        }
+    }
+
+    private renderList(): void {
+        const doc = this.list.ownerDocument;
+        this.list.replaceChildren();
+        const query = this.input.value.trim().toLowerCase();
+        const active = this.opts.currentTool();
+
+        const section = (label: string): void => {
+            const el = doc.createElement('div');
+            el.className = 'vela-dd-section';
+            el.textContent = label;
+            this.list.appendChild(el);
+        };
+        const row = (tool: ToolDefinition): void => {
+            const el = doc.createElement('div');
+            el.className = 'vela-dd-row';
+            if (tool.type === active) el.dataset.active = '1';
+            const glyph = doc.createElement('span');
+            glyph.className = 'vela-dd-glyph';
+            glyph.innerHTML = tool.icon;
+            const label = doc.createElement('span');
+            label.className = 'vela-dd-label';
+            label.textContent = tool.label;
+            const star = doc.createElement('button');
+            star.className = 'vela-dd-star';
+            const paintStar = (on: boolean): void => {
+                star.replaceChildren(iconEl(on ? 'star-filled' : 'star', doc));
+                if (on) star.dataset.on = '1';
+                else delete star.dataset.on;
+            };
+            paintStar(this.opts.isFavorite(tool.type));
+            star.setAttribute('aria-label', `Favorite ${tool.label}`);
+            star.addEventListener('click', (e) => {
+                e.stopPropagation(); // the row underneath arms the tool — a star tap must not
+                const on = !this.opts.isFavorite(tool.type);
+                this.opts.onFavorite(tool.type, on);
+                paintStar(on);
+            });
+            el.append(glyph, label, star);
+            el.addEventListener('click', () => {
+                this.opts.onSelect(tool.type);
+                this.drawer.hide();
+            });
+            this.list.appendChild(el);
+        };
+
+        if (query) {
+            // Search flattens every group; group labels become the section headers.
+            let any = false;
+            for (const group of this.definition.groups) {
+                const hits = group.tools.filter((t) => t.label.toLowerCase().includes(query));
+                if (hits.length === 0) continue;
+                any = true;
+                section(group.label);
+                for (const tool of hits) row(tool);
+            }
+            if (!any) {
+                const empty = doc.createElement('div');
+                empty.className = 'vela-dd-empty';
+                empty.textContent = 'No tools match.';
+                this.list.appendChild(empty);
+            }
+            return;
+        }
+
+        const group = this.definition.groups.find((g) => g.id === this.activeGroup);
+        if (!group) return;
+        if (group.sections && group.sections.length > 0) {
+            for (const s of group.sections) {
+                section(s.label);
+                for (const tool of s.tools) row(tool);
+            }
+        } else {
+            for (const tool of group.tools) row(tool);
+        }
+    }
+}

--- a/src/widget/indicator-picker.ts
+++ b/src/widget/indicator-picker.ts
@@ -33,6 +33,9 @@ const CSS = `
 .vela-ip-searchrow .vela-icon { color: var(--vela-fg-muted); }
 .vela-ip-search { flex: 1; background: transparent; color: var(--vela-fg); border: none; font-size: 14px; outline: none; }
 .vela-ip-list { max-height: 50vh; overflow: auto; min-width: 380px; }
+/* Mobile (fullscreen dialog): no width floor — 380px would overflow a phone —
+   and no height cap; the fullscreen body owns the scrolling. */
+[data-layout='mobile'] .vela-ip-list { min-width: 0; max-height: none; }
 .vela-ip-list::-webkit-scrollbar { width: 8px; }
 .vela-ip-list::-webkit-scrollbar-thumb { background: var(--vela-scroll); border-radius: 4px; border: 2px solid transparent; background-clip: padding-box; }
 .vela-ip-group {

--- a/src/widget/layout-mode.ts
+++ b/src/widget/layout-mode.ts
@@ -1,0 +1,85 @@
+// Layout mode — the shell's size class. The widget is embeddable, so the honest
+// signal is the CONTAINER width, not the viewport: a 380px widget on a desktop page
+// gets the mobile chrome, a full-screen tablet widget keeps the desktop one unless
+// the pointer is coarse and the container is narrow enough that desktop affordances
+// (hover flyouts, 30px targets) stop working.
+import type { Unsubscribe } from '../core/util/types';
+
+export type LayoutMode = 'mobile' | 'desktop';
+export type LayoutModeOption = 'auto' | LayoutMode;
+
+/** Below this container width the shell is unconditionally mobile. */
+export const MOBILE_BREAKPOINT_PX = 640;
+/** With a coarse pointer (touch-first device) the mobile chrome applies wider —
+ *  desktop affordances assume hover, which a coarse pointer does not have. */
+export const COARSE_BREAKPOINT_PX = 920;
+
+/**
+ * Resolve the effective layout mode. Pure — the controller feeds it measurements.
+ * An unmeasured container (width 0: display:none, not yet attached) stays desktop
+ * until a real measurement arrives, so nothing flashes mobile during construction.
+ */
+export function resolveLayoutMode(option: LayoutModeOption, width: number, coarsePointer: boolean): LayoutMode {
+    if (option !== 'auto') return option;
+    if (width <= 0) return 'desktop';
+    if (width < MOBILE_BREAKPOINT_PX) return 'mobile';
+    if (coarsePointer && width < COARSE_BREAKPOINT_PX) return 'mobile';
+    return 'desktop';
+}
+
+/**
+ * Observes one element and keeps its `data-layout` attribute (`'mobile'`/`'desktop'`)
+ * in sync with the resolved mode — chrome stylesheets key off it. Change listeners
+ * fire only on actual transitions, after the attribute is already updated.
+ */
+export class LayoutModeController {
+    private mode: LayoutMode;
+    private readonly listeners = new Set<(mode: LayoutMode) => void>();
+    private ro: ResizeObserver | null = null;
+    private mql: MediaQueryList | null = null;
+    private readonly onMediaChange = (): void => this.evaluate();
+
+    constructor(
+        private readonly el: HTMLElement,
+        private readonly option: LayoutModeOption = 'auto',
+    ) {
+        const win = el.ownerDocument.defaultView;
+        if (win && typeof win.matchMedia === 'function') {
+            this.mql = win.matchMedia('(pointer: coarse)');
+            // Older WebViews only ship addListener — fall back rather than throw.
+            if (typeof this.mql.addEventListener === 'function') this.mql.addEventListener('change', this.onMediaChange);
+        }
+        this.mode = resolveLayoutMode(option, el.getBoundingClientRect().width, this.mql?.matches ?? false);
+        el.dataset.layout = this.mode;
+        if (option === 'auto' && win && typeof win.ResizeObserver === 'function') {
+            this.ro = new win.ResizeObserver(() => this.evaluate());
+            this.ro.observe(el);
+        }
+    }
+
+    get current(): LayoutMode {
+        return this.mode;
+    }
+
+    /** Subscribe to mode transitions (fires with the NEW mode). */
+    onChange(cb: (mode: LayoutMode) => void): Unsubscribe {
+        this.listeners.add(cb);
+        return () => this.listeners.delete(cb);
+    }
+
+    destroy(): void {
+        this.ro?.disconnect();
+        this.ro = null;
+        if (this.mql && typeof this.mql.removeEventListener === 'function') this.mql.removeEventListener('change', this.onMediaChange);
+        this.mql = null;
+        this.listeners.clear();
+    }
+
+    private evaluate(): void {
+        const next = resolveLayoutMode(this.option, this.el.getBoundingClientRect().width, this.mql?.matches ?? false);
+        if (next === this.mode) return;
+        this.mode = next;
+        this.el.dataset.layout = next;
+        for (const cb of [...this.listeners]) cb(next);
+    }
+}

--- a/src/widget/layout-picker.ts
+++ b/src/widget/layout-picker.ts
@@ -123,6 +123,36 @@ const GRID = 4;
 /** The current layout's footprint on the canvas (mirrors the workspace's LayoutShape). */
 export type LayoutPickerShape = { rows: number; cols: number };
 
+/** Build the bare 4×4 canvas (16 squares, row-major). Interaction wiring stays with the
+ *  caller — the desktop popover adds hover previews, the mobile drawer taps to apply. */
+export function layoutGridCanvas(doc: Document): { el: HTMLElement; squares: HTMLButtonElement[] } {
+    injectStyles(STYLE_ID, CSS, doc);
+    const el = doc.createElement('div');
+    el.className = 'vela-lp-grid';
+    const squares: HTMLButtonElement[] = [];
+    for (let r = 0; r < GRID; r += 1) {
+        for (let c = 0; c < GRID; c += 1) {
+            const sq = doc.createElement('button');
+            sq.className = 'vela-lp-sq';
+            sq.dataset.r = String(r);
+            sq.dataset.c = String(c);
+            sq.setAttribute('aria-label', `${c + 1} × ${r + 1}`);
+            squares.push(sq);
+            el.appendChild(sq);
+        }
+    }
+    return { el, squares };
+}
+
+/** Light the `shape` rectangle from the top-left (null = nothing lit). */
+export function paintLayoutGrid(squares: readonly HTMLButtonElement[], shape: LayoutPickerShape | null): void {
+    for (const sq of squares) {
+        const on = shape !== null && Number(sq.dataset.r) < shape.rows && Number(sq.dataset.c) < shape.cols;
+        if (on) sq.dataset.on = '1';
+        else delete sq.dataset.on;
+    }
+}
+
 export interface LayoutPickerOptions {
     /** Topbar button that toggles the panel. */
     trigger: HTMLElement;
@@ -197,19 +227,8 @@ export class LayoutPicker {
             content: () => this.tipNode(),
         });
 
-        const grid = doc.createElement('div');
-        grid.className = 'vela-lp-grid';
-        for (let r = 0; r < GRID; r += 1) {
-            for (let c = 0; c < GRID; c += 1) {
-                const sq = doc.createElement('button');
-                sq.className = 'vela-lp-sq';
-                sq.dataset.r = String(r);
-                sq.dataset.c = String(c);
-                sq.setAttribute('aria-label', `${c + 1} × ${r + 1}`);
-                this.squares.push(sq);
-                grid.appendChild(sq);
-            }
-        }
+        const { el: grid, squares } = layoutGridCanvas(doc);
+        this.squares.push(...squares);
         layoutCol.appendChild(grid);
 
         this.presetsEl = doc.createElement('div');
@@ -325,13 +344,7 @@ export class LayoutPicker {
 
     /** Project the interaction state onto the DOM (the hover/current rectangle). */
     private render(): void {
-        const preview = this.hover ?? this.opts.shape();
-        for (const sq of this.squares) {
-            const { r, c } = this.squarePos(sq);
-            const on = preview !== null && r < preview.rows && c < preview.cols;
-            if (on) sq.dataset.on = '1';
-            else delete sq.dataset.on;
-        }
+        paintLayoutGrid(this.squares, this.hover ?? this.opts.shape());
     }
 
     private renderPresets(): void {

--- a/src/widget/mobile-bar.ts
+++ b/src/widget/mobile-bar.ts
@@ -1,0 +1,112 @@
+// Mobile bottom bar — the ONE navigation surface of the mobile chrome. Six stops, left
+// to right: symbol (fullscreen search), timeframe (drawer), indicators (fullscreen
+// picker), drawings (drawer), the three-dots drawer (everything else), and chart
+// settings. It replaces BOTH desktop bars: this stylesheet also carries the mobile
+// visibility flips for the topbar and the desktop bottombar, so the whole swap lives
+// in one place and follows the root's `data-layout` attribute with no JS.
+import { iconEl } from '../ui/icons';
+import { injectStyles } from '../ui/styles';
+import { parseSymbol } from '../data/ProviderRegistry';
+import { timeframeLabel } from './timeframe';
+
+const STYLE_ID = 'vela-widget-mobilebar';
+const CSS = `
+.vela-mobilebar {
+    display: none;
+    align-items: stretch;
+    gap: 2px;
+    padding: 4px 6px calc(4px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--vela-border);
+    color: var(--vela-fg-muted);
+    flex: none;
+}
+[data-layout='mobile'] .vela-mobilebar { display: flex; }
+[data-layout='mobile'] .vela-widget-topbar { display: none; }
+[data-layout='mobile'] .vela-widget-bottombar { display: none; }
+.vela-mb-item {
+    all: unset;
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border-radius: 6px;
+    cursor: pointer;
+    color: var(--vela-fg-bright);
+    font-size: 13px;
+    font-weight: 600;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-mb-item:active { background: var(--vela-hover); }
+.vela-mb-item .vela-icon { font-size: 18px; width: 18px; height: 18px; }
+.vela-mb-symbol {
+    flex: 1.6 1 0;
+    font-size: 14px;
+    letter-spacing: 0.3px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+    line-height: 44px;
+    text-align: center;
+}
+`;
+
+export interface MobileBarOptions {
+    symbol: string;
+    timeframe: string;
+    onSymbolClick: () => void;
+    onTimeframeClick: () => void;
+    onIndicatorsClick: () => void;
+    onDrawingsClick: () => void;
+    onMoreClick: () => void;
+    onSettingsClick: () => void;
+}
+
+export class MobileBar {
+    readonly el: HTMLElement;
+    private readonly symbolEl: HTMLElement;
+    private readonly tfEl: HTMLElement;
+
+    constructor(host: HTMLElement, opts: MobileBarOptions) {
+        const doc = host.ownerDocument;
+        injectStyles(STYLE_ID, CSS, doc);
+        this.el = doc.createElement('div');
+        this.el.className = 'vela-mobilebar';
+
+        const item = (cls: string, label: string, onClick: () => void, icon?: string): HTMLButtonElement => {
+            const b = doc.createElement('button');
+            b.className = `vela-mb-item ${cls}`;
+            b.setAttribute('aria-label', label);
+            if (icon) b.appendChild(iconEl(icon, doc));
+            b.addEventListener('click', onClick);
+            return b;
+        };
+
+        this.symbolEl = item('vela-mb-symbol', 'Symbol search', opts.onSymbolClick);
+        this.symbolEl.textContent = parseSymbol(opts.symbol).ticker;
+        this.tfEl = item('vela-mb-tf', 'Timeframe', opts.onTimeframeClick);
+        this.tfEl.textContent = timeframeLabel(opts.timeframe);
+        const indicators = item('vela-mb-indicators', 'Indicators', opts.onIndicatorsClick, 'indicators');
+        const drawings = item('vela-mb-drawings', 'Drawings', opts.onDrawingsClick, 'pen');
+        const more = item('vela-mb-more', 'More', opts.onMoreClick, 'kebab');
+        const settings = item('vela-mb-settings', 'Chart settings', opts.onSettingsClick, 'gear');
+
+        this.el.append(this.symbolEl, this.tfEl, indicators, drawings, more, settings);
+        host.appendChild(this.el);
+    }
+
+    setSymbol(symbol: string): void {
+        this.symbolEl.textContent = parseSymbol(symbol).ticker;
+    }
+
+    setTimeframe(tf: string): void {
+        this.tfEl.textContent = timeframeLabel(tf);
+    }
+
+    destroy(): void {
+        this.el.remove();
+    }
+}

--- a/src/widget/more-drawer.ts
+++ b/src/widget/more-drawer.ts
@@ -1,0 +1,336 @@
+// The three-dots drawer (mobile) — the catch-all for everything the hidden topbar and
+// desktop bottombar used to carry: undo/redo/screenshot as an action row, then rows for
+// chart type, the multi-chart layout (workspace shells), the side panels (data window,
+// object tree, contributed), alerts, and every contributed topbar action. Chart type,
+// layout and alerts open as IN-DRAWER sub-views with a back button — a drawer inside a
+// drawer would stack sheets. Time zone lives on a long-press of the time axis (see
+// `timezone-drawer.ts`), not here.
+import { Drawer } from '../ui/components/drawer';
+import { iconEl } from '../ui/icons';
+import { injectStyles } from '../ui/styles';
+import { layoutGridCanvas, paintLayoutGrid } from './layout-picker';
+
+const STYLE_ID = 'vela-widget-more-drawer';
+const CSS = `
+.vela-md-actions {
+    display: flex;
+    gap: 6px;
+    padding: 2px 2px 10px;
+    border-bottom: 1px solid var(--vela-border);
+}
+.vela-md-action {
+    all: unset;
+    flex: 1 1 0;
+    min-height: 48px;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    border-radius: 8px;
+    font-size: 11px;
+    color: var(--vela-fg);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-md-action:active { background: var(--vela-hover); }
+.vela-md-action:disabled { opacity: 0.35; cursor: default; }
+.vela-md-action .vela-icon { font-size: 17px; width: 17px; height: 17px; }
+.vela-md-list { padding: 6px 0 4px; }
+.vela-md-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-height: 46px;
+    padding: 0 2px;
+    border-radius: 8px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-md-row:active { background: var(--vela-hover); }
+.vela-md-row .vela-icon { flex: none; font-size: 17px; width: 17px; height: 17px; color: var(--vela-fg-muted); }
+.vela-md-row-label { flex: 1 1 auto; min-width: 0; font-size: 14px; color: var(--vela-fg-bright); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.vela-md-row-value { flex: none; font-size: 13px; color: var(--vela-fg-muted); }
+.vela-md-back {
+    all: unset;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 42px;
+    padding: 0 2px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--vela-fg-bright);
+    cursor: pointer;
+    border-bottom: 1px solid var(--vela-border);
+    width: 100%;
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+/* The layout sub-view's grid canvas, centered and touch-sized (the base .vela-lp-grid
+   squares are popover-sized for a mouse). */
+.vela-md-gridwrap { display: flex; justify-content: center; padding: 14px 0 10px; }
+.vela-md-gridwrap .vela-lp-grid { grid-template-columns: repeat(4, 44px); grid-auto-rows: 44px; gap: 8px; }
+.vela-md-section {
+    padding: 12px 2px 4px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    color: var(--vela-fg-muted);
+}
+.vela-md-empty { padding: 18px 2px; color: var(--vela-fg-muted); font-size: 13px; }
+`;
+
+export interface MoreDrawerAction {
+    label: string;
+    icon?: string;
+    run: () => void;
+}
+
+export interface MoreDrawerOptions {
+    host: HTMLElement;
+    onUndo: () => void;
+    onRedo: () => void;
+    onScreenshot: () => void;
+    canUndo: () => boolean;
+    canRedo: () => boolean;
+    /** Chart style list + current selection (read live at open). */
+    priceStyles: () => Array<{ id: string; label: string; icon?: string }>;
+    priceStyle: () => string;
+    onPriceStyle: (id: string) => void;
+    /** Docked side panels (built-in + contributed), toggled by id. */
+    panels: () => Array<{ id: string; title: string; icon: string }>;
+    onTogglePanel: (id: string) => void;
+    alerts: () => Array<{ title: string; message: string; time: number }>;
+    /** Contributed topbar actions, projected as plain rows. */
+    actions: () => MoreDrawerAction[];
+    /** Multi-chart layout switching (workspace shells) — the row is hidden when omitted.
+     *  The sub-view carries the SAME surface as the desktop layout dropdown: the 4×4
+     *  tap-to-apply grid canvas, the presets the canvas cannot express as rows, and the
+     *  sync switches. Everything is read live at open. */
+    layout?: {
+        /** Current layout's canvas shape (null = a preset the canvas cannot express). */
+        shape: () => { rows: number; cols: number } | null;
+        /** Registered layouts NOT expressible on the canvas — rendered as labeled rows. */
+        presets: () => Array<{ id: string; label: string; checked: boolean }>;
+        onSelectGrid: (rows: number, cols: number) => void;
+        onSelectPreset: (id: string) => void;
+        syncs?: () => Array<{ id: string; label: string; checked: boolean }>;
+        onToggleSync?: (id: string) => void;
+    };
+    onOpenChange?: (open: boolean) => void;
+}
+
+type MoreView = 'main' | 'style' | 'layout' | 'alerts';
+
+export class MoreDrawer {
+    private readonly drawer: Drawer;
+    private view: MoreView = 'main';
+
+    constructor(private readonly opts: MoreDrawerOptions) {
+        injectStyles(STYLE_ID, CSS, opts.host.ownerDocument);
+        this.drawer = new Drawer({ host: opts.host, onOpenChange: opts.onOpenChange });
+    }
+
+    open(): void {
+        this.view = 'main';
+        this.render();
+        this.drawer.show();
+    }
+
+    close(): void {
+        this.drawer.hide();
+    }
+
+    destroy(): void {
+        this.drawer.destroy();
+    }
+
+    private show(view: MoreView): void {
+        this.view = view;
+        this.render();
+    }
+
+    private render(): void {
+        const doc = this.drawer.body.ownerDocument;
+        this.drawer.body.replaceChildren();
+
+        if (this.view !== 'main') {
+            const back = doc.createElement('button');
+            back.className = 'vela-md-back';
+            back.appendChild(iconEl('chevron-left', doc));
+            back.appendChild(doc.createTextNode(this.view === 'style' ? 'Chart type' : this.view === 'layout' ? 'Layout' : 'Alerts'));
+            back.addEventListener('click', () => this.show('main'));
+            this.drawer.body.appendChild(back);
+        }
+
+        if (this.view === 'main') this.renderMain(doc);
+        else if (this.view === 'style') this.renderStyle(doc);
+        else if (this.view === 'layout') this.renderLayout(doc);
+        else this.renderAlerts(doc);
+    }
+
+    private row(doc: Document, label: string, opts: { icon?: string; value?: string; chevron?: boolean; checked?: boolean; onClick: () => void }): HTMLElement {
+        const el = doc.createElement('div');
+        el.className = 'vela-md-row';
+        if (opts.icon) el.appendChild(iconEl(opts.icon, doc));
+        const text = doc.createElement('span');
+        text.className = 'vela-md-row-label';
+        text.textContent = label;
+        el.appendChild(text);
+        if (opts.value) {
+            const value = doc.createElement('span');
+            value.className = 'vela-md-row-value';
+            value.textContent = opts.value;
+            el.appendChild(value);
+        }
+        if (opts.checked) el.appendChild(iconEl('check', doc));
+        if (opts.chevron) el.appendChild(iconEl('chevron-right', doc));
+        el.addEventListener('click', opts.onClick);
+        return el;
+    }
+
+    private renderMain(doc: Document): void {
+        const actions = doc.createElement('div');
+        actions.className = 'vela-md-actions';
+        const action = (icon: string, label: string, enabled: boolean, run: () => void): void => {
+            const b = doc.createElement('button');
+            b.className = 'vela-md-action';
+            b.disabled = !enabled;
+            b.appendChild(iconEl(icon, doc));
+            b.appendChild(doc.createTextNode(label));
+            b.addEventListener('click', () => {
+                run();
+                this.drawer.hide();
+            });
+            actions.appendChild(b);
+        };
+        action('undo', 'Undo', this.opts.canUndo(), this.opts.onUndo);
+        action('redo', 'Redo', this.opts.canRedo(), this.opts.onRedo);
+        action('camera', 'Screenshot', true, this.opts.onScreenshot);
+        this.drawer.body.appendChild(actions);
+
+        const list = doc.createElement('div');
+        list.className = 'vela-md-list';
+        const current = this.opts.priceStyles().find((s) => s.id === this.opts.priceStyle());
+        list.appendChild(this.row(doc, 'Chart type', { icon: 'style-line', value: current?.label, chevron: true, onClick: () => this.show('style') }));
+        if (this.opts.layout) {
+            const shape = this.opts.layout.shape();
+            const value = shape ? `${shape.cols} × ${shape.rows}` : this.opts.layout.presets().find((p) => p.checked)?.label;
+            list.appendChild(this.row(doc, 'Layout', { icon: 'layout', value, chevron: true, onClick: () => this.show('layout') }));
+        }
+        for (const panel of this.opts.panels()) {
+            list.appendChild(
+                this.row(doc, panel.title, {
+                    icon: panel.icon,
+                    onClick: () => {
+                        this.opts.onTogglePanel(panel.id);
+                        this.drawer.hide();
+                    },
+                }),
+            );
+        }
+        const alertCount = this.opts.alerts().length;
+        list.appendChild(this.row(doc, 'Alerts', { icon: 'bell', value: alertCount > 0 ? String(alertCount) : undefined, chevron: true, onClick: () => this.show('alerts') }));
+        for (const act of this.opts.actions()) {
+            list.appendChild(
+                this.row(doc, act.label, {
+                    icon: act.icon,
+                    onClick: () => {
+                        act.run();
+                        this.drawer.hide();
+                    },
+                }),
+            );
+        }
+        this.drawer.body.appendChild(list);
+    }
+
+    private renderStyle(doc: Document): void {
+        const list = doc.createElement('div');
+        list.className = 'vela-md-list';
+        const current = this.opts.priceStyle();
+        for (const style of this.opts.priceStyles()) {
+            list.appendChild(
+                this.row(doc, style.label, {
+                    icon: style.icon,
+                    checked: style.id === current,
+                    onClick: () => {
+                        this.opts.onPriceStyle(style.id);
+                        this.drawer.hide();
+                    },
+                }),
+            );
+        }
+        this.drawer.body.appendChild(list);
+    }
+
+    private renderLayout(doc: Document): void {
+        const layout = this.opts.layout;
+        if (!layout) return;
+        const list = doc.createElement('div');
+        list.className = 'vela-md-list';
+        // The desktop dropdown's grid canvas, touch-sized: the current rows×cols
+        // rectangle is lit, a tap applies that grid immediately (no hover preview).
+        const wrap = doc.createElement('div');
+        wrap.className = 'vela-md-gridwrap';
+        const { el: grid, squares } = layoutGridCanvas(doc);
+        paintLayoutGrid(squares, layout.shape());
+        grid.addEventListener('click', (e) => {
+            const sq = (e.target as Element | null)?.closest?.('.vela-lp-sq');
+            if (!(sq instanceof HTMLButtonElement)) return;
+            layout.onSelectGrid(Number(sq.dataset.r) + 1, Number(sq.dataset.c) + 1);
+            this.drawer.hide();
+        });
+        wrap.appendChild(grid);
+        list.appendChild(wrap);
+        for (const preset of layout.presets()) {
+            list.appendChild(
+                this.row(doc, preset.label, {
+                    checked: preset.checked,
+                    onClick: () => {
+                        layout.onSelectPreset(preset.id);
+                        this.drawer.hide();
+                    },
+                }),
+            );
+        }
+        const syncs = layout.syncs?.() ?? [];
+        if (syncs.length > 0) {
+            const heading = doc.createElement('div');
+            heading.className = 'vela-md-section';
+            heading.textContent = 'Sync';
+            list.appendChild(heading);
+            for (const s of syncs) {
+                list.appendChild(
+                    this.row(doc, s.label, {
+                        checked: s.checked,
+                        onClick: () => {
+                            layout.onToggleSync?.(s.id);
+                            this.render(); // a toggle stays in the drawer — reflect the flip in place
+                        },
+                    }),
+                );
+            }
+        }
+        this.drawer.body.appendChild(list);
+    }
+
+    private renderAlerts(doc: Document): void {
+        const alerts = this.opts.alerts();
+        if (alerts.length === 0) {
+            const empty = doc.createElement('div');
+            empty.className = 'vela-md-empty';
+            empty.textContent = 'No alerts yet.';
+            this.drawer.body.appendChild(empty);
+            return;
+        }
+        const list = doc.createElement('div');
+        list.className = 'vela-md-list';
+        for (const a of alerts) {
+            list.appendChild(this.row(doc, `${a.title}: ${a.message}`, { value: new Date(a.time).toLocaleTimeString(), onClick: () => undefined }));
+        }
+        this.drawer.body.appendChild(list);
+    }
+}

--- a/src/widget/object-tree.ts
+++ b/src/widget/object-tree.ts
@@ -1318,6 +1318,11 @@ export class ObjectTree extends SidePanel {
                 this.refresh();
             }),
         ];
+        // The legend gear's twin — reachable here even where the legend is folded away
+        // (mobile) or replaced by the overview chip (multi-chart grids).
+        if (chart.renderer.supportsIndicatorSettings) {
+            items.push(b.entry('Indicator settings', 'gear', () => chart.renderer.openIndicatorSettings(row.id)));
+        }
         if (chart.panes.supported) {
             const moves = this.moveItems(b, pass, row.id, paneId);
             if (moves.length > 0) items.push(b.submenu('Move to', 'move-vertical', moves));

--- a/src/widget/panel-dock.ts
+++ b/src/widget/panel-dock.ts
@@ -127,6 +127,12 @@ export class PanelDock {
         return this.entries.find((e) => e.panel.open)?.id ?? null;
     }
 
+    /** The docked panels in dock order — what a non-topbar chrome (the mobile
+     *  three-dots drawer) lists so every panel stays reachable there too. */
+    list(): ReadonlyArray<SidePanelButton> {
+        return this.entries.map((e) => ({ id: e.id, title: e.title, icon: e.icon }));
+    }
+
     /** The dock's persistable state, or null when there is nothing worth saving. */
     getState(): PanelsState | null {
         const out: PanelsState = {};

--- a/src/widget/price-scale-drawer.ts
+++ b/src/widget/price-scale-drawer.ts
@@ -1,0 +1,204 @@
+// Price-scale drawer (mobile) — opened by a long-press on the price axis. Mirrors the
+// desktop right-click price-axis menu: auto / invert / scale modes / label & level
+// toggles, plus a hop into the full Scales settings tab.
+import { Drawer } from '../ui/components/drawer';
+import { iconEl } from '../ui/icons';
+import { injectStyles } from '../ui/styles';
+import {
+    invertWrite,
+    paneScaleAt,
+    priceAxisItems,
+    scaleChoiceOf,
+    scaleWrites,
+    settingsSectionOf,
+    type PaneScaleInfo,
+    type ScaleChoice,
+} from './context-menu-model';
+import type { Vela } from '../Vela';
+
+const STYLE_ID = 'vela-widget-price-scale-drawer';
+const CSS = `
+.vela-psd-list { padding: 2px 0 4px; }
+.vela-psd-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-height: 46px;
+    padding: 0 2px;
+    border-radius: 8px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-psd-row:active { background: var(--vela-hover); }
+.vela-psd-row[data-sep='1'] { margin-top: 6px; padding-top: 6px; border-top: 1px solid var(--vela-border); border-radius: 0 0 8px 8px; }
+.vela-psd-row-label { flex: 1 1 auto; min-width: 0; font-size: 14px; color: var(--vela-fg-bright); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.vela-psd-row .vela-icon { flex: none; color: var(--vela-fg-bright); }
+.vela-psd-section {
+    padding: 12px 2px 4px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    color: var(--vela-fg-muted);
+}
+`;
+
+export interface PriceScaleDrawerOptions {
+    host: HTMLElement;
+    /** Live chart (reads/writes scale features). */
+    chart: () => Vela | null;
+    /** Plot-local y of the long-press — picks which pane's scale the sheet targets. */
+    pressY: () => number;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export class PriceScaleDrawer {
+    private readonly drawer: Drawer;
+    private pane: PaneScaleInfo | null = null;
+
+    constructor(private readonly opts: PriceScaleDrawerOptions) {
+        injectStyles(STYLE_ID, CSS, opts.host.ownerDocument);
+        this.drawer = new Drawer({ host: opts.host, title: 'Price scale', onOpenChange: opts.onOpenChange });
+    }
+
+    open(): void {
+        const chart = this.opts.chart();
+        const panes = chart?.renderer.get('paneScales');
+        this.pane = Array.isArray(panes) ? paneScaleAt(panes as PaneScaleInfo[], this.opts.pressY()) : null;
+        this.render();
+        this.drawer.show();
+    }
+
+    close(): void {
+        this.drawer.hide();
+    }
+
+    destroy(): void {
+        this.drawer.destroy();
+    }
+
+    private flag(feature: string): boolean {
+        return Boolean(this.opts.chart()?.renderer.get(feature));
+    }
+
+    private render(): void {
+        const chart = this.opts.chart();
+        const doc = this.drawer.body.ownerDocument;
+        this.drawer.body.replaceChildren();
+        if (!chart) return;
+
+        const pane = this.pane;
+        const items = priceAxisItems({
+            auto: chart.renderer.get('autoScale') !== false,
+            invert: pane ? pane.invert : this.flag('invertScale'),
+            choice: scaleChoiceOf(pane ?? { mode: String(chart.renderer.get('scaleMode') ?? 'price'), log: this.flag('logScale') }),
+            axisLabels: this.flag('axisLabels'),
+            priceLabel: this.flag('priceLabel'),
+            countdown: this.flag('countdown'),
+            priceLine: this.flag('currentPriceLine'),
+        });
+
+        const list = doc.createElement('div');
+        list.className = 'vela-psd-list';
+
+        const row = (label: string, opts: { checked?: boolean; sep?: boolean; onClick: () => void }): void => {
+            const el = doc.createElement('div');
+            el.className = 'vela-psd-row';
+            if (opts.sep) el.dataset.sep = '1';
+            const text = doc.createElement('span');
+            text.className = 'vela-psd-row-label';
+            text.textContent = label;
+            el.appendChild(text);
+            if (opts.checked) el.appendChild(iconEl('check', doc));
+            el.addEventListener('click', opts.onClick);
+            list.appendChild(el);
+        };
+        const section = (label: string): void => {
+            const el = doc.createElement('div');
+            el.className = 'vela-psd-section';
+            el.textContent = label;
+            list.appendChild(el);
+        };
+
+        for (const item of items) {
+            if (item.id === 'labels' && item.submenu) {
+                section('Labels');
+                for (const sub of item.submenu) {
+                    row(sub.label, {
+                        checked: sub.checked,
+                        onClick: () => {
+                            const feature = sub.id.slice('toggle:'.length);
+                            chart.renderer.set(feature, !this.flag(feature));
+                            this.render();
+                        },
+                    });
+                }
+                continue;
+            }
+            if (item.id === 'levels' && item.submenu) {
+                section('Levels');
+                for (const sub of item.submenu) {
+                    row(sub.label, {
+                        checked: sub.checked,
+                        onClick: () => {
+                            const feature = sub.id.slice('toggle:'.length);
+                            chart.renderer.set(feature, !this.flag(feature));
+                            this.render();
+                        },
+                    });
+                }
+                continue;
+            }
+            if (item.id.startsWith('settings')) {
+                row(item.label, {
+                    sep: true,
+                    onClick: () => {
+                        chart.renderer.openSettings(settingsSectionOf(item.id));
+                        this.drawer.hide();
+                    },
+                });
+                continue;
+            }
+            if (item.id === 'auto') {
+                row(item.label, {
+                    checked: item.checked,
+                    onClick: () => {
+                        chart.renderer.set('autoScale', chart.renderer.get('autoScale') === false);
+                        this.render();
+                    },
+                });
+                continue;
+            }
+            if (item.id === 'invert') {
+                row(item.label, {
+                    checked: item.checked,
+                    onClick: () => {
+                        const [feature, value] = invertWrite(!(pane ? pane.invert : this.flag('invertScale')), pane);
+                        chart.renderer.set(feature, value);
+                        // Refresh pane snapshot so the next invert flip uses the new state.
+                        const panes = chart.renderer.get('paneScales');
+                        this.pane = Array.isArray(panes) ? paneScaleAt(panes as PaneScaleInfo[], this.opts.pressY()) : pane;
+                        this.render();
+                    },
+                });
+                continue;
+            }
+            if (item.id.startsWith('scale:')) {
+                row(item.label, {
+                    checked: item.checked,
+                    sep: item.separatorBefore,
+                    onClick: () => {
+                        for (const [feature, value] of scaleWrites(item.id.slice('scale:'.length) as ScaleChoice, pane)) {
+                            chart.renderer.set(feature, value);
+                        }
+                        const panes = chart.renderer.get('paneScales');
+                        this.pane = Array.isArray(panes) ? paneScaleAt(panes as PaneScaleInfo[], this.opts.pressY()) : pane;
+                        this.render();
+                    },
+                });
+            }
+        }
+
+        this.drawer.body.appendChild(list);
+    }
+}

--- a/src/widget/shell-options.ts
+++ b/src/widget/shell-options.ts
@@ -34,6 +34,11 @@ export interface VelaShellOptions {
     statusline?: boolean;
     watermark?: boolean;
     bottombar?: boolean;
+    /** Chrome size class. `'auto'` (default) follows the CONTAINER width plus a
+     *  coarse-pointer heuristic; `'mobile'` / `'desktop'` pin it. Mobile swaps the
+     *  topbar + desktop bottombar for one touch-first bottom bar, presents pickers
+     *  fullscreen and menus as bottom drawers, and enables the touch chart gestures. */
+    layoutMode?: 'auto' | 'mobile' | 'desktop';
     /** Focus the chart when the shell mounts so keyboard shortcuts work from the first
      *  keystroke — no initial click needed. Default false: an embedded shell must never
      *  steal the page's focus from the host's own controls. */

--- a/src/widget/side-panel.ts
+++ b/src/widget/side-panel.ts
@@ -86,6 +86,17 @@ const CSS = `
 }
 .vela-panel-resizer:hover::after,
 .vela-panel-resizer[data-dragging]::after { background: var(--vela-accent); }
+/* Mobile: a 280px column would crush a phone-width chart — the panel overlays the
+   chart area instead (its flex parent is position:relative), full-bleed, closed by
+   the same header ✕. Width dragging is a pointer affordance; off on mobile. */
+[data-layout='mobile'] .vela-panel {
+    position: absolute;
+    inset: 0;
+    width: auto;
+    z-index: 25;
+    border-left: none;
+}
+[data-layout='mobile'] .vela-panel-resizer { display: none; }
 `;
 
 /** Per-panel width policy. Omitted fields fall back to the module defaults. */

--- a/src/widget/statusline.ts
+++ b/src/widget/statusline.ts
@@ -95,6 +95,53 @@ const CSS = `
  * Statusline constructor) — the stylesheet is document-global, so a bare container
  * class here would shift every chart on the page, including statusline-less ones. */
 .vela-has-statusline [data-vela-pane='price'] { transform: translateY(26px); }
+/* Mobile: two-line chip — logo / symbol / meta / market status on one aligned row, the
+ * bar change on the next. Full O/H/L/C stays hidden (too dense on a phone-width plot). */
+[data-layout='mobile'] .vela-statusline {
+    flex-wrap: wrap;
+    align-items: center;
+    row-gap: 1px;
+    max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
+    font-size: var(--vela-font-size-sm);
+}
+[data-layout='mobile'] .vela-statusline .vela-sl-symbol {
+    font-size: var(--vela-font-size-md);
+    line-height: 1;
+}
+[data-layout='mobile'] .vela-statusline .vela-sl-meta {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1;
+}
+[data-layout='mobile'] .vela-statusline .vela-sl-avatar,
+[data-layout='mobile'] .vela-statusline .vela-sl-market { align-self: center; }
+[data-layout='mobile'] .vela-statusline .vela-sl-ohlc { display: none !important; }
+[data-layout='mobile'] .vela-statusline .vela-sl-change {
+    flex-basis: 100%;
+    /* Sit under the text column (past the avatar + its gap), not under the logo. */
+    padding-left: calc(18px + var(--vela-space-2));
+    font-size: var(--vela-font-size-sm);
+    line-height: 1.2;
+}
+[data-layout='mobile'] .vela-has-statusline [data-vela-pane='price'] { transform: translateY(40px); }
+/* FIT mode (multi-chart cells — see setFitMode): the line never wraps; segments that
+ * don't fit are HIDDEN by fit() (change first, then meta, then the market badge), so
+ * overflow:hidden only guards the transient between a resize and the next measure.
+ * Placed after the mobile block on purpose: same specificity, later wins. */
+.vela-statusline.vela-sl-fit {
+    flex-wrap: nowrap;
+    align-items: center;
+    max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
+    overflow: hidden;
+}
+.vela-statusline.vela-sl-fit .vela-sl-change {
+    flex-basis: auto;
+    padding-left: 0;
+}
+/* One row again — the mobile two-line shift doesn't apply in fit mode. */
+[data-layout='mobile'] .vela-sl-fit-host.vela-has-statusline [data-vela-pane='price'] { transform: translateY(26px); }
 `;
 
 interface BarLike {
@@ -200,6 +247,9 @@ export class Statusline {
     private isUp: ((bar: { open: number; close: number }) => boolean) | null = null;
     /** 'ohlc' for bar-shaped styles; 'value' (the single plotted close) for line styles. */
     private readout: StatuslineReadout = 'ohlc';
+    /** Fit mode (multi-chart cells): one row, overflowing segments hidden — see {@link setFitMode}. */
+    private fitMode = false;
+    private fitRO: ResizeObserver | null = null;
 
     constructor(private readonly host: HTMLElement, symbol: string) {
         const doc = host.ownerDocument;
@@ -237,6 +287,55 @@ export class Statusline {
         const fresh = tickerIconEl(this.el.ownerDocument, baseOfTicker(ticker), ticker, 'vela-sl-avatar');
         this.avatarEl.replaceWith(fresh);
         this.avatarEl = fresh;
+        this.fit();
+    }
+
+    /**
+     * Multi-chart cells: keep the line on ONE row whatever the cell width — never wrap.
+     * Segments that don't fit are hidden outright rather than clipped mid-glyph, least
+     * important first: OHLC, then the bar change, the venue/timeframe meta, and the
+     * market badge; the logo + ticker always stay. Re-fits live on host resizes.
+     */
+    setFitMode(on: boolean): void {
+        if (on === this.fitMode) return;
+        this.fitMode = on;
+        this.el.classList.toggle('vela-sl-fit', on);
+        this.host.classList.toggle('vela-sl-fit-host', on);
+        if (on) {
+            if (typeof ResizeObserver !== 'undefined' && !this.fitRO) {
+                this.fitRO = new ResizeObserver(() => this.fit());
+                this.fitRO.observe(this.host);
+            }
+            this.fit();
+        } else {
+            this.fitRO?.disconnect();
+            this.fitRO = null;
+            this.syncParts(); // restore whatever fit() had hidden
+        }
+    }
+
+    /** Project the parts config onto the segments (the baseline fit() prunes from). */
+    private syncParts(): void {
+        this.symbolEl.style.display = this.parts.name ? '' : 'none';
+        this.marketEl.style.display = this.parts.market ? '' : 'none';
+        this.ohlcEl.style.display = this.parts.ohlc ? '' : 'none';
+        this.changeEl.style.display = this.parts.change ? '' : 'none';
+    }
+
+    /** Hide overflowing segments until the row fits its max-width (fit mode only). */
+    private fit(): void {
+        if (!this.fitMode) return;
+        this.syncParts(); // start from the full (parts-allowed) row, then prune
+        const order: Array<[HTMLElement, boolean]> = [
+            [this.ohlcEl, this.parts.ohlc],
+            [this.changeEl, this.parts.change],
+            [this.metaEl, true],
+            [this.marketEl, this.parts.market],
+        ];
+        for (const [el, shown] of order) {
+            if (this.el.scrollWidth <= this.el.clientWidth) break;
+            if (shown) el.style.display = 'none';
+        }
     }
 
     /** Shape + color the value readout after the active price style: its own up/down
@@ -258,6 +357,7 @@ export class Statusline {
     /** The "· BINANCE · 1h" segment after the symbol — venue first, then resolution. */
     setMeta(timeframe: string, provider: string): void {
         this.metaEl.textContent = `${provider ? `· ${provider.toUpperCase()} ` : ''}· ${timeframeLabel(timeframe)}`;
+        this.fit();
     }
 
     /** Dress the market badge for a session state: its icon, tinted circle, and the
@@ -271,10 +371,8 @@ export class Statusline {
 
     setPartVisible(part: 'name' | 'market' | 'ohlc' | 'change', visible: boolean): void {
         this.parts[part] = visible;
-        this.symbolEl.style.display = this.parts.name ? '' : 'none';
-        this.marketEl.style.display = this.parts.market ? '' : 'none';
-        this.ohlcEl.style.display = this.parts.ohlc ? '' : 'none';
-        this.changeEl.style.display = this.parts.change ? '' : 'none';
+        this.syncParts();
+        this.fit();
     }
 
     partVisible(part: 'name' | 'market' | 'ohlc' | 'change'): boolean {
@@ -301,8 +399,10 @@ export class Statusline {
 
     destroy(): void {
         this.detach();
+        this.fitRO?.disconnect();
+        this.fitRO = null;
         this.marketTip.destroy();
-        this.host.classList.remove('vela-has-statusline'); // the legend shift leaves with the line
+        this.host.classList.remove('vela-has-statusline', 'vela-sl-fit-host'); // the legend shift leaves with the line
         this.el.remove();
     }
 
@@ -340,5 +440,6 @@ export class Statusline {
         this.changeEl.textContent = fmtChange(bar.open, bar.close);
         this.changeEl.dataset.dir = up ? 'up' : 'down';
         this.changeEl.style.color = ink;
+        this.fit(); // the readout's width just changed — cheap no-op outside fit mode
     }
 }

--- a/src/widget/symbol-picker.ts
+++ b/src/widget/symbol-picker.ts
@@ -99,6 +99,13 @@ const CSS = `
     outline: none;
 }
 .vela-sp-tabs { display: flex; gap: 14px; margin: 12px 2px 6px; border-bottom: 1px solid var(--vela-border); padding-bottom: 8px; }
+/* Mobile (fullscreen dialog): the asset-class strip scrolls sideways instead of
+   overflowing the body, and the result list stops capping itself — the body owns
+   the scrolling in the fullscreen presentation. */
+[data-layout='mobile'] .vela-sp-tabs { overflow-x: auto; scrollbar-width: none; gap: 6px; }
+[data-layout='mobile'] .vela-sp-tabs::-webkit-scrollbar { display: none; }
+[data-layout='mobile'] .vela-sp-tab { flex: none; padding: 7px 10px; }
+[data-layout='mobile'] .vela-sp-list { max-height: none; }
 .vela-sp-tab {
     all: unset;
     padding: 3px 10px;

--- a/src/widget/timeframe-drawer.ts
+++ b/src/widget/timeframe-drawer.ts
@@ -1,0 +1,143 @@
+// Timeframe drawer (mobile) — the bottom-sheet counterpart of the topbar timeframe menu
+// PLUS the desktop bottombar's range chips: date ranges first (horizontally scrollable),
+// then the timeframe presets. Selection state is re-read on every open, so it always
+// mirrors whatever path last changed the timeframe (quick entry, API, a range chip).
+import { Drawer } from '../ui/components/drawer';
+import { injectStyles } from '../ui/styles';
+import type { RangePreset } from './bottombar';
+import { timeframeLabel } from './timeframe';
+
+const STYLE_ID = 'vela-widget-tf-drawer';
+const CSS = `
+.vela-tfd-heading {
+    padding: 4px 2px 8px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    color: var(--vela-fg-bright);
+}
+.vela-tfd-heading + .vela-tfd-ranges,
+.vela-tfd-heading + .vela-tfd-grid { padding-top: 0; }
+.vela-tfd-ranges {
+    display: flex;
+    gap: 6px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    padding: 0 2px 14px;
+}
+.vela-tfd-ranges::-webkit-scrollbar { display: none; }
+.vela-tfd-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(64px, 1fr));
+    gap: 6px;
+    padding-bottom: 4px;
+}
+.vela-tfd-chip {
+    all: unset;
+    min-height: 40px;
+    padding: 0 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+    border: 1px solid var(--vela-border);
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--vela-fg);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-tfd-chip:active { background: var(--vela-hover); }
+.vela-tfd-chip[data-active='1'] {
+    color: var(--vela-fg-bright);
+    border-color: var(--vela-fg-bright);
+    background: var(--vela-hover);
+}
+`;
+
+export interface TimeframeDrawerOptions {
+    host: HTMLElement;
+    timeframes: readonly string[];
+    ranges: readonly RangePreset[];
+    /** Read live at open — the current timeframe (highlights its chip). */
+    currentTimeframe: () => string;
+    /** Read live at open — the active range chip id, or null. */
+    activeRange: () => string | null;
+    onTimeframe: (tf: string) => void;
+    onRange: (preset: RangePreset) => void;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export class TimeframeDrawer {
+    private readonly drawer: Drawer;
+    private readonly rangeChips = new Map<string, HTMLButtonElement>();
+    private readonly tfChips = new Map<string, HTMLButtonElement>();
+
+    constructor(private readonly opts: TimeframeDrawerOptions) {
+        const doc = opts.host.ownerDocument;
+        injectStyles(STYLE_ID, CSS, doc);
+        this.drawer = new Drawer({ host: opts.host, onOpenChange: opts.onOpenChange });
+
+        const rangeHeading = doc.createElement('div');
+        rangeHeading.className = 'vela-tfd-heading';
+        rangeHeading.textContent = 'Date Range';
+
+        const ranges = doc.createElement('div');
+        ranges.className = 'vela-tfd-ranges';
+        for (const preset of opts.ranges) {
+            const chip = doc.createElement('button');
+            chip.className = 'vela-tfd-chip';
+            chip.textContent = preset.id;
+            chip.addEventListener('click', () => {
+                opts.onRange(preset);
+                this.drawer.hide();
+            });
+            this.rangeChips.set(preset.id, chip);
+            ranges.appendChild(chip);
+        }
+
+        const tfHeading = doc.createElement('div');
+        tfHeading.className = 'vela-tfd-heading';
+        tfHeading.textContent = 'Timeframes';
+
+        const grid = doc.createElement('div');
+        grid.className = 'vela-tfd-grid';
+        for (const tf of opts.timeframes) {
+            const chip = doc.createElement('button');
+            chip.className = 'vela-tfd-chip';
+            chip.textContent = timeframeLabel(tf);
+            chip.addEventListener('click', () => {
+                opts.onTimeframe(tf);
+                this.drawer.hide();
+            });
+            this.tfChips.set(tf, chip);
+            grid.appendChild(chip);
+        }
+
+        this.drawer.body.append(rangeHeading, ranges, tfHeading, grid);
+    }
+
+    open(): void {
+        const tf = this.opts.currentTimeframe();
+        const range = this.opts.activeRange();
+        for (const [id, chip] of this.rangeChips) {
+            if (range !== null && id === range) chip.dataset.active = '1';
+            else delete chip.dataset.active;
+        }
+        for (const [id, chip] of this.tfChips) {
+            if (range === null && id === tf) chip.dataset.active = '1';
+            else delete chip.dataset.active;
+        }
+        this.drawer.show();
+    }
+
+    close(): void {
+        this.drawer.hide();
+    }
+
+    destroy(): void {
+        this.drawer.destroy();
+    }
+}

--- a/src/widget/timezone-drawer.ts
+++ b/src/widget/timezone-drawer.ts
@@ -1,0 +1,76 @@
+// Timezone drawer (mobile) — opened by a long-press on the time axis. Lists every
+// IANA zone the desktop bottom-bar picker offers; picking one applies and closes.
+import { Drawer } from '../ui/components/drawer';
+import { iconEl } from '../ui/icons';
+import { injectStyles } from '../ui/styles';
+import { TIMEZONES, tzMenuLabel, normalizeTimezone } from './timezones';
+
+const STYLE_ID = 'vela-widget-timezone-drawer';
+const CSS = `
+.vela-tzd-list { padding: 2px 0 4px; }
+.vela-tzd-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-height: 46px;
+    padding: 0 2px;
+    border-radius: 8px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+.vela-tzd-row:active { background: var(--vela-hover); }
+.vela-tzd-row-label { flex: 1 1 auto; min-width: 0; font-size: 14px; color: var(--vela-fg-bright); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.vela-tzd-row .vela-icon { flex: none; color: var(--vela-fg-bright); }
+`;
+
+export interface TimezoneDrawerOptions {
+    host: HTMLElement;
+    timezone: () => string;
+    onTimezone: (zone: string) => void;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export class TimezoneDrawer {
+    private readonly drawer: Drawer;
+
+    constructor(private readonly opts: TimezoneDrawerOptions) {
+        injectStyles(STYLE_ID, CSS, opts.host.ownerDocument);
+        this.drawer = new Drawer({ host: opts.host, title: 'Time zone', onOpenChange: opts.onOpenChange });
+    }
+
+    open(): void {
+        this.render();
+        this.drawer.show();
+    }
+
+    close(): void {
+        this.drawer.hide();
+    }
+
+    destroy(): void {
+        this.drawer.destroy();
+    }
+
+    private render(): void {
+        const doc = this.drawer.body.ownerDocument;
+        this.drawer.body.replaceChildren();
+        const list = doc.createElement('div');
+        list.className = 'vela-tzd-list';
+        const current = normalizeTimezone(this.opts.timezone());
+        for (const tz of TIMEZONES) {
+            const row = doc.createElement('div');
+            row.className = 'vela-tzd-row';
+            const label = doc.createElement('span');
+            label.className = 'vela-tzd-row-label';
+            label.textContent = tzMenuLabel(tz.value, tz.label);
+            row.appendChild(label);
+            if (tz.value === current) row.appendChild(iconEl('check', doc));
+            row.addEventListener('click', () => {
+                this.opts.onTimezone(tz.value);
+                this.drawer.hide();
+            });
+            list.appendChild(row);
+        }
+        this.drawer.body.appendChild(list);
+    }
+}

--- a/src/widget/watermark.ts
+++ b/src/widget/watermark.ts
@@ -4,7 +4,7 @@ import { timeframeLabel } from './timeframe';
 import { parseSymbol } from '../data/ProviderRegistry';
 
 /** The watermark's largest type size — a lone full-size chart renders at this cap. */
-const MAX_FONT_PX = 72;
+const MAX_FONT_PX = 36;
 /** Floor for tiny cells — the mark is a 5%-opacity background, small is fine. */
 const MIN_FONT_PX = 12;
 /** Share of the chart width the text may occupy (breathing room at both edges). */

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -519,6 +519,12 @@ export class ChartCell {
         this.statusline.setDirectionColors(...statuslineInkOf(this.inner.renderer, this.priceStyle));
     }
 
+    /** Multi-cell grids keep the status line on one row and hide what doesn't fit —
+     *  the workspace flips this with the layout (see Statusline.setFitMode). */
+    setStatuslineFit(on: boolean): void {
+        this.statusline?.setFitMode(on);
+    }
+
     /** The workspace shell keeps the app theme; the cell host's tokens re-derive from
      *  the LIVE plot surface (see {@link applyPlotOverlayTokens}). */
     private syncPlotOverlayTokens(): void {

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -19,8 +19,8 @@ import { ensureUIHost, injectStyles, registerIcon, svg16 } from '../ui';
 import { isEditableTarget, KeymapManager } from '../ui/keymap';
 import { Menu } from '../ui/components/menu';
 import type { Vela } from '../Vela';
-import { Topbar } from '../widget/topbar';
-import { Bottombar } from '../widget/bottombar';
+import { Topbar, priceStyleLabel, priceStyleIcon } from '../widget/topbar';
+import { Bottombar, RANGE_PRESETS } from '../widget/bottombar';
 import { ObjectTree } from '../widget/object-tree';
 import { DataWindow } from '../widget/data-window';
 import type { ScriptRun } from '../core/script-run';
@@ -32,7 +32,16 @@ import { ShortcutsHelp } from '../widget/shortcuts-help';
 import { Toast } from '../widget/toast';
 import { Glider, ZOOM_IN, ZOOM_OUT, PAN_FAST } from '../widget/glide';
 import { toolShortcutHints } from '../widget/tool-shortcuts';
-import { legendActionsProviderFor, widgetAttachments } from '../widget/contributions';
+import { legendActionsProviderFor, widgetActions, widgetAttachments } from '../widget/contributions';
+import { LayoutModeController, type LayoutMode } from '../widget/layout-mode';
+import { MobileBar } from '../widget/mobile-bar';
+import { TimeframeDrawer } from '../widget/timeframe-drawer';
+import { DrawingsDrawer } from '../widget/drawings-drawer';
+import { MoreDrawer } from '../widget/more-drawer';
+import { TimezoneDrawer } from '../widget/timezone-drawer';
+import { PriceScaleDrawer } from '../widget/price-scale-drawer';
+import { DrawingPill } from '../widget/drawing-pill';
+import { priceStyleIds } from '../renderers/native/core/chartConfig';
 import { resolveIndicators, type IndicatorManifest, type ResolvedIndicator } from '../widget/indicators';
 import { DrawingToolbar } from '../renderers/native/drawings/DrawingToolbar';
 import { applyAttributionMarkTheme, createAttributionMark, createCustomMark } from '../renderers/native/chrome/AttributionMark';
@@ -149,6 +158,9 @@ const CSS = `
 .vela-ws-splitter:hover::after { content: ''; position: absolute; background: var(--vela-separator-hover-line); }
 .vela-ws-splitter[data-axis='cols']:hover::after { left: calc(50% - 1px); top: 0; width: 2px; height: 100%; }
 .vela-ws-splitter[data-axis='rows']:hover::after { top: calc(50% - 1px); left: 0; height: 2px; width: 100%; }
+/* Mobile: the docked drawing-toolbar column would eat a phone-width grid — the shell's
+   drawings drawer + on-chart pill replace it (same policy as the widget's in-chart bar). */
+[data-layout='mobile'] .vela-ws-toolbar { display: none; }
 `;
 
 /** Grid glyph for the topbar layout dropdown (stroke follows the button color). */
@@ -252,6 +264,19 @@ export class VelaWorkspace {
     private openDialogs = 0;
     private alerts: Array<{ cellId: string; symbol: string; title: string; message: string; time: number }> = [];
     private alertsMenu: Menu | null = null;
+    // ── mobile chrome (same components as the widget shell; CSS keys off data-layout
+    // on the root, the drawers build lazily on first open and act on the ACTIVE cell) ──
+    /** Writes `data-layout` on the root and pushes mode flips into every cell's renderer. */
+    private layoutCtl!: LayoutModeController;
+    private readonly mobileBar: MobileBar | null;
+    private readonly drawingPill: DrawingPill;
+    private tfDrawer: TimeframeDrawer | null = null;
+    private drawingsDrawer: DrawingsDrawer | null = null;
+    private moreDrawer: MoreDrawer | null = null;
+    private timezoneDrawer: TimezoneDrawer | null = null;
+    private priceScaleDrawer: PriceScaleDrawer | null = null;
+    /** Plot-local y of the last price-axis long-press (targets the pane under the finger). */
+    private priceScalePressY = 0;
     private readonly attachmentDisposers = new Map<string, () => void>();
     /** The single grid-wide attribution mark — re-inked on a live theme swap. */
     private attributionMark: HTMLElement | null = null;
@@ -481,7 +506,30 @@ export class VelaWorkspace {
                   })
                 : null;
 
+        // The mobile bar is the bottom bar of the mobile size class — the same chrome
+        // toggle governs both; CSS (data-layout) decides which one is visible. Every
+        // route acts on the ACTIVE cell, exactly like the topbar it replaces.
+        this.mobileBar =
+            opts.bottombar !== false
+                ? new MobileBar(this.root, {
+                      symbol: '',
+                      timeframe: '60',
+                      onSymbolClick: () => this.symbolPicker.open(),
+                      onTimeframeClick: () => this.openTimeframeDrawer(),
+                      onIndicatorsClick: () => this.indicatorPicker.open(),
+                      onDrawingsClick: () => this.openDrawingsDrawer(),
+                      onMoreClick: () => this.openMoreDrawer(),
+                      onSettingsClick: () => this.active.chart.renderer.openSettings(),
+                  })
+                : null;
+        // One pill for the whole grid — rebound to the active cell on every projection.
+        this.drawingPill = new DrawingPill(this.gridEl);
+
         hostEl.appendChild(this.root);
+
+        // Measured AFTER the root is in the DOM so the first evaluation sees a real width.
+        this.layoutCtl = new LayoutModeController(this.root, opts.layoutMode ?? 'auto');
+        this.layoutCtl.onChange((mode) => this.onLayoutModeChange(mode));
 
         this.splitters = new SplitterLayer(this.gridEl, {
             tracks: () => this.currentTracks(),
@@ -507,6 +555,7 @@ export class VelaWorkspace {
         this.cellBackend = this.backendFor(this.def);
         this.applyGrid();
         this.buildCells();
+        this.syncCellPresentation();
         this.setActiveCell(bootActive != null && this.cellsById.has(bootActive) ? bootActive : (this.order[0] ?? null));
         // Shortcuts only fire while focus is INSIDE the workspace (the keymap listens
         // on the root) — autofocus makes them work before the first click.
@@ -685,6 +734,7 @@ export class VelaWorkspace {
         this.cellBackend = this.backendFor(this.def);
         this.applyGrid();
         this.buildCells();
+        this.syncCellPresentation();
         this.topbar.setLayout(this.def.id);
         const nextActive = st.activeCellId && this.cellsById.has(st.activeCellId) ? st.activeCellId : (this.order[0] ?? null);
         if (nextActive === this.activeId) this.projectActiveCell();
@@ -754,6 +804,7 @@ export class VelaWorkspace {
         this.cellBackend = nextBackend;
         this.applyGrid();
         this.buildCells();
+        this.syncCellPresentation();
         this.topbar.setLayout(next.id);
         const nextActive = activeAfterLayout(this.activeId, this.order.slice(0, next.cells.length));
         if (nextActive === this.activeId) this.projectActiveCell(); // same slot, maybe a rebuilt cell
@@ -792,6 +843,14 @@ export class VelaWorkspace {
         this.drawToolbar?.destroy();
         this.topbar.destroy();
         this.bottombar?.destroy();
+        this.mobileBar?.destroy();
+        this.drawingPill.destroy();
+        this.tfDrawer?.destroy();
+        this.drawingsDrawer?.destroy();
+        this.moreDrawer?.destroy();
+        this.timezoneDrawer?.destroy();
+        this.priceScaleDrawer?.destroy();
+        this.layoutCtl.destroy();
         this.dock.destroy(); // contributed panels; the two built-ins are ours to drop
         this.objectTree.destroy();
         this.dataWindow.destroy();
@@ -818,6 +877,9 @@ export class VelaWorkspace {
         this.topbar.setPriceStyle(cell.priceStyle);
         this.topbar.setIndicatorCount(cell.indicatorCount);
         this.topbar.renderActions(); // contributed `when()` gates may depend on the active cell
+        this.mobileBar?.setSymbol(cell.symbol);
+        this.mobileBar?.setTimeframe(cell.timeframe);
+        this.drawingPill.onChart(cell.chart); // the pill mirrors the ACTIVE cell's tool state
         const pushHistory = (): void => this.topbar.setHistoryState(cell.history.canUndo, cell.history.canRedo);
         this.historyUnsub?.();
         this.historyUnsub = cell.history.onChange(pushHistory);
@@ -965,6 +1027,9 @@ export class VelaWorkspace {
             // re-assert the highlight attribute setActiveCell put on the old one.
             if (id === this.activeId) cell.host.dataset.active = '1';
             this.wireCell(cell);
+            // A fresh renderer starts desktop — push the live mode so touch gestures,
+            // fullscreen dialogs and the scroll-button sizing apply from the first frame.
+            cell.chart.renderer.setLayoutMode(this.layoutCtl.current);
             // The shared star set is a workspace pref — every newborn cell inherits it
             // silently (equal-set idempotence keeps the favorites event from echoing).
             if (this.favs.length > 0) cell.chart.drawings.setFavorites(this.favs as never[]);
@@ -1056,6 +1121,13 @@ export class VelaWorkspace {
         // A theme picked in ONE cell (its settings dialog's Canvas → Theme) re-skins the
         // WHOLE workspace — shared chrome plus every other cell.
         chart.on('theme:changed', (t) => this.setTheme(t));
+        // Mobile: long-press an axis strip → timezone / price-scale sheet (desktop keeps
+        // the right-click menu). The press's own pointerdown already activated the cell.
+        chart.renderer.onAxisLongPress((e) => {
+            if (this.layoutCtl.current !== 'mobile') return;
+            if (e.axis === 'time') this.openTimezoneDrawer();
+            else this.openPriceScaleDrawer(e.y);
+        });
     }
 
     // ── sync links ──────────────────────────────────────────────
@@ -1274,6 +1346,8 @@ export class VelaWorkspace {
         if (!cell) return;
         this.topbar.setSymbol(cell.symbol);
         this.topbar.setTimeframe(cell.timeframe);
+        this.mobileBar?.setSymbol(cell.symbol);
+        this.mobileBar?.setTimeframe(cell.timeframe);
         this.objectTree.setSymbol(cell.symbol);
     }
 
@@ -1291,6 +1365,133 @@ export class VelaWorkspace {
     private setActiveTimeframe(tf: string): void {
         this.bottombar?.setActiveRange(null);
         this.active.setTimeframe(tf);
+    }
+
+    /** The mode flipped (container resized across the breakpoint, or a coarse-pointer
+     *  change). Close the open surfaces — a desktop card must not linger over the
+     *  mobile chrome (and vice versa) — and re-present every cell's own chrome. */
+    private onLayoutModeChange(mode: LayoutMode): void {
+        this.symbolPicker.close();
+        this.indicatorPicker.close();
+        this.tfDrawer?.close();
+        this.drawingsDrawer?.close();
+        this.moreDrawer?.close();
+        this.timezoneDrawer?.close();
+        this.priceScaleDrawer?.close();
+        this.alertsMenu?.destroy();
+        this.alertsMenu = null;
+        for (const cell of this.cellsById.values()) {
+            cell.chart.renderer.closeDialogs();
+            cell.chart.renderer.setLayoutMode(mode);
+        }
+        this.syncCellPresentation(); // the legend's overview override is mode-scoped
+    }
+
+    /** Push the layout-shape-dependent chrome onto every cell: multi-cell grids keep
+     *  the status line on one row (segments that don't fit hide), and on MOBILE their
+     *  legends' fold chip routes to the object tree instead of unfolding in place —
+     *  per-indicator controls live there (the legend rows have no room in a grid cell). */
+    private syncCellPresentation(): void {
+        const multi = this.def.cells.length > 1;
+        const overview = multi && this.layoutCtl.current === 'mobile' ? (): void => this.dock.toggle('objects', true) : null;
+        for (const cell of this.cellsById.values()) {
+            cell.setStatuslineFit(multi);
+            cell.chart.renderer.setLegendOverviewAction(overview);
+        }
+    }
+
+    // ── mobile drawers (built on first open; every read is live and hits the ACTIVE cell) ──
+
+    private openTimeframeDrawer(): void {
+        this.tfDrawer ??= new TimeframeDrawer({
+            host: this.root,
+            timeframes: this.opts.timeframes ?? DEFAULT_TIMEFRAMES,
+            ranges: RANGE_PRESETS,
+            currentTimeframe: () => this.active.timeframe,
+            activeRange: () => this.active.activeRangeId,
+            onTimeframe: (tf) => this.setActiveTimeframe(tf),
+            onRange: (preset) => {
+                this.active.applyRange(preset);
+                this.bottombar?.setActiveRange(preset.id); // the desktop bar stays truthful across a mode flip
+            },
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.tfDrawer.open();
+    }
+
+    private openDrawingsDrawer(): void {
+        this.drawingsDrawer ??= new DrawingsDrawer({
+            host: this.root,
+            toolbar: () => defaultToolbar(), // the shared static toolbar's definition (see constructor)
+            currentTool: () => this.active.chart.drawings.getTool(),
+            isFavorite: (type) => this.active.chart.drawings.isFavorite(type),
+            onFavorite: (type, on) => this.active.chart.drawings.setFavorite(type, on),
+            onSelect: (type) => this.active.chart.drawings.setTool(type),
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.drawingsDrawer.open();
+    }
+
+    private openMoreDrawer(): void {
+        this.moreDrawer ??= new MoreDrawer({
+            host: this.root,
+            onUndo: () => this.active.history.undo(),
+            onRedo: () => this.active.history.redo(),
+            onScreenshot: () => this.active.downloadScreenshot(),
+            canUndo: () => this.active.history.canUndo,
+            canRedo: () => this.active.history.canRedo,
+            priceStyles: () => priceStyleIds().map((id) => ({ id, label: priceStyleLabel(id), icon: priceStyleIcon(id) })),
+            priceStyle: () => this.active.priceStyle,
+            onPriceStyle: (id) => this.active.setPriceStyle(id),
+            panels: () => [...this.dock.list()],
+            onTogglePanel: (id) => this.dock.toggle(id),
+            alerts: () => this.alerts.map((a) => ({ title: `[${a.cellId} · ${a.symbol}] ${a.title}`, message: a.message, time: a.time })),
+            actions: () => widgetActions('topbar', this.context()).map((a) => ({ label: a.label, icon: a.icon, run: () => a.run(this.context()) })),
+            // The desktop layout dropdown's whole surface — the grid canvas, the
+            // non-canvas presets and the sync switches — relocated into the kebab
+            // drawer (the topbar is hidden on mobile). Same reads as the topbar block.
+            layout: {
+                shape: () => layoutShape(this.def),
+                presets: () =>
+                    layouts()
+                        .filter((l) => layoutShape(l) === null)
+                        .map((l) => ({ id: l.id, label: l.label, checked: l.id === this.def.id })),
+                onSelectGrid: (rows, cols) => this.setLayout(layoutForGrid(rows, cols)),
+                onSelectPreset: (id) => this.setLayout(id),
+                syncs: () => [
+                    { id: 'symbol', label: 'Symbol', checked: this.syncOpts.symbol === true },
+                    { id: 'timeframe', label: 'Interval', checked: this.syncOpts.timeframe === true },
+                    { id: 'crosshair', label: 'Crosshair', checked: this.syncOpts.crosshair === true },
+                ],
+                onToggleSync: (id) => {
+                    const kind = id as SyncKind;
+                    this.sync.set(kind, this.syncOpts[kind] ? false : true);
+                },
+            },
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.moreDrawer.open();
+    }
+
+    private openTimezoneDrawer(): void {
+        this.timezoneDrawer ??= new TimezoneDrawer({
+            host: this.root,
+            timezone: () => this.timezone,
+            onTimezone: (zone) => this.setTimezone(zone),
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.timezoneDrawer.open();
+    }
+
+    private openPriceScaleDrawer(y: number): void {
+        this.priceScalePressY = y;
+        this.priceScaleDrawer ??= new PriceScaleDrawer({
+            host: this.root,
+            chart: () => (this.activeId ? (this.cellsById.get(this.activeId)?.chart ?? null) : null),
+            pressY: () => this.priceScalePressY,
+            onOpenChange: (open) => this.trackDialog(open),
+        });
+        this.priceScaleDrawer.open();
     }
 
     /** The aggregated alerts bell — entries carry their cell; selecting one activates it. */

--- a/test/input-touch.test.ts
+++ b/test/input-touch.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import { InputController, pinchBarSpacing, pinchPinnedRightOffset, type InputControllerDeps } from '../src/renderers/native/core/InputController';
+import { clampBarSpacing } from '../src/renderers/native/core/ViewportState';
+import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
+
+describe('pinch zoom math', () => {
+    it('scales barSpacing by the finger-distance ratio', () => {
+        expect(pinchBarSpacing(10, 100, 200)).toBeCloseTo(20); // fingers spread 2× ⇒ zoom in 2×
+        expect(pinchBarSpacing(10, 200, 100)).toBeCloseTo(5); // fingers close 2× ⇒ zoom out 2×
+        expect(pinchBarSpacing(10, 100, 100)).toBeCloseTo(10);
+    });
+
+    it('clamps to the viewport zoom bounds', () => {
+        expect(pinchBarSpacing(10, 100, 1e9)).toBe(clampBarSpacing(Number.MAX_VALUE));
+        expect(pinchBarSpacing(10, 1e9, 1)).toBe(clampBarSpacing(0));
+    });
+
+    it('never divides by a degenerate start distance', () => {
+        expect(Number.isFinite(pinchBarSpacing(10, 0, 50))).toBe(true);
+    });
+
+    it('pinchPinnedRightOffset keeps the anchor logical under the anchor pixel', () => {
+        const cs = new CoordinateSystem();
+        cs.setSize(800, 200, 1);
+        cs.setBars([1000, 2000, 3000, 4000, 5000]);
+        cs.setViewport({ barSpacing: 50, rightOffset: 2 });
+        const midX = 300;
+        const anchor = cs.xToLogical(midX);
+        // Zoom to a new spacing, pinning `anchor` at midX (pitch multiplier is 1 here).
+        const barSpacing = 80;
+        const rightOffset = pinchPinnedRightOffset(anchor, cs.barCount, cs.width, midX, barSpacing);
+        cs.setViewport({ barSpacing, rightOffset });
+        expect(cs.logicalToX(anchor)).toBeCloseTo(midX);
+    });
+
+    it('a pure pan (same spacing, moved midpoint) shifts the view with the fingers', () => {
+        const cs = new CoordinateSystem();
+        cs.setSize(800, 200, 1);
+        cs.setBars([1000, 2000, 3000, 4000, 5000]);
+        cs.setViewport({ barSpacing: 50, rightOffset: 2 });
+        const anchor = cs.xToLogical(300);
+        const rightOffset = pinchPinnedRightOffset(anchor, cs.barCount, cs.width, 400, 50);
+        cs.setViewport({ barSpacing: 50, rightOffset });
+        expect(cs.logicalToX(anchor)).toBeCloseTo(400); // the anchored bar followed the fingers
+    });
+});
+
+// ── touch double-tap: two clean taps route through the dblclick semantics ──
+
+/** Bare-bones event-target stand-in — enough surface for InputController.attach(). */
+function fakeElement() {
+    const listeners = new Map<string, Set<(e: unknown) => void>>();
+    return {
+        addEventListener(type: string, fn: (e: unknown) => void) {
+            (listeners.get(type) ?? listeners.set(type, new Set()).get(type)!).add(fn);
+        },
+        removeEventListener(type: string, fn: (e: unknown) => void) {
+            listeners.get(type)?.delete(fn);
+        },
+        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+        setPointerCapture() {},
+        releasePointerCapture() {},
+        fire(type: string, e: Record<string, unknown>) {
+            for (const fn of [...(listeners.get(type) ?? [])]) fn(e);
+        },
+    };
+}
+
+function touchHarness() {
+    const cs = new CoordinateSystem();
+    cs.setSize(800, 200, 1); // data area 800×200; price axis right of x=800, time axis below y=200
+    cs.setBars([1000, 2000, 3000, 4000, 5000]);
+    cs.setViewport({ barSpacing: 50, rightOffset: 2 });
+    const deps = {
+        getCoords: () => cs,
+        apply: vi.fn(),
+        zoomTo: vi.fn(),
+        fling: vi.fn(),
+        onPointerMove: vi.fn(),
+        onClick: vi.fn(),
+        beginPriceScale: vi.fn(),
+        priceScaleBy: vi.fn(),
+        beginPricePan: () => false,
+        pricePanBy: vi.fn(),
+        resetPriceScale: vi.fn(),
+        dataDblClick: vi.fn(),
+        paneSeparatorAt: () => false,
+        beginPaneResize: vi.fn(),
+        paneResizeBy: vi.fn(),
+        resetPaneSize: vi.fn(),
+        resetView: vi.fn(),
+    } satisfies InputControllerDeps;
+    const ctl = new InputController(deps);
+    ctl.axisDrag = true; // axis strips classify as 'price'/'time' regions
+    const el = fakeElement();
+    ctl.attach(el as unknown as HTMLElement);
+    const tap = (x: number, y: number, t: number): void => {
+        const base = { button: 0, pointerId: 1, pointerType: 'touch', clientX: x, clientY: y };
+        el.fire('pointerdown', { ...base, timeStamp: t });
+        el.fire('pointerup', { ...base, timeStamp: t + 40 });
+    };
+    return { deps, tap };
+}
+
+describe('touch double-tap (the touch dblclick)', () => {
+    it('data area: a quick tap pair toggles pane maximize (dataDblClick), one tap does not', () => {
+        const { deps, tap } = touchHarness();
+        tap(400, 100, 0);
+        expect(deps.dataDblClick).not.toHaveBeenCalled();
+        tap(405, 104, 150);
+        expect(deps.dataDblClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('price axis: a tap pair resets that scale to auto', () => {
+        const { deps, tap } = touchHarness();
+        tap(820, 100, 0);
+        tap(820, 102, 120);
+        expect(deps.resetPriceScale).toHaveBeenCalledTimes(1);
+        expect(deps.dataDblClick).not.toHaveBeenCalled();
+    });
+
+    it('time axis: a tap pair fits the view to content', () => {
+        const { deps, tap } = touchHarness();
+        tap(400, 210, 0);
+        tap(398, 211, 200);
+        expect(deps.resetView).toHaveBeenCalledTimes(1);
+    });
+
+    it('taps too far apart in time or space stay two singles', () => {
+        const { deps, tap } = touchHarness();
+        tap(400, 100, 0);
+        tap(400, 100, 500); // beyond the pairing window
+        expect(deps.dataDblClick).not.toHaveBeenCalled();
+        tap(200, 100, 600);
+        tap(300, 100, 700); // beyond the position slop
+        expect(deps.dataDblClick).not.toHaveBeenCalled();
+    });
+
+    it('a third quick tap starts a fresh pair instead of double-firing', () => {
+        const { deps, tap } = touchHarness();
+        tap(400, 100, 0);
+        tap(400, 100, 100);
+        tap(400, 100, 200);
+        expect(deps.dataDblClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/test/layout-mode.test.ts
+++ b/test/layout-mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLayoutMode, MOBILE_BREAKPOINT_PX, COARSE_BREAKPOINT_PX } from '../src/widget/layout-mode';
+
+describe('resolveLayoutMode', () => {
+    it('pins the mode when the option is explicit, regardless of measurements', () => {
+        expect(resolveLayoutMode('mobile', 1920, false)).toBe('mobile');
+        expect(resolveLayoutMode('desktop', 320, true)).toBe('desktop');
+    });
+
+    it('auto: narrow containers are mobile, wide ones desktop', () => {
+        expect(resolveLayoutMode('auto', MOBILE_BREAKPOINT_PX - 1, false)).toBe('mobile');
+        expect(resolveLayoutMode('auto', MOBILE_BREAKPOINT_PX, false)).toBe('desktop');
+        expect(resolveLayoutMode('auto', 1920, false)).toBe('desktop');
+    });
+
+    it('auto: a coarse pointer widens the mobile band (tablets), but not indefinitely', () => {
+        expect(resolveLayoutMode('auto', COARSE_BREAKPOINT_PX - 1, true)).toBe('mobile');
+        expect(resolveLayoutMode('auto', COARSE_BREAKPOINT_PX, true)).toBe('desktop');
+        // The same width with a fine pointer stays desktop.
+        expect(resolveLayoutMode('auto', COARSE_BREAKPOINT_PX - 1, false)).toBe('desktop');
+    });
+
+    it('auto: an unmeasured container (width 0) stays desktop until observed', () => {
+        expect(resolveLayoutMode('auto', 0, true)).toBe('desktop');
+        expect(resolveLayoutMode('auto', -1, true)).toBe('desktop');
+    });
+});

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -115,7 +115,7 @@ describe('widget chrome pure helpers', () => {
         expect(tzMenuLabel('Etc/UTC', 'UTC')).toBe('UTC');
         expect(tzMenuLabel('Europe/Paris', 'Paris')).toMatch(/^\(UTC\+[12]\) Paris$/); // CET/CEST
         expect(tzButtonLabel('Etc/UTC')).toBe('UTC');
-        expect(tzButtonLabel('Asia/Tokyo')).toBe('UTC+9 Tokyo');
+        expect(tzButtonLabel('Asia/Tokyo')).toBe('UTC+9');
     });
 
     it('price-style labels: built-ins + registry labels + raw id fallback', () => {
@@ -569,23 +569,23 @@ describe('resolveIndicators — async loader form', () => {
 
 describe('watermarkFontPx — the mark fits the chart, not the viewport', () => {
     it('keeps the cap when the text already fits with room to spare', () => {
-        // Text is 500px wide at the 72px cap; a 900px chart holds it (900*0.9 = 810 ≥ 500).
-        expect(watermarkFontPx(900, 500)).toBe(72);
+        // Text is 500px wide at the 36px cap; a 900px chart holds it (900*0.9 = 810 ≥ 500).
+        expect(watermarkFontPx(900, 500)).toBe(36);
     });
 
     it('shrinks proportionally when the chart is narrower than the text', () => {
-        // A 400px multichart cell: 72 * (400*0.9)/500 = 51.84 → floored.
-        expect(watermarkFontPx(400, 500)).toBe(51);
+        // A 400px multichart cell: 36 * (400*0.9)/500 = 25.92 → floored.
+        expect(watermarkFontPx(400, 500)).toBe(25);
         // Half the cell again → half the font.
-        expect(watermarkFontPx(200, 500)).toBe(25);
+        expect(watermarkFontPx(200, 500)).toBe(12); // floors at MIN
     });
 
     it('never drops below the floor nor exceeds the cap', () => {
         expect(watermarkFontPx(30, 500)).toBe(12); // tiny cell → floor
-        expect(watermarkFontPx(100000, 10)).toBe(72); // huge chart → cap
+        expect(watermarkFontPx(100000, 10)).toBe(36); // huge chart → cap
     });
 
     it('an unmeasurable text (0 width) keeps the cap instead of dividing by zero', () => {
-        expect(watermarkFontPx(400, 0)).toBe(72);
+        expect(watermarkFontPx(400, 0)).toBe(36);
     });
 });


### PR DESCRIPTION
Enhance mobile experience and introduce new features for the widget and workspace. Implement touch-first bottom bar, adaptive chrome layout, and improved gesture handling. Add support for indicator settings and legend overview actions. Update documentation to reflect mobile changes and new SDK capabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change to input handling, shell chrome, and renderer contracts; regressions could affect desktop pointer behavior or embedded layouts, though APIs are mostly optional and desktop paths are intended to stay unchanged.
> 
> **Overview**
> Adds **container-driven mobile chrome** for the widget (and documented parity for the workspace) via new shell option `layoutMode` (`'auto' | 'mobile' | 'desktop'`). In mobile, the desktop top/bottom bars and docked drawing toolbar are replaced by a **touch bottom bar** and **bottom drawers** (timeframe, drawings, more, timezone, price scale), plus a **floating drawing pill** when a tool is armed. `LayoutModeController` sets `data-layout` on the shell and live-swaps presentation on resize.
> 
> The **native renderer** gains touch-first behavior: pinch zoom, long-press crosshair inspect, axis long-press (host opens sheets), double-tap mirroring double-click, mobile fullscreen chart/indicator settings, collapsed legend by default, and scroll-to-latest without hover proximity. Optional renderer seams extend `chart.renderer`: `setLayoutMode`, `setLegendOverviewAction`, `openIndicatorSettings`, and `onAxisLongPress`.
> 
> **`vela/ui`** exports a new **`Drawer`** bottom sheet; kit dialogs and side panels go fullscreen/overlays under `[data-layout='mobile']`. Object tree adds **Indicator settings** when the legend is folded or overview-routed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965406e7090f4a7ab2c8f7d0c8814f05d8792419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->