### PR TITLE
feat: enhance base painting modulation across all mounted layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Changed
+
+- **`modulateBase` is consulted on every mounted renderer layer.** The hook is no
+  longer limited to the layer whose id matches the active price style — any layer
+  that implements it (a chart type or an overlay) can slim or fade the base
+  candles for the current frame. When several layers speak, each field keeps the
+  strongest (smallest) request; `null` remains no opinion. Overlay indicators that
+  need a gap beside the candles use the same seam the chart types already did.
+
 ## [v0.5.2]
 
 ### Changed

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -114,12 +114,14 @@ Two per-frame levers beyond the basic contract:
   overlay; a layer that hover-tests (tooltips, row highlights) sets this flag and is
   repainted — its own canvas only — whenever the cursor moves, with `args.cursor` fresh.
 - **`modulateBase`** (instance): the gradual counterpart of the chart type's
-  all-or-nothing `basePainting: 'none'`. Called after `render`, only for the layer whose
-  id matches the ACTIVE price style; the returned `{ candleBodyScale?, candleBodyAlpha?,
-  gridAlpha? }` dims/slims the base painting for that same frame (values clamped to
-  [0..1]; omitted fields keep their defaults). Return null to leave the base painting
-  untouched — this is how a reveal-under style fades candles down as its own layer
-  fades in, instead of switching them off entirely.
+  all-or-nothing `basePainting: 'none'`. Called after `render` on every mounted layer
+  that implements it (not only the active price style — an overlay that needs room
+  beside the candles uses the same hook). The returned `{ candleBodyScale?,
+  candleBodyAlpha?, gridAlpha? }` dims/slims the base painting for that same frame
+  (values clamped to [0..1]; omitted fields keep their defaults). Return null for no
+  opinion. When several layers speak, each field keeps the strongest (smallest)
+  request. This is how a reveal-under style — or an overlay — fades candles down as
+  its own layer fades in, instead of switching them off entirely.
 
 ## Native indicators — `registerNativeIndicator`
 

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -57,7 +57,7 @@ import { rescaleAround, shiftScale } from './core/manualScale';
 import { resizeSplit, type PaneSplit } from './core/paneResize';
 import { type ChartConfig, CHART_CONFIG_VERSION, factoryResetConfig, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf, candleOverrideFor } from './core/chartConfig';
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
-import { rendererLayers, type RendererLayerArgs, type RendererLayerDefinition, type RendererLayerInstance } from './layers';
+import { rendererLayers, foldBaseModulation, type RendererLayerArgs, type RendererLayerDefinition, type RendererLayerInstance, type BasePaintingModulation } from './layers';
 import { applyAttributionMarkTheme, attributionMarkColor, createAttributionMark, createCustomMark } from './chrome/AttributionMark';
 import { rasterizeOverlay } from '../shared/dom-raster';
 import type { HostSettingsSection } from './chrome/SettingsDialog';
@@ -2876,22 +2876,20 @@ export class NativeRenderer implements IChartRenderer {
             });
             // SDK renderer layers: shared paint cycle, own channel data, own canvas.
             const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
+            let folded: BasePaintingModulation | null = null;
             for (const l of this.extLayers) {
                 const args = this.extLayerArgs(l.def.id, pane.scale, pane.bounds, nowMs);
                 l.instance.render(args);
-                // The active style's layer may dim/slim the base painting under it (a
-                // gradual counterpart of basePainting 'none') — applied this same frame,
-                // before the backend paints.
-                if (l.def.id === this.scene.priceStyle && l.instance.modulateBase) {
-                    const mod = l.instance.modulateBase(args);
-                    if (mod) {
-                        if (mod.candleBodyScale != null) this.backend.candleBodyScale = clamp01(mod.candleBodyScale) || 0.01;
-                        if (mod.candleBodyAlpha != null) this.backend.candleBodyAlpha = clamp01(mod.candleBodyAlpha) * this.candleBodyAlpha;
-                        if (mod.gridAlpha != null) this.backend.gridAlpha = clamp01(mod.gridAlpha);
-                    }
-                }
+                // Any mounted layer may dim/slim the base painting (chart type or overlay)
+                // — folded this same frame, applied below before the backend paints.
+                folded = foldBaseModulation(folded, l.instance.modulateBase?.(args) ?? null);
                 // A pulsing/fading layer keeps the animator alive; it stops itself when done.
                 if (this.animZoom && l.instance.animating?.()) this.animator.start();
+            }
+            if (folded) {
+                if (folded.candleBodyScale != null) this.backend.candleBodyScale = clamp01(folded.candleBodyScale) || 0.01;
+                if (folded.candleBodyAlpha != null) this.backend.candleBodyAlpha = clamp01(folded.candleBodyAlpha) * this.candleBodyAlpha;
+                if (folded.gridAlpha != null) this.backend.gridAlpha = clamp01(folded.gridAlpha);
             }
         }
         // Live-bar easing: render the eased (gliding) OHLC for the forming bar, then restore the true

--- a/src/renderers/native/layers.ts
+++ b/src/renderers/native/layers.ts
@@ -37,7 +37,7 @@ export interface RendererLayerArgs {
     cursor: { x: number; y: number } | null;
 }
 
