### PR TITLE
Increase wheel-zoom sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Changed
+
+- **Wheel zoom steps further per notch.** Scrolling the chart in or out now
+  covers more of the time axis per turn of the wheel, so reaching a target zoom
+  takes fewer notches.
+
 ## [v0.5.2]
 
 ### Changed

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -91,9 +91,9 @@ const DOUBLE_TAP_SLOP = 30;
 // Time-axis horizontal-zoom sensitivity: dragging left zooms in (e^(Δpx·k)). Kept low so
 // the zoom takes a deliberate, sizeable drag (~2× over ~170px) rather than a twitch.
 const TIME_SCALE_K = 0.004;
-// Wheel-zoom sensitivity: barSpacing scales by e^(-deltaY·k) per notch. Tuned higher than
-// the axis-drag feel so a single scroll notch makes a clearly visible zoom step.
-const WHEEL_ZOOM_K = 0.0025;
+// Wheel-zoom sensitivity: barSpacing scales by e^(-deltaY·k) per notch. A typical
+// mouse-wheel notch (deltaY ≈ 100) is a clearly visible step.
+const WHEEL_ZOOM_K = 0.004;
 
 /** Which strip a gesture started over — the data plot, the right price axis, the bottom
  *  time axis, a sub-pane separator (drag to resize the panes above/below it), or one of


### PR DESCRIPTION
## Summary
- Raise wheel-zoom sensitivity from 0.0025 to 0.004 so each scroll notch covers more of the time axis.
- Changelog conflict on `dev` resolved by keeping only this Unreleased entry (the stashed `modulateBase` note belongs on another branch).

## Test plan
- [ ] Open the playground and scroll the chart: each notch should zoom further than before.
- [ ] Confirm trackpad pinch/two-finger zoom still feels natural.
- [ ] Confirm time-axis drag zoom is unchanged.

Made with [Cursor](https://cursor.com)