### PR TITLE
fix: Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Multi-chart borders stay under chart settings.** Hovering a cell seam in a
+  multi-chart workspace no longer draws the splitter highlight through an open chart
+  settings dialog — the dialog now stacks above the grid chrome.
 - **Screenshots capture the whole chart.** The PNG export now includes everything the
   screen shows: the volume columns, the visible-range volume profile, plugin-drawn
   layers, the status line, the indicator legends (with their values), and the faded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Vela, newest first.
 
 ### Changed
 
+- **Selection in menus reads from the row itself.** The timeframe, chart type, and
+  every other selectable dropdown now mark the active entry with a stronger row
+  background instead of a leading checkmark, and the mobile three-dots sheet does the
+  same — the selected item is visible at a glance without scanning for a glyph.
+- **The symbol watermark yields to loading.** While a chart's bars are loading, the
+  faded symbol watermark stays hidden so it never overlaps the loading indicator; it
+  returns as soon as the first bars paint.
+- **Favorite stars are gold everywhere.** The mobile drawings sheet's favorite star
+  now lights up in the same gold as the desktop drawing toolbar's, instead of blue.
+- **The highlighter's width is typed, not picked.** The drawing quick bar shows a
+  numeric width field for the highlighter (honoring its 4–60px range) instead of the
+  1–4px list, which couldn't even express its 14px default.
 - **Crosshair sync mirrors the price level too.** With crosshair sync on in a
   multi-chart workspace, charts showing the SAME ticker as the hovered one now draw
   the ghost's horizontal price line alongside the vertical time line, with the price
@@ -98,6 +110,10 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Long freehand strokes keep their shape.** Drawing with the brush or highlighter
+  for a long stretch no longer degrades into a single straight line chasing the
+  cursor: when a stroke reaches its point budget, the older trail thins gracefully
+  and the capture keeps going, so the whole gesture lands on the chart.
 - **Multi-chart borders stay under chart settings.** Hovering a cell seam in a
   multi-chart workspace no longer draws the splitter highlight through an open chart
   settings dialog — the dialog now stacks above the grid chrome.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Legend fold count stays readable on a light plot.** The indicator-count chip on a
+  folded legend now paints its number (and chevron) with the plot's own text color, so a
+  white chart no longer shows a near-white digit on a white chip.
 - **Long freehand strokes keep their shape.** Drawing with the brush or highlighter
   for a long stretch no longer degrades into a single straight line chasing the
   cursor: when a stroke reaches its point budget, the older trail thins gracefully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Vela, newest first.
 
 ### Changed
 
+- **Crosshair sync mirrors the price level too.** With crosshair sync on in a
+  multi-chart workspace, charts showing the SAME ticker as the hovered one now draw
+  the ghost's horizontal price line alongside the vertical time line, with the price
+  labeled on their own scale (hover the price pane — a study pane's value is not a
+  price). Charts on other markets keep the time-only ghost: a foreign price level
+  would be noise on their scale. For custom consumers, the crosshair event now names
+  the pane kind under the cursor (`paneKind`), so a host can make the same call.
 - **Mobile chrome polish.** The timeframe sheet labels its date-range chips and
   timeframe grid with matching white section headers (no divider between them), and
   highlights the active chip in white. In the drawings sheet the search field and

