### PR TITLE
Feat: favorite tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Legend load dots sit beside the title, not glued to it.** While an indicator is
+  fetching, the three pulsing dots now keep an 8px gap to the right of the title
+  (they used to sit flush against the last letter) and drop 1px so they optically
+  match the title's midline.
+
 ## [v0.5.2]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to Vela, newest first.
 - **The symbol watermark yields to loading.** While a chart's bars are loading, the
   faded symbol watermark stays hidden so it never overlaps the loading indicator; it
   returns as soon as the first bars paint.
+- **Open menus stay put if their trigger moves.** Starring a timeframe (which adds a
+  chip and shifts the caret) no longer drags the open dropdown with it — the list
+  keeps the position it had when it opened.
 - **Favorite stars are gold everywhere.** The mobile drawings sheet's favorite star
   now lights up in the same gold as the desktop drawing toolbar's, instead of blue.
 - **The highlighter's width is typed, not picked.** The drawing quick bar shows a
@@ -43,6 +46,12 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **Favorite timeframes.** Hover a row in the topbar's timeframe dropdown and a star
+  appears — click it to pin that timeframe (starred rows keep their gold star). Pinned
+  timeframes sit as duration-sorted chips with the current value highlighted in place;
+  an unstarred current sits next to the caret, which opens the full list (or the
+  combined label+caret when nothing is starred). The set persists with the rest of the
+  chart state, and a workspace shares one set across all charts.
 - **Replaceable indicator menu.** A new `indicatorPicker` shell option (widget and
   workspace, default `true`) removes the built-in indicator dialog's entry points —
   the topbar button, the mobile-bar item, and the `/` shortcut — so a host can ship

--- a/docs/user/widget.md
+++ b/docs/user/widget.md
@@ -95,7 +95,10 @@ work from the very first keystroke, before any click.
 
 ## The chrome
 
-- **Topbar** — symbol button (opens the search), timeframe dropdown, chart-style dropdown
+- **Topbar** — symbol button (opens the search), timeframe dropdown (hover a row to
+  star a favorite: starred timeframes sit as duration-sorted chips, the current one
+  highlighted in place; an unstarred current sits next to the caret, and the caret
+  opens the full list — or the combined label+caret when nothing is starred), chart-style dropdown
   (built-ins ∪ [plugin chart types](../contributing/plugin-sdk.md), with their icons and
   labels), Indicators picker, undo/redo (same history as Ctrl+Z / Ctrl+Y), data-window and
   object-tree panel toggles, then any
@@ -186,7 +189,7 @@ the SAME document format — a widget is the single-chart case (`layout: '1'`, o
 ```ts
 const state = widget.getState();
 // → { version: 1, layout: '1', activeCellId: 'c1', timezone, favorites?,
-//     panels?: { open?, widths? },
+//     timeframeFavorites?, panels?: { open?, widths? },
 //     charts: [{ id: 'c1', symbol, provider?, timeframe, priceStyle, bars?, watermark?,
 //                indicatorTitles?, rendererConfig, drawings, indicators }] }
 

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -153,7 +153,8 @@ The state SURFACE is the product; persistence is an adapter on top of it.
 
 ```ts
 const state = ws.getState();
-// → { version: 1, layout, trackSizes?, activeCellId?, sync?, timezone?, favorites?, charts: […] }
+// → { version: 1, layout, trackSizes?, activeCellId?, sync?, timezone?, favorites?,
+//     timeframeFavorites?, charts: […] }
 // One ORDERED `charts` entry per cell, live AND dormant — array position i restores
 // into slot i, `id` is the cell's durable name: { id: 'btc', symbol, provider?, timeframe,
 //   priceStyle, bars?, watermark?, indicatorTitles?, rendererConfig (renderer.getConfig() document),

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -82,6 +82,9 @@ const LEGEND_ROW_PAD_Y = 2;
 const LEGEND_ROW_PAD_X = 6;
 /** Space between the indicator title and the plot-values readout to its right. */
 const LEGEND_TITLE_VALUES_GAP_PX = 6;
+/** Space between the title and the loading/live status (the values gap plus a little
+ *  air — 4px dots flush against 12px type read as glued on). */
+const LEGEND_TITLE_STATUS_GAP_PX = 8;
 /** Uniform space: title → first action icon, and between every action icon. */
 const LEGEND_ACTION_GAP_PX = 6;
 const LEGEND_CTL_CSS =
@@ -707,8 +710,9 @@ export class InputsUI {
             e.stopPropagation();
             this.openRowMenu(id, e.clientX, e.clientY);
         });
-        // Status indicator (appended at the row's right end, below): pulsing load dots while
-        // fetching, a pulse while live, hidden when idle.
+        // Status indicator (right of the title): pulsing load dots while fetching, a
+        // pulse while live, hidden when idle. Lives next to the title — not the row's
+        // far end — so the dots stay a title companion even before values arrive.
         const statusEl = document.createElement('span');
         statusEl.style.cssText = 'display:none;box-sizing:border-box;flex:none;';
         // Title (+ optional "beta" exponent) wrapped so the superscript stays glued to the label and
@@ -729,6 +733,7 @@ export class InputsUI {
             titleWrap.appendChild(beta);
         }
         el.appendChild(titleWrap);
