### PR TITLE
fix: minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.6.4]
+
+### Fixed
+
+- **The workspace toolbar follows chart-style changes.** In a multi-chart
+  workspace, changing the active chart's style now updates the toolbar's style
+  button and its menu checkmark immediately — previously they refreshed only
+  when the active chart changed, so the button kept showing the old style's
+  icon.
+- **The timeframe button no longer looks stuck pressed.** Without favorite
+  timeframes, the compact timeframe trigger drew a permanent highlight
+  background. It now highlights on hover only, like the buttons around it; the
+  in-place highlight still marks the current timeframe among favorite chips.
+
 ## [v0.6.2]
 
 ### Added

--- a/src/widget/topbar.ts
+++ b/src/widget/topbar.ts
@@ -70,12 +70,14 @@ const CSS = `
     color: var(--vela-fg-muted);
 }
 .vela-widget-tf-caret:hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
+/* The merged trigger is a plain button (hover feedback only) — the highlight
+   background marks the CURRENT chip among favorites, and a lone trigger with a
+   permanent highlight would read as stuck-pressed. */
 .vela-widget-tf-caret[data-solo='1'] {
     width: auto;
     padding: 0 6px 0 9px;
     gap: 4px;
     color: var(--vela-fg-bright);
-    background: var(--vela-hover-strong);
     font-size: 13px;
     font-weight: 550;
     white-space: nowrap;

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -135,6 +135,8 @@ export interface CellDeps {
     activate(id: string): void;
     /** The cell's market changed in place (chrome/retention refresh upstream). */
     onMarketChanged(id: string): void;
+    /** The cell's price style changed in place (topbar icon/menu refresh upstream). */
+    onPriceStyleChanged(id: string): void;
     /** The cell's indicator ledger changed (count/picker refresh upstream). */
     onIndicatorsChanged(id: string): void;
     /** Persistable per-cell state changed outside the market/indicator channels
@@ -569,6 +571,7 @@ export class ChartCell {
         this.state.priceStyle = style;
         this.inner?.renderer.set('priceStyle', style);
         this.syncStatuslineColors(); // the OHLC ink follows the newly active style's colors
+        this.deps.onPriceStyleChanged(this.id);
     }
 
     /** OHLC/change ink in the status line follows the ACTIVE price style's configured

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -1043,6 +1043,7 @@ export class VelaWorkspace {
                 context: () => this.context(),
                 activate: (id) => this.setActiveCell(id),
                 onMarketChanged: (id) => this.onCellMarketChanged(id),
+                onPriceStyleChanged: (id) => this.onCellPriceStyleChanged(id),
                 onIndicatorsChanged: (id) => this.onCellIndicatorsChanged(id),
                 onStateDirty: () => this.markStateDirty(),
                 manifestSettled: () => this.manifestSettled,
@@ -1385,6 +1386,17 @@ export class VelaWorkspace {
         this.mobileBar?.setTimeframe(cell.timeframe);
         this.objectTree.setSymbol(cell.symbol);
         this.bottombar?.setSession({ session: cell.session, enabled: cell.sessionAvailable });
+    }
+
+    /** Trigger ② — a cell's price style changed: the topbar button/menu only if active.
+     *  Reads the cell back (not the requested style) so the button reflects what the
+     *  renderer actually applied. */
+    private onCellPriceStyleChanged(id: string): void {
+        this.markStateDirty();
+        if (id !== this.activeId) return;
+        const cell = this.cellsById.get(id);
+        if (!cell) return;
+        this.topbar.setPriceStyle(cell.priceStyle);
     }
 
     /** Trigger ② — a cell's indicator ledger changed: count + picker only if active. */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized workspace/topbar presentation and a new cell callback; no auth, data, or rendering pipeline changes.
> 
> **Overview**
> Two small UI fixes in the workspace chrome.
> 
> **Chart style button stays in sync.** When the active chart’s price style changes in place (`setPriceStyle`), the cell now notifies the workspace via `onPriceStyleChanged`, and the shared topbar updates its icon and style menu checkmark immediately—same “trigger ②” pattern as market/indicator updates, without waiting for a cell switch.
> 
> **Timeframe solo trigger styling.** With no favorite timeframe chips, the merged caret trigger no longer uses a permanent `hover-strong` background (which looked pressed). Current timeframe is still highlighted on favorite chips via `data-current`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57eb16e273377053b6c36745dc269da82d03b712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->