--- a/src/core/ports/IChartRenderer.ts
+++ b/src/core/ports/IChartRenderer.ts
@@ -76,7 +76,14 @@ export interface CrosshairOHLC {
 
 export interface CrosshairEvent {
     time: Millis | null;
+    /** Value at the cursor on ITS pane's scale — a price on the price pane, an
+     *  indicator value on a study pane (which one: see {@link paneKind}). */
     price: number | null;
+    /** The kind of pane the cursor (and thus `price`) is on — how a consumer tells a
+     *  real price from a study-pane value (e.g. crosshair sync only mirrors the
+     *  horizontal level from the price pane). Optional and additive: a renderer that
+     *  doesn't track panes omits it. */
+    paneKind?: 'price' | 'study' | null;
     /** Value at the crosshair per series, keyed by stable series id. */
     values: ReadonlyMap<string, number>;
     /** The hovered price bar's OHLCV (null when the cursor is off any bar). */

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -2308,7 +2308,7 @@ export class NativeRenderer implements IChartRenderer {
             this.lastPointer = null;
             this.scheduler.invalidate(InvalidateLevel.Cursor);
             this.hoverLogical = null; // off the plot ⇒ the readout falls back to the latest bar
-            const empty: CrosshairEvent = { time: null, price: null, values: new Map(), ohlc: null };
+            const empty: CrosshairEvent = { time: null, price: null, paneKind: null, values: new Map(), ohlc: null };
             for (const cb of this.crosshairCbs) cb(empty);
             return;
         }
@@ -2326,7 +2326,7 @@ export class NativeRenderer implements IChartRenderer {
         const logical = Math.round(this.coords.xToLogical(x));
         const onBar = logical >= 0 && logical < this.coords.barCount;
         const time = onBar ? this.coords.logicalToTime(logical) : null;
-        const pane = this.paneAtY(y);
+        const pane = this.paneNodeAtY(y); // the full node — the event also names the pane KIND
         const price = inData && pane ? this.coords.yToPrice(y, pane.scale, pane.bounds) : null;
         const values = new Map<string, number>();
         if (onBar) {
@@ -2345,7 +2345,7 @@ export class NativeRenderer implements IChartRenderer {
             ? { time: bar.time, open: bar.open, high: bar.high, low: bar.low, close: bar.close, volume: bar.volume }
             : null;
         this.hoverLogical = onBar ? logical : null;
-        const event: CrosshairEvent = { time, price, values, ohlc };
+        const event: CrosshairEvent = { time, price, paneKind: inData && pane ? pane.kind : null, values, ohlc };
         for (const cb of this.crosshairCbs) cb(event);
     }
 
@@ -2366,6 +2366,21 @@ export class NativeRenderer implements IChartRenderer {
             if (y >= pane.bounds.top && y <= pane.bounds.top + pane.bounds.height) return pane;
         }
         return null;
+    }
+
+    /** The pane whose bounds sit closest to `y` — the forgiving fallback for points that
+     *  fall BETWEEN bounds (separator gaps, the strip under the last pane). */
+    private nearestPaneToY(y: number): PaneNode | null {
+        let best: PaneNode | null = null;
+        let bestDist = Infinity;
+        for (const pane of this.scene.panes.values()) {
+            const d = y < pane.bounds.top ? pane.bounds.top - y : y - (pane.bounds.top + pane.bounds.height);
+            if (d < bestDist) {
+                bestDist = d;
+                best = pane;
+            }
+        }
+        return best;
     }
 
     // ── manual vertical scaling (price-axis drag + vertical price pan) ──
@@ -2436,7 +2451,9 @@ export class NativeRenderer implements IChartRenderer {
      * still fits the view.)
      */
     private dataDblClick(_x: number, y: number): void {
-        const pane = this.paneNodeAtY(y);
+        // Snap to the nearest pane when the point falls between bounds (separator gap,
+        // the sliver under the last pane) — a double-tap must never land in a dead zone.
+        const pane = this.paneNodeAtY(y) ?? this.nearestPaneToY(y);
         if (!pane) return;
         // Double-click maximizes the clicked pane so it fills the plot and every other pane is
         // fully hidden (zero height, not a strip): the price pane hides all study indicators, a
@@ -2939,7 +2956,7 @@ export class NativeRenderer implements IChartRenderer {
      *  pointer at 14:00 must light THIS day's daily candle, not tomorrow's (a time past
      *  a bar's midpoint still belongs to that bar). Before the first open or past the
      *  forming bar there is no containing bar — no ghost. */
-    private externalCrossPx(): { x: number; y: number | null; time: Millis } | null {
+    private externalCrossPx(): { x: number; y: number | null; time: Millis; price: number | null } | null {
         const ext = this.externalCross;
         if (!ext || this.coords.barCount === 0) return null;
         const logical = Math.floor(this.coords.timeToLogical(ext.time));
@@ -2954,7 +2971,8 @@ export class NativeRenderer implements IChartRenderer {
                 if (!Number.isFinite(y) || y < pricePane.bounds.top || y > pricePane.bounds.top + pricePane.bounds.height) y = null;
             }
         }
-        return { x, y, time: this.coords.logicalToTime(logical) };
+        // The raw price rides along for the axis chip (only meaningful with a resolved y).
+        return { x, y, time: this.coords.logicalToTime(logical), price: y != null ? ext.price : null };
     }
 
     /** Sticky magnet mode for user drawings (off/weak/strong); the drawings toolbar drives it. */

--- a/src/renderers/native/chrome/CrosshairRenderer.ts
+++ b/src/renderers/native/chrome/CrosshairRenderer.ts
@@ -29,7 +29,7 @@ export class CrosshairRenderer {
     /** Clear the cursor canvas and (re)draw the crosshair lines + axis chips. The optional
      *  `separatorHoverY` highlights the draggable pane separator under the cursor;
      *  `external` is a SYNCED ghost crosshair (another chart's pointer, pixel-resolved). */
-    render(scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme, separatorHoverY: number | null = null, external: { x: number; y: number | null; time: number } | null = null): void {
+    render(scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme, separatorHoverY: number | null = null, external: { x: number; y: number | null; time: number; price?: number | null } | null = null): void {
         const ctx = this.ctx;
         const canvas = this.canvas;
         if (!ctx || !canvas) return;
@@ -98,11 +98,11 @@ export class CrosshairRenderer {
 
     /** The synced ghost: a dimmed vertical line at the bar the renderer resolved as
      *  CONTAINING the foreign time (+ horizontal line when a comparable price came
-     *  along), with that bar's time chip in this chart's own timezone. The snap
-     *  happened upstream (`externalCrossPx`, floor-to-containing-bar) — this method
-     *  only draws. No price chip — the ghost answers "when", the local crosshair
-     *  answers "where". */
-    private drawExternal(ctx: CanvasRenderingContext2D, ext: { x: number; y: number | null; time: number }, scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme): void {
+     *  along), with that bar's time chip in this chart's own timezone and — when the
+     *  level resolved — the price chip on the right axis. The snap happened upstream
+     *  (`externalCrossPx`, floor-to-containing-bar) — this method only draws. Chips
+     *  render slightly dimmed so the ghost still reads as foreign. */
+    private drawExternal(ctx: CanvasRenderingContext2D, ext: { x: number; y: number | null; time: number; price?: number | null }, scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme): void {
         const cs = scene.style.crosshair;
         const dataW = coords.width;
         const dataH = coords.height;
@@ -124,8 +124,23 @@ export class CrosshairRenderer {
         ctx.stroke();
         ctx.setLineDash([]);
         ctx.lineWidth = 1;
-        ctx.globalAlpha = 0.8; // the chip stays readable but still reads as foreign
-        this.chip(ctx, x, dataH + 1, formatStamp(ext.time, scene.timezone), cs.labelBackground ?? theme.borderColor, 'center', true, theme.background);
+        ctx.globalAlpha = 0.8; // chips stay readable but still read as foreign
+        const chipBg = cs.labelBackground ?? theme.borderColor;
+        if (ext.y != null && ext.price != null) {
+            // Same chip the local crosshair puts on the axis, at the ghost's level —
+            // formatted on the pane under the line (the price pane, by construction).
+            let pane: PaneNode | undefined;
+            for (const p of scene.panes.values()) {
+                if (ext.y >= p.bounds.top && ext.y <= p.bounds.top + p.bounds.height) {
+                    pane = p;
+                    break;
+                }
+            }
+            if (pane) {
+                this.chip(ctx, dataW + 1, ext.y, formatAxisValue(pane.scale, pane.bounds.height, ext.price, percentScaleFor(scene, pane), scene.priceMintick, pane.axisFormat), chipBg, 'left', false, theme.background);
+            }
+        }
+        this.chip(ctx, x, dataH + 1, formatStamp(ext.time, scene.timezone), chipBg, 'center', true, theme.background);
         ctx.globalAlpha = 1;
     }
 

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -276,7 +276,9 @@ export class SettingsDialog {
         ensureControlStyles();
         const mobile = this.mobileLayout;
         const scrim = document.createElement('div');
-        scrim.style.cssText = 'position:absolute;inset:0;z-index:21;display:flex;align-items:flex-start;justify-content:center;background:transparent;padding-top:8vh;pointer-events:auto;';
+        // Above workspace splitters (z-index 30) and the active-cell ring — those live in
+        // the same stacking context when the dialog mounts on the multi-chart root.
+        scrim.style.cssText = 'position:absolute;inset:0;z-index:var(--vela-z-dialog);display:flex;align-items:flex-start;justify-content:center;background:transparent;padding-top:8vh;pointer-events:auto;';
         if (mobile) {
             // Fullscreen presentation: the card fills the chart area edge to edge.
             scrim.classList.add('vela-sd-mobile');

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -530,7 +530,10 @@ export class InputController {
             // (placing is click-based, so the cursor follow happens with no button down).
             this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey);
         }
-        this.deps.onPointerMove(x, y);
+        // Hover crosshair is a MOUSE affordance. A touch never hovers: its crosshair
+        // comes only from the long-press inspect path (region 'crosshair' above) —
+        // without this guard every panning finger paints the crosshair under itself.
+        if (e.pointerType !== 'touch') this.deps.onPointerMove(x, y);
     };
 
     private readonly onUp = (e: PointerEvent): void => {
@@ -567,11 +570,12 @@ export class InputController {
         }
         const { x, y } = this.local(e);
         const wasTouch = e.pointerType === 'touch';
-        // Click/tap-hood of this release. A mouse uses the latched travel (`moved`); a
-        // touch is judged by the LANDING-to-lift displacement instead — a contact that
-        // wobbles out past the slop and settles back is still a tap on every platform,
-        // and the latch was what made double-taps feel like they hit dead zones.
-        const tapRelease = this.dragging && (wasTouch ? Math.hypot(x - this.startX, y - this.startY) <= TOUCH_TAP_SLOP : !this.moved);
+        // Click/tap-hood of this release. A mouse uses the latched travel (`moved`)
+        // alone; a touch must ALSO land within TOUCH_TAP_SLOP of where it lifted —
+        // the wider release radius forgives a quick tap's sliding contact patch, but
+        // a gesture that latched `moved` (a one-way 9–14px drag) already panned the
+        // chart and must not double as a click/tap on release.
+        const tapRelease = this.dragging && !this.moved && (!wasTouch || Math.hypot(x - this.startX, y - this.startY) <= TOUCH_TAP_SLOP);
         if (this.dragging && this.region === 'drawing') {
             this.deps.drawingsPointerUp?.(x, y);
         } else if (tapRelease && this.region === 'data') {

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -78,6 +78,10 @@ const LONG_PRESS_MS = 350; // touch hold before a data-area press becomes crossh
 // A resting finger wobbles far more than a mouse: within this radius a hold still counts
 // as stationary (long-press keeps arming), beyond it the gesture is a pan.
 const TOUCH_SLOP = 8;
+// A touch release still counts as a TAP within this landing-to-lift displacement — a
+// quick tap's contact patch slides further than the hold wobble above, and judging the
+// release (not the latched mid-gesture travel) means an out-and-back wobble stays a tap.
+const TOUCH_TAP_SLOP = 14;
 // Two clean taps this close together (time and space) are a double-tap — the touch
 // dblclick. The browser never synthesizes dblclick here (the controller owns the touch
 // stream via touch-action:none), so the pairing is detected by hand. 350ms matches the
@@ -561,11 +565,16 @@ export class InputController {
             this.endGesture(e);
             return;
         }
+        const { x, y } = this.local(e);
+        const wasTouch = e.pointerType === 'touch';
+        // Click/tap-hood of this release. A mouse uses the latched travel (`moved`); a
+        // touch is judged by the LANDING-to-lift displacement instead — a contact that
+        // wobbles out past the slop and settles back is still a tap on every platform,
+        // and the latch was what made double-taps feel like they hit dead zones.
+        const tapRelease = this.dragging && (wasTouch ? Math.hypot(x - this.startX, y - this.startY) <= TOUCH_TAP_SLOP : !this.moved);
         if (this.dragging && this.region === 'drawing') {
-            const { x, y } = this.local(e);
             this.deps.drawingsPointerUp?.(x, y);
-        } else if (this.dragging && !this.moved && this.region === 'data') {
-            const { x, y } = this.local(e);
+        } else if (tapRelease && this.region === 'data') {
             this.deps.onClick(x, y);
         } else if (this.dragging && this.region === 'data') {
             const stale = e.timeStamp - this.lastT > FLING_STALE_MS;
@@ -574,17 +583,13 @@ export class InputController {
                 this.deps.fling(-this.vx / pitch); // rightOffset velocity (logical/ms)
             }
         }
-        const wasTouch = e.pointerType === 'touch';
-        // A stationary touch release is a tap — feed the double-tap pairing (touch has
-        // no native dblclick here). Checked before endGesture clears the flags.
-        const wasTap = wasTouch && this.dragging && !this.moved;
+        // A clean touch release is a tap — feed the double-tap pairing (touch has no
+        // native dblclick here). Checked before endGesture clears the flags.
+        const wasTap = wasTouch && tapRelease;
         this.endGesture(e);
         // A finger leaves no resting cursor behind — clear the crosshair a pan/tap drew.
         if (wasTouch) this.deps.onPointerMove(null, null);
-        if (wasTap) {
-            const { x, y } = this.local(e);
-            this.registerTap(e.timeStamp, x, y);
-        }
+        if (wasTap) this.registerTap(e.timeStamp, x, y);
     };
 
     /** Pair clean taps into a double-tap — the touch equivalent of dblclick (same
@@ -593,7 +598,10 @@ export class InputController {
         const paired = this.lastTapT > 0 && t - this.lastTapT <= DOUBLE_TAP_MS && Math.hypot(x - this.lastTapX, y - this.lastTapY) <= DOUBLE_TAP_SLOP;
         if (paired) {
             this.lastTapT = 0; // a triple tap starts a fresh pair, not two doubles
-            this.doubleActivate(x, y);
+            // Route by the FIRST tap: that one was aimed; the second is the sloppier
+            // confirmation and can drift onto a neighboring region (a separator band,
+            // an axis strip) and mis-route the pair.
+            this.doubleActivate(this.lastTapX, this.lastTapY);
             return;
         }
         this.lastTapT = t;

--- a/src/renderers/native/drawings/DrawingInteraction.ts
+++ b/src/renderers/native/drawings/DrawingInteraction.ts
@@ -316,7 +316,15 @@ export class DrawingInteraction {
         const last = draft.anchors[draft.anchors.length - 1];
         const lx = last ? proj.xOf(last.time) : NaN;
         const ly = last ? proj.yOf(last.price, draft.paneId) ?? NaN : NaN;
-        if (draft.anchors.length < this.state.need && Math.hypot(x - lx, y - ly) > FREEHAND_SAMPLE_PX) {
+        if (Math.hypot(x - lx, y - ly) > FREEHAND_SAMPLE_PX) {
+            // At the path cap a long stroke keeps drawing: halve the sampled points
+            // (keep the endpoints, drop every other interior one) so the older trail
+            // gets progressively coarser instead of the capture dying mid-gesture —
+            // frozen anchors plus a live cursor read as one straight rubber band.
+            if (draft.anchors.length >= this.state.need) {
+                const lastIdx = draft.anchors.length - 1;
+                draft.anchors = draft.anchors.filter((_, i) => i % 2 === 0 || i === lastIdx);
+            }
             draft.anchors.push(proj.pxToPoint(x, y, draft.paneId));
         }
         this.state.cursor = proj.pxToPoint(x, y, draft.paneId);

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -157,7 +157,17 @@ export class DrawingSettingsPopup {
             bar.appendChild(this.dropdown('Icon size', STAMP_SIZE_OPTIONS, sz, (s) => stampSizeIcon(s), (v) => actions.patch({ size: v }), { label: sizeLabel }));
         }
         if (paths.has('style.lineColor')) bar.appendChild(this.colorButton('Line color', BRUSH_ICON, drawing.style.lineColor || DEFAULT_DRAWING_COLOR, (v) => actions.patch({ 'style.lineColor': v })));
-        if (paths.has('style.lineWidth')) bar.appendChild(this.dropdown('Line width', [1, 2, 3, 4], drawing.style.lineWidth, (w) => lineIcon(w, 'solid'), (v) => actions.patch({ 'style.lineWidth': v }), { label: (v) => `${v}px`, labelInTrigger: true }));
+        if (paths.has('style.lineWidth')) {
+            // A marker-width field (floor above the hairline ladder, e.g. the
+            // highlighter's 4–60) can't live in the 1–4 dropdown — a free numeric
+            // input honoring the schema's declared range replaces it.
+            const wf = schema.fields.find((f) => f.path === 'style.lineWidth');
+            if (wf?.kind === 'number' && (wf.min ?? 1) > 1) {
+                bar.appendChild(this.widthInput('Line width', drawing.style.lineWidth, wf.min ?? 1, wf.max ?? 60, wf.step ?? 1, (v) => actions.patch({ 'style.lineWidth': v })));
+            } else {
+                bar.appendChild(this.dropdown('Line width', [1, 2, 3, 4], drawing.style.lineWidth, (w) => lineIcon(w, 'solid'), (v) => actions.patch({ 'style.lineWidth': v }), { label: (v) => `${v}px`, labelInTrigger: true }));
+            }
+        }
         if (paths.has('style.lineStyle')) bar.appendChild(this.dropdown('Line style', LINE_STYLE_OPTIONS.map((o) => o.value), drawing.style.lineStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'style.lineStyle': v }), { label: styleLabel }));
         // initialize the Fill swatch to the color actually painted (validity tint / line-color wash /
         // background fallback), not a stale default — same source the renderer fills with.
@@ -1066,6 +1076,40 @@ export class DrawingSettingsPopup {
             onChange(on);
         });
         return b;
+    }
+
+    /** An inline numeric width field for tools whose stroke range outgrows the 1–4px
+     *  ladder — the value is clamped to the schema's declared min/max on commit. */
+    private widthInput(tip: string, value: number, min: number, max: number, step: number, onChange: (v: number) => void): HTMLInputElement {
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.dataset.tip = tip;
+        input.min = String(min);
+        input.max = String(max);
+        input.step = String(step);
+        input.value = String(value);
+        input.style.cssText = `width:52px;height:${BTN}px;box-sizing:border-box;flex:none;background:transparent;color:inherit;border:1px solid var(--vela-border);border-radius:5px;padding:0 4px;font:12px ${this.theme.fontFamily};font-variant-numeric:tabular-nums;outline:none;`;
+        const commit = (): void => {
+            const n = parseFloat(input.value);
+            if (!Number.isFinite(n)) {
+                input.value = String(value);
+                return;
+            }
+            const v = Math.min(max, Math.max(min, n));
+            input.value = String(v);
+            value = v;
+            onChange(v);
+        };
+        input.addEventListener('change', commit);
+        input.addEventListener('keydown', (e) => {
+            e.stopPropagation(); // typing (incl. Delete) must not reach the chart
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                commit();
+                input.blur();
+            }
+        });
+        return input;
     }
 
     /** A pick-one dropdown: the trigger shows the current value's glyph (plus an optional inline

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -255,7 +255,7 @@ export class InputsUI {
             row.el.style.background = open ? theme.background : this.idleRowFill();
             row.el.style.color = theme.textColor;
         }
-        if (this.foldToggle) this.foldToggle.style.background = theme.background;
+        if (this.foldToggle) this.syncFoldToggle(); // rebuild so fill + ink follow the new theme
     }
 
     /** Provide (or clear) the host symbol picker that `input.symbol` opens on activation. */
@@ -592,13 +592,16 @@ export class InputsUI {
         btn.setAttribute('aria-label', this.overviewAction !== null ? 'Indicators' : folded ? 'Show indicator legend' : 'Hide indicator legend');
         // Bordered chip in both states; folded shows chevron then the count to its right
         // (reference: "˅ 12"), expanded is just the up chevron that folds the list away.
-        // Border uses the shared chrome token (same as menus/dialogs) — `--vela-fg-muted`
-        // was too bright against the plot. Extra margin-top clears the last indicator
+        // Fill AND ink follow the LIVE plot theme (same as legend rows) — chrome tokens
+        // track the app surface, so a white plot on a dark app would otherwise put a
+        // near-white count on a white chip. Extra margin-top clears the last indicator
         // title; the legend column's own 3px gap is too tight under a bordered chip.
-        btn.style.cssText = `pointer-events:auto;display:inline-flex;align-items:center;gap:4px;background:${this.theme.background};border:1px solid var(--vela-border);border-radius:4px;padding:2px 6px;margin-top:6px;cursor:pointer;font:inherit;line-height:0;`;
+        const ink = this.theme.textColor;
+        btn.style.cssText = `pointer-events:auto;display:inline-flex;align-items:center;gap:4px;background:${this.theme.background};color:${ink};border:1px solid ${this.theme.borderColor};border-radius:4px;padding:2px 6px;margin-top:6px;cursor:pointer;font:inherit;line-height:0;`;
         btn.replaceChildren();
         const icon = document.createElement('span');
-        icon.style.cssText = 'display:inline-flex;align-items:center;line-height:0;';
+        // Slightly muted against the count — currentColor rides the button's ink.
+        icon.style.cssText = 'display:inline-flex;align-items:center;line-height:0;opacity:0.7;';
         // The overview override wears the list glyph — the chip opens the host's
         // indicator overview rather than unfolding rows in place.
         icon.innerHTML = this.overviewAction !== null ? OVERVIEW_SVG : folded ? UNFOLD_SVG : FOLD_SVG;
@@ -606,7 +609,7 @@ export class InputsUI {
         if (folded) {
             const label = document.createElement('span');
             label.textContent = String(count);
-            label.style.cssText = 'font-weight:600;line-height:normal;font-size:12px;color:var(--vela-fg-bright);';
+            label.style.cssText = `font-weight:600;line-height:normal;font-size:12px;color:${ink};`;
             btn.appendChild(label);
         }
         // The toggle lives on the PRICE pane's legend (created on demand — the price pane
@@ -1508,8 +1511,8 @@ function ensureDialogStyles(): void {
 .vela-ind-ctl:hover{color:var(--vela-fg-bright);}
 .vela-ind-close{transition:color var(--vela-dur-fast) ease;}
 .vela-ind-close:hover{color:var(--vela-danger) !important;}
-.vela-ind-fold{color:var(--vela-fg-muted);transition:color var(--vela-dur-fast) ease,border-color var(--vela-dur-fast) ease;}
-.vela-ind-fold:hover{color:var(--vela-fg-bright);border-color:var(--vela-border-strong);}
+.vela-ind-fold{transition:border-color var(--vela-dur-fast) ease,opacity var(--vela-dur-fast) ease;}
+.vela-ind-fold:hover{border-color:var(--vela-border-strong);opacity:0.9;}
 .vela-ind-menuitem{background:transparent;transition:background var(--vela-dur-fast) ease;}
 .vela-ind-menuitem:hover{background:var(--vela-hover-strong);}
 .vela-ind-btn{cursor:pointer;padding:7px 14px;border-radius:var(--vela-radius-md);border:1px solid transparent;background:transparent;color:var(--vela-fg-muted);font-weight:600;font-size:13px;font-family:inherit;transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease,opacity var(--vela-dur-fast) ease;}

--- a/src/renderers/shared/dom-raster.ts
+++ b/src/renderers/shared/dom-raster.ts
@@ -7,9 +7,11 @@
 //   - text nodes in their computed font/color, at their measured on-screen rects,
 //   - already-loaded <img>s (clipped by their radius) — but only when drawing them
 //     leaves the canvas untainted: a cross-origin ticker icon must not poison the
-//     whole export (`toDataURL` would throw at the end).
-// Inline SVG glyphs (icons, chevrons) are skipped — sync canvas cannot raster them —
-// which loses decoration, never information.
+//     whole export (`toDataURL` would throw at the end),
+//   - inline SVG icons, through the geometry subset the icon registry actually uses
+//     (path / circle / rect / line / polyline / polygon, fill + stroke from computed
+//     style, so `currentColor` and inheritance resolve for free). Elements carrying a
+//     `transform` are skipped — honest absence beats a wrongly placed glyph.
 
 /** How the overlay's viewport coordinates map onto the export canvas. */
 export interface OverlayRasterFrame {
@@ -100,6 +102,77 @@ export function rasterizeOverlay(ctx: CanvasRenderingContext2D, root: Element, f
         ctx.restore();
     };
 
+    const drawSvgShapes = (parent: Element, alpha: number): void => {
+        for (const el of parent.children) {
+            if (el.hasAttribute('transform')) continue;
+            const tag = el.tagName.toLowerCase();
+            if (tag === 'g') {
+                drawSvgShapes(el, alpha);
+                continue;
+            }
+            const num = (name: string): number => parseFloat(el.getAttribute(name) ?? '0') || 0;
+            let path: Path2D | null = null;
+            if (tag === 'path') {
+                const d = el.getAttribute('d');
+                if (d) path = new Path2D(d);
+            } else if (tag === 'circle') {
+                path = new Path2D();
+                path.arc(num('cx'), num('cy'), num('r'), 0, Math.PI * 2);
+            } else if (tag === 'ellipse') {
+                path = new Path2D();
+                path.ellipse(num('cx'), num('cy'), num('rx'), num('ry'), 0, 0, Math.PI * 2);
+            } else if (tag === 'rect') {
+                path = new Path2D();
+                path.rect(num('x'), num('y'), num('width'), num('height'));
+            } else if (tag === 'line') {
+                path = new Path2D();
+                path.moveTo(num('x1'), num('y1'));
+                path.lineTo(num('x2'), num('y2'));
+            } else if (tag === 'polyline' || tag === 'polygon') {
+                const pts = (el.getAttribute('points') ?? '').trim().split(/[\s,]+/).map(Number);
+                if (pts.length < 4 || pts.some(Number.isNaN)) continue;
+                path = new Path2D();
+                path.moveTo(pts[0]!, pts[1]!);
+                for (let i = 2; i + 1 < pts.length; i += 2) path.lineTo(pts[i]!, pts[i + 1]!);
+                if (tag === 'polygon') path.closePath();
+            }
+            if (!path) continue;
+            const cs = win.getComputedStyle(el);
+            if (cs.fill && cs.fill !== 'none' && hasInk(cs.fill)) {
+                ctx.globalAlpha = alpha * (parseFloat(cs.fillOpacity) || 1);
+                ctx.fillStyle = cs.fill;
+                ctx.fill(path);
+            }
+            const sw = parseFloat(cs.strokeWidth) || 0;
+            if (cs.stroke && cs.stroke !== 'none' && hasInk(cs.stroke) && sw > 0) {
+                ctx.globalAlpha = alpha * (parseFloat(cs.strokeOpacity) || 1);
+                ctx.strokeStyle = cs.stroke;
+                ctx.lineWidth = sw;
+                if (cs.strokeLinecap === 'round' || cs.strokeLinecap === 'square' || cs.strokeLinecap === 'butt') ctx.lineCap = cs.strokeLinecap;
+                if (cs.strokeLinejoin === 'round' || cs.strokeLinejoin === 'bevel' || cs.strokeLinejoin === 'miter') ctx.lineJoin = cs.strokeLinejoin;
+                ctx.stroke(path);
+            }
+        }
+    };
+
+    const drawSvg = (svg: SVGSVGElement, parentAlpha: number): void => {
+        const r = svg.getBoundingClientRect();
+        if (r.width <= 0 || r.height <= 0) return;
+        const cs = win.getComputedStyle(svg);
+        if (cs.display === 'none' || cs.visibility === 'hidden') return;
+        const alpha = parentAlpha * (parseFloat(cs.opacity) || 1);
+        if (alpha <= 0.001) return;
+        const vb = svg.viewBox.baseVal;
+        const vw = vb && vb.width > 0 ? vb.width : r.width;
+        const vh = vb && vb.height > 0 ? vb.height : r.height;
+        ctx.save();
+        ctx.translate(r.left - frame.left, r.top - frame.top);
+        ctx.scale(r.width / vw, r.height / vh);
+        if (vb) ctx.translate(-vb.x, -vb.y);
+        drawSvgShapes(svg, alpha);
+        ctx.restore();
+    };
+
     const drawElement = (el: HTMLElement, parentAlpha: number): void => {
         const cs = win.getComputedStyle(el);
         if (cs.display === 'none' || cs.visibility === 'hidden') return;
@@ -128,7 +201,7 @@ export function rasterizeOverlay(ctx: CanvasRenderingContext2D, root: Element, f
         for (const child of el.childNodes) {
             if (child.nodeType === 3) drawText(child as Text, cs, alpha);
             else if (child instanceof win.HTMLImageElement) drawImg(child, win.getComputedStyle(child), alpha);
-            // Non-HTML children (inline SVG icons) are skipped — see the header note.
+            else if (child instanceof win.SVGSVGElement) drawSvg(child, alpha);
             else if (child instanceof win.HTMLElement) drawElement(child, alpha);
         }
     };

--- a/src/ui/components/drawer/styles.ts
+++ b/src/ui/components/drawer/styles.ts
@@ -73,6 +73,12 @@ export const DRAWER_CSS = `
     overflow-y: auto;
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
+    /* Vertical pans stay native scrolling; horizontal moves reach the sheet's gesture
+       recognizer as pointer events (tab swipes). Without this the browser claims a
+       sideways touch as a scroll attempt and CANCELS the pointer stream, so swipes
+       never registered on real touch devices. Sideways-scrolling strips inside the
+       body opt back in with their own touch-action: pan-x. */
+    touch-action: pan-y;
     padding: 0 var(--vela-space-3) calc(var(--vela-space-3) + env(safe-area-inset-bottom, 0px));
 }
 .vela-drawer-body::-webkit-scrollbar { width: 8px; }

--- a/src/ui/components/drawer/view.ts
+++ b/src/ui/components/drawer/view.ts
@@ -199,7 +199,7 @@ export class Drawer {
         this.panel.addEventListener(
             'touchmove',
             (e) => {
-                if (mode === 'drag') {
+                if (mode === 'drag' || mode === 'hswipe') {
                     e.preventDefault();
                     return;
                 }

--- a/src/ui/components/menu/styles.ts
+++ b/src/ui/components/menu/styles.ts
@@ -38,16 +38,11 @@ export const MENU_CSS = `
 .vela-menu-item .vela-icon { width: 16px; height: 16px; font-size: 16px; justify-content: center; color: var(--vela-fg-muted); }
 .vela-menu-item .vela-menu-label { flex: 1 1 auto; }
 .vela-menu-item .vela-menu-hint { color: var(--vela-fg-faint); font-size: var(--vela-font-size-sm); }
-/* Active entry: a LEADING check glyph and bright ink — the row SURFACE stays plain,
-   so background remains the hover language and never marks selection. Every row of a
-   selectable list carries the (mostly empty) slot, keeping labels aligned. Declared
-   after the generic row-icon rule so the glyph's size and color win. */
-.vela-menu-item[data-checked] { color: var(--vela-fg-bright); }
-.vela-menu-item .vela-menu-check {
-    width: 14px;
-    height: 14px;
-    font-size: 14px;
-    flex: none;
+/* Active entry: the row surface carries the selection — a stronger background wash
+   than the hover one, plus bright ink. Declared after the hover rule so a selected
+   row stays visibly selected while highlighted. */
+.vela-menu-item[data-checked] {
+    background: var(--vela-hover-strong);
     color: var(--vela-fg-bright);
 }
 /* Switch rows (boolean settings in a dropdown): a right-aligned toggle pill — the

--- a/src/ui/components/menu/view.ts
+++ b/src/ui/components/menu/view.ts
@@ -134,10 +134,6 @@ class Surface {
     private build(): void {
         const doc = this.doc;
         this.list.replaceChildren();
-        // A list with selectable rows reserves a LEFT check slot on every row (filled
-        // on the active one, empty elsewhere) so labels stay aligned across the list —
-        // toggle rows (switch pill) and branches carry their own state and never one.
-        const hasChecks = this.items.some((i) => i.checked !== undefined && !i.toggle && !(i.submenu && i.submenu.length > 0));
         for (const item of this.items) {
             if (item.separatorBefore) {
                 const sep = doc.createElement('li');
@@ -154,16 +150,9 @@ class Surface {
                 // (Zag owns the item's ARIA props; the pill below is decorative.)
                 li.dataset.toggle = '1';
             } else if (!branch && item.checked) {
-                // Selection reads from a leading check glyph — the row surface stays
-                // plain (background is the hover language, never the selection one).
+                // Selection reads from the row surface: a stronger background wash
+                // marks the active entry (hover stays the lighter wash).
                 li.dataset.checked = '1';
-            }
-            if (hasChecks) {
-                const checked = !branch && !item.toggle && item.checked === true;
-                const slot = checked ? iconEl('check', doc) : doc.createElement('span');
-                slot.classList.add('vela-menu-check');
-                slot.setAttribute('aria-hidden', 'true');
-                li.appendChild(slot);
             }
             if (item.icon) li.appendChild(iconEl(item.icon, doc));
             const label = doc.createElement('span');

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -1070,6 +1070,9 @@ export class VelaWidget {
         chart.on('load:end', () => {
             this.volumeMayBePending = false;
         });
+        // The loading affordance and the watermark never share the canvas.
+        chart.on('load:start', () => this.watermark?.setLoading(true));
+        chart.on('load:end', () => this.watermark?.setLoading(false));
         // Market switches happen IN PLACE (`setMarket`) — the chart instance survives, so
         // reflect them from the event: per-symbol native support may differ, the statusline's
         // resting OHLC belongs to the old market, and an out-of-band switch (host code calling

--- a/src/widget/drawings-drawer.ts
+++ b/src/widget/drawings-drawer.ts
@@ -43,6 +43,9 @@ const CSS = `
     gap: 4px;
     overflow-x: auto;
     scrollbar-width: none;
+    /* The strip scrolls sideways itself — its touches are native scroll, not tab swipes
+       (the drawer body is pan-y so everywhere ELSE a sideways move swipes the tabs). */
+    touch-action: pan-x;
     padding: 0 2px 8px;
     border-bottom: 1px solid var(--vela-border);
     background: var(--vela-surface);

--- a/src/widget/drawings-drawer.ts
+++ b/src/widget/drawings-drawer.ts
@@ -104,7 +104,7 @@ const CSS = `
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
 }
-.vela-dd-star[data-on='1'] { color: var(--vela-accent); }
+.vela-dd-star[data-on='1'] { color: var(--vela-highlight); }
 .vela-dd-empty { padding: 18px 2px; color: var(--vela-fg-muted); font-size: 13px; }
 `;
 

--- a/src/widget/more-drawer.ts
+++ b/src/widget/more-drawer.ts
@@ -48,6 +48,7 @@ const CSS = `
     -webkit-tap-highlight-color: transparent;
 }
 .vela-md-row:active { background: var(--vela-hover); }
+.vela-md-row[data-checked='1'] { background: var(--vela-hover-strong); }
 .vela-md-row .vela-icon { flex: none; font-size: 17px; width: 17px; height: 17px; color: var(--vela-fg-muted); }
 .vela-md-row-label { flex: 1 1 auto; min-width: 0; font-size: 14px; color: var(--vela-fg-bright); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .vela-md-row-value { flex: none; font-size: 13px; color: var(--vela-fg-muted); }
@@ -185,7 +186,7 @@ export class MoreDrawer {
             value.textContent = opts.value;
             el.appendChild(value);
         }
-        if (opts.checked) el.appendChild(iconEl('check', doc));
+        if (opts.checked) el.dataset.checked = '1';
         if (opts.chevron) el.appendChild(iconEl('chevron-right', doc));
         el.addEventListener('click', opts.onClick);
         return el;

--- a/src/widget/symbol-icon.ts
+++ b/src/widget/symbol-icon.ts
@@ -42,6 +42,11 @@ export function tickerIconEl(doc: Document, base: string, name: string, classNam
     }
     const img = doc.createElement('img');
     img.alt = '';
+    // CORS-clean (the CDN serves `Access-Control-Allow-Origin: *`): a plain <img> would
+    // TAINT any canvas it is drawn onto, so the PNG export had to leave the logo out.
+    // If a host swaps in a CDN without CORS, the load errors into the initials badge —
+    // which exports fine — instead of silently poisoning screenshots.
+    img.crossOrigin = 'anonymous';
     img.src = cryptoIconUrl(key);
     img.style.cssText = 'width:100%;height:100%;border-radius:50%;display:block;object-fit:cover;';
     img.addEventListener(

--- a/src/widget/timeframe-drawer.ts
+++ b/src/widget/timeframe-drawer.ts
@@ -24,6 +24,8 @@ const CSS = `
     gap: 6px;
     overflow-x: auto;
     scrollbar-width: none;
+    /* Sideways-scrolling strip: keep its touches native scroll (the drawer body is pan-y). */
+    touch-action: pan-x;
     padding: 0 2px 14px;
 }
 .vela-tfd-ranges::-webkit-scrollbar { display: none; }

--- a/src/widget/watermark.ts
+++ b/src/widget/watermark.ts
@@ -53,6 +53,12 @@ export class Watermark {
     readonly el: HTMLElement;
     private readonly text: HTMLElement;
     private readonly resizeObserver: ResizeObserver | null = null;
+    /** The host's visibility preference (the persisted watermark toggle). */
+    private shown = true;
+    /** A bar load is in flight with nothing painted — the loading affordance owns the
+     *  canvas, so the mark stays out of its way. Starts true: the FIRST `load:start`
+     *  fires during chart construction, before any subscriber can see it. */
+    private loading = true;
 
     constructor(host: HTMLElement, symbol: string, timeframe: string) {
         injectStyles(STYLE_ID, CSS, host.ownerDocument);
@@ -71,10 +77,22 @@ export class Watermark {
             this.resizeObserver.observe(this.el);
         }
         this.update(symbol, timeframe);
+        this.sync();
     }
 
     setVisible(visible: boolean): void {
-        this.el.style.display = visible ? '' : 'none';
+        this.shown = visible;
+        this.sync();
+    }
+
+    /** Loading and the watermark never share the canvas — hidden while a load is up. */
+    setLoading(loading: boolean): void {
+        this.loading = loading;
+        this.sync();
+    }
+
+    private sync(): void {
+        this.el.style.display = this.shown && !this.loading ? '' : 'none';
     }
 
     update(symbol: string, timeframe: string): void {

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -283,6 +283,9 @@ export class ChartCell {
         this.inner.on('load:end', () => {
             this.volumeMayBePending = false;
         });
+        // The loading affordance and the watermark never share the canvas.
+        this.inner.on('load:start', () => this.watermark?.setLoading(true));
+        this.inner.on('load:end', () => this.watermark?.setLoading(false));
         const tz = deps.timezone();
         if (tz !== 'Etc/UTC') this.inner.renderer.set('timezone', tz);
 

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -48,6 +48,7 @@ import { applyAttributionMarkTheme, createAttributionMark, createCustomMark } fr
 import { rendererDefaults } from '../core/renderer-defaults';
 import { defaultToolbar, type DrawingTypeKey, type SerializedDrawing, type SnapMode } from '../core/drawings';
 import { timeframeToMs } from '../data/timeframe';
+import { parseSymbol } from '../data/ProviderRegistry';
 import { syncTargets, rangesWithin, type SyncKind, type SyncOptions, type SyncSetting } from './sync';
 import { encodeState, decodeState, sanitizeState, type WorkspaceState, type WorkspaceStorage } from './persist';
 import { localStorageAdapter } from '../widget/persist';
@@ -1073,7 +1074,9 @@ export class VelaWorkspace {
         });
         // Crosshair sync: mirror THIS cell's pointer time onto its same-group followers
         // as ghost markers. Leave already emits `time: null` — the clear rides along.
-        chart.renderer.onCrosshairMove((e) => this.propagateCrosshair(cell.id, e.time));
+        // The horizontal level travels only when the cursor is on the PRICE pane — a
+        // study pane's `price` is that pane's indicator value, not a chart price.
+        chart.renderer.onCrosshairMove((e) => this.propagateCrosshair(cell.id, e.time, e.paneKind === 'price' ? e.price : null));
         // Drawing edits are cell state (the per-slot drawings document) — persistable.
         // When the drawings link is on, a CREATED drawing copies onto the same-group
         // cells and the set stays LINKED: edits and removals of any member follow
@@ -1174,17 +1177,24 @@ export class VelaWorkspace {
 
     /**
      * Mirror an origin cell's pointer time onto its same-group followers as GHOST
-     * crosshairs (`renderer.setExternalCrosshair`). Leaving the origin propagates
-     * `null` (the event already carries it) and clears every ghost. No busy guard
-     * needed: an external crosshair never re-emits `onCrosshairMove` — the flow is
-     * one-way by port contract, so no echo loop can exist.
+     * crosshairs (`renderer.setExternalCrosshair`). The horizontal price level rides
+     * along ONLY to followers showing the same ticker — price scales are comparable
+     * there, while an origin's price painted on another market's pane would be noise.
+     * Leaving the origin propagates `null` (the event already carries it) and clears
+     * every ghost. No busy guard needed: an external crosshair never re-emits
+     * `onCrosshairMove` — the flow is one-way by port contract, so no echo loop can
+     * exist.
      */
-    private propagateCrosshair(originId: string, time: number | null): void {
+    private propagateCrosshair(originId: string, time: number | null, price: number | null = null): void {
         if (this.destroyed) return;
         const setting = this.syncOpts.crosshair;
         if (!setting) return;
+        const originTicker = parseSymbol(this.cellsById.get(originId)?.symbol ?? '').ticker;
         for (const id of syncTargets(originId, setting, [...this.cellsById.keys()])) {
-            this.cellsById.get(id)?.chart.renderer.setExternalCrosshair(time);
+            const follower = this.cellsById.get(id);
+            if (!follower) continue;
+            const comparable = originTicker !== '' && parseSymbol(follower.symbol).ticker === originTicker;
+            follower.chart.renderer.setExternalCrosshair(time, comparable ? price : null);
         }
     }
 

--- a/test/drawings-interaction.test.ts
+++ b/test/drawings-interaction.test.ts
@@ -3,7 +3,7 @@ import { DrawingInteraction } from '../src/renderers/native/drawings/DrawingInte
 import { createProjector } from '../src/renderers/native/drawings/Projector';
 import { effectiveSnapMode } from '../src/renderers/native/core/InputController';
 import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
-import { createDrawing, DEFAULT_DRAWING_COLOR, type Drawing, type DrawingIntent, type DrawingStyle, type DrawingTypeKey, type Projector } from '../src/core/drawings';
+import { createDrawing, DEFAULT_DRAWING_COLOR, MAX_PATH_POINTS, type Drawing, type DrawingIntent, type DrawingStyle, type DrawingTypeKey, type Projector } from '../src/core/drawings';
 
 /** Linear projector: x = time, y = 100 − price, single pane 'price'. */
 function fakeProjector(): Projector {
@@ -362,6 +362,23 @@ describe('DrawingInteraction: variable + freehand placement', () => {
         const create = h.intents.find((i) => i.kind === 'create');
         expect(create?.kind === 'create' && create.doc.type).toBe('freehand');
         expect(create?.kind === 'create' && (create.doc.anchors.length >= 3)).toBe(true);
+    });
+
+    it('freehand: a marathon stroke keeps capturing past the path cap (the trail thins, never freezes)', () => {
+        const h = harness('freehand');
+        h.it.down(0, 50);
+        const samples = MAX_PATH_POINTS + 200; // enough 5px steps to overflow the cap
+        for (let i = 1; i <= samples; i++) h.it.move(i * 5, 50);
+        h.it.up(samples * 5, 50);
+        const create = h.intents.find((i) => i.kind === 'create');
+        expect(create?.kind).toBe('create');
+        if (create?.kind === 'create') {
+            expect(create.doc.anchors.length).toBeLessThanOrEqual(MAX_PATH_POINTS);
+            // The tail of the stroke — drawn AFTER the cap was first hit — made it into
+            // the committed path instead of being silently discarded.
+            const last = create.doc.anchors[create.doc.anchors.length - 1]!;
+            expect(last.time).toBeGreaterThan(MAX_PATH_POINTS * 5);
+        }
     });
 
     it('freehand: a bare click with no drag keeps nothing', () => {

--- a/test/input-touch.test.ts
+++ b/test/input-touch.test.ts
@@ -58,6 +58,7 @@ function fakeElement() {
             listeners.get(type)?.delete(fn);
         },
         getBoundingClientRect: () => ({ left: 0, top: 0 }),
+        style: { setProperty() {} } as unknown as CSSStyleDeclaration,
         setPointerCapture() {},
         releasePointerCapture() {},
         fire(type: string, e: Record<string, unknown>) {
@@ -114,13 +115,20 @@ function touchHarness() {
         el.fire('pointermove', { ...base, clientX: x + 2, clientY: y + 1, timeStamp: t + 30 });
         el.fire('pointerup', { ...base, clientX: x + 2, clientY: y + 1, timeStamp: t + 45 });
     };
+    /** A one-way horizontal touch drag of `d` px, lifted where it stopped. */
+    const touchDrag = (x: number, y: number, t: number, d: number): void => {
+        const base = { button: 0, pointerId: 1, pointerType: 'touch' };
+        el.fire('pointerdown', { ...base, clientX: x, clientY: y, timeStamp: t });
+        el.fire('pointermove', { ...base, clientX: x + d, clientY: y, timeStamp: t + 20 });
+        el.fire('pointerup', { ...base, clientX: x + d, clientY: y, timeStamp: t + 40 });
+    };
     const mouseDrag = (x: number, y: number, t: number, d: number): void => {
         const base = { button: 0, pointerId: 2, pointerType: 'mouse' };
         el.fire('pointerdown', { ...base, clientX: x, clientY: y, timeStamp: t });
         el.fire('pointermove', { ...base, clientX: x + d, clientY: y, timeStamp: t + 20 });
         el.fire('pointerup', { ...base, clientX: x + d, clientY: y, timeStamp: t + 40 });
     };
-    return { deps, tap, wobbleTap, outAndBackTap, mouseDrag };
+    return { deps, el, tap, wobbleTap, outAndBackTap, touchDrag, mouseDrag };
 }
 
 describe('touch double-tap (the touch dblclick)', () => {
@@ -173,12 +181,22 @@ describe('touch double-tap (the touch dblclick)', () => {
         expect(deps.dataDblClick).toHaveBeenCalledTimes(1);
     });
 
-    it('a contact that wobbles OUT past the slop and settles back is still a tap', () => {
+    it('a contact that slid out past the pan slop already panned — never a tap, even settling back', () => {
         const { deps, outAndBackTap } = touchHarness();
         outAndBackTap(400, 100, 0);
-        expect(deps.onClick).toHaveBeenCalledTimes(1); // release displacement decides, not the latched travel
+        expect(deps.apply).toHaveBeenCalled(); // the excursion panned the chart…
+        expect(deps.onClick).not.toHaveBeenCalled(); // …so the release cannot double as a click
         outAndBackTap(403, 102, 150);
-        expect(deps.dataDblClick).toHaveBeenCalledTimes(1);
+        expect(deps.dataDblClick).not.toHaveBeenCalled();
+    });
+
+    it('a one-way drag between the pan and tap slops (9–14px) is a pan, not a tap', () => {
+        const { deps, touchDrag } = touchHarness();
+        touchDrag(400, 100, 0, 10); // > TOUCH_SLOP (8), ≤ TOUCH_TAP_SLOP (14): the chart shifted
+        expect(deps.apply).toHaveBeenCalled();
+        expect(deps.onClick).not.toHaveBeenCalled();
+        touchDrag(400, 100, 150, 10);
+        expect(deps.dataDblClick).not.toHaveBeenCalled();
     });
 
     it('a touch travelling past the tap slop is a pan, not a tap', () => {
@@ -200,5 +218,37 @@ describe('touch double-tap (the touch dblclick)', () => {
         const { deps, mouseDrag } = touchHarness();
         mouseDrag(400, 100, 0, 5); // 5px is a click on touch but a drag for a mouse
         expect(deps.onClick).not.toHaveBeenCalled();
+    });
+});
+
+// ── touch crosshair: hover is a mouse affordance; a finger earns it by long-pressing ──
+
+describe('touch crosshair', () => {
+    it('a panning finger never paints the hover crosshair; a mouse move still does', () => {
+        const { deps, el, touchDrag } = touchHarness();
+        touchDrag(400, 100, 0, 60);
+        expect(deps.onPointerMove).not.toHaveBeenCalledWith(expect.any(Number), expect.any(Number));
+        el.fire('pointermove', { button: 0, pointerId: 2, pointerType: 'mouse', clientX: 300, clientY: 90, timeStamp: 500 });
+        expect(deps.onPointerMove).toHaveBeenCalledWith(300, 90);
+    });
+
+    it('a long press enters inspect mode: the crosshair follows the finger, the view stays put', () => {
+        vi.useFakeTimers();
+        try {
+            const { deps, el } = touchHarness();
+            const base = { button: 0, pointerId: 1, pointerType: 'touch' };
+            el.fire('pointerdown', { ...base, clientX: 400, clientY: 100, timeStamp: 0 });
+            expect(deps.onPointerMove).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(400); // past LONG_PRESS_MS
+            expect(deps.onPointerMove).toHaveBeenCalledWith(400, 100);
+            deps.apply.mockClear(); // drop the pointerdown's viewport re-apply
+            el.fire('pointermove', { ...base, clientX: 420, clientY: 110, timeStamp: 450 });
+            expect(deps.onPointerMove).toHaveBeenCalledWith(420, 110);
+            expect(deps.apply).not.toHaveBeenCalled();
+            el.fire('pointerup', { ...base, clientX: 420, clientY: 110, timeStamp: 500 });
+            expect(deps.onPointerMove).toHaveBeenLastCalledWith(null, null); // lifting ends the readout
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/test/input-touch.test.ts
+++ b/test/input-touch.test.ts
@@ -106,13 +106,21 @@ function touchHarness() {
         el.fire('pointermove', { ...base, clientX: x + w, clientY: y + w, timeStamp: t + 20 });
         el.fire('pointerup', { ...base, clientX: x + w, clientY: y + w, timeStamp: t + 40 });
     };
+    /** A tap whose contact slides OUT past every slop and settles back near the start. */
+    const outAndBackTap = (x: number, y: number, t: number): void => {
+        const base = { button: 0, pointerId: 1, pointerType: 'touch' };
+        el.fire('pointerdown', { ...base, clientX: x, clientY: y, timeStamp: t });
+        el.fire('pointermove', { ...base, clientX: x + 20, clientY: y + 15, timeStamp: t + 15 });
+        el.fire('pointermove', { ...base, clientX: x + 2, clientY: y + 1, timeStamp: t + 30 });
+        el.fire('pointerup', { ...base, clientX: x + 2, clientY: y + 1, timeStamp: t + 45 });
+    };
     const mouseDrag = (x: number, y: number, t: number, d: number): void => {
         const base = { button: 0, pointerId: 2, pointerType: 'mouse' };
         el.fire('pointerdown', { ...base, clientX: x, clientY: y, timeStamp: t });
         el.fire('pointermove', { ...base, clientX: x + d, clientY: y, timeStamp: t + 20 });
         el.fire('pointerup', { ...base, clientX: x + d, clientY: y, timeStamp: t + 40 });
     };
-    return { deps, tap, wobbleTap, mouseDrag };
+    return { deps, tap, wobbleTap, outAndBackTap, mouseDrag };
 }
 
 describe('touch double-tap (the touch dblclick)', () => {
@@ -165,12 +173,27 @@ describe('touch double-tap (the touch dblclick)', () => {
         expect(deps.dataDblClick).toHaveBeenCalledTimes(1);
     });
 
-    it('a touch travelling past the touch slop is a pan, not a tap', () => {
+    it('a contact that wobbles OUT past the slop and settles back is still a tap', () => {
+        const { deps, outAndBackTap } = touchHarness();
+        outAndBackTap(400, 100, 0);
+        expect(deps.onClick).toHaveBeenCalledTimes(1); // release displacement decides, not the latched travel
+        outAndBackTap(403, 102, 150);
+        expect(deps.dataDblClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('a touch travelling past the tap slop is a pan, not a tap', () => {
         const { deps, wobbleTap } = touchHarness();
-        wobbleTap(400, 100, 0, 12);
-        wobbleTap(400, 100, 150, 12);
+        wobbleTap(400, 100, 0, 20);
+        wobbleTap(400, 100, 150, 20);
         expect(deps.onClick).not.toHaveBeenCalled();
         expect(deps.dataDblClick).not.toHaveBeenCalled();
+    });
+
+    it('the pair routes by the FIRST tap (the aimed one), not the sloppier second', () => {
+        const { deps, tap } = touchHarness();
+        tap(400, 100, 0);
+        tap(420, 120, 150); // drifted, still within the pairing slop
+        expect(deps.dataDblClick).toHaveBeenCalledWith(400, 100);
     });
 
     it('the mouse keeps its strict 2px click slop', () => {


### PR DESCRIPTION
- Enhance crosshair functionality to synchronize price levels across charts in multi-chart workspaces. 
- Update crosshair event structure to include pane kind for better context in custom consumers. 
- Improve touch interaction handling for tap gestures, ensuring accurate detection on mobile devices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Crosshair propagation and touch gesture classification affect core interaction paths; screenshot rasterization touches export and CORS behavior for remote images.
> 
> **Overview**
> **Crosshair sync** now mirrors a **horizontal price level** on linked charts that show the **same ticker** (study-pane values are no longer treated as prices). `CrosshairEvent` adds optional **`paneKind`** (`'price' | 'study'`), and synced ghosts draw the dimmed horizontal line plus a **price chip** on the axis when a level is present.
> 
> **Touch** uses release displacement (`TOUCH_TAP_SLOP`) so out-and-back wobbles still count as taps; **double-tap** routes from the **first** tap’s position. Double-tap in separator gaps snaps via **`nearestPaneToY`**.
> 
> **Screenshots** rasterize inline SVG in DOM overlays and load ticker icons with **`crossOrigin="anonymous`** so exports stay untainted.
> 
> **Mobile drawers**: body **`touch-action: pan-y`** (horizontal swipes for tab changes); tab strips use **`pan-x`**; horizontal swipe mode blocks native scroll cancel.
> 
> **Chart settings** scrim uses **`--vela-z-dialog`** so splitter highlights don’t paint over the dialog in multi-chart workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a123780cb0ac2e22efd362f5168920dfaa0df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->