### PR TITLE
Stop drawings from yanking the scale; rotate trend-line labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to Vela, newest first.
 
 ### Changed
 
+- **Trend-line labels follow the line.** A label on a trend line, ray, extended
+  line, info line, or trend angle sits along the segment instead of staying
+  horizontal, and flips so the text never reads upside-down.
 - **User drawings no longer expand the price scale.** Placing or dragging a drawing
   into the empty margin leaves the pane fitted to the series — the window does not
   jump to follow the cursor. Pine drawings still fold into autoscale as before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to Vela, newest first.
 
 ### Changed
 
+- **User drawings no longer expand the price scale.** Placing or dragging a drawing
+  into the empty margin leaves the pane fitted to the series — the window does not
+  jump to follow the cursor. Pine drawings still fold into autoscale as before.
 - **Open menus stay put if their trigger moves.** Starring a timeframe (which adds a
   chip and shifts the caret) no longer drags the open dropdown with it — the list
   keeps the position it had when it opened.

--- a/docs/contributing/adding-a-drawing-tool.md
+++ b/docs/contributing/adding-a-drawing-tool.md
@@ -8,7 +8,7 @@ in the core, see [ADR 0005](../architecture/adr/0005-core-owns-user-drawings.md)
 
 The key fact: a drawing type is a **renderer-agnostic, data-driven** class. You describe its
 anchors, geometry, and settings as pure functions of *(anchors, projector)*; interaction,
-persistence, undo, the settings popup, autoscale, and the toolbar entry then all work
+persistence, undo, the settings popup, and the toolbar entry then all work
 **automatically**. Most tools are tiny because shared base classes absorb the geometry — a full
 harmonic pattern leaf is around a dozen lines.
 
@@ -84,8 +84,9 @@ rather than asking the type for behavior:
 - **Persistence, undo, clipboard.** The type serializes to plain JSON automatically; any per-instance
   extras go in `props` via `writeProps()` / `readProps()` so the base stays closed. Undo, copy/paste,
   and `toJSON`/`fromJSON` then work unchanged.
