### PR TITLE
feat: trading sessions (RTH/ETH) — a session dimension on the market wired to the bottombar toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.6.1]
+
+### Added
+
+- **Trading sessions (RTH/ETH).** Charts gain a `session` dimension
+  (`'regular'` | `'extended'`) on markets that have one: pass it as a chart option,
+  switch it with `chart.setMarket({ session })`, or click the bottombar's RTH/ETH
+  toggle — previously a disabled stub, now live and enabled automatically when the
+  active symbol's metadata declares real sessions (crypto keeps the disabled chips).
+  A session switch reloads like a timeframe change; the two sessions cache as
+  separate series (their bars genuinely differ), the flag rides every provider
+  request (`BarRange.session`, `subscribe` `opts.session`), persists per cell
+  (`extended` only — documents stay lean), and travels in shareable URLs
+  (`?session=extended`). In a workspace the toggle acts on the ACTIVE cell, like
+  the range chips.
+
 ## [v0.6.0]
 
 ### Added

--- a/docs/contributing/adding-a-data-provider.md
+++ b/docs/contributing/adding-a-data-provider.md
@@ -19,7 +19,7 @@ One method is **required**; the rest are **progressive** — present them when y
 
 #### Required
 
-- **`getBars(ticker, timeframe, range)`** — return bars for the requested window. `ticker` is what the user typed minus any `provider:` prefix (any `.ext` suffix is **kept** — you own its meaning). `range` is `{ from?, to?, limit? }` (epoch ms; `to` omitted = now). The newest bar is treated as the forming candle.
+- **`getBars(ticker, timeframe, range)`** — return bars for the requested window. `ticker` is what the user typed minus any `provider:` prefix (any `.ext` suffix is **kept** — you own its meaning). `range` is `{ from?, to?, limit?, session? }` (epoch ms; `to` omitted = now). The newest bar is treated as the forming candle. `session` (`'regular'` | `'extended'`) names the trading session the chart shows on markets that have one — honor it if your source can filter (regular vs extended bars are cached as separate series), ignore it otherwise. The same flag reaches `subscribe` as `opts.session` (4th argument).
 
 #### Optional
 

