### PR TITLE
feat: add conditional visibility for indicator inputs in settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Indicator inputs that show only when they matter.** An indicator input can now
+  declare a condition on another input's current value (a toggle being on, a dropdown
+  sitting on one choice or any of several), and its row appears in the settings dialog
+  only while that condition holds. The dialog re-evaluates live on every edit — flip
+  the governing toggle and the dependent rows appear or disappear in place, group
+  headings and tabs whose inputs are all hidden leave with them, and a hidden input
+  keeps its value for when it comes back.
+
 ## [v0.6.2]
 
 ### Added

--- a/docs/architecture/settings-rows.md
+++ b/docs/architecture/settings-rows.md
@@ -130,6 +130,13 @@ Gated values are **still stored and delivered** — hiding a row never clears it
 consumers decide what a hidden-but-set value means (usually: the gating toggle already
 disables the feature).
 
+The **indicator inputs dialog speaks the same condition vocabulary**: an `InputSchema`
+may carry a `when` (`InputCondition` / `InputWhen`, evaluated by `inputVisible(when,
+bag)`), and the gear dialog re-applies it live on every edit — rows hide and return,
+a group heading or tab whose inputs are all gated out leaves with them, and hidden
+inputs keep their values. Inputs sharing an `inline=` row show while any member's
+gate passes.
+
 **Duplicate keys across gated rows are supported.** Several `when`-gated rows may store
 under the same key(s) — the pattern for per-mode rows over one shared state (each mode
 gets its own row label, e.g. "Volume gradient" / "Delta gradient", while the gradient

--- a/src/core/model/index.ts
+++ b/src/core/model/index.ts
@@ -1,7 +1,8 @@
 export type { Millis } from './time';
 export type { OHLCV } from './ohlcv';
 
-export type { InputType, InputValue, InputSchema } from './inputs';
+export type { InputType, InputValue, InputSchema, InputCondition, InputWhen } from './inputs';
+export { inputVisible } from './inputs';
 export type {
     LineLikeKind,
     SeriesKind,

--- a/src/core/model/inputs.ts
+++ b/src/core/model/inputs.ts
@@ -28,6 +28,28 @@ export type InputValue = number | string | boolean;
  */
 export type SymbolPickerFn = (current: string, onPick: (symbol: string) => void) => void;
 
+/** One visibility condition on another input's current value: `equals` matches a single
+ *  value (a toggle, one dropdown choice), `anyOf` matches a set (several choices). */
+export interface InputCondition {
+    key: string;
+    equals?: InputValue;
+    anyOf?: readonly InputValue[];
+}
+
+/** An input's visibility gate: one condition, or several AND-ed together. */
+export type InputWhen = InputCondition | readonly InputCondition[];
+
+/**
+ * Evaluate a visibility gate against the dialog's resolved current values (an input's
+ * stored value, else its `defval`). No gate ⇒ visible. Mirrors the chart-settings row
+ * gate (`settingsRowVisible`) so both dialogs share one condition vocabulary.
+ */
+export function inputVisible(when: InputWhen | undefined, values: Record<string, InputValue>): boolean {
+    if (!when) return true;
+    const conds: readonly InputCondition[] = Array.isArray(when) ? when : [when as InputCondition];
+    return conds.every((c) => (c.anyOf ? c.anyOf.some((x) => x === values[c.key]) : values[c.key] === c.equals));
+}
+
 export interface InputSchema {
     /** Stable key used by `setInput()` — the engine's own variable id, falling back to `title`. */
     key: string;
@@ -46,5 +68,9 @@ export interface InputSchema {
     inline?: string;
     /** Settings-dialog tab hosting this input; unset ⇒ the default "Inputs" tab. */
     tab?: string;
+    /** Visibility gate: the input's row shows only while the condition(s) pass against
+     *  the dialog's current values — re-evaluated live on every edit. Inputs sharing an
+     *  `inline=` row show while ANY member's gate passes. A hidden input keeps its value. */
+    when?: InputWhen;
     tooltip?: string;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -131,6 +131,8 @@ export type * from './core/model';
 // Series ids must come from `stableSeriesId` so renderer reconciliation and persisted
 // per-series settings survive re-runs identically whichever engine produced the series.
 export { stableSeriesId } from './core/model';
+// Evaluate an input's `when` gate the way the settings dialog does (host-built inputs UIs).
+export { inputVisible } from './core/model';
 // The semantic palette (fixed brand/meaning colors, never theme-dependent) so plugin
 // output — default plot colors, layer inks — matches core affordances exactly.
 export * from './core/palette';

--- a/src/renderers/shared/IndicatorInputsDialog.ts
+++ b/src/renderers/shared/IndicatorInputsDialog.ts
@@ -1,4 +1,4 @@
-import type { InputSchema, InputValue, SymbolPickerFn } from '../../core/model/inputs';
+import { inputVisible, type InputSchema, type InputValue, type SymbolPickerFn } from '../../core/model/inputs';
 import type { VelaTheme } from '../../core/options';
 import { isDarkColor } from '../../core/color';
 import { iconAt } from '../../core/icons';
@@ -49,6 +49,8 @@ export class IndicatorInputsDialog {
     private row: IndicatorDialogRow | null = null;
     private snapshot: Record<string, InputValue> | null = null;
     private dialogTips: Array<() => void> = [];
+    /** Re-applies every `when` gate against current values; set while the dialog is open. */
+    private refreshVisibility: (() => void) | null = null;
     private choicePop: Popover | null = null;
     private calendarPop: Popover | null = null;
     private calendarAnchor: HTMLElement | null = null;
@@ -112,14 +114,17 @@ export class IndicatorInputsDialog {
         tabs.style.cssText = `display:flex;gap:12px;padding:0 20px;border-bottom:1px solid ${border};flex:0 0 auto;`;
         const tabEls: HTMLElement[] = [];
         const bodies: HTMLElement[] = [];
+        const gates: VisibilityGate[] = [];
+        let active = 0;
         const activate = (idx: number): void => {
+            active = idx;
             for (let i = 0; i < tabEls.length; i += 1) {
-                const active = i === idx;
+                const on = i === idx;
                 const el = tabEls[i]!;
-                el.style.borderBottomColor = active ? fg : 'transparent';
-                el.style.color = active ? 'inherit' : 'var(--vela-fg-muted)';
-                el.classList.toggle('vela-ind-tab-active', active);
-                bodies[i]!.style.display = active ? 'grid' : 'none';
+                el.style.borderBottomColor = on ? fg : 'transparent';
+                el.style.color = on ? 'inherit' : 'var(--vela-fg-muted)';
+                el.classList.toggle('vela-ind-tab-active', on);
+                bodies[i]!.style.display = on ? 'grid' : 'none';
             }
         };
         for (const [idx, def] of tabDefs.entries()) {
@@ -130,11 +135,27 @@ export class IndicatorInputsDialog {
             tab.addEventListener('click', () => activate(idx));
             tabs.appendChild(tab);
             tabEls.push(tab);
-            bodies.push(this.buildTabBody(def.inputs, row));
+            bodies.push(this.buildTabBody(def.inputs, row, gates));
+            // The strip label leaves only when every input on the tab is gated out —
+            // possible only when all of them carry a `when`.
+            if (def.inputs.every((d) => d.when)) {
+                gates.push({ el: tab, visible: (bag) => def.inputs.some((d) => inputVisible(d.when, bag)) });
+            }
         }
         ui.body.appendChild(tabs);
         for (const b of bodies) ui.body.appendChild(b);
         activate(0);
+        const refresh = (): void => {
+            const bag = valuesBag(row);
+            for (const g of gates) g.el.style.display = g.visible(bag) ? '' : 'none';
+            // An edit that gates the ACTIVE tab out lands the user on the first live one.
+            if (tabEls[active]?.style.display === 'none') {
+                const next = tabEls.findIndex((el) => el.style.display !== 'none');
+                if (next >= 0) activate(next);
+            }
+        };
+        this.refreshVisibility = refresh;
+        refresh();
 
         const onBackdropDown = (e: Event): void => {
             if (e.target !== ui.backdrop && e.target !== ui.positioner) return;
@@ -158,7 +179,7 @@ export class IndicatorInputsDialog {
 
     /** One tab's scrollable body — one shared grid so every group's controls share a
      *  left edge (a 100px number field lines up with a wider session/time pair). */
-    private buildTabBody(inputs: InputSchema[], row: IndicatorDialogRow): HTMLElement {
+    private buildTabBody(inputs: InputSchema[], row: IndicatorDialogRow, gates: VisibilityGate[]): HTMLElement {
         const body = document.createElement('div');
         // `display:contents` on each group lets headers + rows participate in this
         // one grid; per-section grids would each pick their own control-column width.
@@ -173,10 +194,22 @@ export class IndicatorInputsDialog {
         for (const group of groupInputs(inputs)) {
             const section = document.createElement('div');
             section.style.cssText = 'display:contents;';
+            let header: HTMLElement | null = null;
             if (group.name) {
-                section.appendChild(fieldSection(group.name, { variant: 'inputs', first: body.childElementCount === 0 }));
+                header = fieldSection(group.name, { variant: 'inputs', first: body.childElementCount === 0 });
+                section.appendChild(header);
             }
-            for (const inputRow of group.rows) this.buildInputRow(section, inputRow, row);
+            for (const inputRow of group.rows) {
+                const el = this.buildInputRow(section, inputRow, row);
+                if (inputRow.some((d) => d.when)) {
+                    gates.push({ el, visible: (bag) => rowVisible(inputRow, bag) });
+                }
+            }
+            // The heading follows its rows out only when every row can actually hide.
+            if (header && group.rows.every((r) => r.every((d) => d.when))) {
+                const rows = group.rows;
+                gates.push({ el: header, visible: (bag) => rows.some((r) => rowVisible(r, bag)) });
+            }
             body.appendChild(section);
         }
         return body;
@@ -185,6 +218,7 @@ export class IndicatorInputsDialog {
     close(): void {
         document.removeEventListener('keydown', this.onDialogKey);
         closeOpenPopovers();
+        this.refreshVisibility = null;
         this.choicePop = null;
         this.calendarPop = null;
         this.calendarAnchor = null;
@@ -216,12 +250,23 @@ export class IndicatorInputsDialog {
         this.close();
     }
 
+    /** Write one edit through: store it, notify the host, and re-apply the `when` gates. */
+    private commit(row: IndicatorDialogRow, key: string, value: InputValue): void {
+        row.values[key] = value;
+        this.host.onChange?.({ indicatorId: row.id, key, value });
+        this.refreshVisibility?.();
+    }
+
     /** One settings row (or several `inline=` inputs) placed into a section's grid. */
-    private buildInputRow(grid: HTMLElement, decls: InputSchema[], row: IndicatorDialogRow): void {
+    private buildInputRow(grid: HTMLElement, decls: InputSchema[], row: IndicatorDialogRow): HTMLElement {
         const idOf = (inp: InputSchema): string => `vela-inp-${row.id}-${inp.key}`;
+        const append = (el: HTMLElement): HTMLElement => {
+            grid.appendChild(el);
+            return el;
+        };
 
         if (decls.length > 1) {
-            grid.appendChild(fieldRow({
+            return append(fieldRow({
                 label: '',
                 inline: decls.map((d) => ({
                     label: nameOf(d) || undefined,
@@ -234,7 +279,6 @@ export class IndicatorInputsDialog {
                     ? this.infoButton([...decls].reverse().find((d) => d.tooltip)!.tooltip!)
                     : undefined,
             }));
-            return;
         }
 
         const lead = decls[0]!;
@@ -243,7 +287,7 @@ export class IndicatorInputsDialog {
 
         if (lead.type === 'bool') {
             const current = Boolean(row.values[lead.key] ?? lead.defval);
-            grid.appendChild(fieldRow({
+            return append(fieldRow({
                 label: nameOf(lead),
                 id,
                 bool: true,
@@ -251,28 +295,23 @@ export class IndicatorInputsDialog {
                 toggle: {
                     id,
                     checked: current,
-                    onChange: (v) => {
-                        row.values[lead.key] = v;
-                        this.host.onChange?.({ indicatorId: row.id, key: lead.key, value: v });
-                    },
+                    onChange: (v) => this.commit(row, lead.key, v),
                 },
             }));
-            return;
         }
 
         if (lead.type === 'text_area') {
-            grid.appendChild(fieldRow({
+            return append(fieldRow({
                 label: nameOf(lead),
                 id,
                 stacked: true,
                 info,
                 control: this.buildControl(row, lead, id),
             }));
-            return;
         }
 
         const fit = lead.type === 'color' || lead.type === 'session' || lead.type === 'time';
-        grid.appendChild(fieldRow({
+        return append(fieldRow({
             label: nameOf(lead),
             id,
             fit,
@@ -285,10 +324,7 @@ export class IndicatorInputsDialog {
     /** Build the typed control for one input, committing edits live via `onChange`. */
     private buildControl(row: IndicatorDialogRow, inp: InputSchema, id: string): HTMLElement {
         const current = row.values[inp.key] ?? inp.defval;
-        const emit = (value: InputValue): void => {
-            row.values[inp.key] = value;
-            this.host.onChange?.({ indicatorId: row.id, key: inp.key, value });
-        };
+        const emit = (value: InputValue): void => this.commit(row, inp.key, value);
 
         if (inp.type === 'bool') {
             return buildFieldControl({ kind: 'switch', id, checked: Boolean(current), onChange: (v) => emit(v) }).el;
@@ -728,6 +764,24 @@ export function tabInputs(inputs: InputSchema[]): InputTab[] {
         names.unshift(DEFAULT_INPUT_TAB);
     }
     return names.map((name) => ({ name, inputs: byTab.get(name)! }));
+}
+
+/** A dialog element shown only while `visible(bag)` holds — a gated row, group heading, or tab label. */
+interface VisibilityGate {
+    el: HTMLElement;
+    visible: (bag: Record<string, InputValue>) => boolean;
+}
+
+/** A row shows while ANY of its `inline=` members' gates pass (a member with no gate always passes). */
+function rowVisible(decls: InputSchema[], bag: Record<string, InputValue>): boolean {
+    return decls.some((d) => inputVisible(d.when, bag));
+}
+
+/** Current values resolved for gate evaluation: the stored value, else the input's `defval`. */
+function valuesBag(row: IndicatorDialogRow): Record<string, InputValue> {
+    const bag: Record<string, InputValue> = {};
+    for (const inp of row.inputs) bag[inp.key] = row.values[inp.key] ?? inp.defval;
+    return bag;
 }
 
 interface InputGroup {

--- a/test/inputs-when.test.ts
+++ b/test/inputs-when.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { inputVisible, type InputWhen, type InputValue } from '../src/core/model/inputs';
+
+const bag: Record<string, InputValue> = {
+    enabled: true,
+    mode: 'Manual',
+    level: 3,
+};
+
+describe('inputVisible — settings-dialog `when` gate', () => {
+    it('shows an input with no gate', () => {
+        expect(inputVisible(undefined, bag)).toBe(true);
+    });
+
+    it('matches a toggle with `equals`', () => {
+        expect(inputVisible({ key: 'enabled', equals: true }, bag)).toBe(true);
+        expect(inputVisible({ key: 'enabled', equals: false }, bag)).toBe(false);
+    });
+
+    it('matches one dropdown choice with `equals`', () => {
+        expect(inputVisible({ key: 'mode', equals: 'Manual' }, bag)).toBe(true);
+        expect(inputVisible({ key: 'mode', equals: 'Auto' }, bag)).toBe(false);
+    });
+
+    it('matches a set of dropdown choices with `anyOf`', () => {
+        expect(inputVisible({ key: 'mode', anyOf: ['Manual', 'Hybrid'] }, bag)).toBe(true);
+        expect(inputVisible({ key: 'mode', anyOf: ['Auto', 'Off'] }, bag)).toBe(false);
+    });
+
+    it('ANDs several conditions together', () => {
+        const both: InputWhen = [
+            { key: 'enabled', equals: true },
+            { key: 'mode', equals: 'Manual' },
+        ];
+        expect(inputVisible(both, bag)).toBe(true);
+        expect(inputVisible(both, { ...bag, mode: 'Auto' })).toBe(false);
+    });
+
+    it('compares strictly — a numeric value never matches its string twin', () => {
+        expect(inputVisible({ key: 'level', equals: 3 }, bag)).toBe(true);
+        expect(inputVisible({ key: 'level', equals: '3' }, bag)).toBe(false);
+    });
+
+    it('fails a condition on a key absent from the values', () => {
+        expect(inputVisible({ key: 'missing', equals: true }, bag)).toBe(false);
+        expect(inputVisible({ key: 'missing', anyOf: [true, false] }, bag)).toBe(false);
+    });
+});


### PR DESCRIPTION
- Introduced `InputCondition` and `InputWhen` types to manage visibility based on other input values.
- Updated `IndicatorInputsDialog` to dynamically show/hide input rows based on conditions.
- Enhanced `inputVisible` function to evaluate visibility gates live during edits.
- Updated documentation to reflect new features and usage of conditional inputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to the indicator settings dialog and new optional schema fields; no data-path or engine behavior changes, with tests covering gate evaluation.
> 
> **Overview**
> Indicator inputs can now declare a **`when`** gate on `InputSchema`, using the same vocabulary as chart-settings rows (`equals`, `anyOf`, AND-ed conditions). **`inputVisible`** evaluates those gates against stored values or `defval`, and **`inputVisible`** is exported from the model and plugin SDK for host-built UIs.
> 
> The indicator gear dialog **re-applies visibility on every live edit** via a central `commit` path: gated rows, group headings, and tab labels hide and show without rebuilding the form. If every input on a tab is gated out, the tab label disappears; if the active tab becomes hidden, focus moves to the first visible tab. **`inline=`** rows stay visible while **any** member’s gate passes. Hidden inputs **retain their values**.
> 
> Docs (`settings-rows.md`, CHANGELOG) and unit tests for `inputVisible` are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a359a66cc4ff2dd57a491fd7473eb18286a33481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->