### PR TITLE
fix: mobile bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ All notable changes to Vela, newest first.
   symbol search, timeframe, indicators, drawings, a three-dots drawer, and chart
   settings. The timeframe entry opens a bottom sheet with the date-range presets and
   the timeframe grid; the drawings entry opens a searchable, tabbed tool sheet with
-  favorite stars, and an armed tool shows a floating pill over the chart with the
+  favorite stars — swipe sideways across the tool list to move between the group
+  tabs — and an armed tool shows a floating pill over the chart with the
   magnet, stay-in-drawing-mode and eraser controls; the three-dots sheet carries
   undo/redo, screenshot, chart type, the side panels (which open full-screen on
   mobile), alerts, and any contributed actions. A long-press on the time axis opens
@@ -64,9 +65,13 @@ All notable changes to Vela, newest first.
   dialog programmatically — the legend gear's twin, surfaced on `chart.renderer` as
   `setLegendOverviewAction` / `openIndicatorSettings` (+ `supportsIndicatorSettings`).
   Both are additive and optional: a renderer without them keeps today's behavior.
-- **`vela/ui` gains a `Drawer`.** A bottom sheet with a grab handle, drag-to-dismiss
-  and a dimmed backdrop — the primitive the mobile chrome's sheets are built on,
-  exported for building your own.
+- **`vela/ui` gains a `Drawer`.** A bottom sheet with a grab handle and a dimmed
+  backdrop — the primitive the mobile chrome's sheets are built on, exported for
+  building your own. Pulling down dismisses from anywhere on the sheet, not just the
+  handle (a scrolled list keeps native scrolling until it is back at the top), an
+  `onSwipe` option turns decidedly horizontal swipes into a callback (the drawings
+  sheet pages its tabs with it), and opening never pops the on-screen keyboard — the
+  sheet itself takes the initial focus, never a search field.
 
 - **Drawings sync across a workspace grid.** A new `drawings` sync kind
   (`ws.sync.set('drawings', true)`, also a toggle on the shared drawing toolbar) links
@@ -83,6 +88,14 @@ All notable changes to Vela, newest first.
   chart event, and `IDrawingsRendererPort` gains an optional `setExternalGhost(doc)` —
   the drawings twin of `setExternalCrosshair`. Both are additive: a renderer that
   implements neither keeps today's behavior (sync at completion, no remote preview).