-- **Autoscale + culling.** `priceRange()` folds the drawing into the pane's autoscale; `timeExtent()`
-  gates off-screen culling.
+- **Culling.** `timeExtent()` gates off-screen culling. `priceRange()` reports the drawing's
+  visible span (kept for a future per-drawing autoscale opt-in); user drawings do not expand
+  the pane's scale today.
 - **The toolbar.** The registry entry's `group` places it; nothing else.
 
 Keep the class **renderer-agnostic** — it must not import anything from `renderers/` (the import ACL

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -156,15 +156,15 @@ Magnet, Measure, and Stay in drawing mode are toolbar *modes*, not placeable typ
 
 | Tool | Type key | What it does |
 |---|---|---|
-| Trend Line | `trendline` | A segment between two points. |
+| Trend Line | `trendline` | A segment between two points. An optional label follows the line's slope. |
 | Horizontal Line | `hline` | A full-width line at one price. |
-| Ray | `ray` | A line from a point, extended one way. |
-| Extended Line | `extendedline` | A line through two points, extended both ways. |
+| Ray | `ray` | A line from a point, extended one way. An optional label follows the line's slope. |
+| Extended Line | `extendedline` | A line through two points, extended both ways. An optional label follows the line's slope. |
 | Vertical Line | `vline` | A full-height line at one time. |
 | Horizontal Ray | `hray` | A horizontal line from a point, extended right. |
 | Cross Line | `crossline` | A full-width + full-height cross through one point. |
-| Info Line | `infoline` | A segment with a readout of its price/%/bar delta. |
-| Trend Angle | `trendangle` | A ray with its angle (°) labelled off the horizontal. |
+| Info Line | `infoline` | A segment with a readout of its price/%/bar delta. An optional label follows the line's slope. |
+| Trend Angle | `trendangle` | A ray with its angle (°) labelled off the horizontal. An optional label follows the line's slope. |
 
 ### Channels
 

--- a/src/core/drawings/Drawing.ts
+++ b/src/core/drawings/Drawing.ts
@@ -206,7 +206,7 @@ export abstract class Drawing {
     abstract handlePoints(proj: Projector): Array<[number, number]>;
     /** Tight pixel bounds (selection box), or null when unresolvable. */
     abstract bounds(proj: Projector): { x: number; y: number; w: number; h: number } | null;
-    /** Visible price span on its pane — folded into autoscale. */
+    /** Visible price span on its pane. Reserved for a future per-drawing autoscale opt-in. */
     abstract priceRange(): { min: number; max: number } | null;
 
     /**

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -3049,7 +3049,6 @@ export class NativeRenderer implements IChartRenderer {
         const n = this.coords.barCount;
         if (n === 0) return;
         const vr = this.coords.visibleLogicalRange();
-        const vtr = this.coords.visibleTimeRange(); // for time-culling user drawings into autoscale
         const i0 = Math.max(0, Math.floor(vr.from));
         const i1 = Math.min(n - 1, Math.ceil(vr.to));
         if (i1 < i0) return;
@@ -3071,11 +3070,9 @@ export class NativeRenderer implements IChartRenderer {
             const models = this.scene.indicatorsForPane(pane.id);
             // A merged (own-scale) indicator does NOT contribute to the pane master scale.
             const masterModels = models.filter((m) => m.ownScale !== true);
-            let dr = this.chrome.paneDrawingsRange(masterModels, this.scene, pane === pricePane, vr);
-            // Fold visible USER drawings on this pane into the price range, exactly like
-            // Pine drawings — so an off-series line/box still expands the scale.
-            const udr = this.userDrawings?.priceRangeForPane(pane.id, vtr.from, vtr.to) ?? null;
-            if (udr) dr = dr ? { min: Math.min(dr.min, udr.min), max: Math.max(dr.max, udr.max) } : udr;
+            // User drawings do not expand the scale (placing one in the empty margin
+            // must not yank the window to follow the cursor). Pine drawings still fold in.
+            const dr = this.chrome.paneDrawingsRange(masterModels, this.scene, pane === pricePane, vr);
             // Hidden candles drop out of the price pane's autoscale, so overlay indicators fill the pane.
             const includeCandles = pane.kind === 'price' && !this.scene.candlesHidden;
             // Each pane logs (or not) on its OWN flag — the price pane from the scene setting,

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -1,7 +1,7 @@
 import type { Drawing, Projector, DrawingStyle } from '../../../core/drawings';
 import { SegmentDrawing, FibRatios, RadialFib, FibSpiral, GannSquare, GANN_SQUARE_ARCS, DedekindTessellation, MachFigure, MeasureBox, PositionTool, PatternDrawing, CalloutBase, Callout, Comment, PriceNote, Signpost, Note, PriceLabel, ArrowMark, GlyphStamp, RegressionChannel, AnchoredVwap, FixedRangeVolumeProfile, lineSegmentIntersection, effectiveFillColor, VALID_FILL, INVALID_FILL, DEFAULT_DRAWING_COLOR } from '../../../core/drawings';
 import type { VelaTheme } from '../../../core/options';
-import { contrastColor, dashPattern, extendEndpoints, namedFontSize, labelLineHeight, TEXT_FRAME_INSET, TEXT_FRAME_RISE } from '../../shared/drawing-geometry';
+import { contrastColor, dashPattern, extendEndpoints, namedFontSize, labelLineHeight, TEXT_FRAME_INSET, TEXT_FRAME_RISE, uprightLineAngle } from '../../shared/drawing-geometry';
 import { BEARISH, BULLISH, NEUTRAL, SLATE, SLATE_DEEP } from '../../../core/palette';
 import { withAlpha } from '../../../core/color';
 import { valueDecimals } from '../chrome/ticks';
@@ -416,13 +416,19 @@ export class DrawingPainter {
         this.paintLabel(ctx, d, proj, theme); // every drawing can carry an optional label
     }
 
-    /** Draw a drawing's optional text label at a type-appropriate anchor (multi-line aware). */
+    /** Draw a drawing's optional text label at a type-appropriate anchor (multi-line aware).
+     *  Two-point line tools rotate the glyphs to follow the segment, kept upright. */
     private paintLabel(ctx: CanvasRenderingContext2D, d: Drawing, proj: Projector, theme: VelaTheme): void {
         const text = d.text;
         if (!text || !text.value || d.id === this.targets.mutedLabel) return;
         const layout = labelLayout(d, proj);
         if (!layout) return;
         const fs = namedFontSize(text.size);
+        ctx.save();
+        if (layout.rotate) {
+            ctx.translate(layout.rotate.cx, layout.rotate.cy);
+            ctx.rotate(layout.rotate.angle);
+        }
         ctx.font = `${text.bold ? 'bold ' : ''}${text.italic ? 'italic ' : ''}${fs}px ${theme.fontFamily}`;
         ctx.textBaseline = 'top';
         ctx.textAlign = layout.align;
@@ -430,8 +436,8 @@ export class DrawingPainter {
         const lh = labelLineHeight(fs);
         const lines = text.value.split('\n');
         lines.forEach((line, i) => ctx.fillText(line, layout.x, layout.top + i * lh));
-        ctx.textAlign = 'left';
         if (d.type === 'text') this.paintTextFrame(ctx, d.id, layout.x, layout.top, lines, fs, theme);
+        ctx.restore();
     }
 
     /** Frame a plain text label while it is the target, so the text reads as a clickable object even
@@ -1445,7 +1451,14 @@ function formatMachRatio(ratio: number): string {
     return Number.isInteger(rounded) ? String(rounded) : String(rounded);
 }
 
-function labelLayout(d: Drawing, proj: Projector): { x: number; top: number; align: CanvasTextAlign } | null {
+/** Where a drawing's label paints. With `rotate`, the canvas is rotated by `angle`
+ *  around `(cx, cy)` first, and `x`/`top` are in that rotated frame. */
+function labelLayout(d: Drawing, proj: Projector): {
+    x: number;
+    top: number;
+    align: CanvasTextAlign;
+    rotate?: { angle: number; cx: number; cy: number };
+} | null {
     const text = d.text;
     if (!text) return null;
     const pts = d.handlePoints(proj);
@@ -1462,7 +1475,14 @@ function labelLayout(d: Drawing, proj: Projector): { x: number; top: number; ali
         case 'infoline':
         case 'trendangle': {
             if (pts.length < 2) return null;
-            return { x: (pts[0]![0] + pts[1]![0]) / 2, top: (pts[0]![1] + pts[1]![1]) / 2 - 6 - lh * lines, align: 'center' };
+            const [x1, y1] = pts[0]!;
+            const [x2, y2] = pts[1]!;
+            return {
+                x: 0,
+                top: -6 - lh * lines,
+                align: 'center',
+                rotate: { angle: uprightLineAngle(x1, y1, x2, y2), cx: (x1 + x2) / 2, cy: (y1 + y2) / 2 },
+            };
         }
         case 'box': {
             if (pts.length < 2) return null;

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -45,7 +45,7 @@ export interface UserDrawingDeps {
     projector(): Projector;
     dpr(): number;
     theme(): VelaTheme;
-    /** Ask the renderer to recompute per-pane autoscale (so a drawing folds into the price range). */
+    /** Ask the renderer to recompute per-pane autoscale (series + Pine drawings; user drawings do not fold in). */
     requestScaleUpdate(): void;
     /** The pane's series z keys (candles + indicators), ascending — the boundaries a drawing's
      *  z is slotted against to decide which interleave layer (if any) it paints on. */
@@ -212,7 +212,7 @@ export class UserDrawingController implements IDrawingsRendererPort {
         if (this.textEditor && !this.editedDrawing(this.textEditor.id)) this.closeTextEditor();
         this.invalidateSlices();
         this.render();
-        this.deps.requestScaleUpdate(); // fold drawing price ranges into autoscale
+        this.deps.requestScaleUpdate();
     }
 
     /** The pane's series stack in z terms — how the core places a new drawing (just under
@@ -224,9 +224,9 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     /**
      * Union of the visible drawings' price ranges on `paneId` whose time extent
-     * intersects [fromTime, toTime] — folded into the pane's autoscale so an
-     * off-series drawing still expands the scale (mirrors Pine drawings). Hidden
-     * drawings and full-width references (hline → null extent) are handled too.
+     * intersects [fromTime, toTime]. Hidden drawings and full-width references
+     * (hline → null extent) are handled too. Kept as the seam for a future
+     * per-drawing autoscale opt-in — the renderer does not fold this in today.
      */
     priceRangeForPane(paneId: string, fromTime: number, toTime: number): { min: number; max: number } | null {
         let lo = Infinity;

--- a/src/renderers/shared/drawing-geometry.ts
+++ b/src/renderers/shared/drawing-geometry.ts
@@ -94,6 +94,17 @@ export function extendEndpoints(
     return [lx, yAt(lx), rx, yAt(rx)];
 }
 
+/**
+ * Canvas angle of the segment `(x1,y1)→(x2,y2)`, flipped 180° when needed so
+ * a label along the line stays upright (never upside-down). Canvas Y grows down.
+ */
+export function uprightLineAngle(x1: number, y1: number, x2: number, y2: number): number {
+    let a = Math.atan2(y2 - y1, x2 - x1);
+    if (a > Math.PI / 2) a -= Math.PI;
+    if (a < -Math.PI / 2) a += Math.PI;
+    return a;
+}
+
 export interface Rgba {
     r: number;
     g: number;

--- a/test/drawing-geometry.test.ts
+++ b/test/drawing-geometry.test.ts
@@ -6,6 +6,7 @@ import {
     extendEndpoints,
     parseColor,
     contrastColor,
+    uprightLineAngle,
 } from '../src/renderers/shared/drawing-geometry';
 
 const TIMES = [0, 100, 200, 300, 400];
@@ -106,5 +107,19 @@ describe('drawing-geometry / colour', () => {
         expect(contrastColor('#ffffff')).toBe('#000000');
         expect(contrastColor('#000000')).toBe('#ffffff');
         expect(contrastColor(undefined)).toBe('#000000');
+    });
+});
+
+describe('drawing-geometry / uprightLineAngle', () => {
+    it('a rightward horizontal is 0, a leftward one flips to 0 so the text stays upright', () => {
+        expect(uprightLineAngle(0, 0, 10, 0)).toBeCloseTo(0);
+        expect(uprightLineAngle(10, 0, 0, 0)).toBeCloseTo(0);
+    });
+
+    it('follows a diagonal and flips past vertical so the glyphs never read upside-down', () => {
+        expect(uprightLineAngle(0, 10, 10, 0)).toBeCloseTo(-Math.PI / 4); // up-right (canvas Y down)
+        expect(uprightLineAngle(0, 0, 10, 10)).toBeCloseTo(Math.PI / 4); // down-right
+        expect(uprightLineAngle(10, 0, 0, 10)).toBeCloseTo(-Math.PI / 4); // down-left → flipped
+        expect(uprightLineAngle(10, 10, 0, 0)).toBeCloseTo(Math.PI / 4); // up-left → flipped
     });
 });

--- a/test/drawings-painter.test.ts
+++ b/test/drawings-painter.test.ts
@@ -42,6 +42,8 @@ function recordingCtx() {
         strokeRect() {},
         save() {},
         restore() {},
+        translate() {},
+        rotate() {},
         fillText() {},
         measureText: () => ({ width: 0 }),
     };
@@ -213,5 +215,44 @@ describe('DrawingPainter.paintAll pane separation', () => {
         new DrawingPainter().paintAll(ctx, drawings, fakeProjector(), theme);
         expect(clips()).toBe(0);
         expect(strokes()).toBeGreaterThan(0);
+    });
+});
+
+describe('DrawingPainter trendline label follows the line', () => {
+    it('rotates the label to the upright segment angle', () => {
+        const d = createDrawing('trendline', {
+            id: 't',
+            paneId: 'price',
+            anchors: [
+                { time: 0, price: 0 },
+                { time: 50, price: 50 },
+            ],
+            text: { value: 'zone', size: 'normal', hAlign: 'center', vAlign: 'top' },
+        })!;
+        const { ctx } = recordingCtx();
+        const angles: number[] = [];
+        (ctx as unknown as Record<string, unknown>).rotate = (a: number) => {
+            angles.push(a);
+        };
+        new DrawingPainter().paintAll(ctx, [d], fakeProjector(), theme);
+        expect(angles).toHaveLength(1);
+        // projector y = 100 − price: (0,100) → (50,50) is up-right → −π/4
+        expect(angles[0]).toBeCloseTo(-Math.PI / 4);
+    });
+
+    it('does not rotate a flat text annotation', () => {
+        const d = createDrawing('text', {
+            id: 'a',
+            paneId: 'price',
+            anchors: [{ time: 10, price: 50 }],
+            text: { value: 'note', size: 'normal', hAlign: 'left', vAlign: 'top' },
+        })!;
+        const { ctx } = recordingCtx();
+        let rotated = 0;
+        (ctx as unknown as Record<string, unknown>).rotate = () => {
+            rotated += 1;
+        };
+        new DrawingPainter().paintAll(ctx, [d], fakeProjector(), theme);
+        expect(rotated).toBe(0);
     });
 });


### PR DESCRIPTION
## Summary
- User drawings no longer fold into pane autoscale, so placing or dragging a drawing into the empty margin leaves the window fitted to the series instead of jumping to follow the cursor. Pine drawings still expand the scale as before.
- Optional labels on trend line, ray, extended line, info line, and trend angle now follow the segment angle and flip so the text never reads upside-down. Flat text annotations stay horizontal.

## Test plan
- [ ] Arm a drawing tool and drag into the empty price margin — the pane should stay fitted to the series, not follow the cursor.
- [ ] Place a sloped trend line, add a label, and confirm the text sits along the line and stays upright when the slope is reversed.
- [ ] Confirm a plain text annotation still paints horizontally.
- [ ] Confirm Pine drawings still expand autoscale as before.

Made with [Cursor](https://cursor.com)