### PR TITLE
v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.6.3]
+
+### Added
+
+- **Auto and Log toggles on the price scale.** Hovering a price scale now reveals
+  two small buttons at its bottom — **A** for autoscale and **L** for the
+  logarithmic scale — sitting on a full-width background strip so the axis values
+  behind them stay readable. Each click toggles its mode for the hovered pane
+  independently (log never snaps the scale back to auto), and an active mode wears
+  the filled (selected) button style, so the scale's state is readable at a glance
+  without opening the axis menu. Hovering a letter shows its themed tooltip
+  (Auto / Logarithmic scale).
+- **Pre- and post-market session shading.** On markets with trading sessions,
+  showing the extended tape now tints the pre-market and post-market time bands
+  behind the candles (faint orange and blue by default), derived from the
+  provider's market calendar. Both colors are editable — chart settings → Symbol →
+  Trading session — and persist with the rest of the chart settings. The same
+  Trading session group also carries a Session dropdown, so RTH/ETH can be
+  switched from the settings dialog as well as from the bottom bar. The group
+  only appears on markets that actually have sessions.
+
+### Changed
+
+- **Right-click menus mark the active choice with a checkmark.** Context menus
+  anchored at the pointer — the price-axis, time-axis and chart-body menus, and
+  the indicator legend's row menu — now show the selected entry with a ✓ on its
+  left instead of a highlighted row, so selection never reads as hover. Dropdown
+  menus opened from a button (timeframe, chart style, time zone) keep the
+  highlighted-row style.
+- **The legend's status indicator steps aside while a row is open.** While an
+  indicator's legend row shows its action buttons (on hover or selection), the
+  loading dots / live pulse move to after the buttons instead of sitting between
+  the title and the actions, so the buttons stay glued to the title.
+- **The RTH/ETH toggle only appears on markets with sessions.** The bottom bar's
+  session switch used to sit disabled on continuous markets (crypto); it is now
+  hidden entirely there and appears once the active symbol declares real trading
+  sessions.
+
+### Fixed
+
+- **Input titles are fully inert.** In the settings and indicator dialogs, an
+  input's title no longer reacts to hover or clicks (native `label[for]`
+  forwarding used to light up and activate the control from its title) — only
+  the input itself is interactive. Titles keep naming their control for
+  assistive tech via `aria-labelledby`.
+
 ## [v0.6.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Indicator inputs that show only when they matter.** An indicator input can now
+  declare a condition on another input's current value (a toggle being on, a dropdown
+  sitting on one choice or any of several), and its row appears in the settings dialog
+  only while that condition holds. The dialog re-evaluates live on every edit — flip
+  the governing toggle and the dependent rows appear or disappear in place, group
+  headings and tabs whose inputs are all hidden leave with them, and a hidden input
+  keeps its value for when it comes back.
+
 ## [v0.6.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.6.4]
+
+### Fixed
+
+- **The workspace toolbar follows chart-style changes.** In a multi-chart
+  workspace, changing the active chart's style now updates the toolbar's style
+  button and its menu checkmark immediately — previously they refreshed only
+  when the active chart changed, so the button kept showing the old style's
+  icon.
+- **The timeframe button no longer looks stuck pressed.** Without favorite
+  timeframes, the compact timeframe trigger drew a permanent highlight
+  background. It now highlights on hover only, like the buttons around it; the
+  in-place highlight still marks the current timeframe among favorite chips.
+
 ## [v0.6.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ All notable changes to Vela, newest first.
   session switch used to sit disabled on continuous markets (crypto); it is now
   hidden entirely there and appears once the active symbol declares real trading
   sessions.
+- **UI text is no longer selectable.** Chrome text everywhere — titles, buttons,
+  menus, legends, dialog labels — can't be text-selected anymore (a drag or a
+  sloppy double-click used to leave blue selections across the UI). Text-entry
+  fields (text, number, textarea) keep normal selection, and the data window's
+  readout stays selectable too — it is data meant to be copied out.
 
 ### Fixed
 

--- a/docs/architecture/settings-rows.md
+++ b/docs/architecture/settings-rows.md
@@ -130,6 +130,13 @@ Gated values are **still stored and delivered** — hiding a row never clears it
 consumers decide what a hidden-but-set value means (usually: the gating toggle already
 disables the feature).
 
