### PR TITLE
feat: add gap between title and load/live status in InputsUI

### DIFF
--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -82,6 +82,8 @@ const LEGEND_ROW_PAD_Y = 2;
 const LEGEND_ROW_PAD_X = 6;
 /** Space between the indicator title and the plot-values readout to its right. */
 const LEGEND_TITLE_VALUES_GAP_PX = 6;
+/** Space between the title (or values/controls, when shown) and the load/live status. */
+const LEGEND_TITLE_STATUS_GAP_PX = 12;
 /** Uniform space: title → first action icon, and between every action icon. */
 const LEGEND_ACTION_GAP_PX = 6;
 const LEGEND_CTL_CSS =
@@ -831,7 +833,9 @@ export class InputsUI {
             return;
         }
         if (status === 'loading') {
-            el.style.cssText = 'display:inline-flex;align-items:center;gap:3px;box-sizing:border-box;flex:none;';
+            el.style.cssText =
+                `display:inline-flex;align-items:center;gap:3px;box-sizing:border-box;flex:none;` +
+                `margin-left:${LEGEND_TITLE_STATUS_GAP_PX}px;`;
             for (let i = 0; i < 3; i += 1) {
                 const dot = document.createElement('span');
                 dot.style.cssText = 'width:4px;height:4px;border-radius:50%;background:currentColor;opacity:0.15;flex:none;';
@@ -845,6 +849,7 @@ export class InputsUI {
         this.ensureStatusKeyframes();
         el.style.cssText =
             `display:inline-block;box-sizing:border-box;flex:none;width:8px;height:8px;border-radius:50%;` +
+            `margin-left:${LEGEND_TITLE_STATUS_GAP_PX}px;` +
             `background:${this.theme.upColor};animation:vela-ind-pulse 1.2s ease-in-out infinite;`;
     }
 


### PR DESCRIPTION
- Introduced a new constant `LEGEND_TITLE_STATUS_GAP_PX` to define the space between the title (or values/controls) and the load/live status.
- Updated the CSS styles in the `InputsUI` class to apply this gap when the status is 'loading' and when displaying the status indicator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Legend-only CSS spacing in `InputsUI.setStatus`; no data, auth, or indicator logic changes.
> 
> **Overview**
> Adds **12px** separation between the indicator legend row content (title, plot values, or action controls) and the **loading** / **live** status affordance at the row’s right end.
> 
> A new `LEGEND_TITLE_STATUS_GAP_PX` constant mirrors the existing title→values gap pattern (`LEGEND_TITLE_VALUES_GAP_PX`). `setStatus` applies `margin-left` on the status element for both the three-dot loading animation and the pulsing live dot; idle status stays hidden with no extra margin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f4b8a6275588a982ac800bc12c5f42e7961d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->