-/** How the active style's layer dims/slims the BASE painting under it (see
+/** How a layer dims/slims the BASE painting under it (see
  *  {@link RendererLayerInstance.modulateBase}). Omitted fields keep their defaults. */
 export interface BasePaintingModulation {
     /** Candle body width multiplier, (0..1] (1 = full width). */
@@ -46,6 +46,27 @@ export interface BasePaintingModulation {
     candleBodyAlpha?: number;
     /** Gridline opacity, [0..1] (fade the grid as a reveal-under layer opens). */
     gridAlpha?: number;
+}
+
+/** Fold one layer's modulation into the running request. Each field keeps the
+ *  stronger (smaller) of the two; omitted stays omitted. `null` is no opinion. */
+export function foldBaseModulation(
+    acc: BasePaintingModulation | null,
+    next: BasePaintingModulation | null,
+): BasePaintingModulation | null {
+    if (next == null) return acc;
+    if (acc == null) return { ...next };
+    return {
+        candleBodyScale: minOpt(acc.candleBodyScale, next.candleBodyScale),
+        candleBodyAlpha: minOpt(acc.candleBodyAlpha, next.candleBodyAlpha),
+        gridAlpha: minOpt(acc.gridAlpha, next.gridAlpha),
+    };
+}
+
+function minOpt(a: number | undefined, b: number | undefined): number | undefined {
+    if (a == null) return b;
+    if (b == null) return a;
+    return Math.min(a, b);
 }
 
 /** One live layer instance (per mounted renderer). */
@@ -59,9 +80,10 @@ export interface RendererLayerInstance {
     /**
      * How the base painting (candles, grid) should be dimmed/slimmed under this layer for
      * the CURRENT frame — a gradual counterpart of the chart type's all-or-nothing
-     * `basePainting: 'none'`. Called after `render`, only for the layer whose id matches
-     * the active price style; returning null (or omitting the method) leaves the base
-     * painting untouched. Values are clamped by the renderer.
+     * `basePainting: 'none'`. Called after `render` on every mounted layer that implements
+     * it (chart-type and overlay alike); returning null (or omitting the method) is no
+     * opinion. When several layers speak, each field keeps the strongest (smallest)
+     * request. Values are clamped by the renderer.
      */
     modulateBase?(args: RendererLayerArgs): BasePaintingModulation | null;
     /** The renderer unmounted — release everything (the canvas itself is removed by the renderer). */

--- a/test/renderer-layers.test.ts
+++ b/test/renderer-layers.test.ts
@@ -2,7 +2,7 @@
 // generic native-data channel routing on the renderer (unmounted — mounted painting is
 // exercised in the browser playground; the channel/scene plumbing is the unit-testable part).
 import { describe, it, expect, afterEach } from 'vitest';
-import { registerRendererLayer, unregisterRendererLayer, rendererLayers, type RendererLayerArgs, type RendererLayerInstance } from '../src/renderers/native/layers';
+import { registerRendererLayer, unregisterRendererLayer, rendererLayers, foldBaseModulation, type RendererLayerArgs, type RendererLayerInstance } from '../src/renderers/native/layers';
 import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
 import { SceneGraph } from '../src/renderers/native/core/SceneGraph';
 
@@ -26,8 +26,9 @@ describe('renderer-layer registry', () => {
 
     it('accepts a base-painting-modulating, cursor-reading instance (contract shape)', () => {
         // Compile-time + shape check for the modulation seam: a layer may read args.cursor
-        // and return partial modulation values; the mounted paint path (clamping + backend
-        // application) is exercised in the browser/oracle suites.
+        // and return partial modulation values. The renderer consults EVERY mounted layer
+        // that implements modulateBase (not only the active price style) and folds them
+        // with foldBaseModulation; clamping + backend application stay on the paint path.
         const instance: RendererLayerInstance = {
             mount() {},
             render(args: RendererLayerArgs) {
@@ -40,6 +41,20 @@ describe('renderer-layer registry', () => {
         registerRendererLayer({ id: 'demo', create: () => instance });
         const mod = rendererLayers().find((d) => d.id === 'demo')!.create().modulateBase?.({ priceStyle: 'demo' } as RendererLayerArgs);
         expect(mod).toEqual({ candleBodyScale: 0.07, gridAlpha: 0 });
+    });
+});
+
+describe('foldBaseModulation', () => {
+    it('null is no opinion; the first speaker wins the field, later speakers keep the stronger (smaller) value', () => {
+        expect(foldBaseModulation(null, null)).toBeNull();
+        expect(foldBaseModulation(null, { candleBodyScale: 0.07 })).toEqual({ candleBodyScale: 0.07 });
+        expect(foldBaseModulation({ candleBodyScale: 0.07, candleBodyAlpha: 1 }, { candleBodyScale: 0.5, gridAlpha: 0 })).toEqual({
+            candleBodyScale: 0.07,
+            candleBodyAlpha: 1,
+            gridAlpha: 0,
+        });
+        // A later null does not wipe the running request (overlay idle, chart type still speaking).
+        expect(foldBaseModulation({ candleBodyScale: 0.07 }, null)).toEqual({ candleBodyScale: 0.07 });
     });
 });
 


### PR DESCRIPTION
Update `modulateBase` to be called on every layer, allowing overlays to influence base candle appearance. Introduce `foldBaseModulation` function to consolidate modulation requests, ensuring the strongest (smallest) values are applied. Update documentation and tests to reflect these changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-frame base candle/grid modulation for plugin layers and overlays; multiple layers can now interact via min-fold, which may shift visuals for types that already used `modulateBase` alongside overlays.
> 
> **Overview**
> **`modulateBase` now runs for every mounted renderer layer**, not only the layer whose id matches the active price style. Overlay layers can slim or fade base candles the same way chart-type layers already did.
> 
> The paint loop collects each layer’s `modulateBase` result and merges them with new **`foldBaseModulation`**: per field (`candleBodyScale`, `candleBodyAlpha`, `gridAlpha`) the **smallest** value wins; `null` means no opinion and does not clear an earlier request. The folded result is applied once before the backend paints.
> 
> Plugin SDK docs, changelog, and unit tests for `foldBaseModulation` and the updated contract are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8196c4eaae9ee04f484c7b9bfd9ab8c1133c7572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->