--- a/docs/user/options.md
+++ b/docs/user/options.md
@@ -17,6 +17,7 @@ How the chart obtains its candles.
 |---|---|---|
 | `symbol` | string | Symbol to load — the string is the WHOLE market identity. A **bare** ticker (`'BTCUSDT'`) resolves against the registered providers in **declaration order** (first one whose index lists it); an `EXCHANGE:` prefix (`'coinbase:BTC-USD'`, case-insensitive) **pins** the venue — a registered provider name, or a [listing prefix](./data-providers.md#listing-prefixes-nasdaqaapl) a provider's index declares (`'NASDAQ:AAPL'`, strict: a wrong venue resolves to nothing). |
 | `timeframe` | string | Bar interval, e.g. `'1h'`. |
+| `session` | `'regular' \| 'extended'` | Trading session to show, on markets that have one (`regular` = RTH, the default; `extended` = pre/post-market included). The flag rides every data request — providers without a session concept ignore it. Switch at runtime with `chart.setMarket({ session })` or the bottombar's RTH/ETH toggle. |
 | `bars` | number | How many bars of history to load. Depths beyond one ~10k-bar chunk paint the recent window first, then backfill older bars in the background — watch `history:progress` / await `chart.historyComplete()` for the full depth. |
 | `visibleRange` | `VisibleRangePreset \| {from,to}` | — | The window to frame on the **first paint** (`'1D'`, `'YTD'`, an explicit range…). The chart then loads its depth in one pass and paints that window straight away, instead of flashing a recent-bars preview and re-framing a moment later. |
 | `data` | `OHLCV[]` | **Offline bars.** When set, no network fetch happens. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/src/Vela.ts
+++ b/src/Vela.ts
@@ -106,6 +106,7 @@ export class Vela {
                 symbol: options.symbol,
                 timeframe: options.timeframe,
                 bars: options.bars,
+                session: options.session,
                 visibleRange: options.visibleRange,
                 data: options.data,
             },

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -484,7 +484,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
      *  an in-flight `setMarket` immediately (the config mutates before the load). */
     marketSnapshot(): MarketSnapshot {
         const m = this.config.market;
-        return { symbol: m.symbol, provider: parseSymbol(m.symbol ?? '').provider ?? undefined, timeframe: m.timeframe, bars: m.bars, offline: m.data !== undefined };
+        return { symbol: m.symbol, provider: parseSymbol(m.symbol ?? '').provider ?? undefined, timeframe: m.timeframe, bars: m.bars, session: m.session, offline: m.data !== undefined };
     }
 
     /**
@@ -507,6 +507,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         const identityChanged =
             (next.symbol !== undefined && next.symbol !== m.symbol) ||
             (next.timeframe !== undefined && next.timeframe !== m.timeframe) ||
+            // A session switch changes WHICH bars exist (RTH vs ETH) — a full reload,
+            // exactly like a timeframe change; the cache keys the sessions apart.
+            (next.session !== undefined && next.session !== m.session) ||
             next.data !== undefined;
         const depthChanged = next.bars !== undefined && next.bars !== m.bars;
         // Same market, only deeper/shallower, with bars already on screen: handled by moving
@@ -544,6 +547,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             if (next.symbol !== undefined) m.symbol = next.symbol;
             if (next.timeframe !== undefined) m.timeframe = next.timeframe;
             if (next.bars !== undefined) m.bars = next.bars;
+            if (next.session !== undefined) m.session = next.session;
             if (next.data !== undefined) m.data = next.data;
             else if (next.symbol !== undefined) delete m.data; // offline → provider switch
             m.visibleRange = next.visibleRange; // consumed by THIS load only (overwritten every switch)

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -8,6 +8,17 @@ import type { DrawingsOption } from './drawings/toolbar';
 /** A registered data-provider name (any string; matched case-insensitively). */
 export type ProviderName = string;
 
+/**
+ * Which trading session the chart shows, on markets that have one: `regular` = RTH
+ * (09:30–16:00 for US equities), `extended` = ETH (pre/post-market included). The
+ * provider owns the actual filtering — the flag rides every data request. Meaningless
+ * (and ignored end-to-end) on continuous markets like crypto.
+ */
+export type MarketSession = 'regular' | 'extended';
+
+/** Narrow an untrusted string (persisted document, URL param) to a {@link MarketSession}. */
+export const normalizeSession = (v: unknown): MarketSession | undefined => (v === 'regular' || v === 'extended' ? v : undefined);
+
 /** How the chart obtains its candles. */
 export interface MarketConfig {
     /** The market's symbol. A bare ticker (`'BTCUSDT'`) resolves against the registered
@@ -16,6 +27,9 @@ export interface MarketConfig {
     symbol?: string;
     timeframe?: string;
     bars?: number;
+    /** Trading session to show ({@link MarketSession}). Absent = the provider's default
+     *  (`regular` on session markets); continuous markets ignore it entirely. */
+    session?: MarketSession;
     /**
      * The window to frame on the FIRST paint — a preset name (`'1D'`, `'YTD'`, …) or an
      * explicit `{from, to}`. Set it when the initial view is known up front (a range
@@ -40,6 +54,8 @@ export interface MarketSwitch {
     symbol?: string;
     timeframe?: string;
     bars?: number;
+    /** Switch the shown trading session (reloads like a timeframe change). */
+    session?: MarketSession;
     data?: OHLCV[];
     visibleRange?: VisibleRangePreset | VisibleRange;
 }
@@ -58,6 +74,8 @@ export interface MarketSnapshot {
     provider?: ProviderName;
     timeframe?: string;
     bars?: number;
+    /** The shown trading session — undefined = the provider's default (regular). */
+    session?: MarketSession;
     offline: boolean;
 }
 

--- a/src/core/ports/DataProvider.ts
+++ b/src/core/ports/DataProvider.ts
@@ -84,9 +84,11 @@ export interface DataProvider {
     /**
      * Open a true live stream for `ticker`/`timeframe`. Each call to `onBar` delivers
      * the forming candle (or a freshly-closed one). Returns an unsubscribe fn. Absent
-     * ⇒ the feed polls `getBars` for ticks instead.
+     * ⇒ the feed polls `getBars` for ticks instead. `opts.session` names the trading
+     * session the chart is showing (see {@link BarRange.session}) — a provider whose
+     * live source cannot filter by session may fall back to polling internally.
      */
-    subscribe?(ticker: string, timeframe: string, onBar: (bar: OHLCV) => void): Unsubscribe;
+    subscribe?(ticker: string, timeframe: string, onBar: (bar: OHLCV) => void, opts?: { session?: string }): Unsubscribe;
 
     /** Apply runtime config (e.g. API keys). Absent ⇒ no configuration needed. */
     configure?(config: unknown): void;

--- a/src/core/ports/MarketDataFeed.ts
+++ b/src/core/ports/MarketDataFeed.ts
@@ -29,6 +29,12 @@ export interface BarRange {
     to?: number;
     /** Max bars. */
     limit?: number;
+    /**
+     * Trading session to serve (`'regular'` | `'extended'`) — rides every request on
+     * markets that have sessions; absent = the provider's default. A provider without
+     * a session concept ignores it.
+     */
+    session?: string;
 }
 
 export interface MarketDataFeed {

--- a/src/data/BarStore.ts
+++ b/src/data/BarStore.ts
@@ -1,8 +1,11 @@
 import type { OHLCV } from '../core/model/ohlcv';
 
-/** Cache key for one series. Symbols/timeframes never contain `|`. */
-export function seriesKey(provider: string, symbol: string, timeframe: string): string {
-    return `${provider}|${symbol}|${timeframe}`;
+/** Cache key for one series. Symbols/timeframes never contain `|`. The session is a
+ *  KEY dimension when non-default: regular and extended bars of one symbol genuinely
+ *  differ (extended has more bars, and session dailies differ in OHLC), so they must
+ *  never share a series. Absent/`regular` stays keyless — existing keys don't move. */
+export function seriesKey(provider: string, symbol: string, timeframe: string, session?: string): string {
+    return `${provider}|${symbol}|${timeframe}${session && session !== 'regular' ? `|${session}` : ''}`;
 }
 
 function symbolOf(key: string): string {

--- a/src/data/CachingDataFeed.ts
+++ b/src/data/CachingDataFeed.ts
@@ -8,10 +8,11 @@ import { timeframeToMs } from './timeframe';
 
 /** Series cache key — the symbol's own grammar carries the venue: a `provider:` prefix
  *  keys per venue (the multi-provider feed hands canonical prefixed symbols down); a
- *  bare symbol keys venue-less, whatever serves it (single-feed setups). */
-function cacheKey(symbol: string, timeframe: string): string {
+ *  bare symbol keys venue-less, whatever serves it (single-feed setups). A non-default
+ *  session keys its own series (regular and extended bars genuinely differ). */
+function cacheKey(symbol: string, timeframe: string, session?: string): string {
     const { provider, ticker } = parseSymbol(symbol);
-    return seriesKey(provider ?? '', ticker, timeframe);
+    return seriesKey(provider ?? '', ticker, timeframe, session);
 }
 
 /** Page size for big ranged fetches (mirrors the orchestrator's history chunks). */
@@ -45,7 +46,7 @@ export class CachingDataFeed implements MarketDataFeed {
         if (cfg.data && cfg.data.length > 0) return this.inner.load(cfg);
 
         const symbol = cfg.symbol ?? 'TEST';
-        const key = cacheKey(symbol, cfg.timeframe ?? '60');
+        const key = cacheKey(symbol, cfg.timeframe ?? '60', cfg.session);
         this.store.retainSymbol(symbol); // current-symbol-only purge
         const cached = this.store.get(key);
         const n = cfg.bars ?? 500;
@@ -81,7 +82,7 @@ export class CachingDataFeed implements MarketDataFeed {
      */
     async loadRange(cfg: MarketConfig, range: BarRange): Promise<OHLCV[]> {
         if (!this.inner.loadRange) return this.inner.load(cfg);
-        const key = cacheKey(cfg.symbol ?? 'TEST', cfg.timeframe ?? '60');
+        const key = cacheKey(cfg.symbol ?? 'TEST', cfg.timeframe ?? '60', cfg.session);
         let cached = this.store.get(key);
         let newest = cached?.[cached.length - 1];
 

--- a/src/data/MultiProviderFeed.ts
+++ b/src/data/MultiProviderFeed.ts
@@ -261,14 +261,14 @@ class RegistryFetchFeed implements MarketDataFeed {
         const { provider: name, ticker } = parseSymbol(cfg.symbol ?? '');
         const provider = this.registry.get(name ?? '');
         if (!provider) return Promise.resolve([]);
-        return safeBars(provider, ticker, cfg.timeframe ?? '60', { limit: cfg.bars ?? 500 });
+        return safeBars(provider, ticker, cfg.timeframe ?? '60', { limit: cfg.bars ?? 500, session: cfg.session });
     }
 
     loadRange(cfg: MarketConfig, range: BarRange): Promise<OHLCV[]> {
         const { provider: name, ticker } = parseSymbol(cfg.symbol ?? '');
         const provider = this.registry.get(name ?? '');
         if (!provider) return Promise.resolve([]);
-        return safeBars(provider, ticker, cfg.timeframe ?? '60', range);
+        return safeBars(provider, ticker, cfg.timeframe ?? '60', { ...range, session: cfg.session });
     }
 
     subscribe(cfg: MarketConfig, onBar: (bar: OHLCV) => void): Unsubscribe {
@@ -276,7 +276,7 @@ class RegistryFetchFeed implements MarketDataFeed {
         const provider = this.registry.get(name ?? '');
         if (!provider) return () => {};
         const tf = cfg.timeframe ?? '60';
-        if (provider.subscribe) return provider.subscribe(ticker, tf, onBar);
+        if (provider.subscribe) return provider.subscribe(ticker, tf, onBar, cfg.session ? { session: cfg.session } : undefined);
 
         let stopped = false;
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -285,7 +285,7 @@ class RegistryFetchFeed implements MarketDataFeed {
             try {
                 // Last two bars: the (possibly just-closed) previous bar and the forming
                 // one. onBar dedupes by time, so the older one is harmless.
-                const bars = await provider.getBars(ticker, tf, { limit: 2 });
+                const bars = await provider.getBars(ticker, tf, { limit: 2, session: cfg.session });
                 // Re-check AFTER the await: an unsubscribe during the fetch (a market
                 // switch) must not push the OLD market's bars into the new series — on the
                 // same timeframe the forming bar shares its open time, so a stale bar would

--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -62,6 +62,8 @@ export interface CellState {
     timeframe?: string;
     priceStyle?: string;
     bars?: number;
+    /** Trading session shown (`'extended'` persisted; absent = regular, the default). */
+    session?: string;
     /** Symbol watermark visibility — a per-chart display pref. */
     watermark?: boolean;
     /** Indicator titles (the in-chart legend rows) visibility — a per-chart display pref. */
@@ -182,6 +184,7 @@ function sanitizeCell(raw: unknown): CellState | null {
     if (typeof c.timeframe === 'string') out.timeframe = c.timeframe;
     if (typeof c.priceStyle === 'string') out.priceStyle = c.priceStyle;
     if (typeof c.bars === 'number' && Number.isFinite(c.bars) && c.bars > 0) out.bars = c.bars;
+    if (c.session === 'regular' || c.session === 'extended') out.session = c.session;
     if (typeof c.watermark === 'boolean') out.watermark = c.watermark;
     if (typeof c.indicatorTitles === 'boolean') out.indicatorTitles = c.indicatorTitles;
     if (typeof c.indicatorValues === 'boolean') out.indicatorValues = c.indicatorValues;

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -7,7 +7,7 @@
 // Cosmetic state (price style, timezone) survives rebuilds via renderer features.
 import { Vela } from '../Vela';
 import { registerBuiltinChartTypes } from '../chart-types/builtins';
-import type { VelaOptions } from '../core/options';
+import { normalizeSession, type MarketSession, type VelaOptions } from '../core/options';
 import { resolveTheme } from '../core/theme';
 import type { DataProvider } from '../core/ports/DataProvider';
 import type { ScriptingEngine } from '../core/ports/ScriptingEngine';
@@ -107,6 +107,8 @@ export class VelaWidget {
     private priceStyle: string;
     private timezone: string;
     private bars: number;
+    /** The shown trading session — undefined = the provider default (regular). */
+    private session: MarketSession | undefined;
     private watermarkOn: boolean;
     /** Indicator titles (the in-chart legend rows) shown — reapplied across rebuilds. */
     private indicatorTitlesOn = true;
@@ -205,6 +207,7 @@ export class VelaWidget {
         this.priceStyle = fromUrl.priceStyle ?? bootCell?.priceStyle ?? opts.priceStyle ?? 'candles';
         this.timezone = fromUrl.timezone ?? boot?.timezone ?? opts.timezone ?? 'Etc/UTC';
         this.bars = Number(fromUrl.bars ?? bootCell?.bars ?? opts.bars ?? 1000);
+        this.session = normalizeSession(fromUrl.session ?? bootCell?.session ?? opts.session);
         this.watermarkOn = bootCell?.watermark !== undefined ? bootCell.watermark : opts.watermark !== false;
         this.indicatorTitlesOn = bootCell?.indicatorTitles ?? true;
         this.indicatorValuesOn = bootCell?.indicatorValues ?? true;
@@ -336,6 +339,7 @@ export class VelaWidget {
                       timezone: this.timezone,
                       onRange: (preset) => this.applyRange(preset),
                       onTimezone: (zone) => this.setTimezone(zone),
+                      onSession: (session) => this.setSession(session),
                       onSettingsClick: () => this.inner?.renderer.openSettings(),
                   })
                 : null;
@@ -629,6 +633,32 @@ export class VelaWidget {
         void this.inner?.setMarket({ timeframe: tf, bars: this.bars });
     }
 
+    /**
+     * Switch the shown trading session (RTH/ETH) in place — a full reload, like a
+     * timeframe change (the two sessions are different bar series). No-op on a chart
+     * already showing that session; meaningless on continuous markets (the toggle is
+     * disabled there, but the API tolerates the call — the provider ignores the flag).
+     */
+    setSession(session: MarketSession): void {
+        if (session === this.session || (session === 'regular' && this.session === undefined) || this.destroyed) return;
+        this.session = session;
+        this.refreshSessionToggle();
+        this.markStateDirty();
+        void this.inner?.setMarket({ session });
+    }
+
+    /** Re-derive the RTH/ETH toggle's posture from the ACTIVE symbol's metadata: enabled
+     *  iff the resolved symbol declares a real session vocabulary (not `24x7`). */
+    private refreshSessionToggle(): void {
+        const chart = this.inner;
+        if (!chart || !this.bottombar) return;
+        void chart.data.symbolInfo(this.symbol).then((si) => {
+            if (this.destroyed || this.inner !== chart) return;
+            const enabled = typeof si?.session === 'string' && si.session !== '' && si.session !== '24x7';
+            this.bottombar?.setSession({ session: this.session ?? 'regular', enabled });
+        });
+    }
+
     /** Star/unstar a timeframe — the topbar chips and dropdown stars follow, and the
      *  set persists with the rest of the shell state. */
     private setTimeframeFavorite(tf: string, on: boolean): void {
@@ -686,6 +716,10 @@ export class VelaWidget {
         cell.timeframe = live?.timeframe ?? this.timeframe;
         cell.priceStyle = this.priceStyle;
         if (this.bars > 0) cell.bars = this.bars;
+        // Only the non-default persists: absent = regular, so toggling back to RTH
+        // leaves the document as lean as before the feature existed.
+        const session = normalizeSession(live?.session ?? this.session);
+        if (session === 'extended') cell.session = session;
         cell.watermark = this.watermarkOn;
         cell.indicatorTitles = this.indicatorTitlesOn;
         cell.indicatorValues = this.indicatorValuesOn;
@@ -759,9 +793,15 @@ export class VelaWidget {
             const symbol = fromUrl.symbol ?? prefixedSymbol(cell);
             const timeframe = fromUrl.timeframe ?? cell.timeframe;
             const bars = Number(fromUrl.bars ?? cell.bars ?? 0);
-            const next: { symbol?: string; timeframe?: string; bars?: number } = {};
+            const session = normalizeSession(fromUrl.session ?? cell.session);
+            const next: { symbol?: string; timeframe?: string; bars?: number; session?: MarketSession } = {};
             if (symbol && symbol !== this.symbol) next.symbol = symbol;
             if (timeframe && timeframe !== this.timeframe) next.timeframe = timeframe;
+            if (session && session !== (this.session ?? 'regular')) {
+                this.session = session;
+                next.session = session;
+                this.refreshSessionToggle();
+            }
             if (bars > 0 && bars !== this.bars) {
                 this.bars = bars;
                 next.bars = Math.max(bars, this.rangeBars);
@@ -1015,6 +1055,7 @@ export class VelaWidget {
             symbol: this.symbol,
             timeframe: this.timeframe,
             bars: Math.max(this.bars, this.rangeBars),
+            session: this.session,
             volume: this.ledgerVolume ?? chartOpts.volume,
             // A pending range chip frames the FIRST paint (no preview flash, no re-frame).
             ...(this.pendingRange ? { visibleRange: this.pendingRange.preset } : {}),
@@ -1027,7 +1068,9 @@ export class VelaWidget {
         // The venue chip painted from the typed/persisted prefix is provisional: once the
         // indexes settle, re-derive it from the DATA (listing prefix beats registration name).
         void chart.data.ready().then(() => {
-            if (this.inner === chart) this.statusline?.setMeta(this.timeframe, this.providerLabel());
+            if (this.inner !== chart) return;
+            this.statusline?.setMeta(this.timeframe, this.providerLabel());
+            this.refreshSessionToggle(); // symbol metadata can now answer "has sessions?"
         });
         // A fresh renderer starts desktop — push the live mode (constructor-time builds
         // run before layoutCtl exists; the controller's first evaluation covers them).
@@ -1138,6 +1181,7 @@ export class VelaWidget {
                 this.statusline?.setSymbol(symbol);
                 this.objectTree.setSymbol(symbol);
                 this.watermark?.update(symbol, this.timeframe);
+                this.refreshSessionToggle(); // the new symbol may (not) have sessions
             }
             if (timeframe !== this.timeframe) this.syncTimeframeChrome(timeframe);
         });
@@ -1480,6 +1524,8 @@ export class VelaWidget {
                 priceStyle: this.priceStyle,
                 timezone: this.timezone,
                 bars: String(this.bars),
+                // Empty clears the param — the default (regular) keeps links lean.
+                session: this.session === 'extended' ? 'extended' : '',
                 watermark: this.watermarkOn ? '1' : '0',
                 favorites: this.favs.join(','),
             });

--- a/src/widget/bottombar.ts
+++ b/src/widget/bottombar.ts
@@ -91,10 +91,12 @@ const CSS = `
     color: var(--vela-fg-muted);
     font-size: 11px;
     font-weight: 600;
-    cursor: not-allowed;
-    opacity: 0.55;
+    cursor: pointer;
 }
-.vela-bb-session-btn.is-active { color: var(--vela-fg); background: var(--vela-surface-elev); opacity: 0.8; }
+.vela-bb-session-btn:disabled { cursor: not-allowed; opacity: 0.55; }
+.vela-bb-session-btn:not(:disabled):hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
+.vela-bb-session-btn.is-active { color: var(--vela-fg); background: var(--vela-surface-elev); }
+.vela-bb-session-btn.is-active:disabled { opacity: 0.8; }
 .vela-bb-settings {
     all: unset;
     display: inline-flex;
@@ -115,6 +117,8 @@ export interface BottombarOptions {
     timezone: string;
     onRange: (preset: RangePreset) => void;
     onTimezone: (zone: string) => void;
+    /** RTH/ETH toggled by the user. Fires only while the toggle is ENABLED (see {@link Bottombar.setSession}). */
+    onSession?: (session: 'regular' | 'extended') => void;
     onSettingsClick?: () => void;
 }
 
@@ -126,6 +130,8 @@ export class Bottombar {
     private readonly tzMenu: Menu;
     private readonly settingsTip: Tooltip | null = null;
     private readonly rangeButtons = new Map<string, HTMLButtonElement>();
+    private readonly sessionButtons = new Map<'regular' | 'extended', HTMLButtonElement>();
+    private sessionEl: HTMLElement | null = null;
     private timezone: string;
     private timer: ReturnType<typeof setInterval> | null = null;
 
@@ -161,14 +167,21 @@ export class Bottombar {
         this.tzButton.append(this.clockEl, this.tzLabelEl);
         const session = doc.createElement('span');
         session.className = 'vela-bb-session';
-        // Reference-exact stub: RTH is the active chip, both disabled — sessions only
-        // apply to stocks/ETFs and the renderer has no session model (documented gap).
+        this.sessionEl = session;
+        // Boots in the DISABLED posture (sessions only apply to markets that have them);
+        // the host enables it per active chart via `setSession` once symbol metadata lands.
         session.title = 'Session — stocks & ETFs only';
-        for (const [label, active] of [['RTH', true], ['ETH', false]] as const) {
+        for (const [key, label] of [['regular', 'RTH'], ['extended', 'ETH']] as const) {
             const b = doc.createElement('button');
-            b.className = 'vela-bb-session-btn' + (active ? ' is-active' : '');
+            b.className = 'vela-bb-session-btn' + (key === 'regular' ? ' is-active' : '');
             b.textContent = label;
             b.disabled = true;
+            b.addEventListener('click', () => {
+                if (b.disabled) return;
+                this.setSession({ session: key, enabled: true }); // optimistic — the reload confirms
+                opts.onSession?.(key);
+            });
+            this.sessionButtons.set(key, b);
             session.appendChild(b);
         }
         const settingsBtn = doc.createElement('button');
@@ -208,6 +221,20 @@ export class Bottombar {
         for (const [key, b] of this.rangeButtons) {
             if (id !== null && key === id) b.dataset.active = '1';
             else delete b.dataset.active;
+        }
+    }
+
+    /**
+     * Reflect the ACTIVE chart's session posture. `enabled: false` (a continuous
+     * market, or metadata not landed yet) shows the disabled RTH-active stub — the
+     * pre-session-model look, byte-for-byte. Enabled, the chips become clickable and
+     * the active one tracks the chart's current session.
+     */
+    setSession(state: { session: 'regular' | 'extended'; enabled: boolean }): void {
+        if (this.sessionEl) this.sessionEl.title = state.enabled ? 'Session — regular (RTH) vs extended (ETH) hours' : 'Session — stocks & ETFs only';
+        for (const [key, b] of this.sessionButtons) {
+            b.disabled = !state.enabled;
+            b.classList.toggle('is-active', state.enabled ? key === state.session : key === 'regular');
         }
     }
 

--- a/src/widget/persist.ts
+++ b/src/widget/persist.ts
@@ -60,6 +60,8 @@ export interface PersistedState {
     priceStyle?: string;
     timezone?: string;
     bars?: string;
+    /** Trading session (`regular` | `extended`) — URL param `session`. */
+    session?: string;
     watermark?: string;
     /** Comma-joined favorite drawing-tool types. */
     favorites?: string;

--- a/src/widget/url-state.ts
+++ b/src/widget/url-state.ts
@@ -10,6 +10,7 @@ const PARAMS: ReadonlyArray<[key: keyof PersistedState, param: string]> = [
     ['priceStyle', 'style'],
     ['timezone', 'tz'],
     ['bars', 'bars'],
+    ['session', 'session'],
 ];
 
 export function readUrlState(search: string): PersistedState {

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -7,7 +7,7 @@
 // layout change — its state then round-trips through the workspace pool, so shrinking
 // 4 → 2 → 4 restores the third and fourth exactly, indicators and drawings included).
 import { Vela } from '../Vela';
-import type { VelaTheme, NativeBackend, VelaOptions } from '../core/options';
+import { normalizeSession, type MarketSession, type NativeBackend, type VelaOptions, type VelaTheme } from '../core/options';
 import type { OHLCV } from '../core/model/ohlcv';
 import type { VisibleRangePreset } from '../core/visible-range';
 import type { VisibleRange } from '../core/ports/IChartRenderer';
@@ -37,6 +37,8 @@ export interface CellSeed {
     timeframe?: string;
     priceStyle?: string;
     bars?: number;
+    /** Trading session to show (markets that have one; `regular` is the default). */
+    session?: string;
     /** Offline bars for this cell — replaces the provider (boot-only). */
     data?: OHLCV[];
     /** Initial visible window (boot-only). */
@@ -53,12 +55,13 @@ export type CellBoot = PooledCellState & Pick<CellSeed, 'data' | 'visibleRange'>
 
 /** The per-cell SEED the workspace's top-level chart options provide — same words as
  *  the widget; `cells[id]` spreads over this. */
-export function seedDefaults(opts: Pick<VelaOptions, 'symbol' | 'timeframe' | 'bars' | 'priceStyle' | 'data' | 'visibleRange'>): CellSeed {
+export function seedDefaults(opts: Pick<VelaOptions, 'symbol' | 'timeframe' | 'bars' | 'priceStyle' | 'session' | 'data' | 'visibleRange'>): CellSeed {
     return {
         symbol: opts.symbol,
         timeframe: opts.timeframe,
         bars: opts.bars,
         priceStyle: opts.priceStyle,
+        session: opts.session,
         data: opts.data,
         visibleRange: opts.visibleRange,
     };
@@ -152,6 +155,8 @@ export class ChartCell {
     lastCrossPrice: number | null = null;
     /** The bottombar range chip this cell is framed on (null = none). */
     activeRangeId: string | null = null;
+    /** Latched verdict of {@link sessionAvailable} (async metadata, sticky per symbol). */
+    private sessionAvailableFlag = false;
 
     private inner: Vela | null;
     /** The live app theme — seeded from deps, updated on `theme:changed` (the base the
@@ -195,7 +200,7 @@ export class ChartCell {
         // The canonical symbol form: pre-prefix pooled/persisted states carried the venue
         // in `provider` beside a bare symbol — weld them back together once, at boot.
         const symbol = prefixedSymbol(seed);
-        this.state = { symbol, provider: parseSymbol(symbol ?? '').provider ?? undefined, timeframe: seed.timeframe, priceStyle: seed.priceStyle, bars: seed.bars };
+        this.state = { symbol, provider: parseSymbol(symbol ?? '').provider ?? undefined, timeframe: seed.timeframe, priceStyle: seed.priceStyle, bars: seed.bars, session: normalizeSession(seed.session) };
         const doc = gridHost.ownerDocument;
         this.host = doc.createElement('div');
         this.host.className = 'vela-cell';
@@ -215,6 +220,7 @@ export class ChartCell {
                 timeframe: seed.timeframe,
                 bars: seed.bars,
                 priceStyle: seed.priceStyle,
+                session: normalizeSession(seed.session),
                 data: seed.data,
                 visibleRange: seed.visibleRange,
                 theme: deps.theme,
@@ -304,6 +310,7 @@ export class ChartCell {
         // `edgx:AAPL` must come back up reading NASDAQ.
         void this.inner.data.ready().then(() => {
             if (this.inner && this.state.symbol) this.statusline?.setMeta(this.state.timeframe ?? '60', this.inner.data.displayPrefix(this.state.symbol) ?? this.state.provider ?? '');
+            this.refreshSessionAvailable();
         });
         this.syncStatuslineColors();
         this.contextMenu = new ChartContextMenu(this.host, {
@@ -444,12 +451,50 @@ export class ChartCell {
             this.state.symbol = symbol;
             this.state.provider = parseSymbol(symbol).provider ?? undefined;
             this.state.timeframe = timeframe;
+            this.state.session = normalizeSession(this.inner?.market.session);
             this.watermark?.update(symbol, timeframe);
             this.statusline?.setSymbol(symbol);
             this.statusline?.setMeta(timeframe, this.inner?.data.displayPrefix(symbol) ?? this.state.provider ?? '');
             if (this.inner) this.statusline?.onChart(this.inner); // drop the old market's resting OHLC
             this.refreshNativeCatalog(); // per-symbol support flags may differ
+            this.refreshSessionAvailable(); // the new symbol may (not) have sessions
             this.deps.onMarketChanged(this.id);
+        });
+    }
+
+    /**
+     * Does this cell's market HAVE sessions (RTH/ETH meaningful)? Derived from the
+     * symbol's own metadata (`syminfo.session !== '24x7'`), asynchronously — the
+     * workspace re-projects the shared bottombar when the verdict lands or changes.
+     */
+    get sessionAvailable(): boolean {
+        return this.sessionAvailableFlag;
+    }
+
+    /** This cell's shown session (`regular` when unset — the provider default). */
+    get session(): MarketSession {
+        return normalizeSession(this.state.session) ?? 'regular';
+    }
+
+    /** Switch this cell's shown session in place (a reload — RTH and ETH are different bars). */
+    setSession(session: MarketSession): void {
+        if (session === this.session) return;
+        this.state.session = session;
+        this.deps.onStateDirty();
+        void this.inner?.setMarket({ session });
+    }
+
+    private refreshSessionAvailable(): void {
+        const chart = this.inner;
+        const symbol = this.state.symbol;
+        if (!chart || !symbol) return;
+        void chart.data.symbolInfo(symbol).then((si) => {
+            if (this.inner !== chart) return;
+            const available = typeof si?.session === 'string' && si.session !== '' && si.session !== '24x7';
+            if (available !== this.sessionAvailableFlag) {
+                this.sessionAvailableFlag = available;
+                this.deps.onMarketChanged(this.id); // re-project the shared bottombar toggle
+            }
         });
     }
 

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -516,6 +516,9 @@ export class VelaWorkspace {
                           this.bottombar?.setActiveRange(preset.id);
                       },
                       onTimezone: (zone) => this.setTimezone(zone),
+                      // RTH/ETH acts on the ACTIVE cell (like the range chips): sessions
+                      // are a per-chart market dimension, not a shell preference.
+                      onSession: (session) => this.active.setSession(session),
                       onSettingsClick: () => this.active.chart.renderer.openSettings(),
                   })
                 : null;
@@ -909,6 +912,7 @@ export class VelaWorkspace {
         this.objectTree.setSymbol(cell.symbol);
         this.dock.onChart(cell.chart); // every docked panel follows the active cell
         this.bottombar?.setActiveRange(cell.activeRangeId);
+        this.bottombar?.setSession({ session: cell.session, enabled: cell.sessionAvailable });
         this.indicatorPicker?.sync(); // the dialog may be open while the active cell changes
         this.glider.stop(); // a mid-glide switch must not steer the next cell's viewport
         // Shared drawing toolbar ⇄ the active cell: re-apply the GLOBAL tool + magnet + stay
@@ -1380,6 +1384,7 @@ export class VelaWorkspace {
         this.mobileBar?.setSymbol(cell.symbol);
         this.mobileBar?.setTimeframe(cell.timeframe);
         this.objectTree.setSymbol(cell.symbol);
+        this.bottombar?.setSession({ session: cell.session, enabled: cell.sessionAvailable });
     }
 
     /** Trigger ② — a cell's indicator ledger changed: count + picker only if active. */

--- a/test/caching-data-feed.test.ts
+++ b/test/caching-data-feed.test.ts
@@ -384,3 +384,23 @@ describe('BarStore', () => {
         expect(store.get(seriesKey('binance', 'ETHUSDT', '240'))).toBeUndefined();
     });
 });
+
+describe('session-keyed series (RTH vs ETH are different bars)', () => {
+    it('seriesKey keys extended apart and leaves regular/absent on the legacy key', () => {
+        expect(seriesKey('edgx', 'AAPL', '60')).toBe('edgx|AAPL|60');
+        expect(seriesKey('edgx', 'AAPL', '60', 'regular')).toBe('edgx|AAPL|60'); // default = keyless
+        expect(seriesKey('edgx', 'AAPL', '60', 'extended')).toBe('edgx|AAPL|60|extended');
+    });
+
+    it('the two sessions never share cached bars, and the flag reaches the inner feed', async () => {
+        const { feed, store, cf } = setup(600);
+        const regular = await cf.load({ symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500 });
+        // Extended is a COLD series of its own — a fresh full load, not the cached regular bars.
+        const callsAfterRegular = feed.loadCalls;
+        const extended = await cf.load({ symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500, session: 'extended' });
+        expect(feed.loadCalls).toBe(callsAfterRegular + 1);
+        expect(times(extended)).toEqual(times(regular)); // same fake universe...
+        expect(store.get(seriesKey('binance', 'BTCUSDT', '60'))).toBeDefined();
+        expect(store.get(seriesKey('binance', 'BTCUSDT', '60', 'extended'))).toBeDefined(); // ...two series
+    });
+});

--- a/test/multi-provider-feed.test.ts
+++ b/test/multi-provider-feed.test.ts
@@ -595,3 +595,41 @@ describe('listing-prefix resolution (TradingView parity)', () => {
         expect(feed.displayPrefix('NOPE:NOPE')).toBeNull();
     });
 });
+
+describe('session flag propagation (provider seam)', () => {
+    it('rides getBars ranges (load, loadRange, poll) and the subscribe opts', async () => {
+        const ranges: Array<Record<string, unknown>> = [];
+        const subOpts: unknown[] = [];
+        const provider: DataProvider = {
+            getBars(_t, _tf, range) {
+                ranges.push({ ...range });
+                return Promise.resolve(makeBars(range.limit ?? 10));
+            },
+            listSymbols: () => Promise.resolve([{ ticker: 'AAPL', prefix: 'NASDAQ' }]),
+            subscribe(_t, _tf, _onBar, opts) {
+                subOpts.push(opts);
+                return () => {};
+            },
+        };
+        const feed = new MultiProviderFeed(new BarStore());
+        feed.registerProvider('edgx', provider);
+        await feed.ready();
+
+        await feed.load({ symbol: 'NASDAQ:AAPL', timeframe: '60', bars: 5, session: 'extended' });
+        expect(ranges[ranges.length - 1]!.session).toBe('extended');
+
+        await feed.loadRange!({ symbol: 'NASDAQ:AAPL', timeframe: '60', session: 'extended' }, { from: 0, limit: 5 });
+        expect(ranges[ranges.length - 1]).toMatchObject({ from: 0, session: 'extended' });
+
+        const off = feed.subscribe({ symbol: 'NASDAQ:AAPL', timeframe: '60', session: 'extended' }, () => {});
+        off();
+        expect(subOpts).toEqual([{ session: 'extended' }]);
+
+        // No session set -> nothing invented: the flag is simply absent.
+        await feed.load({ symbol: 'NASDAQ:AAPL', timeframe: '60', bars: 5 });
+        expect(ranges[ranges.length - 1]!.session).toBeUndefined();
+        const off2 = feed.subscribe({ symbol: 'NASDAQ:AAPL', timeframe: '60' }, () => {});
+        off2();
+        expect(subOpts[1]).toBeUndefined();
+    });
+});

--- a/test/set-market.test.ts
+++ b/test/set-market.test.ts
@@ -286,6 +286,28 @@ describe('setMarket — in-place market switch', () => {
         expect(chart.market.symbol).toBe('BBB');
     });
 
+    it('a SESSION switch reloads like a timeframe change, and the flag rides the load config', async () => {
+        const feed = new SwitchFeed();
+        const renderer = new FakeRenderer();
+        const chart = make({ symbol: 'AAA', timeframe: '60', volume: false }, { renderer, engines: [], dataFeed: feed });
+        await chart.ready();
+        const events: unknown[] = [];
+        chart.on('market:changed', (e) => events.push(e));
+
+        await chart.setMarket({ session: 'extended' });
+
+        // The reload happened (same symbol — the SESSION is the changed identity),
+        // and the feed saw the flag on the load config (providers read it off BarRange).
+        expect(feed.loads[feed.loads.length - 1]).toMatchObject({ symbol: 'AAA', session: 'extended' });
+        expect(chart.market.session).toBe('extended');
+        expect(events).toHaveLength(1); // an identity change — the chrome must re-sync
+
+        // Same session again: a no-op, no reload.
+        const loadsBefore = feed.loads.length;
+        await chart.setMarket({ session: 'extended' });
+        expect(feed.loads.length).toBe(loadsBefore);
+    });
+
     it('frames a requested visibleRange on the first paint of the new market', async () => {
         const feed = new SwitchFeed();
         const renderer = new FakeRenderer();

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -261,6 +261,7 @@ describe('readUrlState', () => {
         expect(readUrlState('?interval=240')).toEqual({ timeframe: '240' });
         expect(readUrlState('')).toEqual({});
         expect(readUrlState('?symbol=')).toEqual({});
+        expect(readUrlState('?session=extended')).toEqual({ session: 'extended' }); // shareable ETH links
     });
 });
 

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -88,6 +88,21 @@ describe('sanitizeState (the applyState gate)', () => {
         });
     });
 
+    it('keeps a valid session value and drops anything else', () => {
+        const doc = sanitizeState({
+            version: 1,
+            layout: '1',
+            charts: [
+                { id: 'c1', symbol: 'NASDAQ:AAPL', session: 'extended' },
+                { id: 'c2', symbol: 'BTCUSDT', session: 'after-hours' }, // not a session → dropped
+            ],
+        });
+        expect(doc?.charts).toEqual([
+            { id: 'c1', symbol: 'NASDAQ:AAPL', session: 'extended' },
+            { id: 'c2', symbol: 'BTCUSDT' },
+        ]);
+    });
+
     it('filters non-string favorite entries, dropping empty sets entirely', () => {
         const doc = sanitizeState({
             version: 1,


### PR DESCRIPTION

Charts gain `session: 'regular' | 'extended'` on markets that have one. It is a MARKET dimension end-to-end: a chart option, `setMarket({ session })` (reloads like a timeframe change — the two sessions are different bar series), a snapshot field, and a flag riding every provider request (`BarRange.session`; `subscribe` grows an `opts.session` 4th argument — additive, existing providers ignore it).

The cache keys the sessions apart: `seriesKey` gains a session segment for non-default sessions only, so extended bars never pollute the regular series while every existing key stays byte-identical (crypto untouched).

The bottombar's RTH/ETH chips — a disabled stub until now — come alive: enabled when the ACTIVE symbol's metadata declares real sessions (`syminfo.session` ≠ `24x7`), the disabled stub look preserved everywhere else. In a workspace the toggle acts on the active cell, like the range chips, and re-projects on cell switches. The choice persists per cell (`extended` only — documents stay lean), survives restores, and travels in shareable URLs (`?session=extended`).

Docs: options, adding-a-data-provider, changelog. Tests: 5 new (session switch reloads + no-op dedup, session-keyed cache series, provider-seam propagation, sanitize gate, URL param);