+The **indicator inputs dialog speaks the same condition vocabulary**: an `InputSchema`
+may carry a `when` (`InputCondition` / `InputWhen`, evaluated by `inputVisible(when,
+bag)`), and the gear dialog re-applies it live on every edit — rows hide and return,
+a group heading or tab whose inputs are all gated out leaves with them, and hidden
+inputs keep their values. Inputs sharing an `inline=` row show while any member's
+gate passes.
+
 **Duplicate keys across gated rows are supported.** Several `when`-gated rows may store
 under the same key(s) — the pattern for per-mode rows over one shared state (each mode
 gets its own row label, e.g. "Volume gradient" / "Delta gradient", while the gradient

--- a/docs/user/renderer-features.md
+++ b/docs/user/renderer-features.md
@@ -47,6 +47,7 @@ Available on every renderer:
 | `candleZOrder` | number | `0` | Draw-order key of the price candles relative to overlay indicators. Indicators default to z ≥ 1, so candles sit behind all overlays by default. |
 | `seriesOrder` | `{ id, to: 'front' \| 'back' }` or `{ id, z }` | — | Reorder one indicator's series layer — move it to front/back, or set an explicit z key. |
 | `highlights` | `HighlightArea[]` | `[]` | Shaded vertical time bands (session highlighting, e.g. weekends or pre/regular/post), drawn behind grid + data. Malformed entries are dropped; bands are sorted by start time. |
+| `sessionZones` | `{ pre, post }` \| `null` | `null` | Pre/post-market time bands (`[start, end)` epoch-ms pairs per phase), shaded behind grid + data with the config's `sessions.premarketColor` / `sessions.postmarketColor`. A host derives them from its market calendar (the widget does this automatically on markets with sessions); `null` means the market has no session structure. |
 | `tradeMarkers` | `{ visible?, labels?, qty?, colors? }` | everything on | Strategy trade markers (the order-fill arrows a strategy indicator emits via `IndicatorModel.trades`). Partial merge: `visible` hides the units, `labels` the order-id line, `qty` the signed-quantity line; `colors` overrides `{ long, short, exit }` (defaults `#2962ff` / `#f23645` / `#d500f9`). Malformed fields are dropped. |
 
 ### Interaction

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/playground/demo-engine.ts
+++ b/playground/demo-engine.ts
@@ -163,8 +163,21 @@ function parseProgram(source: string): Program {
                 prog.overlay = tail !== 'false';
                 break;
             case 'input': {
+                // A bar-source default (`input source = close`) declares a dropdown over
+                // the sources; anything else must be numeric.
+                const src = /^(\w+)\s*=\s*([a-z]\w*)$/.exec(tail);
+                if (src && src[2]! in SOURCES) {
+                    prog.inputs.push({
+                        key: src[1]!,
+                        title: src[1]!,
+                        type: 'string',
+                        defval: src[2]!,
+                        options: Object.keys(SOURCES),
+                    });
+                    break;
+                }
                 const m = /^(\w+)\s*=\s*(-?\d+(?:\.\d+)?)$/.exec(tail);
-                if (!m) throw new Error(`bad input declaration: "${line}" (expected: input name = number)`);
+                if (!m) throw new Error(`bad input declaration: "${line}" (expected: input name = number|source)`);
                 const defval = Number(m[2]);
                 prog.inputs.push({
                     key: m[1]!,
@@ -243,6 +256,7 @@ function evaluate(node: Node, bars: OHLCV[], inputs: Record<string, InputValue>)
             if (src) return bars.map(src);
             const iv = inputs[node.name];
             if (typeof iv === 'number') return iv;
+            if (typeof iv === 'string' && SOURCES[iv]) return bars.map(SOURCES[iv]!);
             throw new Error(`unknown name "${node.name}"`);
         }
         case 'bin': {
@@ -423,7 +437,8 @@ export const DEMO_SCRIPTS = {
     ema: `title    EMA 20
 overlay  true
 input    length = 20
-plot     ema(close, length) "EMA" #f0b90b width=2`,
+input    source = close
+plot     ema(source, length) "EMA" #f0b90b width=2`,
     bands: `title    Bollinger Bands
 overlay  true
 input    length = 20

--- a/src/core/model/index.ts
+++ b/src/core/model/index.ts
@@ -1,7 +1,8 @@
 export type { Millis } from './time';
 export type { OHLCV } from './ohlcv';
 
-export type { InputType, InputValue, InputSchema } from './inputs';
+export type { InputType, InputValue, InputSchema, InputCondition, InputWhen } from './inputs';
+export { inputVisible } from './inputs';
 export type {
     LineLikeKind,
     SeriesKind,

--- a/src/core/model/inputs.ts
+++ b/src/core/model/inputs.ts
@@ -28,6 +28,28 @@ export type InputValue = number | string | boolean;
  */
 export type SymbolPickerFn = (current: string, onPick: (symbol: string) => void) => void;
 
+/** One visibility condition on another input's current value: `equals` matches a single
+ *  value (a toggle, one dropdown choice), `anyOf` matches a set (several choices). */
+export interface InputCondition {
+    key: string;
+    equals?: InputValue;
+    anyOf?: readonly InputValue[];
+}
+
+/** An input's visibility gate: one condition, or several AND-ed together. */
+export type InputWhen = InputCondition | readonly InputCondition[];
+
+/**
+ * Evaluate a visibility gate against the dialog's resolved current values (an input's
+ * stored value, else its `defval`). No gate ⇒ visible. Mirrors the chart-settings row
+ * gate (`settingsRowVisible`) so both dialogs share one condition vocabulary.
+ */
+export function inputVisible(when: InputWhen | undefined, values: Record<string, InputValue>): boolean {
+    if (!when) return true;
+    const conds: readonly InputCondition[] = Array.isArray(when) ? when : [when as InputCondition];
+    return conds.every((c) => (c.anyOf ? c.anyOf.some((x) => x === values[c.key]) : values[c.key] === c.equals));
+}
+
 export interface InputSchema {
     /** Stable key used by `setInput()` — the engine's own variable id, falling back to `title`. */
     key: string;
@@ -46,5 +68,9 @@ export interface InputSchema {
     inline?: string;
     /** Settings-dialog tab hosting this input; unset ⇒ the default "Inputs" tab. */
     tab?: string;
+    /** Visibility gate: the input's row shows only while the condition(s) pass against
+     *  the dialog's current values — re-evaluated live on every edit. Inputs sharing an
+     *  `inline=` row show while ANY member's gate passes. A hidden input keeps its value. */
+    when?: InputWhen;
     tooltip?: string;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -131,6 +131,8 @@ export type * from './core/model';
 // Series ids must come from `stableSeriesId` so renderer reconciliation and persisted
 // per-series settings survive re-runs identically whichever engine produced the series.
 export { stableSeriesId } from './core/model';
+// Evaluate an input's `when` gate the way the settings dialog does (host-built inputs UIs).
+export { inputVisible } from './core/model';
 // The semantic palette (fixed brand/meaning colors, never theme-dependent) so plugin
 // output — default plot colors, layer inks — matches core affordances exactly.
 export * from './core/palette';

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1238,7 +1238,9 @@ export class NativeRenderer implements IChartRenderer {
         this.surfaceTextColor = theme.textColor;
 
         this.wrapper = document.createElement('div');
-        Object.assign(this.wrapper.style, { position: 'relative', width: '100%', height: '100%', overflow: 'hidden', cursor: 'crosshair' });
+        // user-select none: in-chart chrome text (legend, dialogs, axis buttons) is UI,
+        // never selectable — the kit's text-entry controls opt back in in their own CSS.
+        Object.assign(this.wrapper.style, { position: 'relative', width: '100%', height: '100%', overflow: 'hidden', cursor: 'crosshair', userSelect: 'none', webkitUserSelect: 'none' });
         // Every DOM overlay below is a descendant, so the chrome tokens land once here.
         applyChromeTokens(this.wrapper, this.chromeTheme());
 

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -29,6 +29,7 @@ import type { Unsubscribe } from '../../core/util/types';
 import { isLineLikeSeries } from '../../core/model/series';
 import { InputsUI, type LegendPlotValue } from '../shared/InputsUI';
 import { PaneControls } from './chrome/PaneControls';
+import { AxisScaleButtons, type AxisScaleView } from './chrome/AxisScaleButtons';
 import { TableOverlay } from '../shared/TableOverlay';
 import { NATIVE_CAPABILITIES, supportsWebGL2 } from './capabilities';
 import { WebGL2Backend } from './backend/WebGL2Backend';
@@ -37,7 +38,7 @@ import { Scheduler, InvalidateLevel, repaintsData, repaintsChrome } from './core
 import { Animator, easeToward } from './core/Animator';
 import { InputController } from './core/InputController';
 import { KeyboardController } from './core/KeyboardController';
-import { SceneGraph, paneLogScale, paneScaleMode, paneInvert, type PaneNode, type HighlightArea, type ScaleMode } from './core/SceneGraph';
+import { SceneGraph, paneLogScale, paneScaleMode, paneInvert, type PaneNode, type HighlightArea, type SessionZones, type ScaleMode } from './core/SceneGraph';
 import { clampBarSpacing, defaultViewport, MIN_BAR_SPACING, MAX_BAR_SPACING, type ViewportState } from './core/ViewportState';
 import { Canvas2dBackend } from './backend/Canvas2dBackend';
 import type { IRenderBackend } from './backend/IRenderBackend';
@@ -244,6 +245,7 @@ export class NativeRenderer implements IChartRenderer {
     private maximizedPaneId: string | null = null; // pane filling the plot (others hidden), or null
     private rightAxisW = RIGHT_AXIS_W; // total right-gutter width (master column + merged-scale columns)
     private paneControls: PaneControls | null = null; // per-pane hover button cluster (top-right)
+    private axisScaleButtons: AxisScaleButtons | null = null; // A/L hover buttons at the bottom of each pane's price scale
     private readonly paneActionCbs = new Set<(a: PaneAction) => void>();
 
     // ── data window (crosshair OHLC + per-series readout, pulled by host panels) ──
@@ -309,7 +311,7 @@ export class NativeRenderer implements IChartRenderer {
     }
 
     readonly name = 'native';
-    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles', 'indicatorValues'];
+    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'sessionZones', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles', 'indicatorValues'];
 
     /** Apply a render feature live — mutate the field + invalidate, no engine re-run. */
     applyFeature(key: string, value: unknown): void {
@@ -380,6 +382,11 @@ export class NativeRenderer implements IChartRenderer {
                 break;
             case 'highlights':
                 this.scene.highlights = sanitizeHighlights(value);
+                break;
+            case 'sessionZones':
+                // Pre/post-market bands from the host's market calendar; painted with the
+                // config's session colors. Null ⇒ the market has no session structure.
+                this.scene.sessionZones = sanitizeSessionZones(value);
                 break;
             case 'gridlines':
                 this.scene.showGrid = Boolean(value);
@@ -492,6 +499,7 @@ export class NativeRenderer implements IChartRenderer {
             case 'candleVisible': return !this.scene.candlesHidden;
             case 'seriesOrder': return this.scene.indicatorZOrder();
             case 'highlights': return this.scene.highlights;
+            case 'sessionZones': return this.scene.sessionZones;
             case 'gridlines': return this.scene.showGrid;
             case 'axisLabels': return this.scene.showAxisLabels;
             case 'scaleMode': return this.scene.scaleMode;
@@ -700,6 +708,7 @@ export class NativeRenderer implements IChartRenderer {
                 };
             })(),
             series: { style: this.scene.priceStyle, baseline: this.scene.baselineValue, spacing: this.coords.spacingScale },
+            sessions: { premarketColor: s.sessions.premarketColor, postmarketColor: s.sessions.postmarketColor },
         };
     }
 
@@ -813,6 +822,8 @@ export class NativeRenderer implements IChartRenderer {
             width: next.baseline.width,
             baselineLevel: next.baseline.baselineLevel,
         };
+        // session shading
+        s.sessions = { premarketColor: next.sessions.premarketColor, postmarketColor: next.sessions.postmarketColor };
         // series
         this.setPriceStyle(next.series.style);
         // Re-read the active style's candle override: setPriceStyle no-ops when the style
@@ -834,6 +845,7 @@ export class NativeRenderer implements IChartRenderer {
         }
         this.inputsUI?.setTheme(this.theme);
         this.paneControls?.setTheme(this.theme);
+        this.axisScaleButtons?.setTheme(this.theme);
         // Re-theme the docked drawing toolbar on the STABLE chrome surface, so editing the
         // plot background (layout.background) never bleeds into the toolbar.
         this.userDrawings?.setTheme(this.chromeTheme());
@@ -1440,6 +1452,16 @@ export class NativeRenderer implements IChartRenderer {
             },
         });
 
+        this.axisScaleButtons = new AxisScaleButtons(this.plot, theme, {
+            panes: () => this.axisScaleViews(),
+            rightAxis: () => this.rightAxisW,
+            onToggleAuto: (paneId) => this.togglePaneAuto(paneId),
+            onToggleLog: (paneId) => {
+                const pane = this.scene.panes.get(paneId);
+                if (pane) this.setPaneLog(paneId, !paneLogScale(this.scene, pane));
+            },
+        });
+
         this.resizeObserver = new ResizeObserver(() => this.resize());
         this.resizeObserver.observe(this.wrapper);
         this.watchDpr();
@@ -1527,6 +1549,7 @@ export class NativeRenderer implements IChartRenderer {
         this.applyBackground();
         this.inputsUI.setTheme(theme);
         this.paneControls?.setTheme(this.theme);
+        this.axisScaleButtons?.setTheme(this.theme);
         // An open dialog rebuilds on setTheme — hand it the re-based config + the new
         // current of its Theme row first, so the rebuilt controls show live values.
         this.settingsDialog?.refreshConfig(this.getConfig());
@@ -1577,6 +1600,7 @@ export class NativeRenderer implements IChartRenderer {
         this.liveRegion = null;
         this.inputsUI?.destroy();
         this.paneControls?.destroy();
+        this.axisScaleButtons?.destroy();
         for (const overlay of this.tableOverlays.values()) overlay.destroy();
         this.tableOverlays.clear();
         this.resizeObserver?.disconnect();
@@ -3225,6 +3249,27 @@ export class NativeRenderer implements IChartRenderer {
         }));
     }
 
+    /** Thin projection of the panes for the axis A/L hover buttons (top-to-bottom order). */
+    private axisScaleViews(): AxisScaleView[] {
+        return this.scene.orderedPanes().map((p) => ({
+            id: p.id,
+            top: p.bounds.top,
+            height: p.bounds.height,
+            collapsed: p.collapsed,
+            auto: p.manualScale == null,
+            log: paneLogScale(this.scene, p),
+        }));
+    }
+
+    /** Toggle one pane's autoscale (the A axis button): off freezes the current window into
+     *  manual mode, on drops it — the per-pane twin of the chart-level `autoScale` feature. */
+    private togglePaneAuto(paneId: string): void {
+        const pane = this.scene.panes.get(paneId);
+        if (!pane) return;
+        pane.manualScale = pane.manualScale == null ? { ...pane.scale } : null;
+        this.scheduler?.invalidate(InvalidateLevel.Full);
+    }
+
     /** Set one pane's axis mode. The price pane routes to the scene-level setting (persisted +
      *  keyboard shortcuts); a study pane keeps its own, so panes never affect each other. */
     private setPaneScaleMode(paneId: string, mode: ScaleMode): void {
@@ -3237,19 +3282,20 @@ export class NativeRenderer implements IChartRenderer {
         this.scheduler?.invalidate(InvalidateLevel.Full);
     }
 
-    /** Set one pane's logarithmic flag. Clears that pane's frozen (manual) window so the new
-     *  space re-fits, and routes the price pane to the scene-level flag. */
+    /** Set one pane's logarithmic flag; the price pane routes to the scene-level flag.
+     *  Log and auto are INDEPENDENT: a frozen (manual) window is kept — its price bounds
+     *  stay put and only its `log` tag flips, so the same range re-renders in the new
+     *  space instead of snapping back to autoscale. */
     private setPaneLog(paneId: string, log: boolean): void {
-        if (paneId === PRICE_PANE_ID) {
-            this.scene.logScale = log;
-            const price = this.scene.orderedPanes().find((p) => p.kind === 'price');
-            if (price) price.manualScale = null;
-        } else {
-            const p = this.scene.panes.get(paneId);
-            if (!p) return;
-            p.logScale = log;
-            p.manualScale = null;
+        const pane = paneId === PRICE_PANE_ID
+            ? this.scene.orderedPanes().find((p) => p.kind === 'price')
+            : this.scene.panes.get(paneId);
+        if (paneId === PRICE_PANE_ID) this.scene.logScale = log;
+        else {
+            if (!pane) return;
+            pane.logScale = log;
         }
+        if (pane?.manualScale) pane.manualScale.log = log;
         this.scheduler?.invalidate(InvalidateLevel.Full);
     }
 
@@ -3354,6 +3400,7 @@ export class NativeRenderer implements IChartRenderer {
             }
             this.inputsUI?.reposition();
             this.paneControls?.reposition();
+            this.axisScaleButtons?.reposition();
             this.repositionScrollButton();
             this.positionAttribution();
             this.publishPricePaneBounds();
@@ -3373,6 +3420,7 @@ export class NativeRenderer implements IChartRenderer {
         }
         this.inputsUI?.reposition(); // keep each pane's legend pinned to its pane top
         this.paneControls?.reposition();
+        this.axisScaleButtons?.reposition();
         this.repositionScrollButton();
         this.positionAttribution(); // the mark follows the lowest open pane's bottom edge
         this.publishPricePaneBounds();
@@ -3625,6 +3673,24 @@ function sanitizeHighlights(value: unknown): HighlightArea[] {
         out.push({ from, to, color: typeof r.color === 'string' ? r.color : 'rgba(120,130,160,0.10)' });
     }
     return out.sort((a, b) => a.from - b.from);
+}
+
+/** Coerce arbitrary input into clean pre/post session bands, or null (no session structure). */
+function sanitizeSessionZones(value: unknown): SessionZones | null {
+    if (value == null || typeof value !== 'object') return null;
+    const v = value as { pre?: unknown; post?: unknown };
+    const windows = (raw: unknown): Array<readonly [number, number]> => {
+        if (!Array.isArray(raw)) return [];
+        const out: Array<readonly [number, number]> = [];
+        for (const w of raw) {
+            if (!Array.isArray(w)) continue;
+            const from = Number(w[0]);
+            const to = Number(w[1]);
+            if (Number.isFinite(from) && Number.isFinite(to) && to > from) out.push([from, to]);
+        }
+        return out.sort((a, b) => a[0] - b[0]);
+    };
+    return { pre: windows(v.pre), post: windows(v.post) };
 }
 
 /** Whether a value is one of the supported price-series styles (built-ins + SDK-registered). */

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -790,10 +790,12 @@ export class Canvas2dBackend implements IRenderBackend {
         ctx.fillRect(x1, pane.bounds.top, x2 - x1, pane.bounds.height);
     }
 
-    /** Renderer-owned session highlight bands: full-height (all panes), behind grid + data. */
+    /** Renderer-owned session highlight bands: full-height (all panes), behind grid + data.
+     *  Session-zone washes (pre/post-market) paint first, host highlights on top. */
     private drawHighlights(ctx: CanvasRenderingContext2D, scene: SceneGraph, coords: CoordinateSystem): void {
-        if (scene.highlights.length === 0) return;
-        for (const band of scene.highlights) {
+        const bands = [...scene.sessionHighlightBands(), ...scene.highlights];
+        if (bands.length === 0) return;
+        for (const band of bands) {
             const x1 = coords.timeToX(band.from);
             const x2 = coords.timeToX(band.to);
             if (x2 < 0 || x1 > coords.width || x2 <= x1) continue;

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -627,10 +627,12 @@ export class WebGL2Backend implements IRenderBackend {
         // Pane separators are drawn on the chrome layer (full-width, above the data), so nothing here.
     }
 
-    /** Renderer-owned session highlight bands, clipped per-pane (scissor reconstructs full height). */
+    /** Renderer-owned session highlight bands, clipped per-pane (scissor reconstructs full height).
+     *  Session-zone washes (pre/post-market) paint first, host highlights on top. */
     private emitHighlights(b: Batch, scene: SceneGraph, pane: PaneNode, coords: CoordinateSystem): void {
-        if (scene.highlights.length === 0) return;
-        for (const band of scene.highlights) {
+        const bands = [...scene.sessionHighlightBands(), ...scene.highlights];
+        if (bands.length === 0) return;
+        for (const band of bands) {
             const x1 = coords.timeToX(band.from);
             const x2 = coords.timeToX(band.to);
             if (x2 < 0 || x1 > coords.width || x2 <= x1) continue;

--- a/src/renderers/native/chrome/AxisScaleButtons.ts
+++ b/src/renderers/native/chrome/AxisScaleButtons.ts
@@ -1,0 +1,182 @@
+import type { VelaTheme } from '../../../core/options';
+import { attachChromeTooltip } from '../../shared/chrome-tooltip';
+import { AXIS_MASTER_W } from './axisLayout';
+
+/** A pane as seen by the axis scale buttons (its pixel band + current scale state). */
+export interface AxisScaleView {
+    id: string;
+    top: number;
+    height: number;
+    collapsed: boolean;
+    /** Autoscale on — the pane's master scale holds no frozen (manual) window. */
+    auto: boolean;
+    log: boolean;
+}
+
+export interface AxisScaleButtonsDeps {
+    panes(): AxisScaleView[];
+    /** Total right-gutter width in px (master column + merged-scale columns). */
+    rightAxis(): number;
+    onToggleAuto(paneId: string): void;
+    onToggleLog(paneId: string): void;
+}
+
+const STYLE_ID = 'vela-axis-scale-buttons';
+
+const BTN_PX = 18; // square hit target per letter button
+const BTN_GAP = 4; // air between A and L — close enough to read as a pair
+/** The chrome's 1px vertical frame at the data/gutter seam (`drawPriceAxes`). The strip
+ *  stays INSIDE the scale — it must not paint over that line. */
+const AXIS_BORDER = 1;
+const CLUSTER_W = AXIS_MASTER_W - AXIS_BORDER;
+/** Solid chart-background strip spanning the master scale column (inside the axis frame),
+ *  flush with the pane's bottom edge and a little above the buttons, so axis tick labels
+ *  never show through. No border, no radius — it is a backdrop, not a chip. */
+const PAD_TOP = 8;
+const PAD_BOTTOM = 6;
+const CLUSTER_H = BTN_PX + PAD_TOP + PAD_BOTTOM;
+/** Panes shorter than this skip the buttons — they would sit on top of the tick labels. */
+const MIN_PANE_H = 48;
+
+/** Hover/active states as CSS so they track the theme tokens (same idiom as PaneControls). */
+function ensureStyles(): void {
+    if (typeof document === 'undefined' || document.getElementById(STYLE_ID)) return;
+    const st = document.createElement('style');
+    st.id = STYLE_ID;
+    st.textContent = `
+.vela-axis-btn{display:inline-flex;align-items:center;justify-content:center;padding:0;border:none;border-radius:var(--vela-radius-sm);background:transparent;cursor:pointer;font:600 10px/1 -apple-system,Segoe UI,sans-serif;color:var(--vela-fg-muted);}
+.vela-axis-btn:hover{background:var(--vela-active);color:var(--vela-fg-bright);}
+.vela-axis-on,.vela-axis-on:hover{background:var(--vela-selected-bg);color:var(--vela-selected-fg);}
+`;
+    document.head.appendChild(st);
+}
+
+/**
+ * Inline A (auto) / L (log) buttons at the bottom of a pane's price scale, revealed while
+ * the cursor hovers that pane's master scale column. Each toggles its mode for the hovered
+ * pane; an active mode wears the selected (inverse-chip) button style. A DOM overlay on
+ * the plot, matching the pane-controls pattern.
+ */
+export class AxisScaleButtons {
+    private readonly cluster: HTMLDivElement;
+    private readonly autoBtn: HTMLButtonElement;
+    private readonly logBtn: HTMLButtonElement;
+    private readonly tipDisposers: Array<() => void> = [];
+    private hoverPaneId: string | null = null;
+
+    constructor(private readonly plot: HTMLElement, private theme: VelaTheme, private readonly deps: AxisScaleButtonsDeps) {
+        ensureStyles();
+        this.cluster = document.createElement('div');
+        Object.assign(this.cluster.style, {
+            position: 'absolute',
+            display: 'none',
+            justifyContent: 'center',
+            alignItems: 'center',
+            gap: `${BTN_GAP}px`,
+            padding: `${PAD_TOP}px 0 ${PAD_BOTTOM}px`,
+            width: `${CLUSTER_W}px`,
+            boxSizing: 'border-box',
+            zIndex: '6',
+            pointerEvents: 'auto',
+        });
+        this.applyTheme();
+        this.autoBtn = this.button('A', 'Auto (fits data to screen)', () => this.deps.onToggleAuto(this.hoverPaneId ?? ''));
+        this.logBtn = this.button('L', 'Logarithmic scale', () => this.deps.onToggleLog(this.hoverPaneId ?? ''));
+        this.cluster.append(this.autoBtn, this.logBtn);
+        this.plot.appendChild(this.cluster);
+        // Track hover on the PLOT so moving the cursor onto the buttons themselves — plot
+        // children above the canvas — keeps them revealed instead of flickering away.
+        this.plot.addEventListener('pointermove', this.onPlotMove);
+        this.plot.addEventListener('pointerleave', this.onPlotLeave);
+    }
+
+    private button(label: string, title: string, onClick: () => void): HTMLButtonElement {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.setAttribute('aria-label', title); // not `title` — native tooltips are banned on renderer chrome
+        b.textContent = label;
+        b.className = 'vela-axis-btn';
+        Object.assign(b.style, { width: `${BTN_PX}px`, height: `${BTN_PX}px` });
+        this.tipDisposers.push(attachChromeTooltip(b, {
+            host: this.plot,
+            theme: () => this.theme,
+            text: () => title,
+            placement: 'above',
+        }));
+        b.addEventListener('click', (e) => {
+            e.stopPropagation();
+            onClick();
+            this.sync();
+        });
+        return b;
+    }
+
+    /** Reveal over the master scale column of the pane under the cursor (mouse only —
+     *  touch has no hover, and a drag-rescale on the axis must not sprout buttons). */
+    private readonly onPlotMove = (e: PointerEvent): void => {
+        if (e.pointerType !== 'mouse') return;
+        const rect = this.plot.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const gutterLeft = rect.width - this.deps.rightAxis();
+        let hit: string | null = null;
+        if (x >= gutterLeft && x <= gutterLeft + AXIS_MASTER_W) {
+            const y = e.clientY - rect.top;
+            for (const p of this.deps.panes()) {
+                if (p.collapsed || p.height < MIN_PANE_H) continue;
+                if (y >= p.top && y <= p.top + p.height) { hit = p.id; break; }
+            }
+        }
+        this.setHoverPane(hit);
+        if (hit) this.sync(); // scale state can change under a still cursor (dblclick reset, drag)
+    };
+
+    private readonly onPlotLeave = (): void => this.setHoverPane(null);
+
+    /** Re-tint the chip when the plot background/border change (theme swap, config edit). */
+    setTheme(theme: VelaTheme): void {
+        this.theme = theme;
+        this.applyTheme();
+    }
+
+    /** The strip is SOLID chart background: the buttons cover axis labels, never blend with them. */
+    private applyTheme(): void {
+        this.cluster.style.background = this.theme.background;
+    }
+
+    private setHoverPane(paneId: string | null): void {
+        if (this.hoverPaneId === paneId) return;
+        this.hoverPaneId = paneId;
+        this.reposition();
+    }
+
+    /** Re-place (or hide) the cluster after a hover or pane-layout change. */
+    reposition(): void {
+        const pane = this.hoverPaneId ? this.deps.panes().find((p) => p.id === this.hoverPaneId) : undefined;
+        if (!pane || pane.collapsed || pane.height < MIN_PANE_H) {
+            this.cluster.style.display = 'none';
+            return;
+        }
+        // Flush with the pane's bottom edge, inset 1px from the axis frame so the scale
+        // border stays visible. The extra PAD_TOP is the air above the letters.
+        this.cluster.style.right = `${this.deps.rightAxis() - AXIS_MASTER_W}px`;
+        this.cluster.style.top = `${pane.top + pane.height - CLUSTER_H}px`;
+        this.cluster.style.display = 'flex';
+        this.sync();
+    }
+
+    /** Reflect the hovered pane's current auto/log state on the buttons. */
+    private sync(): void {
+        const pane = this.deps.panes().find((p) => p.id === this.hoverPaneId);
+        if (!pane) return;
+        this.autoBtn.classList.toggle('vela-axis-on', pane.auto);
+        this.logBtn.classList.toggle('vela-axis-on', pane.log);
+    }
+
+    destroy(): void {
+        this.plot.removeEventListener('pointermove', this.onPlotMove);
+        this.plot.removeEventListener('pointerleave', this.onPlotLeave);
+        for (const dispose of this.tipDisposers) dispose();
+        this.tipDisposers.length = 0;
+        this.cluster.remove();
+    }
+}

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -45,11 +45,13 @@ type ConfigPatch = Record<string, unknown>;
  */
 
 /** A host-contributed settings row: callback-based (the host owns the state).
- *  `heading` opens a titled group inside the tab (an in-pane section title). */
+ *  `heading` opens a titled group inside the tab (an in-pane section title);
+ *  `color` is a swatch opening the themed picker (any CSS color, alpha included). */
 export type HostSettingsRow =
     | { kind: 'heading'; label: string }
     | { kind: 'toggle'; label: string; get: () => boolean; set: (v: boolean) => void }
-    | { kind: 'select'; label: string; options: readonly string[]; get: () => string; set: (v: string) => void };
+    | { kind: 'select'; label: string; options: readonly string[]; get: () => string; set: (v: string) => void }
+    | { kind: 'color'; label: string; get: () => string; set: (v: string) => void };
 
 /** A host-contributed settings tab (see `RendererControl.setSettingsSections`). */
 export interface HostSettingsSection {
@@ -405,7 +407,8 @@ export class SettingsDialog {
                 for (const hr of hs.rows) {
                     if (hr.kind === 'heading') body.append(this.sectionTitle(hr.label));
                     else if (hr.kind === 'toggle') body.append(this.boolRow(hr.label, hr.get(), (v) => hr.set(v)));
-                    else body.append(this.selectRowLabeled(hr.label, hr.get() as string, hr.options.map((o) => [o, o] as const), (v) => hr.set(v)));
+                    else if (hr.kind === 'color') body.append(this.colorRow(hr.label, hr.get(), (v) => hr.set(v)));
+                    else body.append(this.selectRowLabeled(hr.label, hr.get(), hr.options.map((o) => [o, o] as const), (v) => hr.set(v)));
                 }
             }
         };

--- a/src/renderers/native/core/SceneGraph.ts
+++ b/src/renderers/native/core/SceneGraph.ts
@@ -20,6 +20,15 @@ export interface HighlightArea {
     color: string;
 }
 
+/** Pre/post-market time bands (the `sessionZones` feature): `[start, end)` epoch-ms
+ *  pairs a host derives from its market calendar. The renderer shades them with the
+ *  config's session colors (`ChartStyle.sessions`), behind grid + data — null means
+ *  the market has no session structure at all (continuous venues). */
+export interface SessionZones {
+    pre: ReadonlyArray<readonly [number, number]>;
+    post: ReadonlyArray<readonly [number, number]>;
+}
+
 /** Price-axis display mode: absolute price, percent change vs a visible baseline, or
  *  values indexed to 100 at that same baseline (`index = price / baseline * 100`). */
 export type ScaleMode = 'price' | 'percent' | 'indexed';
@@ -169,6 +178,8 @@ export class SceneGraph {
     tradeMarkers: TradeMarkersState = defaultTradeMarkersState();
     /** Renderer-owned shaded time bands (session highlighting), behind grid + data. */
     highlights: HighlightArea[] = [];
+    /** Pre/post-market bands pushed by the host (`sessionZones` feature); null ⇒ no sessions. */
+    sessionZones: SessionZones | null = null;
     /** Draw-order key of the price candles, relative to indicator series z (see `seriesZ`).
      *  Indicators with z below this draw BEHIND the candles; at/above draw in front.
      *  Default 0 with indicators mounting at z < 0 ⇒ the price reads on top of every overlay,
@@ -202,6 +213,16 @@ export class SceneGraph {
     orderedPanes(): PaneNode[] {
         if (!this.orderedCache) this.orderedCache = [...this.panes.values()].sort((a, b) => a.order - b.order);
         return this.orderedCache;
+    }
+
+    /** The session zones resolved into colored bands (pre/post-market washes from the
+     *  config's session colors) — consumed by the same painting path as {@link highlights}. */
+    sessionHighlightBands(): HighlightArea[] {
+        if (!this.sessionZones) return [];
+        const out: HighlightArea[] = [];
+        for (const [from, to] of this.sessionZones.pre) out.push({ from, to, color: this.style.sessions.premarketColor });
+        for (const [from, to] of this.sessionZones.post) out.push({ from, to, color: this.style.sessions.postmarketColor });
+        return out;
     }
 
     indicatorsForPane(paneId: string): IndicatorModel[] {

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -1,7 +1,7 @@
 import type { LineStyle } from '../../../core/model/series';
 import { chartTypes, settingsRowValueKeys, type SettingsRowDescriptor } from '../../../chart-types/registry';
 import { withAlpha } from '../../../core/color';
-import { BEARISH, BULLISH, CROSSHAIR, SERIES_LINE, SLATE } from '../../../core/palette';
+import { ACCENT, BEARISH, BULLISH, CROSSHAIR, SERIES_LINE, SLATE, WARNING } from '../../../core/palette';
 import type { PriceStyle } from '../../../core/options';
 import type { ScaleMode } from './SceneGraph';
 
@@ -121,6 +121,17 @@ export interface BaselineSeriesStyle {
     baselineLevel: number;
 }
 
+/** Session-zone shading (the `sessionZones` feature): the wash painted over
+ *  pre-market and post-market time bands. Alpha belongs in the color itself. */
+export interface SessionShadeStyle {
+    premarketColor: string;
+    postmarketColor: string;
+}
+
+/** Default session washes — faint enough to sit behind candles and gridlines. */
+export const PREMARKET_SHADE = withAlpha(WARNING, 0.08);
+export const POSTMARKET_SHADE = withAlpha(ACCENT, 0.08);
+
 export interface ChartStyle {
     /** Per-chart-type settings (plugin SDK sections), keyed by type id then row key. */
     chartTypes: Record<string, Record<string, unknown>>;
@@ -138,6 +149,7 @@ export interface ChartStyle {
     line: LineSeriesStyle;
     area: AreaSeriesStyle;
     baseline: BaselineSeriesStyle;
+    sessions: SessionShadeStyle;
 }
 
 /** A fresh live style store with every value at its "inherit / current behavior" default. */
@@ -172,6 +184,7 @@ export function defaultChartStyle(): ChartStyle {
             width: 2,
             baselineLevel: BASELINE_LEVEL_DEFAULT,
         },
+        sessions: { premarketColor: PREMARKET_SHADE, postmarketColor: POSTMARKET_SHADE },
     };
 }
 
@@ -271,6 +284,12 @@ export interface ChartConfig {
         /** Spacing multiplier for non-connecting styles (candles/bars/HA/plugin types): scales the
          *  center-to-center pitch (and the crosshair step) without changing body width. 1 = default. */
         spacing: number;
+    };
+    /** Session-zone shading — the washes painted over the pre/post-market bands a host
+     *  pushes through the `sessionZones` feature (no bands ⇒ the colors are dormant). */
+    sessions: {
+        premarketColor: string;
+        postmarketColor: string;
     };
     /** Draw-order keys — what paints in front of what. The candles' own key plus one per
      *  indicator id; user drawings persist their keys in the drawings document, in the same
@@ -505,6 +524,7 @@ export function mergeConfig(base: ChartConfig, patch: unknown): ChartConfig {
     const area = asObject(p.area);
     const baseline = asObject(p.baseline);
     const series = asObject(p.series);
+    const sessions = asObject(p.sessions);
     const stacking = asObject(p.stacking);
     const stackSeries = asObject(stacking.series);
 
@@ -597,6 +617,10 @@ export function mergeConfig(base: ChartConfig, patch: unknown): ChartConfig {
             style: isPriceStyle(series.style) ? series.style : base.series.style,
             baseline: series.baseline === null ? null : isNum(series.baseline) ? series.baseline : base.series.baseline,
             spacing: isNum(series.spacing) ? clampSpacing(series.spacing) : base.series.spacing,
+        },
+        sessions: {
+            premarketColor: isColor(sessions.premarketColor) ? sessions.premarketColor : base.sessions.premarketColor,
+            postmarketColor: isColor(sessions.postmarketColor) ? sessions.postmarketColor : base.sessions.postmarketColor,
         },
         stacking: {
             candles: isNum(stacking.candles) ? stacking.candles : base.stacking.candles,

--- a/src/renderers/shared/IndicatorInputsDialog.ts
+++ b/src/renderers/shared/IndicatorInputsDialog.ts
@@ -1,4 +1,4 @@
-import type { InputSchema, InputValue, SymbolPickerFn } from '../../core/model/inputs';
+import { inputVisible, type InputSchema, type InputValue, type SymbolPickerFn } from '../../core/model/inputs';
 import type { VelaTheme } from '../../core/options';
 import { isDarkColor } from '../../core/color';
 import { iconAt } from '../../core/icons';
@@ -49,6 +49,8 @@ export class IndicatorInputsDialog {
     private row: IndicatorDialogRow | null = null;
     private snapshot: Record<string, InputValue> | null = null;
     private dialogTips: Array<() => void> = [];
+    /** Re-applies every `when` gate against current values; set while the dialog is open. */
+    private refreshVisibility: (() => void) | null = null;
     private choicePop: Popover | null = null;
     private calendarPop: Popover | null = null;
     private calendarAnchor: HTMLElement | null = null;
@@ -112,14 +114,17 @@ export class IndicatorInputsDialog {
         tabs.style.cssText = `display:flex;gap:12px;padding:0 20px;border-bottom:1px solid ${border};flex:0 0 auto;`;
         const tabEls: HTMLElement[] = [];
         const bodies: HTMLElement[] = [];
+        const gates: VisibilityGate[] = [];
+        let active = 0;
         const activate = (idx: number): void => {
+            active = idx;
             for (let i = 0; i < tabEls.length; i += 1) {
-                const active = i === idx;
+                const on = i === idx;
                 const el = tabEls[i]!;
-                el.style.borderBottomColor = active ? fg : 'transparent';
-                el.style.color = active ? 'inherit' : 'var(--vela-fg-muted)';
-                el.classList.toggle('vela-ind-tab-active', active);
-                bodies[i]!.style.display = active ? 'grid' : 'none';
+                el.style.borderBottomColor = on ? fg : 'transparent';
+                el.style.color = on ? 'inherit' : 'var(--vela-fg-muted)';
+                el.classList.toggle('vela-ind-tab-active', on);
+                bodies[i]!.style.display = on ? 'grid' : 'none';
             }
         };
         for (const [idx, def] of tabDefs.entries()) {
@@ -130,11 +135,27 @@ export class IndicatorInputsDialog {
             tab.addEventListener('click', () => activate(idx));
             tabs.appendChild(tab);
             tabEls.push(tab);
-            bodies.push(this.buildTabBody(def.inputs, row));
+            bodies.push(this.buildTabBody(def.inputs, row, gates));
+            // The strip label leaves only when every input on the tab is gated out —
+            // possible only when all of them carry a `when`.
+            if (def.inputs.every((d) => d.when)) {
+                gates.push({ el: tab, visible: (bag) => def.inputs.some((d) => inputVisible(d.when, bag)) });
+            }
         }
         ui.body.appendChild(tabs);
         for (const b of bodies) ui.body.appendChild(b);
         activate(0);
+        const refresh = (): void => {
+            const bag = valuesBag(row);
+            for (const g of gates) g.el.style.display = g.visible(bag) ? '' : 'none';
+            // An edit that gates the ACTIVE tab out lands the user on the first live one.
+            if (tabEls[active]?.style.display === 'none') {
+                const next = tabEls.findIndex((el) => el.style.display !== 'none');
+                if (next >= 0) activate(next);
+            }
+        };
+        this.refreshVisibility = refresh;
+        refresh();
 
         const onBackdropDown = (e: Event): void => {
             if (e.target !== ui.backdrop && e.target !== ui.positioner) return;
@@ -158,7 +179,7 @@ export class IndicatorInputsDialog {
 
     /** One tab's scrollable body — one shared grid so every group's controls share a
      *  left edge (a 100px number field lines up with a wider session/time pair). */
-    private buildTabBody(inputs: InputSchema[], row: IndicatorDialogRow): HTMLElement {
+    private buildTabBody(inputs: InputSchema[], row: IndicatorDialogRow, gates: VisibilityGate[]): HTMLElement {
         const body = document.createElement('div');
         // `display:contents` on each group lets headers + rows participate in this
         // one grid; per-section grids would each pick their own control-column width.
@@ -173,10 +194,22 @@ export class IndicatorInputsDialog {
         for (const group of groupInputs(inputs)) {
             const section = document.createElement('div');
             section.style.cssText = 'display:contents;';
+            let header: HTMLElement | null = null;
             if (group.name) {
-                section.appendChild(fieldSection(group.name, { variant: 'inputs', first: body.childElementCount === 0 }));
+                header = fieldSection(group.name, { variant: 'inputs', first: body.childElementCount === 0 });
+                section.appendChild(header);
             }
-            for (const inputRow of group.rows) this.buildInputRow(section, inputRow, row);
+            for (const inputRow of group.rows) {
+                const el = this.buildInputRow(section, inputRow, row);
+                if (inputRow.some((d) => d.when)) {
+                    gates.push({ el, visible: (bag) => rowVisible(inputRow, bag) });
+                }
+            }
+            // The heading follows its rows out only when every row can actually hide.
+            if (header && group.rows.every((r) => r.every((d) => d.when))) {
+                const rows = group.rows;
+                gates.push({ el: header, visible: (bag) => rows.some((r) => rowVisible(r, bag)) });
+            }
             body.appendChild(section);
         }
         return body;
@@ -185,6 +218,7 @@ export class IndicatorInputsDialog {
     close(): void {
         document.removeEventListener('keydown', this.onDialogKey);
         closeOpenPopovers();
+        this.refreshVisibility = null;
         this.choicePop = null;
         this.calendarPop = null;
         this.calendarAnchor = null;
@@ -216,12 +250,23 @@ export class IndicatorInputsDialog {
         this.close();
     }
 
+    /** Write one edit through: store it, notify the host, and re-apply the `when` gates. */
+    private commit(row: IndicatorDialogRow, key: string, value: InputValue): void {
+        row.values[key] = value;
+        this.host.onChange?.({ indicatorId: row.id, key, value });
+        this.refreshVisibility?.();
+    }
+
     /** One settings row (or several `inline=` inputs) placed into a section's grid. */
-    private buildInputRow(grid: HTMLElement, decls: InputSchema[], row: IndicatorDialogRow): void {
+    private buildInputRow(grid: HTMLElement, decls: InputSchema[], row: IndicatorDialogRow): HTMLElement {
         const idOf = (inp: InputSchema): string => `vela-inp-${row.id}-${inp.key}`;
+        const append = (el: HTMLElement): HTMLElement => {
+            grid.appendChild(el);
+            return el;
+        };
 
         if (decls.length > 1) {
-            grid.appendChild(fieldRow({
+            return append(fieldRow({
                 label: '',
                 inline: decls.map((d) => ({
                     label: nameOf(d) || undefined,
@@ -234,7 +279,6 @@ export class IndicatorInputsDialog {
                     ? this.infoButton([...decls].reverse().find((d) => d.tooltip)!.tooltip!)
                     : undefined,
             }));
-            return;
         }
 
         const lead = decls[0]!;
@@ -243,7 +287,7 @@ export class IndicatorInputsDialog {
 
         if (lead.type === 'bool') {
             const current = Boolean(row.values[lead.key] ?? lead.defval);
-            grid.appendChild(fieldRow({
+            return append(fieldRow({
                 label: nameOf(lead),
                 id,
                 bool: true,
@@ -251,28 +295,23 @@ export class IndicatorInputsDialog {
                 toggle: {
                     id,
                     checked: current,
-                    onChange: (v) => {
-                        row.values[lead.key] = v;
-                        this.host.onChange?.({ indicatorId: row.id, key: lead.key, value: v });
-                    },
+                    onChange: (v) => this.commit(row, lead.key, v),
                 },
             }));
-            return;
         }
 
         if (lead.type === 'text_area') {
-            grid.appendChild(fieldRow({
+            return append(fieldRow({
                 label: nameOf(lead),
                 id,
                 stacked: true,
                 info,
                 control: this.buildControl(row, lead, id),
             }));
-            return;
         }
 
         const fit = lead.type === 'color' || lead.type === 'session' || lead.type === 'time';
-        grid.appendChild(fieldRow({
+        return append(fieldRow({
             label: nameOf(lead),
             id,
             fit,
@@ -285,10 +324,7 @@ export class IndicatorInputsDialog {
     /** Build the typed control for one input, committing edits live via `onChange`. */
     private buildControl(row: IndicatorDialogRow, inp: InputSchema, id: string): HTMLElement {
         const current = row.values[inp.key] ?? inp.defval;
-        const emit = (value: InputValue): void => {
-            row.values[inp.key] = value;
-            this.host.onChange?.({ indicatorId: row.id, key: inp.key, value });
-        };
+        const emit = (value: InputValue): void => this.commit(row, inp.key, value);
 
         if (inp.type === 'bool') {
             return buildFieldControl({ kind: 'switch', id, checked: Boolean(current), onChange: (v) => emit(v) }).el;
@@ -728,6 +764,24 @@ export function tabInputs(inputs: InputSchema[]): InputTab[] {
         names.unshift(DEFAULT_INPUT_TAB);
     }
     return names.map((name) => ({ name, inputs: byTab.get(name)! }));
+}
+
+/** A dialog element shown only while `visible(bag)` holds — a gated row, group heading, or tab label. */
+interface VisibilityGate {
+    el: HTMLElement;
+    visible: (bag: Record<string, InputValue>) => boolean;
+}
+
+/** A row shows while ANY of its `inline=` members' gates pass (a member with no gate always passes). */
+function rowVisible(decls: InputSchema[], bag: Record<string, InputValue>): boolean {
+    return decls.some((d) => inputVisible(d.when, bag));
+}
+
+/** Current values resolved for gate evaluation: the stored value, else the input's `defval`. */
+function valuesBag(row: IndicatorDialogRow): Record<string, InputValue> {
+    const bag: Record<string, InputValue> = {};
+    for (const inp of row.inputs) bag[inp.key] = row.values[inp.key] ?? inp.defval;
+    return bag;
 }
 
 interface InputGroup {

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -459,6 +459,8 @@ export class InputsUI {
                 host: this.container,
                 items,
                 placement: 'bottom-start',
+                // Right-click action menu — checked state reads as a leading ✓ (see the kit Menu).
+                checkmarks: true,
                 onSelect: (itemId) => {
                     if (itemId !== 'values' || !this.rowMenuId) return;
                     const target = this.rows.get(this.rowMenuId);
@@ -689,6 +691,8 @@ export class InputsUI {
         // Status indicator (right of the title): pulsing load dots while fetching, a
         // pulse while live, hidden when idle. Lives next to the title — not the row's
         // far end — so the dots stay a title companion even before values arrive.
+        // While the row is open (hovered/selected) it trails the action cluster instead,
+        // so the buttons stay glued to the title (see syncRowActions).
         const statusEl = document.createElement('span');
         statusEl.style.cssText = 'display:none;box-sizing:border-box;flex:none;';
         // Title (+ optional "beta" exponent) wrapped so the superscript stays glued to the label and
@@ -893,6 +897,11 @@ export class InputsUI {
     private syncRowActions(row: LegendRow): void {
         const open = row.highlighted;
         row.controlsEl.style.display = open || row.hidden ? 'inline-flex' : 'none';
+        // The status indicator steps aside while the controls are out — moved after the
+        // action cluster (its title-side margin rides along) — and returns to the title's
+        // side when the row closes.
+        if (open) row.el.appendChild(row.statusEl);
+        else row.el.insertBefore(row.statusEl, row.valuesEl);
         for (const child of Array.from(row.controlsEl.children)) {
             if (!(child instanceof HTMLElement) || child === row.eyeEl) continue;
             if (child === row.extrasEl) {

--- a/src/renderers/shared/chrome-tooltip.ts
+++ b/src/renderers/shared/chrome-tooltip.ts
@@ -16,8 +16,9 @@ export interface ChromeTooltipOptions {
     text: () => string;
     /** Hover delay before the tip opens. Default 700 ms. */
     delayMs?: number;
-    /** `below` the anchor (legend rows) or to its `right` (a vertical toolbar). Default below. */
-    placement?: 'below' | 'right';
+    /** `below` the anchor (legend rows), to its `right` (a vertical toolbar), or `above`
+     *  (controls sitting on the bottom edge). Default below. */
+    placement?: 'below' | 'right' | 'above';
     /** Allow wrapping (long texts, e.g. an input's docs). Default false — one line. */
     wrap?: boolean;
 }
@@ -63,10 +64,13 @@ export function attachChromeTooltip(anchor: HTMLElement, opts: ChromeTooltipOpti
             tip.style.left = `${a.right - h.left + 8}px`;
             tip.style.top = `${a.top - h.top + (a.height - tip.offsetHeight) / 2}px`;
         } else {
-            // Below the anchor, left-aligned, clamped so it never spills out of the host.
+            // Left-aligned, clamped so it never spills out of the host. `above` is for
+            // anchors sitting on the bottom edge (the A/L scale buttons).
             const left = Math.min(a.left - h.left, Math.max(0, h.width - tip.offsetWidth - 4));
             tip.style.left = `${Math.max(0, left)}px`;
-            tip.style.top = `${a.bottom - h.top + 6}px`;
+            tip.style.top = opts.placement === 'above'
+                ? `${Math.max(0, a.top - h.top - tip.offsetHeight - 6)}px`
+                : `${a.bottom - h.top + 6}px`;
         }
     };
 

--- a/src/ui/components/field/styles.ts
+++ b/src/ui/components/field/styles.ts
@@ -27,6 +27,8 @@ export const FIELD_CSS = `
     font-size: 14px;
 }
 .vela-field-label[data-size='sm'] { font-size: inherit; opacity: 0.85; }
+/* Titles are fully inert: spans, not label[for] — native labels propagate :hover and
+   clicks onto their control, and both belong to the input alone. */
 .vela-field-cell { display: flex; align-items: center; gap: 8px; justify-self: start; }
 .vela-field-bool { display: flex; align-items: center; gap: 8px; min-height: 22px; }
 .vela-field-stacked { display: flex; flex-direction: column; gap: 8px; }

--- a/src/ui/components/field/view.ts
+++ b/src/ui/components/field/view.ts
@@ -93,11 +93,23 @@ export interface FieldRowOptions {
 }
 
 function labelEl(text: string, opts: { id?: string; size?: FieldLabelSize }): HTMLElement {
-    const el = opts.id ? document.createElement('label') : document.createElement('span');
-    if (opts.id && el instanceof HTMLLabelElement) el.htmlFor = opts.id;
+    // A SPAN on purpose, never a `<label for>`: the title is fully INERT — it neither
+    // reacts to hover (native labels propagate `:hover` onto their control) nor to
+    // clicks. Only the input itself is interactive. The a11y association a label would
+    // have given lives on the control as `aria-labelledby` instead.
+    const el = document.createElement('span');
     el.className = 'vela-field-label';
     if (opts.size) el.dataset.size = opts.size;
     el.textContent = text;
+    const id = opts.id;
+    if (id) {
+        el.id = `${id}--title`;
+        // The control exists but may not be attached yet (rows are assembled before the
+        // dialog mounts); after the current task it is, so the name lands reliably.
+        queueMicrotask(() => {
+            el.ownerDocument.getElementById(id)?.setAttribute('aria-labelledby', el.id);
+        });
+    }
     return el;
 }
 
@@ -130,9 +142,7 @@ export function fieldRow(opts: FieldRowOptions): HTMLElement {
             it.className = 'vela-field-inline-item';
             if (item.toggleFirst) it.style.flexDirection = 'row-reverse';
             if (item.label) {
-                const lbl = labelEl(item.label, { id: item.id, size });
-                if (item.toggleFirst) lbl.style.cursor = 'pointer';
-                it.appendChild(lbl);
+                it.appendChild(labelEl(item.label, { id: item.id, size }));
             }
             if (item.fit) it.appendChild(item.control);
             else {
@@ -158,7 +168,7 @@ export function fieldRow(opts: FieldRowOptions): HTMLElement {
             tone: 'bright',
             onChange: (v) => opts.toggle?.onChange(v),
         });
-        wrap.append(sw.el, labelEl(opts.label, { size }));
+        wrap.append(sw.el, labelEl(opts.label, { id: opts.toggle?.id ?? opts.id, size }));
         if (opts.info) wrap.appendChild(opts.info);
         if (opts.toggle?.get) {
             const get = opts.toggle.get;
@@ -198,7 +208,7 @@ export function fieldRow(opts: FieldRowOptions): HTMLElement {
                 if (controls.length > 0) dimControls(controls, v);
             },
         });
-        left.append(sw.el, labelEl(opts.label, { size }));
+        left.append(sw.el, labelEl(opts.label, { id: opts.toggle.id ?? opts.id, size }));
         wrap.appendChild(left);
         if (controls.length > 0) dimControls(controls, opts.toggle.checked);
         if (opts.toggle.get) {

--- a/src/ui/components/menu/controller.ts
+++ b/src/ui/components/menu/controller.ts
@@ -13,7 +13,8 @@ export interface MenuItemDescriptor {
     /** Right-aligned hint (e.g. a shortcut display from KeymapManager). */
     hint?: string;
     /** Selected state (undefined = plain item). A plain checked item renders as a
-     *  highlighted row (brighter surface + bright ink). */
+     *  highlighted row (brighter surface + bright ink) — or, in a menu built with
+     *  `checkmarks`, as a leading ✓ with the row surface left free for hover. */
     checked?: boolean;
     /** Render as a SWITCH row (a right-aligned toggle pill reflecting `checked`)
      *  instead of the selected-row highlight, and keep the menu OPEN on selection —

--- a/src/ui/components/menu/styles.ts
+++ b/src/ui/components/menu/styles.ts
@@ -45,6 +45,23 @@ export const MENU_CSS = `
     background: var(--vela-hover-strong);
     color: var(--vela-fg-bright);
 }
+/* Checkmark mode (context/action menus): every row reserves the leading mark column so
+   labels align; a checked row fills it with a ✓ and brightens its ink — the row surface
+   stays free for the hover wash. */
+.vela-menu-item .vela-menu-mark {
+    width: 14px;
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.vela-menu-item .vela-menu-mark .vela-icon {
+    width: 14px;
+    height: 14px;
+    font-size: 14px;
+    color: var(--vela-fg-bright);
+}
+.vela-menu-item[data-checkmark] { color: var(--vela-fg-bright); }
 /* Switch rows (boolean settings in a dropdown): a right-aligned toggle pill — the
    same control language as the settings dialog's toggles. */
 .vela-menu-switch {

--- a/src/ui/components/menu/view.ts
+++ b/src/ui/components/menu/view.ts
@@ -21,6 +21,13 @@ export interface MenuOptions extends MenuControllerOptions {
     /** Star-toggle reports from items carrying `favorite` (the menu stays open — starring
      *  is a side action on a row, never a selection). */
     onFavorite?: (id: string, on: boolean) => void;
+    /** Mark checked items with a leading ✓ instead of the selected-row background wash —
+     *  the shape for pointer-anchored action menus (right-click context menus), where a
+     *  washed row reads as hover state. A level holding checkable rows reserves the mark
+     *  column on all its rows so labels align; an all-action level keeps its natural left
+     *  edge. Submenus inherit the mode. Dropdown menus (a trigger button opening a
+     *  picker) keep the default wash. */
+    checkmarks?: boolean;
 }
 
 interface SurfaceOptions {
@@ -33,6 +40,7 @@ interface SurfaceOptions {
     id?: string;
     minWidth?: string;
     onFavorite?: (id: string, on: boolean) => void;
+    checkmarks?: boolean;
 }
 
 /**
@@ -50,6 +58,7 @@ class Surface {
     private readonly host: HTMLElement;
     private readonly onSelect: (id: string) => void;
     private readonly onFavorite?: (id: string, on: boolean) => void;
+    private readonly checkmarks: boolean;
     private items: readonly MenuItemDescriptor[] = [];
     /** Branch item id → the surface it opens. */
     private readonly subs = new Map<string, Surface>();
@@ -62,6 +71,7 @@ class Surface {
         this.host = opts.host;
         this.onSelect = opts.onSelect;
         this.onFavorite = opts.onFavorite;
+        this.checkmarks = opts.checkmarks === true;
 
         this.positioner = doc.createElement('div');
         this.positioner.className = 'vela-ui-layer';
@@ -152,6 +162,11 @@ class Surface {
     private build(): void {
         const doc = this.doc;
         this.list.replaceChildren();
+        // Reserve the leading mark column only when THIS level actually holds checkable
+        // rows — an all-action list (e.g. the chart-body context menu) keeps its natural
+        // left edge instead of carrying an empty gutter.
+        const markable = this.checkmarks
+            && this.items.some((i) => !(i.submenu && i.submenu.length > 0) && !i.toggle && i.checked !== undefined);
         for (const item of this.items) {
             if (item.separatorBefore) {
                 const sep = doc.createElement('li');
@@ -167,7 +182,19 @@ class Surface {
                 // Switch row: the pill carries the state.
                 // (Zag owns the item's ARIA props; the pill below is decorative.)
                 li.dataset.toggle = '1';
-            } else if (!branch && item.checked) {
+            }
+            if (markable) {
+                // Mark mode: a leading ✓ slot on every row of this level (empty when
+                // unchecked, so labels share a left edge); the row surface stays free
+                // for hover.
+                const mark = doc.createElement('span');
+                mark.className = 'vela-menu-mark';
+                if (!branch && !item.toggle && item.checked) {
+                    mark.appendChild(iconEl('check', doc));
+                    li.dataset.checkmark = '1';
+                }
+                li.appendChild(mark);
+            } else if (!branch && !item.toggle && item.checked) {
                 // Selection reads from the row surface: a stronger background wash
                 // marks the active entry (hover stays the lighter wash).
                 li.dataset.checked = '1';
@@ -220,6 +247,7 @@ class Surface {
                     placement: 'right-start',
                     onSelect: this.onSelect,
                     onFavorite: this.onFavorite,
+                    checkmarks: this.checkmarks,
                     id: `${this.mid}--${item.id}`,
                 });
                 sub.setItems(item.submenu ?? []);
@@ -248,6 +276,7 @@ export class Menu {
             id: opts.id,
             minWidth: opts.minWidth,
             onFavorite: opts.onFavorite,
+            checkmarks: opts.checkmarks,
         });
         this.root.setItems(opts.items);
     }

--- a/src/ui/components/number-input/styles.ts
+++ b/src/ui/components/number-input/styles.ts
@@ -20,6 +20,9 @@ export const NUMBER_CSS = `
     transition: border-color 0.12s ease, box-shadow 0.12s ease;
     -moz-appearance: textfield;
     appearance: textfield;
+    /* Selectable even under a user-select:none host (chart wrapper, .vela-ui). */
+    user-select: text;
+    -webkit-user-select: text;
 }
 .vela-num input::-webkit-inner-spin-button, .vela-num input::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
 .vela-num input:hover { border-color: var(--vela-fg-muted); }

--- a/src/ui/components/text-area/styles.ts
+++ b/src/ui/components/text-area/styles.ts
@@ -18,6 +18,9 @@ export const TEXTAREA_CSS = `
     resize: vertical;
     outline: none;
     transition: border-color 0.12s ease, box-shadow 0.12s ease;
+    /* Selectable even under a user-select:none host (chart wrapper, .vela-ui). */
+    user-select: text;
+    -webkit-user-select: text;
 }
 .vela-textarea-field:hover { border-color: var(--vela-fg-muted); }
 .vela-textarea-field:focus { border-color: var(--vela-focus); box-shadow: 0 0 0 3px var(--vela-focus-soft); }

--- a/src/ui/components/text-field/styles.ts
+++ b/src/ui/components/text-field/styles.ts
@@ -23,6 +23,9 @@ export const TEXT_CSS = `
     overflow: hidden;
     text-overflow: ellipsis;
     transition: border-color 0.12s ease, box-shadow 0.12s ease;
+    /* Selectable even under a user-select:none host (chart wrapper, .vela-ui). */
+    user-select: text;
+    -webkit-user-select: text;
 }
 .vela-text-field:hover { border-color: var(--vela-fg-muted); }
 .vela-text-field:focus { border-color: var(--vela-focus); box-shadow: 0 0 0 3px var(--vela-focus-soft); }

--- a/src/ui/tokens.ts
+++ b/src/ui/tokens.ts
@@ -20,8 +20,13 @@ const STATIC_CSS = `
 ${STATIC_DECLS}
     font-family: var(--vela-font, -apple-system, system-ui, sans-serif);
     box-sizing: border-box;
+    /* Chrome text (titles, buttons, menus, readouts) is UI, not copy — never selectable. */
+    user-select: none;
+    -webkit-user-select: none;
 }
 .vela-ui *, .vela-ui-layer * { box-sizing: border-box; }
+/* Text ENTRY is the one exception: selection is part of editing. */
+.vela-ui :is(input, textarea), .vela-ui-layer :is(input, textarea) { user-select: text; -webkit-user-select: text; }
 .vela-icon { display: inline-flex; align-items: center; flex: none; }
 .vela-icon svg { display: block; }
 `;

--- a/src/widget/VelaWidget.ts
+++ b/src/widget/VelaWidget.ts
@@ -16,6 +16,8 @@ import { isEditableTarget, KeymapManager } from '../ui/keymap';
 import { Topbar } from './topbar';
 import { Statusline, statuslineInkOf } from './statusline';
 import { MarketStatusTracker } from './market-status';
+import { SessionShadingTracker } from './session-shading';
+import { timeframeMs } from './timeframe';
 import { Watermark } from './watermark';
 import { Bottombar, RANGE_PRESETS, type RangePreset } from './bottombar';
 import { SymbolPicker } from './symbol-picker';
@@ -80,6 +82,11 @@ export class VelaWidget {
     private readonly statusline: Statusline | null;
     /** Keeps the statusline's market badge on the symbol's real calendar (see {@link MarketStatusTracker}). */
     private readonly marketStatus: MarketStatusTracker | null;
+    /** Keeps the pre/post-market shading on the symbol's real calendar (see {@link SessionShadingTracker}). */
+    private readonly sessionShading = new SessionShadingTracker((zones) => this.inner?.renderer.set('sessionZones', zones));
+    /** Whether the ACTIVE symbol declares real trading sessions (RTH/ETH meaningful) —
+     *  gates the bottombar toggle and the settings dialog's Trading session group. */
+    private sessionsAvailable = false;
     private readonly watermark: Watermark | null;
     private readonly bottombar: Bottombar | null;
     private readonly objectTree: ObjectTree;
@@ -651,16 +658,143 @@ export class VelaWidget {
         void this.inner?.setMarket({ session });
     }
 
-    /** Re-derive the RTH/ETH toggle's posture from the ACTIVE symbol's metadata: enabled
-     *  iff the resolved symbol declares a real session vocabulary (not `24x7`). */
+    /** Re-derive the session chrome from the ACTIVE symbol's metadata: the RTH/ETH
+     *  toggle shows (and the settings dialog's Trading session group appears) iff the
+     *  resolved symbol declares a real session vocabulary (not `24x7`); the pre/post
+     *  shading re-derives for the new market either way. */
     private refreshSessionToggle(): void {
         const chart = this.inner;
-        if (!chart || !this.bottombar) return;
+        if (!chart) return;
         void chart.data.symbolInfo(this.symbol).then((si) => {
             if (this.destroyed || this.inner !== chart) return;
             const enabled = typeof si?.session === 'string' && si.session !== '' && si.session !== '24x7';
             this.bottombar?.setSession({ session: this.session ?? 'regular', enabled });
+            if (enabled !== this.sessionsAvailable) {
+                this.sessionsAvailable = enabled;
+                this.pushSettingsSections(); // the Trading session group follows the symbol
+            }
+            this.refreshSessionShading();
         });
+    }
+
+    /** (Re)derive the pre/post-market shading bands for the current market. The loaded
+     *  depth (bars × timeframe) bounds the calendar fetch; the tracker clamps it. */
+    private refreshSessionShading(): void {
+        const chart = this.inner;
+        if (!chart) return;
+        const lookbackMs = Math.max(this.bars, this.rangeBars) * timeframeMs(this.timeframe);
+        this.sessionShading.track(chart.data, this.symbol, { session: this.session ?? 'regular', lookbackMs });
+    }
+
+    /** The session-shade colors live in the renderer CONFIG (persisted with it, edited
+     *  live by the dialog swatch) — the widget only proxies them into its settings rows. */
+    private sessionShadeColor(key: 'premarketColor' | 'postmarketColor'): string {
+        const cfg = this.inner?.renderer.getConfig() as { sessions?: Record<string, unknown> } | null | undefined;
+        const v = cfg?.sessions?.[key];
+        return typeof v === 'string' ? v : '';
+    }
+
+    private setSessionShadeColor(key: 'premarketColor' | 'postmarketColor', color: string): void {
+        this.inner?.renderer.applyConfig({ sessions: { [key]: color } });
+        this.markStateDirty(); // the colors persist with the renderer config document
+    }
+
+    /**
+     * (Re)contribute the widget's settings-dialog sections: status line parts, the fetch
+     * depth, the watermark toggle, and — only while the active symbol HAS sessions — the
+     * Trading session group (RTH/ETH switch + the pre/post-market shading colors) inside
+     * the Symbol tab. Re-run whenever a gate changes (the dialog reads them on open).
+     */
+    private pushSettingsSections(): void {
+        const chart = this.inner;
+        if (!chart) return;
+        const rth = 'Regular hours (RTH)';
+        const eth = 'Extended hours (ETH)';
+        const sessionSection = {
+            title: 'Trading session',
+            placement: 'symbol' as const,
+            rows: [
+                {
+                    kind: 'select' as const,
+                    label: 'Session',
+                    options: [rth, eth],
+                    get: () => ((this.session ?? 'regular') === 'extended' ? eth : rth),
+                    set: (v: string) => this.setSession(v === eth ? 'extended' : 'regular'),
+                },
+                {
+                    kind: 'color' as const,
+                    label: 'Pre-market',
+                    get: () => this.sessionShadeColor('premarketColor'),
+                    set: (v: string) => this.setSessionShadeColor('premarketColor', v),
+                },
+                {
+                    kind: 'color' as const,
+                    label: 'Post-market',
+                    get: () => this.sessionShadeColor('postmarketColor'),
+                    set: (v: string) => this.setSessionShadeColor('postmarketColor', v),
+                },
+            ],
+        };
+        const advanced = {
+            title: 'Advanced',
+            placement: 'end' as const,
+            rows: [
+                {
+                    kind: 'select' as const,
+                    label: 'Bars to fetch',
+                    options: ['500', '1000', '2000', '5000', '10000', '20000'],
+                    get: () => String(this.bars),
+                    set: (v: string) => {
+                        this.bars = Number(v);
+                        this.markStateDirty();
+                        void this.inner?.setMarket({ bars: Math.max(this.bars, this.rangeBars) });
+                    },
+                },
+            ],
+        };
+        const watermarkSection = {
+            title: 'Watermark',
+            placement: 'symbol' as const,
+            rows: [
+                {
+                    kind: 'toggle' as const,
+                    label: 'Symbol watermark',
+                    get: () => this.watermarkOn,
+                    set: (v: boolean) => this.setWatermarkVisible(v),
+                },
+            ],
+        };
+        const sections: Array<{ title: string; rows: readonly unknown[]; placement?: 'after-symbol' | 'end' | 'symbol' }> = [];
+        if (this.statusline) {
+            const sl = this.statusline;
+            sections.push({
+                title: 'Status line',
+                rows: [
+                    { kind: 'heading', label: 'Status line' },
+                    { kind: 'toggle', label: 'Symbol name', get: () => sl.partVisible('name'), set: (v: boolean) => sl.setPartVisible('name', v) },
+                    { kind: 'toggle', label: 'Market status', get: () => sl.partVisible('market'), set: (v: boolean) => sl.setPartVisible('market', v) },
+                    { kind: 'toggle', label: 'OHLC values', get: () => sl.partVisible('ohlc'), set: (v: boolean) => sl.setPartVisible('ohlc', v) },
+                    { kind: 'toggle', label: 'Bar change values', get: () => sl.partVisible('change'), set: (v: boolean) => sl.setPartVisible('change', v) },
+                    { kind: 'heading', label: 'Indicators' },
+                    {
+                        kind: 'toggle',
+                        label: 'Titles',
+                        get: () => this.indicatorTitlesOn,
+                        set: (v: boolean) => this.setIndicatorTitlesVisible(v),
+                    },
+                    {
+                        kind: 'toggle',
+                        label: 'Values',
+                        get: () => this.indicatorValuesOn,
+                        set: (v: boolean) => this.setIndicatorValuesVisible(v),
+                    },
+                ],
+            });
+        }
+        sections.push(advanced);
+        if (this.sessionsAvailable) sections.push(sessionSection);
+        sections.push(watermarkSection);
+        chart.renderer.setSettingsSections(sections);
     }
 
     /** Star/unstar a timeframe — the topbar chips and dropdown stars follow, and the
@@ -1013,6 +1147,7 @@ export class VelaWidget {
         this.indicatorPicker?.destroy();
         this.tfQuick.destroy();
         this.marketStatus?.stop();
+        this.sessionShading.stop();
         this.statusline?.destroy();
         this.watermark?.destroy();
         this.bottombar?.destroy();
@@ -1190,7 +1325,10 @@ export class VelaWidget {
                 this.refreshSessionToggle(); // the new symbol may (not) have sessions
                 this.marketStatus?.track(chart.data, symbol); // …and its own market clock
             }
-            if (timeframe !== this.timeframe) this.syncTimeframeChrome(timeframe);
+            if (timeframe !== this.timeframe) {
+                this.syncTimeframeChrome(timeframe);
+                this.refreshSessionShading(); // the loaded span (bars × tf) bounds the bands
+            }
         });
         this.history.onChart(chart);
         chart.on('alert', (alert) => {
@@ -1250,67 +1388,7 @@ export class VelaWidget {
         this.statusline?.onChart(chart);
         this.drawingPill.onChart(chart);
         this.syncStatuslineColors();
-        const advanced = {
-            title: 'Advanced',
-            placement: 'end' as const,
-            rows: [
-                {
-                    kind: 'select' as const,
-                    label: 'Bars to fetch',
-                    options: ['500', '1000', '2000', '5000', '10000', '20000'],
-                    get: () => String(this.bars),
-                    set: (v: string) => {
-                        this.bars = Number(v);
-                        this.markStateDirty();
-                        void this.inner?.setMarket({ bars: Math.max(this.bars, this.rangeBars) });
-                    },
-                },
-            ],
-        };
-        const watermarkSection = {
-            title: 'Watermark',
-            placement: 'symbol' as const,
-            rows: [
-                {
-                    kind: 'toggle' as const,
-                    label: 'Symbol watermark',
-                    get: () => this.watermarkOn,
-                    set: (v: boolean) => this.setWatermarkVisible(v),
-                },
-            ],
-        };
-        if (this.statusline) {
-            const sl = this.statusline;
-            chart.renderer.setSettingsSections([
-                {
-                    title: 'Status line',
-                    rows: [
-                        { kind: 'heading', label: 'Status line' },
-                        { kind: 'toggle', label: 'Symbol name', get: () => sl.partVisible('name'), set: (v: boolean) => sl.setPartVisible('name', v) },
-                        { kind: 'toggle', label: 'Market status', get: () => sl.partVisible('market'), set: (v: boolean) => sl.setPartVisible('market', v) },
-                        { kind: 'toggle', label: 'OHLC values', get: () => sl.partVisible('ohlc'), set: (v: boolean) => sl.setPartVisible('ohlc', v) },
-                        { kind: 'toggle', label: 'Bar change values', get: () => sl.partVisible('change'), set: (v: boolean) => sl.setPartVisible('change', v) },
-                        { kind: 'heading', label: 'Indicators' },
-                        {
-                            kind: 'toggle',
-                            label: 'Titles',
-                            get: () => this.indicatorTitlesOn,
-                            set: (v: boolean) => this.setIndicatorTitlesVisible(v),
-                        },
-                        {
-                            kind: 'toggle',
-                            label: 'Values',
-                            get: () => this.indicatorValuesOn,
-                            set: (v: boolean) => this.setIndicatorValuesVisible(v),
-                        },
-                    ],
-                },
-                advanced,
-                watermarkSection,
-            ]);
-        } else {
-            chart.renderer.setSettingsSections([advanced, watermarkSection]);
-        }
+        this.pushSettingsSections();
 
         void chart.ready().then(() => {
             if (this.buildSeq !== seq || this.destroyed) return;

--- a/src/widget/bottombar.ts
+++ b/src/widget/bottombar.ts
@@ -168,9 +168,10 @@ export class Bottombar {
         const session = doc.createElement('span');
         session.className = 'vela-bb-session';
         this.sessionEl = session;
-        // Boots in the DISABLED posture (sessions only apply to markets that have them);
-        // the host enables it per active chart via `setSession` once symbol metadata lands.
-        session.title = 'Session — stocks & ETFs only';
+        // Boots HIDDEN (sessions only apply to markets that have them); the host reveals
+        // it per active chart via `setSession` once symbol metadata declares sessions.
+        session.style.display = 'none';
+        session.title = 'Session — regular (RTH) vs extended (ETH) hours';
         for (const [key, label] of [['regular', 'RTH'], ['extended', 'ETH']] as const) {
             const b = doc.createElement('button');
             b.className = 'vela-bb-session-btn' + (key === 'regular' ? ' is-active' : '');
@@ -226,15 +227,15 @@ export class Bottombar {
 
     /**
      * Reflect the ACTIVE chart's session posture. `enabled: false` (a continuous
-     * market, or metadata not landed yet) shows the disabled RTH-active stub — the
-     * pre-session-model look, byte-for-byte. Enabled, the chips become clickable and
-     * the active one tracks the chart's current session.
+     * market, or metadata not landed yet) HIDES the toggle entirely — RTH/ETH is
+     * meaningless there. Enabled, the chips appear and the active one tracks the
+     * chart's current session.
      */
     setSession(state: { session: 'regular' | 'extended'; enabled: boolean }): void {
-        if (this.sessionEl) this.sessionEl.title = state.enabled ? 'Session — regular (RTH) vs extended (ETH) hours' : 'Session — stocks & ETFs only';
+        if (this.sessionEl) this.sessionEl.style.display = state.enabled ? '' : 'none';
         for (const [key, b] of this.sessionButtons) {
             b.disabled = !state.enabled;
-            b.classList.toggle('is-active', state.enabled ? key === state.session : key === 'regular');
+            b.classList.toggle('is-active', key === (state.enabled ? state.session : 'regular'));
         }
     }
 

--- a/src/widget/context-menu.ts
+++ b/src/widget/context-menu.ts
@@ -55,6 +55,9 @@ export class ChartContextMenu {
             host,
             items: [],
             placement: 'bottom-start',
+            // Pointer-anchored action menu: checked state reads as a leading ✓, not a
+            // washed row (which would read as hover in a menu with no trigger button).
+            checkmarks: true,
             onSelect: (id) => this.run(id),
         });
         host.addEventListener('contextmenu', this.onContextMenu);

--- a/src/widget/data-window.ts
+++ b/src/widget/data-window.ts
@@ -22,6 +22,9 @@ const CSS = `
     letter-spacing: 0.08em;
 }
 .vela-dw-group:first-child { border-top: none; margin-top: 0; padding-top: 8px; }
+/* The readout is DATA, not chrome: selectable (an exception to the UI-wide
+   user-select:none) so values can be copied out. The panel header stays chrome. */
+.vela-dw-group, .vela-dw-row { user-select: text; -webkit-user-select: text; cursor: text; }
 .vela-dw-row {
     display: flex;
     align-items: center;

--- a/src/widget/session-shading.ts
+++ b/src/widget/session-shading.ts
@@ -1,0 +1,99 @@
+// Session-zone derivation + tracker behind the pre/post-market chart shading: turns a
+// provider's RESOLVED calendar windows (`DataProvider.getCalendar`) into the pre/post
+// bands the renderer's `sessionZones` feature shades. Symbols with no calendar (crypto,
+// a provider without the capability) report null — no session structure, nothing shaded.
+import type { DataControl } from '../core/DataControl';
+import type { MarketSession } from '../core/options';
+import type { CalendarWindow } from './market-status';
+
+/** The `sessionZones` feature payload: `[start, end)` epoch-ms bands per phase. */
+export interface SessionZonesUpdate {
+    pre: CalendarWindow[];
+    post: CalendarWindow[];
+}
+
+/**
+ * The extended tape minus regular hours, split into pre/post bands: inside one extended
+ * window, every gap BEFORE a regular open still ahead is pre-market (a lunch-break gap
+ * counts — the day's session resumes), and the remainder after the last regular close is
+ * post-market. An extended window with no regular hours at all (a data quirk) reads as
+ * post — nothing opens ahead within it.
+ */
+export function deriveSessionZones(regular: ReadonlyArray<CalendarWindow>, extended: ReadonlyArray<CalendarWindow>): SessionZonesUpdate {
+    const pre: CalendarWindow[] = [];
+    const post: CalendarWindow[] = [];
+    for (const [extStart, extEnd] of extended) {
+        const inside = regular
+            .filter(([s, e]) => e > extStart && s < extEnd)
+            .sort((a, b) => a[0] - b[0]);
+        let cursor = extStart;
+        for (const [regStart, regEnd] of inside) {
+            if (regStart > cursor) pre.push([cursor, Math.min(regStart, extEnd)]);
+            cursor = Math.max(cursor, regEnd);
+        }
+        if (cursor < extEnd) post.push([cursor, extEnd]);
+    }
+    return { pre, post };
+}
+
+/** How far past `now` one evaluation fetches windows — covers the live right edge for
+ *  days of an open chart (a market change re-evaluates long before this runs out). */
+const FETCH_AHEAD_MS = 10 * 86_400_000;
+/** Lookback clamp: at least a few days of bands, at most a calendar fetch that stays cheap. */
+const MIN_LOOKBACK_MS = 3 * 86_400_000;
+const MAX_LOOKBACK_MS = 120 * 86_400_000;
+
+/**
+ * Keeps ONE chart's session shading honest: resolves the symbol's provider, reads its
+ * calendar when it has one (`getCalendar` + a real session vocabulary on syminfo), and
+ * reports the pre/post bands over the chart's loaded span. `track` rebinds on any
+ * market change; `stop` invalidates in-flight work. Reports:
+ *  - `null` — no session structure at all (continuous market / no calendar);
+ *  - empty bands — sessions exist but the REGULAR tape is shown (no pre/post bars on
+ *    screen to shade);
+ *  - the derived bands — the extended tape is shown.
+ */
+export class SessionShadingTracker {
+    /** Invalidates detached async work — bumped by every track()/stop(). */
+    private epoch = 0;
+
+    constructor(private readonly onZones: (zones: SessionZonesUpdate | null) => void) {}
+
+    /** (Re)bind to a chart's data surface + market and evaluate once. */
+    track(data: DataControl, symbol: string, opts: { session: MarketSession; lookbackMs: number }): void {
+        const my = ++this.epoch;
+        void this.evaluate(my, data, symbol, opts);
+    }
+
+    stop(): void {
+        this.epoch += 1;
+    }
+
+    private async evaluate(my: number, data: DataControl, symbol: string, opts: { session: MarketSession; lookbackMs: number }): Promise<void> {
+        const resolved = data.resolve(symbol);
+        const provider = resolved ? data.providerInstance(resolved.provider) : undefined;
+        const si = await data.symbolInfo(symbol).catch(() => undefined);
+        if (my !== this.epoch) return;
+        const hasSessions = typeof si?.session === 'string' && si.session !== '' && si.session !== '24x7';
+        if (!provider?.getCalendar || !hasSessions || !resolved) {
+            this.onZones(null);
+            return;
+        }
+        if (opts.session !== 'extended') {
+            // Regular tape: pre/post bars aren't on screen — bands would collapse into
+            // the inter-session gap. Keep the structure known but shade nothing.
+            this.onZones({ pre: [], post: [] });
+            return;
+        }
+        const now = Date.now();
+        const lookback = Math.max(MIN_LOOKBACK_MS, Math.min(MAX_LOOKBACK_MS, opts.lookbackMs));
+        const range = { from: now - lookback, to: now + FETCH_AHEAD_MS };
+        const [regular, extended] = await Promise.all([
+            provider.getCalendar(resolved.ticker, { ...range, session: 'regular' }).catch(() => null),
+            provider.getCalendar(resolved.ticker, { ...range, session: 'extended' }).catch(() => null),
+        ]);
+        if (my !== this.epoch) return;
+        if (!regular || !extended) return; // transient fetch failure — keep the last bands
+        this.onZones(deriveSessionZones(regular, extended));
+    }
+}

--- a/src/widget/topbar.ts
+++ b/src/widget/topbar.ts
@@ -70,12 +70,14 @@ const CSS = `
     color: var(--vela-fg-muted);
 }
 .vela-widget-tf-caret:hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
+/* The merged trigger is a plain button (hover feedback only) — the highlight
+   background marks the CURRENT chip among favorites, and a lone trigger with a
+   permanent highlight would read as stuck-pressed. */
 .vela-widget-tf-caret[data-solo='1'] {
     width: auto;
     padding: 0 6px 0 9px;
     gap: 4px;
     color: var(--vela-fg-bright);
-    background: var(--vela-hover-strong);
     font-size: 13px;
     font-weight: 550;
     white-space: nowrap;

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -135,6 +135,8 @@ export interface CellDeps {
     activate(id: string): void;
     /** The cell's market changed in place (chrome/retention refresh upstream). */
     onMarketChanged(id: string): void;
+    /** The cell's price style changed in place (topbar icon/menu refresh upstream). */
+    onPriceStyleChanged(id: string): void;
     /** The cell's indicator ledger changed (count/picker refresh upstream). */
     onIndicatorsChanged(id: string): void;
     /** Persistable per-cell state changed outside the market/indicator channels
@@ -569,6 +571,7 @@ export class ChartCell {
         this.state.priceStyle = style;
         this.inner?.renderer.set('priceStyle', style);
         this.syncStatuslineColors(); // the OHLC ink follows the newly active style's colors
+        this.deps.onPriceStyleChanged(this.id);
     }
 
     /** OHLC/change ink in the status line follows the ACTIVE price style's configured

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -17,6 +17,8 @@ import type { ScriptingEngine } from '../core/ports/ScriptingEngine';
 import type { IndicatorHandle } from '../core/IndicatorHandle';
 import { Statusline, statuslineInkOf } from '../widget/statusline';
 import { MarketStatusTracker } from '../widget/market-status';
+import { SessionShadingTracker } from '../widget/session-shading';
+import { timeframeMs } from '../widget/timeframe';
 import { Watermark } from '../widget/watermark';
 import { ChartContextMenu } from '../widget/context-menu';
 import { WidgetHistory } from '../widget/history';
@@ -166,6 +168,8 @@ export class ChartCell {
     private readonly statusline: Statusline | null;
     /** Keeps this cell's market badge on the symbol's real calendar (see {@link MarketStatusTracker}). */
     private readonly marketStatus: MarketStatusTracker | null;
+    /** Keeps the pre/post-market shading on the symbol's real calendar (see {@link SessionShadingTracker}). */
+    private readonly sessionShading = new SessionShadingTracker((zones) => this.inner?.renderer.set('sessionZones', zones));
     private readonly watermark: Watermark | null;
     private readonly contextMenu: ChartContextMenu;
     private readonly offMarket: () => void;
@@ -383,71 +387,8 @@ export class ChartCell {
         this.refreshNativeCatalog();
 
         // HOST settings sections — the same set the widget contributes, per cell
-        // (the shared topbar gear opens the ACTIVE cell's dialog): status line parts,
-        // the per-cell fetch depth, and the per-cell watermark/titles toggles.
-        // Bars/watermark/titles are persistable cell state; a depth-only reload is
-        // silent, so mark dirty here.
-        const advanced = {
-            title: 'Advanced',
-            placement: 'end' as const,
-            rows: [
-                {
-                    kind: 'select' as const,
-                    label: 'Bars to fetch',
-                    options: ['500', '1000', '2000', '5000', '10000', '20000'],
-                    get: () => String(this.state.bars ?? 1000),
-                    set: (v: string) => {
-                        this.state.bars = Number(v);
-                        this.deps.onStateDirty();
-                        void this.inner?.setMarket({ bars: Math.max(this.state.bars, this.rangeBars) });
-                    },
-                },
-            ],
-        };
-        const watermarkSection = {
-            title: 'Watermark',
-            placement: 'symbol' as const,
-            rows: [
-                {
-                    kind: 'toggle' as const,
-                    label: 'Symbol watermark',
-                    get: () => this.watermarkOn,
-                    set: (v: boolean) => this.setWatermarkVisible(v),
-                },
-            ],
-        };
-        if (this.statusline) {
-            const sl = this.statusline;
-            this.inner.renderer.setSettingsSections([
-                {
-                    title: 'Status line',
-                    rows: [
-                        { kind: 'heading', label: 'Status line' },
-                        { kind: 'toggle', label: 'Symbol name', get: () => sl.partVisible('name'), set: (v: boolean) => sl.setPartVisible('name', v) },
-                        { kind: 'toggle', label: 'Market status', get: () => sl.partVisible('market'), set: (v: boolean) => sl.setPartVisible('market', v) },
-                        { kind: 'toggle', label: 'OHLC values', get: () => sl.partVisible('ohlc'), set: (v: boolean) => sl.setPartVisible('ohlc', v) },
-                        { kind: 'toggle', label: 'Bar change values', get: () => sl.partVisible('change'), set: (v: boolean) => sl.setPartVisible('change', v) },
-                        { kind: 'heading', label: 'Indicators' },
-                        {
-                            kind: 'toggle',
-                            label: 'Titles',
-                            get: () => this.indicatorTitlesOn,
-                            set: (v: boolean) => this.setIndicatorTitlesVisible(v),
-                        },
-                        {
-                            kind: 'toggle',
-                            label: 'Values',
-                            get: () => this.indicatorValuesOn,
-                            set: (v: boolean) => this.setIndicatorValuesVisible(v),
-                        },
-                    ],
-                },
-                advanced,
-                watermarkSection,
-            ]);
-        } else {
-            this.inner.renderer.setSettingsSections([advanced, watermarkSection]);
-        }
+        // (the shared topbar gear opens the ACTIVE cell's dialog).
+        this.pushSettingsSections();
 
         // The ONE bookkeeping seam: every market change — cell setters, sync links, or
         // host code calling chart.setMarket directly — lands here and updates the cell
@@ -500,8 +441,133 @@ export class ChartCell {
             if (available !== this.sessionAvailableFlag) {
                 this.sessionAvailableFlag = available;
                 this.deps.onMarketChanged(this.id); // re-project the shared bottombar toggle
+                this.pushSettingsSections(); // the Trading session group follows the symbol
             }
+            this.refreshSessionShading();
         });
+    }
+
+    /** (Re)derive the pre/post-market shading bands for this cell's market. The loaded
+     *  depth (bars × timeframe) bounds the calendar fetch; the tracker clamps it. */
+    private refreshSessionShading(): void {
+        const chart = this.inner;
+        const symbol = this.state.symbol;
+        if (!chart || !symbol) return;
+        const lookbackMs = Math.max(this.state.bars ?? 1000, this.rangeBars) * timeframeMs(this.state.timeframe ?? '60');
+        this.sessionShading.track(chart.data, symbol, { session: this.session, lookbackMs });
+    }
+
+    /** The session-shade colors live in the renderer CONFIG (persisted with it, edited
+     *  live by the dialog swatch) — the cell only proxies them into its settings rows. */
+    private sessionShadeColor(key: 'premarketColor' | 'postmarketColor'): string {
+        const cfg = this.inner?.renderer.getConfig() as { sessions?: Record<string, unknown> } | null | undefined;
+        const v = cfg?.sessions?.[key];
+        return typeof v === 'string' ? v : '';
+    }
+
+    private setSessionShadeColor(key: 'premarketColor' | 'postmarketColor', color: string): void {
+        this.inner?.renderer.applyConfig({ sessions: { [key]: color } });
+        this.deps.onStateDirty(); // the colors persist with the renderer config document
+    }
+
+    /**
+     * (Re)contribute this cell's settings-dialog sections: status line parts, the
+     * per-cell fetch depth, the watermark toggle, and — only while the cell's symbol
+     * HAS sessions — the Trading session group (RTH/ETH switch + the pre/post-market
+     * shading colors) inside the Symbol tab. Bars/watermark/titles are persistable
+     * cell state; a depth-only reload is silent, so mark dirty here. Re-run whenever
+     * a gate changes (the dialog reads the sections on open).
+     */
+    private pushSettingsSections(): void {
+        const chart = this.inner;
+        if (!chart) return;
+        const rth = 'Regular hours (RTH)';
+        const eth = 'Extended hours (ETH)';
+        const sessionSection = {
+            title: 'Trading session',
+            placement: 'symbol' as const,
+            rows: [
+                {
+                    kind: 'select' as const,
+                    label: 'Session',
+                    options: [rth, eth],
+                    get: () => (this.session === 'extended' ? eth : rth),
+                    set: (v: string) => this.setSession(v === eth ? 'extended' : 'regular'),
+                },
+                {
+                    kind: 'color' as const,
+                    label: 'Pre-market',
+                    get: () => this.sessionShadeColor('premarketColor'),
+                    set: (v: string) => this.setSessionShadeColor('premarketColor', v),
+                },
+                {
+                    kind: 'color' as const,
+                    label: 'Post-market',
+                    get: () => this.sessionShadeColor('postmarketColor'),
+                    set: (v: string) => this.setSessionShadeColor('postmarketColor', v),
+                },
+            ],
+        };
+        const advanced = {
+            title: 'Advanced',
+            placement: 'end' as const,
+            rows: [
+                {
+                    kind: 'select' as const,
+                    label: 'Bars to fetch',
+                    options: ['500', '1000', '2000', '5000', '10000', '20000'],
+                    get: () => String(this.state.bars ?? 1000),
+                    set: (v: string) => {
+                        this.state.bars = Number(v);
+                        this.deps.onStateDirty();
+                        void this.inner?.setMarket({ bars: Math.max(this.state.bars, this.rangeBars) });
+                    },
+                },
+            ],
+        };
+        const watermarkSection = {
+            title: 'Watermark',
+            placement: 'symbol' as const,
+            rows: [
+                {
+                    kind: 'toggle' as const,
+                    label: 'Symbol watermark',
+                    get: () => this.watermarkOn,
+                    set: (v: boolean) => this.setWatermarkVisible(v),
+                },
+            ],
+        };
+        const sections: Array<{ title: string; rows: readonly unknown[]; placement?: 'after-symbol' | 'end' | 'symbol' }> = [];
+        if (this.statusline) {
+            const sl = this.statusline;
+            sections.push({
+                title: 'Status line',
+                rows: [
+                    { kind: 'heading', label: 'Status line' },
+                    { kind: 'toggle', label: 'Symbol name', get: () => sl.partVisible('name'), set: (v: boolean) => sl.setPartVisible('name', v) },
+                    { kind: 'toggle', label: 'Market status', get: () => sl.partVisible('market'), set: (v: boolean) => sl.setPartVisible('market', v) },
+                    { kind: 'toggle', label: 'OHLC values', get: () => sl.partVisible('ohlc'), set: (v: boolean) => sl.setPartVisible('ohlc', v) },
+                    { kind: 'toggle', label: 'Bar change values', get: () => sl.partVisible('change'), set: (v: boolean) => sl.setPartVisible('change', v) },
+                    { kind: 'heading', label: 'Indicators' },
+                    {
+                        kind: 'toggle',
+                        label: 'Titles',
+                        get: () => this.indicatorTitlesOn,
+                        set: (v: boolean) => this.setIndicatorTitlesVisible(v),
+                    },
+                    {
+                        kind: 'toggle',
+                        label: 'Values',
+                        get: () => this.indicatorValuesOn,
+                        set: (v: boolean) => this.setIndicatorValuesVisible(v),
+                    },
+                ],
+            });
+        }
+        sections.push(advanced);
+        if (this.sessionAvailableFlag) sections.push(sessionSection);
+        sections.push(watermarkSection);
+        chart.renderer.setSettingsSections(sections);
     }
 
     /** Show/hide this cell's symbol watermark (persisted per cell). */
@@ -821,6 +887,7 @@ export class ChartCell {
         this.contextMenu.destroy();
         this.history.destroy();
         this.marketStatus?.stop();
+        this.sessionShading.stop();
         this.statusline?.destroy();
         this.watermark?.destroy();
         this.inner?.destroy();

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -1043,6 +1043,7 @@ export class VelaWorkspace {
                 context: () => this.context(),
                 activate: (id) => this.setActiveCell(id),
                 onMarketChanged: (id) => this.onCellMarketChanged(id),
+                onPriceStyleChanged: (id) => this.onCellPriceStyleChanged(id),
                 onIndicatorsChanged: (id) => this.onCellIndicatorsChanged(id),
                 onStateDirty: () => this.markStateDirty(),
                 manifestSettled: () => this.manifestSettled,
@@ -1385,6 +1386,17 @@ export class VelaWorkspace {
         this.mobileBar?.setTimeframe(cell.timeframe);
         this.objectTree.setSymbol(cell.symbol);
         this.bottombar?.setSession({ session: cell.session, enabled: cell.sessionAvailable });
+    }
+
+    /** Trigger ② — a cell's price style changed: the topbar button/menu only if active.
+     *  Reads the cell back (not the requested style) so the button reflects what the
+     *  renderer actually applied. */
+    private onCellPriceStyleChanged(id: string): void {
+        this.markStateDirty();
+        if (id !== this.activeId) return;
+        const cell = this.cellsById.get(id);
+        if (!cell) return;
+        this.topbar.setPriceStyle(cell.priceStyle);
     }
 
     /** Trigger ② — a cell's indicator ledger changed: count + picker only if active. */

--- a/test/inputs-when.test.ts
+++ b/test/inputs-when.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { inputVisible, type InputWhen, type InputValue } from '../src/core/model/inputs';
+
+const bag: Record<string, InputValue> = {
+    enabled: true,
+    mode: 'Manual',
+    level: 3,
+};
+
+describe('inputVisible — settings-dialog `when` gate', () => {
+    it('shows an input with no gate', () => {
+        expect(inputVisible(undefined, bag)).toBe(true);
+    });
+
+    it('matches a toggle with `equals`', () => {
+        expect(inputVisible({ key: 'enabled', equals: true }, bag)).toBe(true);
+        expect(inputVisible({ key: 'enabled', equals: false }, bag)).toBe(false);
+    });
+
+    it('matches one dropdown choice with `equals`', () => {
+        expect(inputVisible({ key: 'mode', equals: 'Manual' }, bag)).toBe(true);
+        expect(inputVisible({ key: 'mode', equals: 'Auto' }, bag)).toBe(false);
+    });
+
+    it('matches a set of dropdown choices with `anyOf`', () => {
+        expect(inputVisible({ key: 'mode', anyOf: ['Manual', 'Hybrid'] }, bag)).toBe(true);
+        expect(inputVisible({ key: 'mode', anyOf: ['Auto', 'Off'] }, bag)).toBe(false);
+    });
+
+    it('ANDs several conditions together', () => {
+        const both: InputWhen = [
+            { key: 'enabled', equals: true },
+            { key: 'mode', equals: 'Manual' },
+        ];
+        expect(inputVisible(both, bag)).toBe(true);
+        expect(inputVisible(both, { ...bag, mode: 'Auto' })).toBe(false);
+    });
+
+    it('compares strictly — a numeric value never matches its string twin', () => {
+        expect(inputVisible({ key: 'level', equals: 3 }, bag)).toBe(true);
+        expect(inputVisible({ key: 'level', equals: '3' }, bag)).toBe(false);
+    });
+
+    it('fails a condition on a key absent from the values', () => {
+        expect(inputVisible({ key: 'missing', equals: true }, bag)).toBe(false);
+        expect(inputVisible({ key: 'missing', anyOf: [true, false] }, bag)).toBe(false);
+    });
+});

--- a/test/session-shading.test.ts
+++ b/test/session-shading.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { deriveSessionZones } from '../src/widget/session-shading';
+
+// One synthetic trading day, hour-granular epoch ms (readable offsets).
+const H = 3_600_000;
+
+describe('deriveSessionZones', () => {
+    it('splits an extended window into pre and post around the regular hours', () => {
+        // ETH 4:00–20:00, RTH 9:30–16:00 (the US-equities shape).
+        const zones = deriveSessionZones([[9.5 * H, 16 * H]], [[4 * H, 20 * H]]);
+        expect(zones.pre).toEqual([[4 * H, 9.5 * H]]);
+        expect(zones.post).toEqual([[16 * H, 20 * H]]);
+    });
+
+    it('emits no pre band when the extended tape opens with regular hours', () => {
+        const zones = deriveSessionZones([[4 * H, 16 * H]], [[4 * H, 20 * H]]);
+        expect(zones.pre).toEqual([]);
+        expect(zones.post).toEqual([[16 * H, 20 * H]]);
+    });
+
+    it('emits no post band on an early-close day whose extended window ends at the bell', () => {
+        const zones = deriveSessionZones([[9.5 * H, 13 * H]], [[4 * H, 13 * H]]);
+        expect(zones.pre).toEqual([[4 * H, 9.5 * H]]);
+        expect(zones.post).toEqual([]);
+    });
+
+    it('classifies a mid-session gap as pre (the session resumes ahead)', () => {
+        // A lunch-break market: two regular windows inside one extended window.
+        const zones = deriveSessionZones(
+            [[9 * H, 11.5 * H], [12.5 * H, 15 * H]],
+            [[8 * H, 17 * H]],
+        );
+        expect(zones.pre).toEqual([[8 * H, 9 * H], [11.5 * H, 12.5 * H]]);
+        expect(zones.post).toEqual([[15 * H, 17 * H]]);
+    });
+
+    it('treats an extended window with no regular hours as post', () => {
+        const zones = deriveSessionZones([], [[4 * H, 20 * H]]);
+        expect(zones.pre).toEqual([]);
+        expect(zones.post).toEqual([[4 * H, 20 * H]]);
+    });
+
+    it('handles multiple days independently', () => {
+        const day = 24 * H;
+        const zones = deriveSessionZones(
+            [[9.5 * H, 16 * H], [day + 9.5 * H, day + 16 * H]],
+            [[4 * H, 20 * H], [day + 4 * H, day + 20 * H]],
+        );
+        expect(zones.pre).toEqual([[4 * H, 9.5 * H], [day + 4 * H, day + 9.5 * H]]);
+        expect(zones.post).toEqual([[16 * H, 20 * H], [day + 16 * H, day + 20 * H]]);
+    });
+});


### PR DESCRIPTION
### Added

- **Indicator inputs that show only when they matter.** An indicator input can now
  declare a condition on another input's current value (a toggle being on, a dropdown
  sitting on one choice or any of several), and its row appears in the settings dialog
  only while that condition holds. The dialog re-evaluates live on every edit — flip
  the governing toggle and the dependent rows appear or disappear in place, group
  headings and tabs whose inputs are all hidden leave with them, and a hidden input
  keeps its value for when it comes back.

- **Auto and Log toggles on the price scale.** Hovering a price scale now reveals
  two small buttons at its bottom — **A** for autoscale and **L** for the
  logarithmic scale — sitting on a full-width background strip so the axis values
  behind them stay readable. Each click toggles its mode for the hovered pane
  independently (log never snaps the scale back to auto), and an active mode wears
  the filled (selected) button style, so the scale's state is readable at a glance
  without opening the axis menu. Hovering a letter shows its themed tooltip
  (Auto / Logarithmic scale).
- **Pre- and post-market session shading.** On markets with trading sessions,
  showing the extended tape now tints the pre-market and post-market time bands
  behind the candles (faint orange and blue by default), derived from the
  provider's market calendar. Both colors are editable — chart settings → Symbol →
  Trading session — and persist with the rest of the chart settings. The same
  Trading session group also carries a Session dropdown, so RTH/ETH can be
  switched from the settings dialog as well as from the bottom bar. The group
  only appears on markets that actually have sessions.

### Changed

- **Right-click menus mark the active choice with a checkmark.** Context menus
  anchored at the pointer — the price-axis, time-axis and chart-body menus, and
  the indicator legend's row menu — now show the selected entry with a ✓ on its
  left instead of a highlighted row, so selection never reads as hover. Dropdown
  menus opened from a button (timeframe, chart style, time zone) keep the
  highlighted-row style.
- **The legend's status indicator steps aside while a row is open.** While an
  indicator's legend row shows its action buttons (on hover or selection), the
  loading dots / live pulse move to after the buttons instead of sitting between
  the title and the actions, so the buttons stay glued to the title.
- **The RTH/ETH toggle only appears on markets with sessions.** The bottom bar's
  session switch used to sit disabled on continuous markets (crypto); it is now
  hidden entirely there and appears once the active symbol declares real trading
  sessions.
- **UI text is no longer selectable.** Chrome text everywhere — titles, buttons,
  menus, legends, dialog labels — can't be text-selected anymore (a drag or a
  sloppy double-click used to leave blue selections across the UI). Text-entry
  fields (text, number, textarea) keep normal selection, and the data window's
  readout stays selectable too — it is data meant to be copied out.

### Fixed

- **Input titles are fully inert.** In the settings and indicator dialogs, an
  input's title no longer reacts to hover or clicks (native `label[for]`
  forwarding used to light up and activate the control from its title) — only
  the input itself is interactive. Titles keep naming their control for
  assistive tech via `aria-labelledby`.

- **The workspace toolbar follows chart-style changes.** In a multi-chart
  workspace, changing the active chart's style now updates the toolbar's style
  button and its menu checkmark immediately — previously they refreshed only
  when the active chart changed, so the button kept showing the old style's
  icon.
- **The timeframe button no longer looks stuck pressed.** Without favorite
  timeframes, the compact timeframe trigger drew a permanent highlight
  background. It now highlights on hover only, like the buttons around it; the
  in-place highlight still marks the current timeframe among favorite chips.
