### PR TITLE
feat: cancel drawing & minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to Vela, newest first.
 - **The symbol watermark yields to loading.** While a chart's bars are loading, the
   faded symbol watermark stays hidden so it never overlaps the loading indicator; it
   returns as soon as the first bars paint.
+- **The symbol watermark sits on the price pane only.** The faded "SYMBOL · TF" mark
+  used to center on the whole plot, so a study pane (RSI, MACD, …) carried the same
+  ghost text as the candles. It now clips to the price pane's bounds — including
+  when that pane is resized, collapsed, or a study is maximized (the mark hides
+  rather than landing on the study).
 - **Favorite stars are gold everywhere.** The mobile drawings sheet's favorite star
   now lights up in the same gold as the desktop drawing toolbar's, instead of blue.
 - **The highlighter's width is typed, not picked.** The drawing quick bar shows a
@@ -113,6 +118,11 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Pane separators stay visible while a market switch loads.** Changing the timeframe
+  or the symbol clears the chart while the new bars load; the dividers between stacked
+  panes used to vanish for that whole window (and slightly beyond it), leaving the
+  price pane and the study panes reading as one undivided plot. The separators now
+  stay in place through the load.
 - **Legend fold count stays readable on a light plot.** The indicator-count chip on a
   folded legend now paints its number (and chevron) with the plot's own text color, so a
   white chart no longer shows a near-white digit on a white chip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **Right-click cancels an in-progress drawing.** While placing a drawing, a
+  right-click discards the unfinished shape and returns to the pointer — even in
+  stay-in-drawing-mode — without opening the chart's context menu. A right-click with
+  nothing being placed keeps opening the context menu as before.
 - **Replaceable indicator menu.** A new `indicatorPicker` shell option (widget and
   workspace, default `true`) removes the built-in indicator dialog's entry points —
   the topbar button, the mobile-bar item, and the `/` shortcut — so a host can ship

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -107,9 +107,10 @@ When a drawing is selected (or hovered), with focus on the chart:
 Shortcuts stand down while a text field (e.g. a label editor) is focused, so typing is never
 hijacked.
 