+        el.appendChild(statusEl);
         // Plot values readout, right of the title — filled by setPlotValues, hidden until
         // values arrive (or while the values toggle is off for this row).
         const valuesEl = document.createElement('span');
@@ -797,7 +802,6 @@ export class InputsUI {
         close.addEventListener('click', () => this.onRemove?.(id));
         controlsEl.appendChild(close);
         el.appendChild(controlsEl);
-        el.appendChild(statusEl); // status sits at the row's right end, after values and controls
 
         this.attach(this.legendFor(paneId), el, !!opts.native);
         this.rows.set(id, { id, title, settingsTitle, inputs, values: { ...values }, el, titleEl, statusEl, valuesEl, plotValues: [], plotValuesKey: '', showValues: null, highlighted: false, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
@@ -819,7 +823,7 @@ export class InputsUI {
     /**
      * Reflect an indicator's live status in its legend row: `'loading'` shows three pulsing
      * dots (a fetch is in flight — the same load affordance as the chart's own bar-load dots,
-     * at legend scale), `'live'` a pulsing dot, `'idle'` nothing. Rendered at the row's right end.
+     * at legend scale), `'live'` a pulsing dot, `'idle'` nothing. Rendered just right of the title.
      */
     setStatus(id: string, status: 'idle' | 'loading' | 'live'): void {
         const row = this.rows.get(id);
@@ -831,7 +835,12 @@ export class InputsUI {
             return;
         }
         if (status === 'loading') {
-            el.style.cssText = 'display:inline-flex;align-items:center;gap:3px;box-sizing:border-box;flex:none;';
+            // line-height:0 kills the font strut so the 4px dots are the box; translateY is
+            // optical — the dots already share the title's geometric midline, but 4px discs
+            // next to 12px type read a hair high without the nudge.
+            el.style.cssText =
+                `display:inline-flex;align-items:center;gap:3px;box-sizing:border-box;flex:none;` +
+                `margin-left:${LEGEND_TITLE_STATUS_GAP_PX}px;line-height:0;transform:translateY(1px);`;
             for (let i = 0; i < 3; i += 1) {
                 const dot = document.createElement('span');
                 dot.style.cssText = 'width:4px;height:4px;border-radius:50%;background:currentColor;opacity:0.15;flex:none;';
@@ -845,6 +854,7 @@ export class InputsUI {
         this.ensureStatusKeyframes();
         el.style.cssText =
             `display:inline-block;box-sizing:border-box;flex:none;width:8px;height:8px;border-radius:50%;` +
+            `margin-left:${LEGEND_TITLE_STATUS_GAP_PX}px;transform:translateY(1px);` +
             `background:${this.theme.upColor};animation:vela-ind-pulse 1.2s ease-in-out infinite;`;
     }
 

--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -99,6 +99,8 @@ export interface WorkspaceState {
     timezone?: string;
     /** Favorite drawing-tool types — a SHARED preference (one star set per shell). */
     favorites?: string[];
+    /** Favorite timeframes (the topbar's quick-switch chips) — a SHARED preference. */
+    timeframeFavorites?: string[];
     /** The docked side panels: which one is open, and the widths the user dragged. */
     panels?: PanelsState;
     /** Per-chart state, one entry per SLOT (a single `c1` entry for the widget).
@@ -157,6 +159,10 @@ export function sanitizeState(doc: unknown): WorkspaceState | null {
     if (Array.isArray(d.favorites)) {
         const favs = d.favorites.filter((f): f is string => typeof f === 'string');
         if (favs.length > 0) out.favorites = favs;
+    }
+    if (Array.isArray(d.timeframeFavorites)) {
+        const favs = d.timeframeFavorites.filter((f): f is string => typeof f === 'string');
+        if (favs.length > 0) out.timeframeFavorites = favs;
     }
     const sync = sanitizeSync(d.sync);
     if (sync) out.sync = sync;

--- a/src/ui/components/menu/controller.ts
+++ b/src/ui/components/menu/controller.ts
@@ -21,6 +21,11 @@ export interface MenuItemDescriptor {
     toggle?: boolean;
     /** Icon id (see the `vela/ui` icon registry) rendered before the label. */
     icon?: string;
+    /** Favorite-star affordance at the row's right edge: `false` renders an outline
+     *  star revealed on row hover, `true` a filled star that stays visible. Clicking
+     *  it reports through the menu's `onFavorite` WITHOUT selecting (or closing) the
+     *  row — undefined rows carry no star at all. */
+    favorite?: boolean;
     /** Nested entries — the row becomes a submenu trigger opening its own list to the side.
      *  A branch is not selectable itself: `onSelect` only ever reports leaf ids. */
     submenu?: readonly MenuItemDescriptor[];
@@ -35,6 +40,11 @@ export interface MenuControllerOptions {
             : never
         : never;
     onOpenChange?: (open: boolean) => void;
+    /** Pin the floating list to this rect (viewport coords). Used to keep an open
+     *  menu still when its trigger moves — starring a timeframe adds a chip and
+     *  would otherwise drag the list with the caret. `null` falls through to the
+     *  live trigger. */
+    getAnchorRect?: () => { x: number; y: number; width: number; height: number } | null;
     /** Share the trigger's DOM id with other machines composed on the same element. */
     triggerId?: string;
     /** Pin the machine's own id instead of taking a fresh one. A parent registers its
@@ -58,7 +68,10 @@ export function menuController(opts: MenuControllerOptions): MenuController {
         props: {
             id: opts.id ?? nextUid('vela-menu'),
             ids: opts.triggerId ? { trigger: opts.triggerId } : undefined,
-            positioning: { placement: opts.placement ?? 'bottom-start' },
+            positioning: {
+                placement: opts.placement ?? 'bottom-start',
+                ...(opts.getAnchorRect ? { getAnchorRect: () => opts.getAnchorRect!() } : {}),
+            },
             onSelect: (d: menu.SelectionDetails) => opts.onSelect?.(d.value),
             onOpenChange: (d: menu.OpenChangeDetails) => opts.onOpenChange?.(d.open),
         } satisfies Partial<menu.Props>,

--- a/src/ui/components/menu/styles.ts
+++ b/src/ui/components/menu/styles.ts
@@ -72,6 +72,22 @@ export const MENU_CSS = `
 }
 .vela-menu-switch.on { background: var(--vela-accent-bright, var(--vela-accent)); border-color: var(--vela-accent-bright, var(--vela-accent)); }
 .vela-menu-switch.on::after { transform: translateX(16px); background: var(--vela-bg); }
+/* Favorite star (rows carrying \`favorite\`): reserved space always — it fades in on row
+   hover instead of shifting the layout — and a starred row keeps its filled star visible.
+   Same control language as the drawing toolbar's flyout stars. */
+.vela-menu-item .vela-menu-star {
+    order: 98;
+    /* Pad the 16px icon slot into a bigger hit target without moving the row's layout. */
+    margin: -3px -5px -3px 0;
+    padding: 3px 5px;
+    box-sizing: content-box;
+    border-radius: var(--vela-radius-sm);
+    opacity: 0;
+    transition: opacity 0.1s ease, background 0.1s ease;
+}
+.vela-menu-item[data-highlighted] .vela-menu-star { opacity: 0.55; }
+.vela-menu-item .vela-menu-star:hover { opacity: 1; background: var(--vela-hover-strong); }
+.vela-menu-item .vela-menu-star.vela-fav { opacity: 0.95; color: var(--vela-highlight); }
 .vela-menu-sep { height: 1px; margin: 4px 6px; background: var(--vela-border); }
 /* Submenu trigger row: a right-aligned chevron, and it stays highlighted while its own
    list is open so the path you came down remains readable. */

--- a/src/ui/components/menu/view.ts
+++ b/src/ui/components/menu/view.ts
@@ -18,6 +18,9 @@ export interface MenuOptions extends MenuControllerOptions {
      *  compact lists like the timeframe dropdown pass something snug). Submenus keep the
      *  default. */
     minWidth?: string;
+    /** Star-toggle reports from items carrying `favorite` (the menu stays open — starring
+     *  is a side action on a row, never a selection). */
+    onFavorite?: (id: string, on: boolean) => void;
 }
 
 interface SurfaceOptions {
@@ -29,6 +32,7 @@ interface SurfaceOptions {
     triggerId?: string;
     id?: string;
     minWidth?: string;
+    onFavorite?: (id: string, on: boolean) => void;
 }
 
 /**
@@ -45,14 +49,19 @@ class Surface {
     private readonly doc: Document;
     private readonly host: HTMLElement;
     private readonly onSelect: (id: string) => void;
+    private readonly onFavorite?: (id: string, on: boolean) => void;
     private items: readonly MenuItemDescriptor[] = [];
     /** Branch item id → the surface it opens. */
     private readonly subs = new Map<string, Surface>();
+    /** Trigger rect captured when this level opened — the list stays put if the
+     *  trigger then moves (favorite chips shifting the caret). */
+    private pinnedAnchor: { x: number; y: number; width: number; height: number } | null = null;
 
     constructor(doc: Document, opts: SurfaceOptions) {
         this.doc = doc;
         this.host = opts.host;
         this.onSelect = opts.onSelect;
+        this.onFavorite = opts.onFavorite;
 
         this.positioner = doc.createElement('div');
         this.positioner.className = 'vela-ui-layer';
@@ -62,16 +71,25 @@ class Surface {
         this.positioner.appendChild(this.list);
         this.host.appendChild(this.positioner);
 
+        const trigger = opts.trigger;
         this.ctrl = menuController({
             items: [],
             id: opts.id,
             placement: opts.placement,
             onSelect: (id) => this.onSelect(id),
-            onOpenChange: opts.onOpenChange,
+            getAnchorRect: () => this.pinnedAnchor,
+            onOpenChange: (open) => {
+                if (open && trigger) {
+                    const r = trigger.getBoundingClientRect();
+                    this.pinnedAnchor = { x: r.x, y: r.y, width: r.width, height: r.height };
+                } else {
+                    this.pinnedAnchor = null;
+                }
+                opts.onOpenChange?.(open);
+            },
             triggerId: opts.triggerId,
         });
         this.mid = String(this.ctrl.props.id);
-        const trigger = opts.trigger;
         if (opts.triggerId && trigger) trigger.id = opts.triggerId;
         this.handle = runMachine(this.ctrl.machine, this.ctrl.props, (service) => {
             const api = this.ctrl.connect(service);
@@ -165,6 +183,27 @@ class Surface {
                 hint.textContent = item.hint;
                 li.appendChild(hint);
             }
+            if (item.favorite !== undefined && this.onFavorite) {
+                const on = item.favorite;
+                const star = iconEl(on ? 'star-filled' : 'star', doc);
+                star.classList.add('vela-menu-star');
+                if (on) star.classList.add('vela-fav');
+                star.removeAttribute('aria-hidden'); // iconEl hides decorative icons; this one is a control
+                star.setAttribute('role', 'button');
+                star.setAttribute('aria-label', on ? 'Remove from favorites' : 'Add to favorites');
+                star.setAttribute('aria-pressed', on ? 'true' : 'false');
+                // Swallow the whole pointer sequence: the machine selects rows on click,
+                // and a press that starts on the star must never reach the row.
+                for (const ev of ['pointerdown', 'pointerup', 'mousedown', 'mouseup'] as const) {
+                    star.addEventListener(ev, (e) => e.stopPropagation());
+                }
+                star.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.onFavorite?.(item.id, !on);
+                });
+                li.appendChild(star);
+            }
             if (item.toggle) {
                 const sw = doc.createElement('span');
                 sw.className = 'vela-menu-switch' + (item.checked ? ' on' : '');
@@ -180,6 +219,7 @@ class Surface {
                     host: this.host,
                     placement: 'right-start',
                     onSelect: this.onSelect,
+                    onFavorite: this.onFavorite,
                     id: `${this.mid}--${item.id}`,
                 });
                 sub.setItems(item.submenu ?? []);
@@ -207,6 +247,7 @@ export class Menu {
             triggerId: opts.triggerId,
             id: opts.id,
             minWidth: opts.minWidth,
+            onFavorite: opts.onFavorite,
         });
         this.root.setItems(opts.items);
     }

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -149,6 +149,8 @@ export class VelaWidget {
     private readonly stateListeners = new Set<() => void>();
     /** Favorite drawing-tool types — mirrored from chart events, reapplied on rebuilds. */
     private favs: string[] = [];
+    /** Favorite timeframes — the topbar's quick-switch chips, persisted with the shell. */
+    private tfFavs: string[] = [];
     /** Mounted attachment disposers (by id), torn down at destroy. */
     private readonly attachmentDisposers = new Map<string, () => void>();
     private readonly onUnload = (): void => this.persistNow();
@@ -207,6 +209,7 @@ export class VelaWidget {
         this.indicatorTitlesOn = bootCell?.indicatorTitles ?? true;
         this.indicatorValuesOn = bootCell?.indicatorValues ?? true;
         this.favs = boot?.favorites ? [...boot.favorites] : [];
+        this.tfFavs = boot?.timeframeFavorites ? [...boot.timeframeFavorites] : [];
         this.savedConfig = bootCell?.rendererConfig ?? null;
         this.savedDrawings = bootCell?.drawings ?? null;
         this.pendingIndicators = bootCell?.indicators ?? null;
@@ -285,8 +288,10 @@ export class VelaWidget {
             onAlertsClick: (anchor) => this.openAlertsMenu(anchor),
             timeframe: this.timeframe,
             timeframes: opts.timeframes ?? DEFAULT_TIMEFRAMES,
+            timeframeFavorites: this.tfFavs,
             priceStyle: this.priceStyle,
             onTimeframe: (tf) => this.setTimeframe(tf),
+            onTimeframeFavorite: (tf, on) => this.setTimeframeFavorite(tf, on),
             onPriceStyle: (style) => this.setPriceStyle(style),
             getContext: () => this.context(),
         });
@@ -622,6 +627,15 @@ export class VelaWidget {
         void this.inner?.setMarket({ timeframe: tf, bars: this.bars });
     }
 
+    /** Star/unstar a timeframe — the topbar chips and dropdown stars follow, and the
+     *  set persists with the rest of the shell state. */
+    private setTimeframeFavorite(tf: string, on: boolean): void {
+        if (on === this.tfFavs.includes(tf)) return;
+        this.tfFavs = on ? [tf, ...this.tfFavs] : this.tfFavs.filter((f) => f !== tf);
+        this.topbar.setTimeframeFavorites(this.tfFavs);
+        this.markStateDirty();
+    }
+
     /**
      * Switch the chart symbol in place. An `EXCHANGE:` prefix pins the venue (the
      * symbol picker composes one from the row the user pointed at) — a bare ticker
@@ -693,6 +707,7 @@ export class VelaWidget {
         });
         const state: WorkspaceState = { version: 1, layout: '1', activeCellId: 'c1', timezone: this.timezone, charts: [{ id: 'c1', ...cell }] };
         if (this.favs.length > 0) state.favorites = [...this.favs];
+        if (this.tfFavs.length > 0) state.timeframeFavorites = [...this.tfFavs];
         const panels = this.dock.getState();
         if (panels) state.panels = panels;
         return state;
@@ -716,6 +731,10 @@ export class VelaWidget {
         if (st.favorites) {
             this.favs = [...st.favorites];
             this.inner?.drawings.setFavorites(this.favs as never[]);
+        }
+        if (st.timeframeFavorites) {
+            this.tfFavs = [...st.timeframeFavorites];
+            this.topbar.setTimeframeFavorites(this.tfFavs);
         }
         // Absent in documents written before the dock existed — those leave the column closed.
         this.dock.applyState(st.panels);

--- a/src/widget/timeframe.ts
+++ b/src/widget/timeframe.ts
@@ -115,6 +115,28 @@ export function timeframeMs(value: string): number {
     return count * UNIT_MS[key];
 }
 
+/** Favorite chips in duration order (shortest first). First-seen wins on duplicates;
+ *  values that do not parse sort last, keeping their relative order. The current
+ *  timeframe is included when it is a favorite so the highlight can sit in place. */
+export function favoriteTimeframeChips(favorites: readonly string[]): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const tf of favorites) {
+        if (seen.has(tf)) continue;
+        seen.add(tf);
+        out.push(tf);
+    }
+    return out.sort((a, b) => {
+        const ma = timeframeMs(a);
+        const mb = timeframeMs(b);
+        const aOk = Number.isFinite(ma);
+        const bOk = Number.isFinite(mb);
+        if (aOk && bOk && ma !== mb) return ma - mb;
+        if (aOk !== bOk) return aOk ? -1 : 1;
+        return 0;
+    });
+}
+
 /** Compact display label for any timeframe value ("60" → "1h", "D" → "1D"). */
 export function timeframeLabel(value: string): string {
     const parsed = parseTimeframe(value);

--- a/src/widget/topbar.ts
+++ b/src/widget/topbar.ts
@@ -8,7 +8,7 @@ import { injectStyles } from '../ui/styles';
 import { chartType } from '../chart-types/registry';
 import { widgetActions, type SidePanelButton, type WidgetContext } from './contributions';
 import { BUILTIN_PRICE_STYLES, priceStyleIds } from '../renderers/native/core/chartConfig';
-import { timeframeLabel } from './timeframe';
+import { favoriteTimeframeChips, timeframeLabel } from './timeframe';
 import { parseSymbol } from '../data/ProviderRegistry';
 
 // The component owns its stylesheet (id-guarded, injected at construction) so EVERY
@@ -51,6 +51,36 @@ const CSS = `
     color: var(--vela-fg-bright);
 }
 .vela-widget-symbol:hover, .vela-widget-tf:hover, .vela-widget-style:hover, .vela-widget-indicators:hover, .vela-widget-action-left:hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
+/* Timeframe cluster: duration-sorted favorite chips, highlight in place, caret
+   opening the full dropdown. With no favorites the caret is the merged trigger
+   (label + chevron). An unstarred current value sits as an extra chip by the caret. */
+.vela-widget-tf-group { display: inline-flex; align-items: center; gap: 2px; }
+.vela-widget-tf-chips { display: inline-flex; align-items: center; gap: 2px; }
+.vela-widget-tf-chips:empty { display: none; }
+.vela-widget-tf[data-current='1'] { background: var(--vela-hover-strong); color: var(--vela-fg-bright); }
+.vela-widget-tf-caret {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 30px;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--vela-fg-muted);
+}
+.vela-widget-tf-caret:hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
+.vela-widget-tf-caret[data-solo='1'] {
+    width: auto;
+    padding: 0 6px 0 9px;
+    gap: 4px;
+    color: var(--vela-fg-bright);
+    background: var(--vela-hover-strong);
+    font-size: 13px;
+    font-weight: 550;
+    white-space: nowrap;
+}
+.vela-widget-topbar .vela-widget-tf-caret .vela-icon { font-size: 14px; width: 14px; height: 14px; }
 .vela-widget-topbar .vela-icon { color: inherit; font-size: 16px; width: 16px; height: 16px; }
 /* Width is set in syncHairlines() to exactly one device pixel — a CSS 1px at
    fractional DPR (1.25, 1.5…) straddles two physical pixels and siblings end
@@ -135,8 +165,14 @@ export interface TopbarOptions {
     onSymbolClick?: () => void;
     timeframe: string;
     timeframes: readonly string[];
+    /** Favorite timeframes — duration-sorted quick-switch chips, stars in the
+     *  dropdown rows. Push later changes with {@link Topbar.setTimeframeFavorites}. */
+    timeframeFavorites?: readonly string[];
     priceStyle: string;
     onTimeframe: (tf: string) => void;
+    /** A dropdown star was toggled. Omitted, the dropdown carries no stars and the
+     *  chips never render — the host owns (and persists) the favorite set. */
+    onTimeframeFavorite?: (tf: string, on: boolean) => void;
     onPriceStyle: (style: string) => void;
     /** Optional workspace LAYOUT dropdown (rendered after the style dropdown when
      *  given) — the grid-canvas picker composing uniform grids, with the workspace
@@ -168,7 +204,10 @@ export interface TopbarOptions {
 export class Topbar {
     readonly el: HTMLElement;
     private readonly symbolEl: HTMLElement;
-    private readonly tfButton: HTMLElement;
+    /** Duration-sorted favorite chips (plus an unstarred current, when needed). */
+    private readonly tfChipsHost: HTMLElement;
+    private readonly tfCaret: HTMLButtonElement;
+    private tfFavs: string[];
     private readonly styleButton: HTMLElement;
     private layoutButton: HTMLElement | null = null;
     private layoutPicker: LayoutPicker | null = null;
@@ -220,9 +259,18 @@ export class Topbar {
         // shell's state (the statusline meta and the picker badges name the venue).
         this.symbolEl.textContent = parseSymbol(opts.symbol).ticker;
         if (opts.onSymbolClick) this.symbolEl.addEventListener('click', opts.onSymbolClick);
-        this.tfButton = doc.createElement('button');
-        this.tfButton.className = 'vela-widget-tf';
-        this.tfButton.textContent = timeframeLabel(this.timeframe);
+        // Duration-sorted chips with highlight in place; the caret is the dropdown
+        // trigger (merged with the current label when there are no favorites).
+        this.tfFavs = [...(opts.timeframeFavorites ?? [])];
+        this.tfChipsHost = doc.createElement('span');
+        this.tfChipsHost.className = 'vela-widget-tf-chips';
+        this.tfCaret = doc.createElement('button');
+        this.tfCaret.className = 'vela-widget-tf-caret';
+        this.tfCaret.appendChild(iconEl('chevron-down', doc));
+        this.tfCaret.setAttribute('aria-label', 'Timeframes');
+        const tfGroup = doc.createElement('span');
+        tfGroup.className = 'vela-widget-tf-group';
+        tfGroup.append(this.tfChipsHost, this.tfCaret);
         this.styleButton = doc.createElement('button');
         this.styleButton.className = 'vela-widget-style';
         this.renderStyleButton(doc);
@@ -272,7 +320,7 @@ export class Topbar {
             d.className = 'vela-sep';
             return d;
         };
-        const leading: Array<HTMLElement> = [this.symbolEl, sep(), this.tfButton, sep(), this.styleButton, sep()];
+        const leading: Array<HTMLElement> = [this.symbolEl, sep(), tfGroup, sep(), this.styleButton, sep()];
         if (this.layoutButton) leading.push(this.layoutButton, sep());
         if (indicatorsBtn) leading.push(indicatorsBtn, sep());
         // The left action cluster sits where the built-in Indicators button lives; its
@@ -281,6 +329,7 @@ export class Topbar {
         this.leftActionsSep.hidden = true;
         this.el.append(...leading, this.leftActionsHost, this.leftActionsSep, this.undoBtn, this.redoBtn, this.actionsHost, this.alertsBtn, this.panelsHost, screenshotBtn);
         host.appendChild(this.el);
+        this.renderTfChips();
         // Snap after layout; RO catches later reflows (symbol / timeframe length).
         this.onHairlineSync();
         this.hairlineRo = new ResizeObserver(this.onHairlineSync);
@@ -288,7 +337,7 @@ export class Topbar {
         doc.defaultView?.addEventListener('resize', this.onHairlineSync);
         this.renderActions();
 
-        this.tooltips.push(new Tooltip(this.tfButton, { content: 'Timeframe', triggerId: 'vela-topbar-tf', host }));
+        this.tooltips.push(new Tooltip(this.tfCaret, { content: 'Timeframe', triggerId: 'vela-topbar-tf', host }));
         this.tooltips.push(new Tooltip(this.styleButton, { content: 'Chart style', triggerId: 'vela-topbar-style', host }));
         if (this.layoutButton && opts.layout) {
             this.tooltips.push(new Tooltip(this.layoutButton, { content: 'Layout', triggerId: 'vela-topbar-layout', host }));
@@ -305,11 +354,12 @@ export class Topbar {
             });
         }
         this.tfMenu = new Menu({
-            trigger: this.tfButton,
+            trigger: this.tfCaret,
             triggerId: 'vela-topbar-tf',
             host,
             items: this.tfItems(),
             onSelect: (id) => opts.onTimeframe(id),
+            onFavorite: (id, on) => opts.onTimeframeFavorite?.(id, on),
             // Timeframe labels are two-or-three characters ("1m", "4h", "1D") — the
             // stylesheet's default min-width would leave the list mostly empty.
             minWidth: '84px',
@@ -329,8 +379,51 @@ export class Topbar {
 
     setTimeframe(tf: string): void {
         this.timeframe = tf;
-        this.tfButton.textContent = timeframeLabel(tf);
         this.tfMenu.setItems(this.tfItems());
+        this.renderTfChips();
+    }
+
+    /** Reflect the favorite-timeframe set — the quick-switch chips and the dropdown stars. */
+    setTimeframeFavorites(favs: readonly string[]): void {
+        this.tfFavs = [...favs];
+        this.renderTfChips();
+        this.tfMenu.setItems(this.tfItems());
+    }
+
+    /** Rebuild the quick-switch chips (current value changed, or the favorite set did). */
+    private renderTfChips(): void {
+        const doc = this.el.ownerDocument;
+        this.tfChipsHost.replaceChildren();
+        const stars = this.opts.onTimeframeFavorite !== undefined;
+        const chips = stars ? favoriteTimeframeChips(this.tfFavs) : [];
+        const currentIsFav = chips.includes(this.timeframe);
+        // Unstarred current sits next to the caret so the favorite row never jumps.
+        const shown = currentIsFav || chips.length === 0 ? chips : [...chips, this.timeframe];
+        for (const tf of shown) {
+            const b = doc.createElement('button');
+            b.className = 'vela-widget-tf';
+            const label = timeframeLabel(tf);
+            b.textContent = label;
+            if (tf === this.timeframe) {
+                b.dataset.current = '1';
+                b.setAttribute('aria-current', 'true');
+            } else {
+                b.setAttribute('aria-label', `Switch timeframe to ${label}`);
+                b.addEventListener('click', () => this.opts.onTimeframe(tf));
+            }
+            this.tfChipsHost.appendChild(b);
+        }
+        this.tfCaret.replaceChildren();
+        if (chips.length === 0) {
+            this.tfCaret.dataset.solo = '1';
+            this.tfCaret.append(doc.createTextNode(timeframeLabel(this.timeframe)), iconEl('chevron-down', doc));
+            this.tfCaret.setAttribute('aria-label', `Timeframe — ${timeframeLabel(this.timeframe)}`);
+        } else {
+            delete this.tfCaret.dataset.solo;
+            this.tfCaret.appendChild(iconEl('chevron-down', doc));
+            this.tfCaret.setAttribute('aria-label', 'Timeframes');
+        }
+        this.onHairlineSync(); // the cluster width changed
     }
 
     setPriceStyle(style: string): void {
@@ -472,7 +565,14 @@ export class Topbar {
     }
 
     private tfItems(): MenuItemDescriptor[] {
-        return this.opts.timeframes.map((tf) => ({ id: tf, label: timeframeLabel(tf), checked: tf === this.timeframe }));
+        // Stars only when the host handles the toggle — a starless dropdown otherwise.
+        const stars = this.opts.onTimeframeFavorite !== undefined;
+        return this.opts.timeframes.map((tf) => ({
+            id: tf,
+            label: timeframeLabel(tf),
+            checked: tf === this.timeframe,
+            ...(stars ? { favorite: this.tfFavs.includes(tf) } : {}),
+        }));
     }
 
     private styleItems(): MenuItemDescriptor[] {

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -239,6 +239,8 @@ export class VelaWorkspace {
     private historyUnsub: (() => void) | null = null;
     /** Favorite drawing tools — a WORKSPACE preference (one star set, every cell). */
     private favs: string[] = [];
+    /** Favorite timeframes — the shared topbar's quick-switch chips, one set for the grid. */
+    private tfFavs: string[] = [];
     /** Live sync configuration (mutable copy of the option). */
     private readonly syncOpts: SyncOptions = {};
     // ── persistence (state surface + adapter plumbing) ──
@@ -306,6 +308,7 @@ export class VelaWorkspace {
         }
         this.timezone = boot?.timezone ?? opts.timezone ?? 'Etc/UTC';
         if (boot?.favorites) this.favs = [...boot.favorites];
+        if (boot?.timeframeFavorites) this.tfFavs = [...boot.timeframeFavorites];
         const sync = boot?.sync ?? opts.sync;
         for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair', 'drawings'] as const) {
             this.applySyncSetting(kind, sync?.[kind]);
@@ -381,8 +384,10 @@ export class VelaWorkspace {
             onAlertsClick: (anchor) => this.openAlertsMenu(anchor),
             timeframe: '60',
             timeframes: opts.timeframes ?? DEFAULT_TIMEFRAMES,
+            timeframeFavorites: this.tfFavs,
             priceStyle: 'candles',
             onTimeframe: (tf) => this.setActiveTimeframe(tf),
+            onTimeframeFavorite: (tf, on) => this.setTimeframeFavorite(tf, on),
             onPriceStyle: (style) => this.active.setPriceStyle(style),
             layout: {
                 current: this.def.id,
@@ -704,6 +709,7 @@ export class VelaWorkspace {
         const state: WorkspaceState = { version: 1, layout: this.def.id, timezone: this.timezone, sync: { ...this.syncOpts }, charts };
         if (this.activeId) state.activeCellId = this.activeId;
         if (this.favs.length > 0) state.favorites = [...this.favs];
+        if (this.tfFavs.length > 0) state.timeframeFavorites = [...this.tfFavs];
         if (this.trackSizes.size > 0) state.trackSizes = Object.fromEntries([...this.trackSizes].map(([k, v]) => [k, { ...v }]));
         const panels = this.dock.getState();
         if (panels) state.panels = panels;
@@ -725,6 +731,10 @@ export class VelaWorkspace {
             this.bottombar?.setTimezone(st.timezone);
         }
         if (st.favorites) this.favs = [...st.favorites]; // newborn cells inherit below (buildCells)
+        if (st.timeframeFavorites) {
+            this.tfFavs = [...st.timeframeFavorites];
+            this.topbar.setTimeframeFavorites(this.tfFavs);
+        }
         // Absent in documents written before the dock existed — those leave the column closed.
         this.dock.applyState(st.panels);
         for (const kind of ['viewport', 'symbol', 'timeframe', 'crosshair', 'drawings'] as const) this.applySyncSetting(kind, st.sync?.[kind]);
@@ -1386,6 +1396,15 @@ export class VelaWorkspace {
     private setActiveTimeframe(tf: string): void {
         this.bottombar?.setActiveRange(null);
         this.active.setTimeframe(tf);
+    }
+
+    /** Star/unstar a timeframe — a WORKSPACE preference (one chip row, whatever the
+     *  active cell); the topbar follows and the set persists with the document. */
+    private setTimeframeFavorite(tf: string, on: boolean): void {
+        if (on === this.tfFavs.includes(tf)) return;
+        this.tfFavs = on ? [tf, ...this.tfFavs] : this.tfFavs.filter((f) => f !== tf);
+        this.topbar.setTimeframeFavorites(this.tfFavs);
+        this.markStateDirty();
     }
 
     /** The mode flipped (container resized across the breakpoint, or a coarse-pointer

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -1,7 +1,7 @@
 // The widget's pure modules: the timeframe grammar (src/widget/timeframe.ts) and the
 // indicator-manifest resolution (src/widget/indicators.ts). DOM-free — node env.
 import { describe, it, expect, vi } from 'vitest';
-import { parseTimeframe, timeframeMs, timeframeLabel } from '../src/widget/timeframe';
+import { parseTimeframe, timeframeMs, timeframeLabel, favoriteTimeframeChips } from '../src/widget/timeframe';
 import { indicatorLedger, resolveIndicators } from '../src/widget/indicators';
 import { fmtPrice, fmtChange, decimalsFor } from '../src/widget/format';
 import { tzMenuLabel, tzButtonLabel } from '../src/widget/timezones';
@@ -49,6 +49,15 @@ describe('parseTimeframe', () => {
         expect(timeframeLabel('15')).toBe('15m');
         expect(timeframeLabel('D')).toBe('1D');
         expect(timeframeLabel('W')).toBe('1W');
+    });
+
+    it('favoriteTimeframeChips sorts by duration and keeps the current value when favorited', () => {
+        expect(favoriteTimeframeChips(['D', '60'])).toEqual(['60', 'D']);
+        expect(favoriteTimeframeChips(['D', '60', '15'])).toEqual(['15', '60', 'D']);
+        expect(favoriteTimeframeChips(['60', '5', '60'])).toEqual(['5', '60']);
+        expect(favoriteTimeframeChips([])).toEqual([]);
+        expect(favoriteTimeframeChips(['15'])).toEqual(['15']);
+        expect(favoriteTimeframeChips(['nope', '60', 'also'])).toEqual(['60', 'nope', 'also']);
     });
 });
 

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -13,6 +13,7 @@ const fullDoc: WorkspaceState = {
     activeCellId: 'c2',
     timezone: 'Europe/Paris',
     favorites: ['trendline', 'hline'],
+    timeframeFavorites: ['15', '60', 'D'],
     sync: { viewport: true, symbol: { c1: 'a', c2: 'a' }, crosshair: true, drawings: true },
     trackSizes: { '4': { cols: [1.4, 0.6], rows: [1, 1] } },
     charts: [
@@ -85,6 +86,20 @@ describe('sanitizeState (the applyState gate)', () => {
                 { id: 'c3', indicators: { manifest: ['EMA'], natives: [] } },
             ],
         });
+    });
+
+    it('filters non-string favorite entries, dropping empty sets entirely', () => {
+        const doc = sanitizeState({
+            version: 1,
+            layout: '1',
+            favorites: ['trendline', 7],
+            timeframeFavorites: ['60', null, 'D'],
+            charts: [],
+        });
+        expect(doc!.favorites).toEqual(['trendline']);
+        expect(doc!.timeframeFavorites).toEqual(['60', 'D']);
+        const empty = sanitizeState({ version: 1, layout: '1', timeframeFavorites: [42], charts: [] });
+        expect(empty!.timeframeFavorites).toBeUndefined();
     });
 
     it('dedupes chart entries by id — the LAST duplicate wins', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI and persisted preference fields only; no auth, data, or market-loading path changes. State codec filters invalid favorite entries like existing `favorites`.
> 
> **Overview**
> Adds **favorite timeframes** in the topbar: star rows in the timeframe dropdown (when the host wires `onTimeframeFavorite`), show duration-sorted quick-switch chips with the active interval highlighted, and persist the set as shared shell state via **`timeframeFavorites`** on the widget/workspace document (same pattern as drawing `favorites`). With no favorites, the caret becomes a merged label+chevron trigger; with favorites, an unstarred current interval can appear as an extra chip beside the caret.
> 
> Extends the shared **`Menu`** with optional row **`favorite`** stars and **`onFavorite`** (toggle without selecting/closing), plus **`getAnchorRect`** so an open menu stays anchored when the trigger moves—starring adds a chip and would otherwise drag the list with the caret.
> 
> **Legend:** loading/live status indicators move to sit **right after the title** (not the row’s far end), with an **8px** gap and **1px** vertical nudge for optical alignment with 12px titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce93ed3f2da7c10286b746fd39f052ffbeaddab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->