+
+### Fixed
+
+- **Screenshots capture the whole chart.** The PNG export now includes everything the
+  screen shows: the volume columns, the visible-range volume profile, plugin-drawn
+  layers, the status line, the indicator legends (with their values), and the faded
+  symbol watermark — previously only the candles, axes and drawings made it into the
+  image. Only the crosshair stays out.
 
 ## [v0.5.0]
 

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -59,6 +59,7 @@ import { type ChartConfig, CHART_CONFIG_VERSION, factoryResetConfig, mergeConfig
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
 import { rendererLayers, type RendererLayerArgs, type RendererLayerDefinition, type RendererLayerInstance } from './layers';
 import { applyAttributionMarkTheme, attributionMarkColor, createAttributionMark, createCustomMark } from './chrome/AttributionMark';
+import { rasterizeOverlay } from '../shared/dom-raster';
 import type { HostSettingsSection } from './chrome/SettingsDialog';
 import { VpvrRenderer } from './vpvr/VpvrRenderer';
 import { DARK_THEME, LIGHT_THEME } from '../../core/theme';
@@ -1069,17 +1070,20 @@ export class NativeRenderer implements IChartRenderer {
     }
 
     /**
-     * Export the current chart as a PNG data URL by compositing the geometry (L0)
-     * + chrome (L1) + user-drawings (L1.5) canvases onto an offscreen canvas. The
-     * background is filled first (the canvas2d data layer is transparent — its bg
-     * lives on the wrapper), and a fresh synchronous paint runs first so the WebGL2
-     * backend's (non-preserved) drawing buffer is populated before it's read back
-     * this tick — the same paint also repaints the drawings layers, so they're
-     * current (interleaved drawings are already inside the data composite). They're
-     * drawn bottom-up in DOM stacking order so the front user drawings (trend lines,
-     * boxes, etc.) sit above the Pine drawings on the chrome layer, matching what's
-     * on screen. The crosshair (L2) and DOM overlays (tables, legend) are
-     * intentionally excluded.
+     * Export the current chart as a PNG data URL by compositing EVERY plot canvas onto
+     * an offscreen canvas, in the same stacking order the DOM shows: plugin layers
+     * below the data, geometry (L0), volume columns (L0.25), the visible-range volume
+     * profile (L0.6), plugin layers above the data, chrome (L1), and user drawings
+     * (L1.5). The background is filled first (the canvas2d data layer is transparent —
+     * its bg lives on the wrapper), and a fresh synchronous paint runs first so the
+     * WebGL2 backend's (non-preserved) drawing buffer is populated before it's read
+     * back this tick — the same paint also repaints the drawings layers, so they're
+     * current. DOM chrome joins as a best-effort text/chip raster (see
+     * `rasterizeOverlay`): the per-pane indicator legends, plus any host overlay that
+     * opts in with a `data-vela-screenshot` attribute on the mount container's
+     * subtree (the widget marks its status line, and its symbol watermark with
+     * `"under"` — drawn beneath the canvases, where it sits on screen). Only the
+     * crosshair (L2) is intentionally excluded.
      */
     screenshot(): string | null {
         if (!this.dataCanvas) return null;
@@ -1092,9 +1096,26 @@ export class NativeRenderer implements IChartRenderer {
         if (!ctx) return null;
         ctx.fillStyle = this.theme.background;
         ctx.fillRect(0, 0, out.width, out.height);
-        ctx.drawImage(this.dataCanvas, 0, 0);
-        ctx.drawImage(this.chromeCanvas, 0, 0);
-        ctx.drawImage(this.drawingsCanvas, 0, 0);
+        // DOM replicas share the plot's coordinate space (the canvases fill it).
+        const plotRect = this.plot?.getBoundingClientRect();
+        const frame = plotRect && plotRect.width > 0 ? { left: plotRect.left, top: plotRect.top, dpr: out.width / plotRect.width } : null;
+        const hostMarked = [...(this.mountContainer?.querySelectorAll('[data-vela-screenshot]') ?? [])];
+        if (frame) {
+            for (const el of hostMarked) {
+                if (el.getAttribute('data-vela-screenshot') === 'under') rasterizeOverlay(ctx, el, frame);
+            }
+        }
+        const below = this.extLayers.filter((l) => l.def.placement === 'below-data').map((l) => l.canvas);
+        const above = this.extLayers.filter((l) => l.def.placement !== 'below-data').map((l) => l.canvas);
+        for (const canvas of [...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above, this.chromeCanvas, this.drawingsCanvas]) {
+            if (canvas && canvas.width > 0 && canvas.height > 0) ctx.drawImage(canvas, 0, 0);
+        }
+        if (frame) {
+            for (const lg of this.plot?.querySelectorAll('[data-vela-pane]') ?? []) rasterizeOverlay(ctx, lg, frame);
+            for (const el of hostMarked) {
+                if (el.getAttribute('data-vela-screenshot') !== 'under') rasterizeOverlay(ctx, el, frame);
+            }
+        }
         return out.toDataURL('image/png');
     }
 

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -80,8 +80,9 @@ const LONG_PRESS_MS = 350; // touch hold before a data-area press becomes crossh
 const TOUCH_SLOP = 8;
 // Two clean taps this close together (time and space) are a double-tap — the touch
 // dblclick. The browser never synthesizes dblclick here (the controller owns the touch
-// stream via touch-action:none), so the pairing is detected by hand.
-const DOUBLE_TAP_MS = 300;
+// stream via touch-action:none), so the pairing is detected by hand. 350ms matches the
+// platform double-tap windows; 300 was tight enough to drop casual pairs.
+const DOUBLE_TAP_MS = 350;
 const DOUBLE_TAP_SLOP = 30;
 // Time-axis horizontal-zoom sensitivity: dragging left zooms in (e^(Δpx·k)). Kept low so
 // the zoom takes a deliberate, sizeable drag (~2× over ~170px) rather than a twitch.
@@ -472,32 +473,38 @@ export class InputController {
         }
         // Once a touch travels past the wobble slop it is a pan, not a nascent long-press.
         if (this.lpTimer !== null && Math.hypot(x - this.startX, y - this.startY) > TOUCH_SLOP) this.cancelLongPress();
+        // Click/tap-vs-drag classification: a resting finger wobbles far more than a
+        // mouse, so a touch keeps its tap-hood through TOUCH_SLOP of travel — with the
+        // 2px mouse slop, most real taps read as micro-pans and double-taps almost
+        // never paired. (The view still pans by those few px either way; `moved` only
+        // decides what the RELEASE means.)
+        const slop = e.pointerType === 'touch' ? TOUCH_SLOP : DRAG_SLOP;
         if (this.dragging) {
             if (this.region === 'price') {
-                if (Math.abs(y - this.startY) > DRAG_SLOP) this.moved = true;
+                if (Math.abs(y - this.startY) > slop) this.moved = true;
                 this.deps.priceScaleBy(y - this.startY);
             } else if (this.region === 'separator') {
-                if (Math.abs(y - this.startY) > DRAG_SLOP) this.moved = true;
+                if (Math.abs(y - this.startY) > slop) this.moved = true;
                 this.deps.paneResizeBy(y - this.startY);
             } else if (this.region === 'time') {
-                if (Math.abs(x - this.startX) > DRAG_SLOP) this.moved = true;
+                if (Math.abs(x - this.startX) > slop) this.moved = true;
                 // Pin the right edge (keep rightOffset): logicalToX(rightEdge) == width for
                 // any barSpacing, so only barSpacing changes. Drag left ⇒ zoom in.
                 const barSpacing = clampBarSpacing(this.startBarSpacing * Math.exp((this.startX - x) * TIME_SCALE_K));
                 this.deps.apply({ barSpacing, rightOffset: this.startRightOffset });
             } else if (this.region === 'drawing') {
-                if (Math.abs(x - this.startX) > DRAG_SLOP || Math.abs(y - this.startY) > DRAG_SLOP) this.moved = true;
+                if (Math.abs(x - this.startX) > slop || Math.abs(y - this.startY) > slop) this.moved = true;
                 this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey);
             } else {
                 const coords = this.deps.getCoords();
                 const vp = coords.getViewport();
                 const dx = x - this.startX;
-                if (Math.abs(dx) > DRAG_SLOP) this.moved = true;
+                if (Math.abs(dx) > slop) this.moved = true;
                 // Drag right → reveal earlier bars → rightOffset decreases. Track by the effective
                 // pitch (zoom × spacing multiplier) so the chart follows the cursor 1:1.
                 this.deps.apply({ barSpacing: vp.barSpacing, rightOffset: this.startRightOffset - dx / coords.pxPerBar() });
                 if (this.verticalPan) {
-                    if (Math.abs(y - this.startY) > DRAG_SLOP) this.moved = true;
+                    if (Math.abs(y - this.startY) > slop) this.moved = true;
                     this.deps.pricePanBy(y - this.startY);
                 }
                 // Track a low-passed pointer velocity for the release flick.

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -70,7 +70,10 @@ function ensureStyles(): void {
 .vela-dpop-btn[data-active='1']{background:var(--vela-active);color:var(--vela-fg-bright);}
 .vela-dpop-item{background:transparent;transition:background var(--vela-dur-fast) ease;}
 .vela-dpop-item:hover{background:var(--vela-hover-strong);}
-.vela-dpop-item[data-active='1']{background:var(--vela-active);}`;
+.vela-dpop-item[data-active='1']{background:var(--vela-active);}
+/* A finger needs a wider grab zone than a cursor — grow the move handle on touch-first
+   devices (the glyph stays centered; only the hit target widens). */
+@media (pointer: coarse){.vela-dpop-grip{width:${BTN + 14}px !important;}}`;
     document.head.appendChild(s);
 }
 
@@ -895,7 +898,11 @@ export class DrawingSettingsPopup {
     private dragHandle(): HTMLButtonElement {
         const b = document.createElement('button');
         b.type = 'button';
-        b.style.cssText = `width:${BTN}px;height:${BTN}px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;padding:0;cursor:grab;color:var(--vela-fg-faint);`;
+        b.className = 'vela-dpop-grip';
+        // touch-action:none — the handle owns its touches: without it the browser claims
+        // the move for scrolling and CANCELS the pointer stream, which is why the bar
+        // could barely be dragged on a phone.
+        b.style.cssText = `width:${BTN}px;height:${BTN}px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;padding:0;cursor:grab;touch-action:none;color:var(--vela-fg-faint);`;
         b.innerHTML = sized(GRIP_ICON);
         b.addEventListener('pointerdown', (e) => {
             const el = this.el;
@@ -911,6 +918,13 @@ export class DrawingSettingsPopup {
             const origLeft = parseFloat(el.style.left) || 0;
             const origTop = parseFloat(el.style.top) || 0;
             b.style.cursor = 'grabbing';
+            // Capture keeps the move stream on the handle even when a finger (a far
+            // blunter pointer than a cursor) slides off the 30px grip mid-drag.
+            try {
+                b.setPointerCapture((e as PointerEvent).pointerId);
+            } catch {
+                /* detached target or a test double without capture support */
+            }
             const move = (ev: PointerEvent): void => {
                 const w = el.offsetWidth;
                 const h = el.offsetHeight;
@@ -923,9 +937,11 @@ export class DrawingSettingsPopup {
                 b.style.cursor = 'grab';
                 window.removeEventListener('pointermove', move);
                 window.removeEventListener('pointerup', up);
+                window.removeEventListener('pointercancel', up);
             };
             window.addEventListener('pointermove', move);
             window.addEventListener('pointerup', up);
+            window.addEventListener('pointercancel', up);
         });
         return b;
     }

--- a/src/renderers/shared/chrome-tooltip.ts
+++ b/src/renderers/shared/chrome-tooltip.ts
@@ -70,18 +70,23 @@ export function attachChromeTooltip(anchor: HTMLElement, opts: ChromeTooltipOpti
         }
     };
 
-    const arm = (): void => {
+    // Mouse only: a tap fires a SYNTHETIC mouseenter/pointerenter with no leave to
+    // follow (the emulated cursor stays put), so a touch-armed tip would open after the
+    // tap and stick around forever. pointerenter carries the pointer type; mouseenter
+    // does not — which is why the mouse events are not used here.
+    const arm = (e: PointerEvent): void => {
+        if (e.pointerType !== 'mouse') return;
         clear();
         timer = window.setTimeout(show, opts.delayMs ?? 700);
     };
 
-    anchor.addEventListener('mouseenter', arm);
-    anchor.addEventListener('mouseleave', clear);
+    anchor.addEventListener('pointerenter', arm);
+    anchor.addEventListener('pointerleave', clear);
     anchor.addEventListener('pointerdown', clear); // a click answers the question the tip poses
 
     return () => {
-        anchor.removeEventListener('mouseenter', arm);
-        anchor.removeEventListener('mouseleave', clear);
+        anchor.removeEventListener('pointerenter', arm);
+        anchor.removeEventListener('pointerleave', clear);
         anchor.removeEventListener('pointerdown', clear);
         clear();
     };

--- a/src/renderers/shared/dom-raster.ts
+++ b/src/renderers/shared/dom-raster.ts
@@ -1,0 +1,138 @@
+// Best-effort SYNCHRONOUS rasterization of DOM chrome overlays for the PNG export —
+// the indicator legend, a host status line, the symbol watermark. Screenshot export is
+// a synchronous port (`screenshot(): string | null`), so a full HTML renderer is out of
+// reach; what a chart overlay actually carries is text on (rounded) color chips, and
+// that subset rasterizes faithfully with plain canvas calls:
+//   - element backgrounds and borders (border-radius honored, '50%' reads as a circle),
+//   - text nodes in their computed font/color, at their measured on-screen rects,
+//   - already-loaded <img>s (clipped by their radius) — but only when drawing them
+//     leaves the canvas untainted: a cross-origin ticker icon must not poison the
+//     whole export (`toDataURL` would throw at the end).
+// Inline SVG glyphs (icons, chevrons) are skipped — sync canvas cannot raster them —
+// which loses decoration, never information.
+
+/** How the overlay's viewport coordinates map onto the export canvas. */
+export interface OverlayRasterFrame {
+    /** The canvas' top-left in viewport coordinates (the plot's bounding rect). */
+    left: number;
+    top: number;
+    /** Device-pixel ratio of the export canvas (canvas px per CSS px). */
+    dpr: number;
+}
+
+/** True when a computed color actually puts ink down (not transparent). */
+function hasInk(color: string): boolean {
+    if (!color || color === 'transparent') return false;
+    const m = /rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)/.exec(color);
+    return m ? parseFloat(m[1]!) > 0.001 : true;
+}
+
+/** Uniform corner radius in px — '50%' (and any percentage) resolves against the box. */
+function cornerRadius(cs: CSSStyleDeclaration, w: number, h: number): number {
+    const raw = cs.borderTopLeftRadius;
+    const v = parseFloat(raw) || 0;
+    const px = raw.endsWith('%') ? (v / 100) * Math.min(w, h) : v;
+    return Math.max(0, Math.min(px, Math.min(w, h) / 2));
+}
+
+/** Trace a rounded rect (falls back to a plain rect where roundRect is missing). */
+function tracePath(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+    ctx.beginPath();
+    if (r > 0 && typeof ctx.roundRect === 'function') ctx.roundRect(x, y, w, h, r);
+    else ctx.rect(x, y, w, h);
+}
+
+/** Probe-draw on a throwaway canvas: a cross-origin image without CORS taints whatever
+ *  it lands on, and `toDataURL` then throws for the WHOLE export — test it in isolation. */
+function canDrawUntainted(img: HTMLImageElement): boolean {
+    try {
+        const probe = img.ownerDocument.createElement('canvas');
+        probe.width = 1;
+        probe.height = 1;
+        const ctx = probe.getContext('2d');
+        if (!ctx) return false;
+        ctx.drawImage(img, 0, 0, 1, 1);
+        probe.toDataURL();
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Draw `root`'s subtree onto `ctx`. Coordinates come from live layout
+ * (`getBoundingClientRect`), so what lands on the canvas is what is on screen —
+ * hidden segments (`display:none`), folded legend rows and zero-size boxes are
+ * skipped, and subtree opacity multiplies down (the 5%-alpha watermark stays 5%).
+ */
+export function rasterizeOverlay(ctx: CanvasRenderingContext2D, root: Element, frame: OverlayRasterFrame): void {
+    const win = root.ownerDocument.defaultView;
+    if (!win) return;
+    ctx.save();
+    ctx.scale(frame.dpr, frame.dpr);
+
+    const drawText = (node: Text, cs: CSSStyleDeclaration, alpha: number): void => {
+        const text = node.textContent?.replace(/\s+/g, ' ').trim();
+        if (!text) return;
+        const range = node.ownerDocument.createRange();
+        range.selectNodeContents(node);
+        const r = range.getBoundingClientRect();
+        if (r.width <= 0 || r.height <= 0) return;
+        ctx.globalAlpha = alpha;
+        ctx.fillStyle = cs.color;
+        ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
+        ctx.textBaseline = 'middle';
+        ctx.textAlign = 'left';
+        ctx.fillText(text, r.left - frame.left, r.top - frame.top + r.height / 2);
+    };
+
+    const drawImg = (img: HTMLImageElement, cs: CSSStyleDeclaration, alpha: number): void => {
+        if (!img.complete || img.naturalWidth <= 0 || !canDrawUntainted(img)) return;
+        const r = img.getBoundingClientRect();
+        if (r.width <= 0 || r.height <= 0) return;
+        const x = r.left - frame.left;
+        const y = r.top - frame.top;
+        ctx.save();
+        ctx.globalAlpha = alpha;
+        tracePath(ctx, x, y, r.width, r.height, cornerRadius(cs, r.width, r.height));
+        ctx.clip();
+        ctx.drawImage(img, x, y, r.width, r.height);
+        ctx.restore();
+    };
+
+    const drawElement = (el: HTMLElement, parentAlpha: number): void => {
+        const cs = win.getComputedStyle(el);
+        if (cs.display === 'none' || cs.visibility === 'hidden') return;
+        const alpha = parentAlpha * (parseFloat(cs.opacity) || 1);
+        if (alpha <= 0.001) return;
+        const r = el.getBoundingClientRect();
+        if (r.width > 0 && r.height > 0) {
+            const x = r.left - frame.left;
+            const y = r.top - frame.top;
+            const radius = cornerRadius(cs, r.width, r.height);
+            if (hasInk(cs.backgroundColor)) {
+                ctx.globalAlpha = alpha;
+                ctx.fillStyle = cs.backgroundColor;
+                tracePath(ctx, x, y, r.width, r.height, radius);
+                ctx.fill();
+            }
+            const bw = parseFloat(cs.borderTopWidth) || 0;
+            if (bw > 0 && cs.borderTopStyle !== 'none' && hasInk(cs.borderTopColor)) {
+                ctx.globalAlpha = alpha;
+                ctx.strokeStyle = cs.borderTopColor;
+                ctx.lineWidth = bw;
+                tracePath(ctx, x + bw / 2, y + bw / 2, r.width - bw, r.height - bw, Math.max(0, radius - bw / 2));
+                ctx.stroke();
+            }
+        }
+        for (const child of el.childNodes) {
+            if (child.nodeType === 3) drawText(child as Text, cs, alpha);
+            else if (child instanceof win.HTMLImageElement) drawImg(child, win.getComputedStyle(child), alpha);
+            // Non-HTML children (inline SVG icons) are skipped — see the header note.
+            else if (child instanceof win.HTMLElement) drawElement(child, alpha);
+        }
+    };
+
+    if (root instanceof win.HTMLElement) drawElement(root, 1);
+    ctx.restore();
+}

--- a/src/ui/components/dialog/controller.ts
+++ b/src/ui/components/dialog/controller.ts
@@ -7,6 +7,8 @@ export interface DialogControllerOptions {
     modal?: boolean;
     closeOnEscape?: boolean;
     closeOnInteractOutside?: boolean;
+    /** Element to focus on open (default: the machine's first-tabbable pick). */
+    initialFocusEl?: () => HTMLElement | null;
     onOpenChange?: (open: boolean) => void;
 }
 
@@ -27,6 +29,7 @@ export function dialogController(opts: DialogControllerOptions = {}): DialogCont
             modal: opts.modal ?? true,
             closeOnEscape: opts.closeOnEscape ?? true,
             closeOnInteractOutside: opts.closeOnInteractOutside ?? false,
+            initialFocusEl: opts.initialFocusEl,
             onOpenChange: (d: dialog.OpenChangeDetails) => opts.onOpenChange?.(d.open),
         } satisfies Partial<dialog.Props>,
         connect: (service: DialogService): DialogApi => dialog.connect(service, normalizeProps),

--- a/src/ui/components/dialog/view.ts
+++ b/src/ui/components/dialog/view.ts
@@ -40,6 +40,9 @@ export class Dialog {
         this.positioner.className = 'vela-dialog-positioner vela-ui-layer';
         this.panel = doc.createElement('div');
         this.panel.className = 'vela-dialog';
+        // Programmatically focusable — the mobile chrome routes the machine's initial
+        // focus here (see the controller wiring below).
+        this.panel.tabIndex = -1;
 
         const header = doc.createElement('div');
         header.className = 'vela-dialog-header';
@@ -78,7 +81,18 @@ export class Dialog {
         this.positioner.appendChild(this.panel);
         host.append(this.backdrop, this.positioner);
 
-        this.ctrl = dialogController(opts);
+        this.ctrl = dialogController({
+            ...opts,
+            // Mobile chrome (fullscreen presentation): opening must never land focus on
+            // an input — that pops the on-screen keyboard over the just-opened dialog.
+            // Focus goes to the panel; a caller that WANTS the keyboard focuses its
+            // input explicitly. Desktop keeps the caller's pick, else the machine's
+            // first-tabbable default.
+            initialFocusEl: () => {
+                if (this.positioner.closest('[data-layout="mobile"]')) return this.panel;
+                return opts.initialFocusEl?.() ?? null;
+            },
+        });
         const mid = String(this.ctrl.props.id);
         this.handle = runMachine(this.ctrl.machine, this.ctrl.props, (service) => {
             const api = this.ctrl.connect(service);

--- a/src/ui/components/drawer/controller.ts
+++ b/src/ui/components/drawer/controller.ts
@@ -8,6 +8,10 @@ export interface DrawerControllerOptions {
     closeOnEscape?: boolean;
     /** Tap outside (on the backdrop) dismisses — default true. */
     closeOnInteractOutside?: boolean;
+    /** Element to focus on open (default: the machine's first-tabbable pick). The view
+     *  points this at the sheet itself so opening never focuses an input — on touch
+     *  devices that would pop the on-screen keyboard over the sheet. */
+    initialFocusEl?: () => HTMLElement | null;
     onOpenChange?: (open: boolean) => void;
 }
 
@@ -28,6 +32,7 @@ export function drawerController(opts: DrawerControllerOptions = {}): DrawerCont
             modal: true,
             closeOnEscape: opts.closeOnEscape ?? true,
             closeOnInteractOutside: opts.closeOnInteractOutside ?? true,
+            initialFocusEl: opts.initialFocusEl,
             onOpenChange: (d: dialog.OpenChangeDetails) => opts.onOpenChange?.(d.open),
         } satisfies Partial<dialog.Props>,
         connect: (service: DrawerService): DrawerApi => dialog.connect(service, normalizeProps),

--- a/src/ui/components/drawer/view.ts
+++ b/src/ui/components/drawer/view.ts
@@ -11,11 +11,48 @@ import * as zagDialog from '@zag-js/dialog';
  *  smaller) and the release dismisses; anything less springs back. */
 const DISMISS_FRACTION = 0.33;
 const DISMISS_PX = 96;
+/** Movement below this is a tap; past it the gesture commits to a direction. */
+const SLOP_PX = 8;
+/** A horizontal swipe must travel at least this far to fire `onSwipe`. */
+const HSWIPE_MIN_PX = 48;
 
 export interface DrawerOptions extends DrawerControllerOptions {
     title?: string;
     content?: Node | ((body: HTMLElement) => void);
     host?: HTMLElement;
+    /** Horizontal swipe across the sheet (fires on release; `'left'` = the finger moved
+     *  left). Gestures that start inside a horizontally scrollable strip (tabs, chip
+     *  rows) keep their native scroll instead. */
+    onSwipe?: (dir: 'left' | 'right') => void;
+}
+
+/** What the active pointer gesture has committed to (decided once past the slop). */
+type GestureMode = 'idle' | 'pending' | 'drag' | 'hswipe' | 'scroll';
+
+/**
+ * Classify a pointer gesture over the sheet — PURE. `'pending'` until the movement
+ * clears the slop; then a decidedly vertical downward pull becomes the dismiss `'drag'`
+ * (only while every scroller under the finger is at rest — a scrolled list keeps native
+ * scrolling), a decidedly horizontal move becomes an `'hswipe'` (when the sheet has a
+ * swipe handler and the finger is not on a strip that scrolls sideways itself), and
+ * everything else stays native `'scroll'`.
+ */
+export function classifyGesture(dx: number, dy: number, ctx: { canSwipe: boolean; scrolled: boolean; hScrollable: boolean }): 'pending' | 'drag' | 'hswipe' | 'scroll' {
+    if (Math.max(Math.abs(dx), Math.abs(dy)) < SLOP_PX) return 'pending';
+    if (Math.abs(dy) > Math.abs(dx)) return dy > 0 && !ctx.scrolled ? 'drag' : 'scroll';
+    return ctx.canSwipe && !ctx.hScrollable ? 'hswipe' : 'scroll';
+}
+
+/** Whether releasing a dismiss drag at `dy` px closes the sheet — PURE. */
+export function dragDismisses(dy: number, panelHeightPx: number): boolean {
+    return dy >= Math.min(DISMISS_PX, panelHeightPx * DISMISS_FRACTION);
+}
+
+/** The direction a released horizontal swipe fires, or null when it was too short
+ *  (or more vertical than horizontal after all) — PURE. */
+export function swipeDirection(dx: number, dy: number): 'left' | 'right' | null {
+    if (Math.abs(dx) < HSWIPE_MIN_PX || Math.abs(dx) <= Math.abs(dy)) return null;
+    return dx < 0 ? 'left' : 'right';
 }
 
 export class Drawer {
@@ -39,6 +76,10 @@ export class Drawer {
         this.positioner.className = 'vela-drawer-positioner vela-ui-layer';
         this.panel = doc.createElement('div');
         this.panel.className = 'vela-drawer';
+        // Programmatically focusable: the sheet itself takes the dialog machine's initial
+        // focus — focusing the first tabbable (often a search input) would pop the
+        // on-screen keyboard over a surface that just slid in.
+        this.panel.tabIndex = -1;
 
         const grab = doc.createElement('div');
         grab.className = 'vela-drawer-grab';
@@ -54,9 +95,9 @@ export class Drawer {
         this.panel.append(grab, this.titleEl, this.body);
         this.positioner.appendChild(this.panel);
         host.append(this.backdrop, this.positioner);
-        this.wireDragToDismiss(grab);
+        this.wireGestures(grab, opts.onSwipe);
 
-        this.ctrl = drawerController(opts);
+        this.ctrl = drawerController({ ...opts, initialFocusEl: () => this.panel });
         const mid = String(this.ctrl.props.id);
         this.handle = runMachine(this.ctrl.machine, this.ctrl.props, (service) => {
             const api = this.ctrl.connect(service);
@@ -71,33 +112,122 @@ export class Drawer {
         });
     }
 
-    /** Pull the sheet down by its handle; past the threshold the release dismisses. */
-    private wireDragToDismiss(grab: HTMLElement): void {
+    /** Any element between `from` and the panel that has already been scrolled down —
+     *  a downward pull there must scroll it back up, never drag the sheet. */
+    private scrolledAncestor(from: EventTarget | null): boolean {
+        let el = from instanceof Element ? from : null;
+        while (el && el !== this.panel) {
+            if (el.scrollTop > 0) return true;
+            el = el.parentElement;
+        }
+        return false;
+    }
+
+    /** Any element between `from` and the panel that scrolls horizontally on its own
+     *  (the tab strip, chip rows) — a sideways move there is ITS scroll, not a swipe. */
+    private hScrollableAncestor(from: EventTarget | null): boolean {
+        let el = from instanceof Element ? from : null;
+        while (el && el !== this.panel) {
+            if (el.scrollWidth > el.clientWidth + 1) return true;
+            el = el.parentElement;
+        }
+        return false;
+    }
+
+    /**
+     * One gesture recognizer for the whole sheet. A downward pull dismisses from
+     * anywhere — the grab handle immediately, the content once it is decidedly vertical
+     * and its scroller is at rest (a scrolled list keeps native scrolling). A decidedly
+     * horizontal move becomes an `onSwipe` (tabbed drawers flip pages with it). The
+     * non-passive touchmove hook is what keeps the browser from claiming the pull as a
+     * scroll once the sheet is (or may become) the drag target.
+     */
+    private wireGestures(grab: HTMLElement, onSwipe?: (dir: 'left' | 'right') => void): void {
+        let startX = 0;
         let startY = 0;
+        let dx = 0;
         let dy = 0;
-        let dragging = false;
-        grab.addEventListener('pointerdown', (e) => {
-            dragging = true;
+        let mode: GestureMode = 'idle';
+
+        const beginDrag = (e: PointerEvent): void => {
+            mode = 'drag';
+            // Rebase so the sheet tracks from the commit point instead of jumping by the slop.
             startY = e.clientY;
-            dy = 0;
             this.panel.style.transition = 'none';
-            grab.setPointerCapture(e.pointerId);
-        });
-        grab.addEventListener('pointermove', (e) => {
-            if (!dragging) return;
-            dy = Math.max(0, e.clientY - startY);
-            this.panel.style.transform = dy > 0 ? `translateY(${dy}px)` : '';
-        });
-        const settle = (): void => {
-            if (!dragging) return;
-            dragging = false;
-            this.panel.style.transition = '';
-            this.panel.style.transform = '';
-            const threshold = Math.min(DISMISS_PX, this.panel.getBoundingClientRect().height * DISMISS_FRACTION);
-            if (dy >= threshold) this.hide();
+            try {
+                this.panel.setPointerCapture(e.pointerId);
+            } catch {
+                /* detached target or a test double without capture support */
+            }
         };
-        grab.addEventListener('pointerup', settle);
-        grab.addEventListener('pointercancel', settle);
+
+        this.panel.addEventListener('pointerdown', (e) => {
+            if (e.isPrimary === false) return;
+            startX = e.clientX;
+            startY = e.clientY;
+            dx = 0;
+            dy = 0;
+            // The handle is a dedicated dismiss affordance (touch-action:none) — no slop.
+            if (grab.contains(e.target as Node)) beginDrag(e);
+            else mode = 'pending';
+        });
+
+        this.panel.addEventListener('pointermove', (e) => {
+            if (mode === 'idle' || mode === 'scroll') return;
+            dx = e.clientX - startX;
+            dy = e.clientY - startY;
+            if (mode === 'pending') {
+                const intent = classifyGesture(dx, dy, {
+                    canSwipe: !!onSwipe,
+                    scrolled: this.scrolledAncestor(e.target),
+                    hScrollable: this.hScrollableAncestor(e.target),
+                });
+                if (intent === 'pending') return;
+                if (intent === 'drag') beginDrag(e);
+                else mode = intent;
+            }
+            if (mode === 'drag') {
+                dy = Math.max(0, e.clientY - startY);
+                this.panel.style.transform = dy > 0 ? `translateY(${dy}px)` : '';
+            }
+        });
+
+        // Keep the browser's scroll logic off a pull the sheet owns (or may still claim):
+        // without preventDefault here, the scroller grabs the touch and cancels the
+        // pointer stream before the drag can commit. Only downward pulls on an at-rest
+        // scroller are blocked — everything else keeps native behavior.
+        this.panel.addEventListener(
+            'touchmove',
+            (e) => {
+                if (mode === 'drag') {
+                    e.preventDefault();
+                    return;
+                }
+                if (mode !== 'pending') return;
+                const t = e.touches[0];
+                if (!t) return;
+                const mdx = t.clientX - startX;
+                const mdy = t.clientY - startY;
+                if (mdy > Math.abs(mdx) && !this.scrolledAncestor(e.target)) e.preventDefault();
+            },
+            { passive: false },
+        );
+
+        const settle = (): void => {
+            if (mode === 'idle') return;
+            const finished = mode;
+            mode = 'idle';
+            if (finished === 'drag') {
+                this.panel.style.transition = '';
+                this.panel.style.transform = '';
+                if (dragDismisses(dy, this.panel.getBoundingClientRect().height)) this.hide();
+            } else if (finished === 'hswipe') {
+                const dir = swipeDirection(dx, dy);
+                if (dir) onSwipe?.(dir);
+            }
+        };
+        this.panel.addEventListener('pointerup', settle);
+        this.panel.addEventListener('pointercancel', settle);
     }
 
     setTitle(title: string): void {

--- a/src/widget/drawings-drawer.ts
+++ b/src/widget/drawings-drawer.ts
@@ -127,7 +127,13 @@ export class DrawingsDrawer {
     constructor(private readonly opts: DrawingsDrawerOptions) {
         const doc = opts.host.ownerDocument;
         injectStyles(STYLE_ID, CSS, doc);
-        this.drawer = new Drawer({ host: opts.host, title: 'Drawings', onOpenChange: opts.onOpenChange });
+        this.drawer = new Drawer({
+            host: opts.host,
+            title: 'Drawings',
+            onOpenChange: opts.onOpenChange,
+            // Swiping across the tool list pages through the group tabs.
+            onSwipe: (dir) => this.stepGroup(dir === 'left' ? 1 : -1),
+        });
 
         const sticky = doc.createElement('div');
         sticky.className = 'vela-dd-sticky';
@@ -166,6 +172,19 @@ export class DrawingsDrawer {
 
     destroy(): void {
         this.drawer.destroy();
+    }
+
+    /** Move the active group tab by `step` (a horizontal swipe on the list). Search mode
+     *  shows the flattened results — no tabs to page through, so the swipe is inert. */
+    private stepGroup(step: number): void {
+        if (this.input.value.trim()) return;
+        const groups = this.definition.groups;
+        const next = groups[groups.findIndex((g) => g.id === this.activeGroup) + step];
+        if (!next) return;
+        this.activeGroup = next.id;
+        this.renderTabs();
+        this.renderList();
+        this.tabs.querySelector('[data-active="1"]')?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
     }
 
     private renderTabs(): void {

--- a/src/widget/indicator-picker.ts
+++ b/src/widget/indicator-picker.ts
@@ -134,7 +134,9 @@ export class IndicatorPicker {
                 if (open) {
                     this.search.value = '';
                     this.refresh();
-                    setTimeout(() => this.search.focus(), 0);
+                    // Desktop only: focusing the search on a touch device would pop the
+                    // on-screen keyboard over the just-opened fullscreen picker.
+                    if (!this.search.closest('[data-layout="mobile"]')) setTimeout(() => this.search.focus(), 0);
                 }
                 opts.onOpenChange?.(open);
             },

--- a/src/widget/statusline.ts
+++ b/src/widget/statusline.ts
@@ -96,9 +96,15 @@ const CSS = `
  * class here would shift every chart on the page, including statusline-less ones. */
 .vela-has-statusline [data-vela-pane='price'] { transform: translateY(26px); }
 /* Mobile: two-line chip — logo / symbol / meta / market status on one aligned row, the
- * bar change on the next. Full O/H/L/C stays hidden (too dense on a phone-width plot). */
+ * bar change on the next. Full O/H/L/C stays hidden (too dense on a phone-width plot).
+ * GRID, not a wrapping flexbox: an absolutely positioned wrapping flex container sizes
+ * to the one-line sum of ALL segments (max-content), so its background used to stretch
+ * far past the market badge; a grid hugs the widest actual row. The meta column may
+ * shrink (it carries the ellipsis), the others wrap their content. */
 [data-layout='mobile'] .vela-statusline {
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: auto auto minmax(0, auto) auto;
+    justify-content: start;
     align-items: center;
     row-gap: 1px;
     max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
@@ -119,9 +125,8 @@ const CSS = `
 [data-layout='mobile'] .vela-statusline .vela-sl-market { align-self: center; }
 [data-layout='mobile'] .vela-statusline .vela-sl-ohlc { display: none !important; }
 [data-layout='mobile'] .vela-statusline .vela-sl-change {
-    flex-basis: 100%;
-    /* Sit under the text column (past the avatar + its gap), not under the logo. */
-    padding-left: calc(18px + var(--vela-space-2));
+    /* Second row, under the text column — the avatar keeps the first column. */
+    grid-column: 2 / -1;
     font-size: var(--vela-font-size-sm);
     line-height: 1.2;
 }
@@ -131,6 +136,7 @@ const CSS = `
  * overflow:hidden only guards the transient between a resize and the next measure.
  * Placed after the mobile block on purpose: same specificity, later wins. */
 .vela-statusline.vela-sl-fit {
+    display: flex; /* undo the mobile grid — fit mode is one flex row again */
     flex-wrap: nowrap;
     align-items: center;
     max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
@@ -257,6 +263,8 @@ export class Statusline {
         host.classList.add('vela-has-statusline'); // scopes the price-legend shift to THIS host
         this.el = doc.createElement('div');
         this.el.className = 'vela-statusline';
+        // Opt into the renderer's PNG export — the status line is part of what's on screen.
+        this.el.dataset.velaScreenshot = '1';
         // Display the bare ticker — the venue prefix is identity, not label; the venue
         // itself shows in the meta segment ("· BINANCE · 1h") beside it.
         const ticker = parseSymbol(symbol).ticker;

--- a/src/widget/watermark.ts
+++ b/src/widget/watermark.ts
@@ -58,6 +58,9 @@ export class Watermark {
         injectStyles(STYLE_ID, CSS, host.ownerDocument);
         this.el = host.ownerDocument.createElement('div');
         this.el.className = 'vela-watermark';
+        // Opt into the renderer's PNG export, beneath the canvases — on screen the mark
+        // sits behind the candles.
+        this.el.dataset.velaScreenshot = 'under';
         this.text = host.ownerDocument.createElement('span');
         this.el.appendChild(this.text);
         host.appendChild(this.el);

--- a/test/drawer-gestures.test.ts
+++ b/test/drawer-gestures.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { classifyGesture, dragDismisses, swipeDirection } from '../src/ui/components/drawer/view';
+import { attachChromeTooltip } from '../src/renderers/shared/chrome-tooltip';
+import type { VelaTheme } from '../src/core/options';
+
+// ── the drawer's gesture classifier (swipe-down-to-close from anywhere, swipe-to-tab) ──
+
+const rest = { canSwipe: true, scrolled: false, hScrollable: false };
+
+describe('drawer gesture classification', () => {
+    it('stays pending inside the slop', () => {
+        expect(classifyGesture(3, 5, rest)).toBe('pending');
+        expect(classifyGesture(-7, 0, rest)).toBe('pending');
+    });
+
+    it('a decidedly vertical downward pull on an at-rest sheet is the dismiss drag', () => {
+        expect(classifyGesture(2, 30, rest)).toBe('drag');
+    });
+
+    it('a downward pull over a scrolled list keeps native scrolling', () => {
+        expect(classifyGesture(2, 30, { ...rest, scrolled: true })).toBe('scroll');
+    });
+
+    it('an upward move is always native scrolling', () => {
+        expect(classifyGesture(2, -30, rest)).toBe('scroll');
+    });
+
+    it('a decidedly horizontal move is a swipe — for sheets that handle one', () => {
+        expect(classifyGesture(40, 5, rest)).toBe('hswipe');
+        expect(classifyGesture(-40, 5, { ...rest, canSwipe: false })).toBe('scroll');
+    });
+
+    it('a horizontal move on a sideways-scrolling strip stays that strip’s scroll', () => {
+        expect(classifyGesture(40, 5, { ...rest, hScrollable: true })).toBe('scroll');
+    });
+});
+
+describe('drawer drag release', () => {
+    it('dismisses past min(96px, a third of the sheet)', () => {
+        expect(dragDismisses(96, 600)).toBe(true);
+        expect(dragDismisses(95, 600)).toBe(false);
+        // Short sheet: the fractional bound is the smaller one.
+        expect(dragDismisses(40, 120)).toBe(true);
+        expect(dragDismisses(39, 120)).toBe(false);
+    });
+});
+
+describe('drawer swipe release', () => {
+    it('fires only past the travel floor, in the finger’s direction', () => {
+        expect(swipeDirection(-60, 5)).toBe('left');
+        expect(swipeDirection(60, 5)).toBe('right');
+        expect(swipeDirection(-40, 5)).toBeNull(); // too short
+    });
+
+    it('a release that ended more vertical than horizontal is not a swipe', () => {
+        expect(swipeDirection(-60, 70)).toBeNull();
+    });
+});
+
+// ── chrome tooltip: mouse-only arming (a tap must never leave a stuck tip) ──
+
+/** Bare-bones event-target stand-in (same shape as the InputController test double). */
+function fakeAnchor() {
+    const listeners = new Map<string, Set<(e: unknown) => void>>();
+    return {
+        types: () => [...listeners.keys()],
+        addEventListener(type: string, fn: (e: unknown) => void) {
+            (listeners.get(type) ?? listeners.set(type, new Set()).get(type)!).add(fn);
+        },
+        removeEventListener(type: string, fn: (e: unknown) => void) {
+            listeners.get(type)?.delete(fn);
+        },
+        fire(type: string, e: Record<string, unknown>) {
+            for (const fn of [...(listeners.get(type) ?? [])]) fn(e);
+        },
+    };
+}
+
+describe('chrome tooltip arming', () => {
+    afterEach(() => {
+        delete (globalThis as { window?: unknown }).window;
+    });
+
+    it('arms on a mouse pointerenter only — touch taps never open (or strand) a tip', () => {
+        const setTimeoutSpy = vi.fn(() => 1);
+        (globalThis as { window?: unknown }).window = { setTimeout: setTimeoutSpy };
+        const anchor = fakeAnchor();
+        const dispose = attachChromeTooltip(anchor as unknown as HTMLElement, {
+            host: {} as HTMLElement,
+            theme: () => ({}) as VelaTheme,
+            text: () => 'Hide indicator legend',
+        });
+
+        // The stuck-tip bug came from mouseenter, which mobile browsers synthesize after
+        // a tap with no mouseleave to follow — the tip must not listen to it at all.
+        expect(anchor.types()).toContain('pointerenter');
+        expect(anchor.types()).not.toContain('mouseenter');
+
+        anchor.fire('pointerenter', { pointerType: 'touch' });
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+        anchor.fire('pointerenter', { pointerType: 'mouse' });
+        expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+        dispose();
+    });
+});

--- a/test/input-touch.test.ts
+++ b/test/input-touch.test.ts
@@ -99,7 +99,20 @@ function touchHarness() {
         el.fire('pointerdown', { ...base, timeStamp: t });
         el.fire('pointerup', { ...base, timeStamp: t + 40 });
     };
-    return { deps, tap };
+    /** A REAL finger tap: the contact wobbles `w` px between touch-down and lift. */
+    const wobbleTap = (x: number, y: number, t: number, w = 5): void => {
+        const base = { button: 0, pointerId: 1, pointerType: 'touch' };
+        el.fire('pointerdown', { ...base, clientX: x, clientY: y, timeStamp: t });
+        el.fire('pointermove', { ...base, clientX: x + w, clientY: y + w, timeStamp: t + 20 });
+        el.fire('pointerup', { ...base, clientX: x + w, clientY: y + w, timeStamp: t + 40 });
+    };
+    const mouseDrag = (x: number, y: number, t: number, d: number): void => {
+        const base = { button: 0, pointerId: 2, pointerType: 'mouse' };
+        el.fire('pointerdown', { ...base, clientX: x, clientY: y, timeStamp: t });
+        el.fire('pointermove', { ...base, clientX: x + d, clientY: y, timeStamp: t + 20 });
+        el.fire('pointerup', { ...base, clientX: x + d, clientY: y, timeStamp: t + 40 });
+    };
+    return { deps, tap, wobbleTap, mouseDrag };
 }
 
 describe('touch double-tap (the touch dblclick)', () => {
@@ -142,5 +155,27 @@ describe('touch double-tap (the touch dblclick)', () => {
         tap(400, 100, 100);
         tap(400, 100, 200);
         expect(deps.dataDblClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('taps that wobble a few px (a real finger) still tap, click, and pair', () => {
+        const { deps, wobbleTap } = touchHarness();
+        wobbleTap(400, 100, 0);
+        expect(deps.onClick).toHaveBeenCalledTimes(1); // the wobble is not a drag on touch
+        wobbleTap(402, 103, 150);
+        expect(deps.dataDblClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('a touch travelling past the touch slop is a pan, not a tap', () => {
+        const { deps, wobbleTap } = touchHarness();
+        wobbleTap(400, 100, 0, 12);
+        wobbleTap(400, 100, 150, 12);
+        expect(deps.onClick).not.toHaveBeenCalled();
+        expect(deps.dataDblClick).not.toHaveBeenCalled();
+    });
+
+    it('the mouse keeps its strict 2px click slop', () => {
+        const { deps, mouseDrag } = touchHarness();
+        mouseDrag(400, 100, 0, 5); // 5px is a click on touch but a drag for a mouse
+        expect(deps.onClick).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Enhance chart screenshot functionality to include all visible elements, including volume profiles and indicator legends. Improve gesture handling for drawer and dialog components, ensuring better mobile usability. Update styles for touch interactions and refine event handling for improved responsiveness. Document new features and adjustments in the changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Screenshot export touches core renderer compositing and synchronous DOM rasterization (CORS-tainted images are skipped); touch and focus changes affect gesture classification across chart input and shared UI primitives.
> 
> **Overview**
> Fixes a cluster of **mobile usability** issues and expands **PNG screenshot** output to match on-screen chrome.
> 
> **Screenshots** now composite every plot layer (volume, VRVP, plugin layers above/below data, drawings) and rasterize DOM overlays via new `rasterizeOverlay` — indicator legends, the status line (`data-vela-screenshot`), and the watermark (`under`). Crosshair stays excluded.
> 
> **Drawer / dialog** opening focuses the sheet or panel instead of the first input so the OS keyboard does not cover mobile sheets. The **Drawer** dismisses on a downward pull from anywhere on the sheet (not only the handle), respects scrolled lists, supports **`onSwipe`** for horizontal paging (drawings tool groups), and the drawings drawer steps tabs on swipe.
> 
> **Touch input** uses **8px slop** for tap vs drag (fixes wobbly taps and double-tap pairing); **double-tap window** widened to 350ms. **Chrome tooltips** arm on mouse `pointerenter` only so taps do not leave stuck tips. Drawing settings popup grip gets **`touch-action: none`**, pointer capture, and a wider hit target on coarse pointers.
> 
> **Mobile status line** layout switches from wrapping flex to a **grid** so the chip background does not stretch past content; indicator picker skips auto-focusing search on mobile layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108ccd294123e060abb4af6491a3f25ba6d447e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->