-Two mouse shortcuts complement these, and need no selection first: **middle-click** a drawing to
-delete it, and **Shift+click** an empty spot to start the [measure ruler](#the-toolbar) at that
-exact point.
+Three mouse shortcuts complement these, and need no selection first: **middle-click** a drawing
+to delete it, **right-click** while placing a drawing to cancel it and return to the pointer —
+even in stay-in-drawing-mode, and without opening the chart's context menu for that click — and
+**Shift+click** an empty spot to start the [measure ruler](#the-toolbar) at that exact point.
 ## Depth: anywhere in the stack
 
 A new drawing starts **just under the price** — the candles read on top of it, the way they read

--- a/docs/user/widget.md
+++ b/docs/user/widget.md
@@ -3,7 +3,7 @@
 `vela/widget` is the batteries-included chart app: a headless `Vela` core wrapped in a
 complete, keyboard-first UI. One constructor gives you the topbar (symbol search,
 timeframe and chart-style dropdowns, indicator picker, object tree), an in-chart status
-line and watermark, and a bottom bar with range presets, a live clock, and a timezone
+line and a symbol watermark on the price pane, and a bottom bar with range presets, a live clock, and a timezone
 picker.
 
 ```ts

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -262,7 +262,7 @@ export class NativeRenderer implements IChartRenderer {
     private pointerNearScrollBtn = false; // cursor is within the reveal radius of the button
     private scrollTargetRO: number | null = null; // eased rightOffset target while gliding back to the latest bars
     // Distance (px) from the plot's bottom edge to the button — tracks the bottom-most EXPANDED
-    // pane like the watermark: when the lower sub-panes collapse it rides up into the open pane.
+    // pane: when the lower sub-panes collapse it rides up into the open pane.
     private scrollBtnBottomPx = SCROLL_BTN_BOTTOM;
     // Distance (px) from the plot's right edge — clears the FULL scale gutter, which widens when a
     // pane carries merged (own-scale) columns; the constant only clears a single-column scale.
@@ -1604,6 +1604,8 @@ export class NativeRenderer implements IChartRenderer {
         this.attributionEl = null;
         this.mountContainer?.style.removeProperty('--vela-toolbar-gutter');
         this.mountContainer?.style.removeProperty('--vela-scale-gutter');
+        this.mountContainer?.style.removeProperty('--vela-price-pane-top');
+        this.mountContainer?.style.removeProperty('--vela-price-pane-bottom');
         this.mountContainer = null;
         this.wrapper?.remove();
     }
@@ -3359,6 +3361,7 @@ export class NativeRenderer implements IChartRenderer {
             this.paneControls?.reposition();
             this.repositionScrollButton();
             this.positionAttribution();
+            this.publishPricePaneBounds();
             return;
         }
         // Collapsed panes take a fixed strip; the rest share the remaining height by weight.
@@ -3377,10 +3380,11 @@ export class NativeRenderer implements IChartRenderer {
         this.paneControls?.reposition();
         this.repositionScrollButton();
         this.positionAttribution(); // the mark follows the lowest open pane's bottom edge
+        this.publishPricePaneBounds();
     }
 
-    /** Pin the scroll-to-realtime button above the bottom-most EXPANDED pane's data area (like the
-     *  watermark): with all lower sub-panes collapsed it settles into the lowest open pane. */
+    /** Pin the scroll-to-realtime button above the bottom-most EXPANDED pane's data area:
+     *  with all lower sub-panes collapsed it settles into the lowest open pane. */
     private repositionScrollButton(): void {
         const dataHeight = this.coords.height;
         if (dataHeight <= 0) return;
@@ -3432,6 +3436,22 @@ export class NativeRenderer implements IChartRenderer {
     private publishGutters(): void {
         this.mountContainer?.style.setProperty('--vela-toolbar-gutter', `${this.toolbarGutter}px`);
         this.mountContainer?.style.setProperty('--vela-scale-gutter', `${this.rightAxisW}px`);
+    }
+
+    /** Publish the price pane's vertical insets as `--vela-price-pane-top` /
+     *  `--vela-price-pane-bottom` on the mount container, so the symbol watermark
+     *  (and any other host overlay) can clip to the price pane instead of spanning
+     *  study panes and the time axis. A maximized study pane collapses the box to
+     *  zero height — the mark does not appear on a study. */
+    private publishPricePaneBounds(): void {
+        if (!this.mountContainer) return;
+        const plotH = this.coords.height + TIME_AXIS_H;
+        const price = this.scene.panes.get(PRICE_PANE_ID);
+        const top = price ? price.bounds.top : 0;
+        const height = price ? price.bounds.height : this.coords.height;
+        const bottom = Math.max(0, plotH - (top + height));
+        this.mountContainer.style.setProperty('--vela-price-pane-top', `${top}px`);
+        this.mountContainer.style.setProperty('--vela-price-pane-bottom', `${bottom}px`);
     }
 
     /** The built-in mark, or the host's own when one is set. */

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1324,6 +1324,7 @@ export class NativeRenderer implements IChartRenderer {
             drawingsClaim: (x, y) => this.userDrawings?.claim(x, y) ?? false,
             drawingsMeasureStart: (x, y) => this.userDrawings?.beginMeasureAt(x, y) ?? false,
             drawingsDeleteAt: (x, y) => this.userDrawings?.deleteAt(x, y) ?? false,
+            drawingsCancelPlacement: () => this.userDrawings?.cancelPlacement() ?? false,
             drawingsSnapMode: () => this.snapMode,
             drawingsPointerDown: (x, y, snap, shift) => this.userDrawings?.pointerDown(x, y, snap, shift),
             drawingsPointerMove: (x, y, snap, shift) => this.userDrawings?.pointerMove(x, y, snap, shift),

--- a/src/renderers/native/chrome/ChromeRenderer.ts
+++ b/src/renderers/native/chrome/ChromeRenderer.ts
@@ -95,8 +95,16 @@ export class ChromeRenderer {
         ctx.font = `${scene.style.fontSize}px ${theme.fontFamily}`;
         ctx.textBaseline = 'middle';
 
-        if (coords.barCount === 0) return;
         const panes = scene.orderedPanes();
+        if (coords.barCount === 0) {
+            // A market switch (timeframe/symbol) clears the series while the new bars
+            // load, and any chrome frame in that window (crosshair move, resize) lands
+            // here. The pane SEPARATORS are structural — they depend on pane bounds
+            // alone, not bars — so they must survive the empty frame, or the stacked
+            // panes read as one undivided plot until the load completes.
+            this.drawPaneSeparators(ctx, scene, theme, fullW, panes);
+            return;
+        }
         const pricePane = panes.find((p) => p.kind === 'price') ?? null;
 
         // ── Pine drawings — above series. Own drawings on each model's pane;

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -53,6 +53,9 @@ export interface InputControllerDeps {
     drawingsMeasureStart?(x: number, y: number): boolean;
     /** Middle-click: delete the drawing under the cursor. True when one was removed. */
     drawingsDeleteAt?(x: number, y: number): boolean;
+    /** Right-click: cancel an in-progress drawing placement (and revert to the pointer).
+     *  True when consumed — the companion contextmenu is then suppressed. */
+    drawingsCancelPlacement?(): boolean;
     /** A claimed press began. `snap` = effective magnet mode; `shift` = additive (multi-) select. */
     drawingsPointerDown?(x: number, y: number, snap: SnapMode, shift: boolean): void;
     /** Pointer moved (forwarded for the placing ghost / drag preview). `snap` = effective magnet
@@ -202,6 +205,7 @@ export class InputController {
     private lastT = 0;
     private vx = 0; // smoothed pointer velocity, px/ms
     private middleDeleted = false; // the last middle press deleted a drawing (suppress autoscroll/paste)
+    private rightCancelled = false; // the last right press cancelled a placement (suppress the context menu)
     // Last cursor position over the element (NaN once it leaves) — lets a modifier
     // press/release re-shape the drawings preview with the pointer stationary.
     private cursorX = NaN;
@@ -244,6 +248,9 @@ export class InputController {
         // drawing (see onDown) can veto them here.
         el.addEventListener('mousedown', this.onMiddleGuard);
         el.addEventListener('auxclick', this.onMiddleGuard);
+        // Right-press companion: contextmenu also fires AFTER pointerdown, so a right
+        // press that cancelled a placement (see onDown) vetoes the host's menu here.
+        el.addEventListener('contextmenu', this.onContextGuard);
         // Modifiers change the drawings preview (Shift = angle lock, Ctrl/Cmd = magnet
         // override) and must take effect the moment they are pressed/released, not on the
         // next mouse move — window-level so no chart focus is required. Optional chaining
@@ -273,6 +280,7 @@ export class InputController {
         el.removeEventListener('wheel', this.onWheel);
         el.removeEventListener('mousedown', this.onMiddleGuard);
         el.removeEventListener('auxclick', this.onMiddleGuard);
+        el.removeEventListener('contextmenu', this.onContextGuard);
         this.cancelLongPress();
         this.touches.clear();
         this.el = null;
@@ -287,6 +295,15 @@ export class InputController {
 
     private readonly onMiddleGuard = (e: MouseEvent): void => {
         if (e.button === 1 && this.middleDeleted) e.preventDefault();
+    };
+
+    /** A right press that cancelled a placement must not ALSO open the host's chart
+     *  context menu — swallow its companion event before it bubbles to the host. */
+    private readonly onContextGuard = (e: MouseEvent): void => {
+        if (!this.rightCancelled) return;
+        this.rightCancelled = false;
+        e.preventDefault();
+        e.stopPropagation();
     };
 
     /** A modifier press/release with the pointer stationary: re-issue the last cursor
@@ -330,6 +347,14 @@ export class InputController {
             const { x, y } = this.local(e);
             this.middleDeleted = this.deps.drawingsDeleteAt?.(x, y) ?? false;
             if (this.middleDeleted) e.preventDefault();
+            return;
+        }
+        if (e.button === 2) {
+            // Right-click cancels an in-progress placement (reverting to the pointer).
+            // The flag lets the contextmenu companion suppress the host's chart menu
+            // for THIS press only — a plain right-click still opens it.
+            this.rightCancelled = this.deps.drawingsCancelPlacement?.() ?? false;
+            if (this.rightCancelled) e.preventDefault();
             return;
         }
         if (e.button !== 0) return;

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -643,6 +643,17 @@ export class UserDrawingController implements IDrawingsRendererPort {
         return this.interaction.cursorAt(x, y);
     }
 
+    /** Right-click while placing: cancel the in-progress drawing and revert to the
+     *  pointer — the gesture is an explicit escape, so it disarms even in
+     *  stay-in-drawing-mode (where Escape would leave the tool armed). Returns whether
+     *  the press was consumed; false lets the host's context menu open normally. */
+    cancelPlacement(): boolean {
+        if (!this.interaction.isPlacing()) return false;
+        this.interaction.cancel(); // emits tool-finished → the core disarms (stay-mode/brush excepted)
+        if (this.activeTool != null) this.emit({ kind: 'arm', type: null });
+        return true;
+    }
+
     /** Double-click over a drawing → suppress the chart's view reset (single-click already
      *  opens settings). Returns true only when a drawing is under the cursor. */
     dblClick(x: number, y: number): boolean {

--- a/src/widget/watermark.ts
+++ b/src/widget/watermark.ts
@@ -1,4 +1,4 @@
-// Symbol watermark — large faded "SYMBOL · TF" centered behind the chart chrome.
+// Symbol watermark — large faded "SYMBOL · TF" centered on the price pane.
 import { injectStyles } from '../ui/styles';
 import { timeframeLabel } from './timeframe';
 import { parseSymbol } from '../data/ProviderRegistry';
@@ -14,17 +14,17 @@ const STYLE_ID = 'vela-widget-watermark';
 const CSS = `
 .vela-watermark {
     position: absolute;
-    /* Insets follow the renderer-published gutters (mount container), so the mark
-     * centers and fits within the PLOT — never bleeding into the drawings toolbar
-     * on the left or the price scale on the right (visible in small multi-chart
-     * cells, where the scale is a large share of the width). */
-    top: 0;
-    bottom: 0;
+    /* Insets follow the renderer-published gutters AND the price-pane vertical
+     * bounds (mount container), so the mark centers on the PRICE PANE — never
+     * the study panes below, the drawings toolbar, or the price scale. */
+    top: var(--vela-price-pane-top, 0px);
+    bottom: var(--vela-price-pane-bottom, 0px);
     left: var(--vela-toolbar-gutter, 0px);
     right: var(--vela-scale-gutter, 0px);
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: hidden;
     pointer-events: none;
     z-index: 1;
     color: var(--vela-fg);
@@ -70,8 +70,8 @@ export class Watermark {
         this.text = host.ownerDocument.createElement('span');
         this.el.appendChild(this.text);
         host.appendChild(this.el);
-        // The el is inset:0, so observing it tracks the chart's size (splitter drags,
-        // layout changes) — refit whenever the space changes.
+        // The el tracks the price pane (CSS insets on the host), so observing it
+        // refits on splitter drags and pane-layout changes.
         if (typeof ResizeObserver !== 'undefined') {
             this.resizeObserver = new ResizeObserver(() => this.fit());
             this.resizeObserver.observe(this.el);
@@ -101,7 +101,7 @@ export class Watermark {
         this.fit();
     }
 
-    /** Measure the text at the cap and shrink it to the chart's own width. */
+    /** Measure the text at the cap and shrink it to the price pane's width. */
     private fit(): void {
         if (this.el.clientWidth <= 0 || !this.text.textContent) return;
         this.el.style.fontSize = `${MAX_FONT_PX}px`;

--- a/test/chrome-separators.test.ts
+++ b/test/chrome-separators.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { ChromeRenderer } from '../src/renderers/native/chrome/ChromeRenderer';
+import { SceneGraph } from '../src/renderers/native/core/SceneGraph';
+import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
+import { DARK_THEME } from '../src/core/theme';
+
+// ── pane separators are STRUCTURAL chrome: they must survive a chrome frame while a
+// market switch has the series cleared (barCount 0), or the stacked panes read as one
+// undivided plot for the whole load ──
+
+/** A recording 2d-context stand-in — just enough surface for the empty-bars path. */
+function fakeCanvas(width: number, height: number) {
+    const fills: Array<[number, number, number, number]> = [];
+    const ctx = {
+        setTransform() {},
+        clearRect() {},
+        fillRect(x: number, y: number, w: number, h: number) {
+            fills.push([x, y, w, h]);
+        },
+        font: '',
+        textBaseline: '',
+        fillStyle: '',
+    };
+    return { canvas: { width, height, getContext: () => ctx } as unknown as HTMLCanvasElement, fills };
+}
+
+function scene(): SceneGraph {
+    const s = new SceneGraph();
+    s.ensurePane('price', 'price', 0, 3);
+    const study = s.ensurePane('pane-x', 'study', 1, 1);
+    study.bounds = { top: 300, height: 100 };
+    return s;
+}
+
+describe('chrome pane separators', () => {
+    it('draws each stacked pane separator even while the series is empty (loading)', () => {
+        const { canvas, fills } = fakeCanvas(800, 400);
+        const coords = new CoordinateSystem();
+        coords.setSize(800, 400, 1); // no bars set → barCount 0, the market-switch load state
+        const chrome = new ChromeRenderer();
+        chrome.mount(canvas);
+        chrome.render(scene(), coords, DARK_THEME);
+        // The study pane's divider: full width at its top edge (top - 1, 3px thick).
+        expect(fills).toContainEqual([0, 299, 800, 3]);
+    });
+
+    it('never draws a separator above the price pane', () => {
+        const { canvas, fills } = fakeCanvas(800, 400);
+        const coords = new CoordinateSystem();
+        coords.setSize(800, 400, 1);
+        const s = new SceneGraph();
+        s.ensurePane('price', 'price', 0, 3); // lone price pane → no dividers at all
+        const chrome = new ChromeRenderer();
+        chrome.mount(canvas);
+        chrome.render(s, coords, DARK_THEME);
+        expect(fills.filter(([, , , h]) => h === 3)).toEqual([]);
+    });
+});

--- a/test/input-right-cancel.test.ts
+++ b/test/input-right-cancel.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { InputController, type InputControllerDeps } from '../src/renderers/native/core/InputController';
+import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
+
+// ── right-click cancel: a right press aborts an in-progress drawing placement and
+// vetoes the companion contextmenu, so the host's chart menu never opens over it ──
+
+/** Bare-bones event-target stand-in — enough surface for InputController.attach(). */
+function fakeElement() {
+    const listeners = new Map<string, Set<(e: unknown) => void>>();
+    return {
+        addEventListener(type: string, fn: (e: unknown) => void) {
+            (listeners.get(type) ?? listeners.set(type, new Set()).get(type)!).add(fn);
+        },
+        removeEventListener(type: string, fn: (e: unknown) => void) {
+            listeners.get(type)?.delete(fn);
+        },
+        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+        style: { setProperty() {} } as unknown as CSSStyleDeclaration,
+        setPointerCapture() {},
+        releasePointerCapture() {},
+        fire(type: string, e: Record<string, unknown>) {
+            for (const fn of [...(listeners.get(type) ?? [])]) fn(e);
+        },
+    };
+}
+
+function harness(cancelPlacement: () => boolean) {
+    const cs = new CoordinateSystem();
+    cs.setSize(800, 200, 1);
+    cs.setBars([1000, 2000, 3000, 4000, 5000]);
+    cs.setViewport({ barSpacing: 50, rightOffset: 2 });
+    const deps = {
+        getCoords: () => cs,
+        apply: vi.fn(),
+        zoomTo: vi.fn(),
+        fling: vi.fn(),
+        onPointerMove: vi.fn(),
+        onClick: vi.fn(),
+        beginPriceScale: vi.fn(),
+        priceScaleBy: vi.fn(),
+        beginPricePan: () => false,
+        pricePanBy: vi.fn(),
+        resetPriceScale: vi.fn(),
+        dataDblClick: vi.fn(),
+        paneSeparatorAt: () => false,
+        beginPaneResize: vi.fn(),
+        paneResizeBy: vi.fn(),
+        resetPaneSize: vi.fn(),
+        resetView: vi.fn(),
+        drawingsCancelPlacement: vi.fn(cancelPlacement),
+    } satisfies InputControllerDeps;
+    const ctl = new InputController(deps);
+    const el = fakeElement();
+    ctl.attach(el as unknown as HTMLElement);
+    const rightPress = (): { prevented: boolean } => {
+        const e = { button: 2, pointerId: 1, pointerType: 'mouse', clientX: 100, clientY: 100, timeStamp: 0, prevented: false };
+        el.fire('pointerdown', { ...e, preventDefault: () => (e.prevented = true) });
+        return e;
+    };
+    const contextmenu = (): { prevented: boolean; stopped: boolean } => {
+        const e = { prevented: false, stopped: false };
+        el.fire('contextmenu', { preventDefault: () => (e.prevented = true), stopPropagation: () => (e.stopped = true) });
+        return e;
+    };
+    return { deps, el, rightPress, contextmenu };
+}
+
+describe('right-click drawing cancel', () => {
+    it('a right press that cancels a placement swallows the companion contextmenu', () => {
+        const h = harness(() => true);
+        const press = h.rightPress();
+        expect(h.deps.drawingsCancelPlacement).toHaveBeenCalledTimes(1);
+        expect(press.prevented).toBe(true);
+        expect(h.deps.apply).not.toHaveBeenCalled(); // never starts a pan gesture
+        const menu = h.contextmenu();
+        expect(menu.prevented).toBe(true);
+        expect(menu.stopped).toBe(true); // the host's chart menu (an ancestor listener) never sees it
+    });
+
+    it('a plain right press (nothing placing) leaves the contextmenu to the host', () => {
+        const h = harness(() => false);
+        const press = h.rightPress();
+        expect(press.prevented).toBe(false);
+        const menu = h.contextmenu();
+        expect(menu.prevented).toBe(false);
+        expect(menu.stopped).toBe(false);
+    });
+
+    it('the veto covers exactly ONE contextmenu — the next press starts clean', () => {
+        let placing = true;
+        const h = harness(() => placing);
+        h.rightPress();
+        expect(h.contextmenu().stopped).toBe(true);
+        placing = false; // the placement is gone — a second right-click is a normal one
+        h.rightPress();
+        expect(h.contextmenu().stopped).toBe(false);
+    });
+});

--- a/test/watermark-price-pane.test.ts
+++ b/test/watermark-price-pane.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+import { SceneGraph } from '../src/renderers/native/core/SceneGraph';
+import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
+
+// TIME_AXIS_H in NativeRenderer — the overlay bottom inset includes this strip so the
+// mark stays in the price pane's data area, not the time axis.
+const TIME_AXIS_H = 22;
+const DATA_H = 400;
+
+type OverlayHost = {
+    style: {
+        setProperty: (k: string, v: string) => void;
+        getPropertyValue: (k: string) => string;
+        removeProperty: (k: string) => void;
+    };
+};
+
+function fakeHost(): OverlayHost {
+    const props = new Map<string, string>();
+    return {
+        style: {
+            setProperty: (k, v) => { props.set(k, v); },
+            getPropertyValue: (k) => props.get(k) ?? '',
+            removeProperty: (k) => { props.delete(k); },
+        },
+    };
+}
+
+type LayoutPriv = {
+    scene: SceneGraph;
+    coords: CoordinateSystem;
+    mountContainer: OverlayHost | null;
+    maximizedPaneId: string | null;
+    layoutPanes: () => void;
+};
+
+function primed(extra?: (scene: SceneGraph) => void): { r: LayoutPriv; host: OverlayHost } {
+    const renderer = new NativeRenderer();
+    const r = renderer as unknown as LayoutPriv;
+    const host = fakeHost();
+    r.mountContainer = host;
+    r.coords.setSize(800, DATA_H, 1);
+    r.scene.ensurePane('price', 'price', 0, 3);
+    extra?.(r.scene);
+    r.layoutPanes();
+    return { r, host };
+}
+
+describe('price-pane overlay insets (symbol watermark clip)', () => {
+    it('with only the price pane, the bottom inset is just the time axis', () => {
+        const { host } = primed();
+        expect(host.style.getPropertyValue('--vela-price-pane-top')).toBe('0px');
+        expect(host.style.getPropertyValue('--vela-price-pane-bottom')).toBe(`${TIME_AXIS_H}px`);
+    });
+
+    it('with a study pane below, the bottom inset covers the study plus the time axis', () => {
+        // Weights 3 + 1 on a 400px data area → price 300, study 100.
+        const { host } = primed((scene) => {
+            scene.ensurePane('rsi', 'study', 1, 1);
+        });
+        expect(host.style.getPropertyValue('--vela-price-pane-top')).toBe('0px');
+        expect(host.style.getPropertyValue('--vela-price-pane-bottom')).toBe(`${100 + TIME_AXIS_H}px`);
+    });
+
+    it('a maximized study pane collapses the overlay to zero height', () => {
+        const { r, host } = primed((scene) => {
+            scene.ensurePane('rsi', 'study', 1, 1);
+        });
+        r.maximizedPaneId = 'rsi';
+        r.layoutPanes();
+        const top = Number.parseFloat(host.style.getPropertyValue('--vela-price-pane-top'));
+        const bottom = Number.parseFloat(host.style.getPropertyValue('--vela-price-pane-bottom'));
+        // Overlay height = plotH − top − bottom. plotH = data + time axis.
+        expect(DATA_H + TIME_AXIS_H - top - bottom).toBe(0);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized input, overlay CSS, and chrome early-return behavior with new unit tests; no auth, persistence, or data-path changes.
> 
> **Overview**
> **Right-click cancels drawing placement.** While a shape is being placed, a right-click aborts it and returns to the pointer—including in stay-in-drawing-mode—and suppresses the chart context menu for that click. Idle right-clicks still open the menu. Wired through `InputController` → `UserDrawingController.cancelPlacement()` with tests.
> 
> **Symbol watermark on the price pane only.** `NativeRenderer` publishes `--vela-price-pane-top` / `--vela-price-pane-bottom` on the mount container whenever pane layout runs; the widget watermark uses those insets (plus existing gutter vars) so ghost text centers on candles, not RSI/MACD panes or the time axis, and collapses when a study is maximized.
> 
> **Pane separators during load.** `ChromeRenderer` no longer skips all chrome when `barCount === 0`; it still draws pane separators so timeframe/symbol switches don’t leave stacked panes looking like one plot until bars return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c054b0883f128d50cf90b02108c0005a8eb844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->