### PR TITLE
v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Layer-drawn indicators obey the object tree.** Indicators that paint through a
+  plugin renderer layer (order-flow overlays and the like) now take part in the
+  chart's stacking and pane structure like any other indicator: dragging one in the
+  object tree — or using Bring to front / Send to back — actually moves it in front
+  of or behind the candles, moving it to another pane takes its painting along (the
+  new pane scales itself to the visible bars, and collapsing it blanks the painting),
+  and a fresh add is recorded at the top of the stack, which is where such overlays
+  really paint — so the tree reads true from the start. Screenshots composite in the
+  same order the chart shows.
+
 - **The symbol picker browses past its first page.** The search dialog's list was
   hard-capped at 100 rows with no way to load more — on a 13k-symbol venue (US
   equities) the Stocks tab stopped mid-alphabet and everything beyond needed an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to Vela, newest first.
 
-
-## [Unreleased]
+## [v0.6.5]
 
 ### Fixed
 
@@ -23,7 +22,6 @@ All notable changes to Vela, newest first.
   explicit search. Scrolling near the bottom now loads the next 100 rows in place,
   repeatedly, until the pool is exhausted; the rows already on screen never
   reshuffle, and a new query or tab starts back at one page.
-
 
 ## [v0.6.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Vela, newest first.
 
 
+## [Unreleased]
+
+### Fixed
+
+- **The symbol picker browses past its first page.** The search dialog's list was
+  hard-capped at 100 rows with no way to load more — on a 13k-symbol venue (US
+  equities) the Stocks tab stopped mid-alphabet and everything beyond needed an
+  explicit search. Scrolling near the bottom now loads the next 100 rows in place,
+  repeatedly, until the pool is exhausted; the rows already on screen never
+  reshuffle, and a new query or tab starts back at one page.
+
+
 ## [v0.6.4]
 
 ### Added

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -108,6 +108,26 @@ registerRendererLayer({
 });
 ```
 
+**Ownership — layers backed by a native indicator.** When a mounted native indicator's
+type equals a layer's id, that indicator OWNS the layer, and the layer joins the chart's
+normal object model instead of sitting outside it:
+
+- **Stacking:** the layer canvas follows the owner's z key (`seriesOrder`, the object
+  tree's drag/bring-to-front/send-to-back) against the candles' `candleZOrder` — restack
+  the indicator below the candles and its layer paints behind them. Such an indicator
+  mounts at the top of the stack (that is where an `above-data` canvas actually paints),
+  so the recorded order is honest from the first frame. Granularity is the data canvas:
+  model series composite inside ONE canvas, so an owned layer sits below or above that
+  whole canvas, never between two individual plots.
+- **Pane:** `args.scale`/`args.bounds` are the owner's pane — moving the indicator to
+  its own pane takes the layer along. A study pane whose master content is only such
+  layer natives autoscales from the visible bars (layer natives paint at bar prices), a
+  collapsed host pane blanks the layer, and `modulateBase` is consulted only while the
+  owner sits on the price pane.
+
+Chart-type channels (no owning indicator) keep the declared `placement` and the price
+pane, exactly as before.
+
 Two per-frame levers beyond the basic contract:
 
 - **`repaintOnCursor`** (definition): pointer moves normally repaint only the crosshair

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -59,6 +59,7 @@ import { resizeSplit, type PaneSplit } from './core/paneResize';
 import { type ChartConfig, CHART_CONFIG_VERSION, factoryResetConfig, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf, candleOverrideFor } from './core/chartConfig';
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
 import { rendererLayers, foldBaseModulation, type RendererLayerArgs, type RendererLayerDefinition, type RendererLayerInstance, type BasePaintingModulation } from './layers';
+import { stackLayers } from './core/layerStacking';
 import { applyAttributionMarkTheme, attributionMarkColor, createAttributionMark, createCustomMark } from './chrome/AttributionMark';
 import { rasterizeOverlay } from '../shared/dom-raster';
 import type { HostSettingsSection } from './chrome/SettingsDialog';
@@ -145,6 +146,8 @@ export class NativeRenderer implements IChartRenderer {
     private readonly volumeRenderer = new VolumeRenderer();
     /** SDK renderer layers instantiated at mount ({@link registerRendererLayer}). */
     private extLayers: Array<{ def: RendererLayerDefinition; instance: RendererLayerInstance; canvas: HTMLCanvasElement }> = [];
+    /** Last applied layer-canvas order (ids below + above the data canvas) — re-slotted only on change. */
+    private layerOrderSig = '';
     // The attribution mark (see chrome/AttributionMark + the NOTICE file): default-on;
     // disabling requires an equivalent visible attribution elsewhere in the host UI.
     private attributionEl: HTMLElement | null = null;
@@ -1117,9 +1120,7 @@ export class NativeRenderer implements IChartRenderer {
                 if (el.getAttribute('data-vela-screenshot') === 'under') rasterizeOverlay(ctx, el, frame);
             }
         }
-        const below = this.extLayers.filter((l) => l.def.placement === 'below-data').map((l) => l.canvas);
-        const above = this.extLayers.filter((l) => l.def.placement !== 'below-data').map((l) => l.canvas);
-        for (const canvas of [...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above, this.chromeCanvas, this.drawingsCanvas]) {
+        for (const canvas of [...this.canvasPile(), this.chromeCanvas, this.drawingsCanvas]) {
             if (canvas && canvas.width > 0 && canvas.height > 0) ctx.drawImage(canvas, 0, 0);
         }
         if (frame) {
@@ -1293,6 +1294,7 @@ export class NativeRenderer implements IChartRenderer {
         const below = this.extLayers.filter((l) => l.def.placement === 'below-data').map((l) => l.canvas);
         const above = this.extLayers.filter((l) => l.def.placement !== 'below-data').map((l) => l.canvas);
         this.plot.append(...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above, this.chromeCanvas, this.drawingsCanvas, this.cursorCanvas, this.overlayRoot);
+        this.layerOrderSig = ''; // recomputed on the first data frame (owned layers follow their indicator's z)
         this.wrapper.appendChild(this.plot);
         this.factoryConfig = this.getConfig();
         this.attributionEl = this.buildAttributionEl();
@@ -1896,7 +1898,11 @@ export class NativeRenderer implements IChartRenderer {
     mountIndicator(model: IndicatorModel): IndicatorRenderHandle {
         this.scene.indicators.set(model.id, model);
         this.refreshAnchorOffset(model);
-        this.scene.assignIndicatorZ(model.id); // default z = mount order (later ⇒ in front)
+        // Default z = mount order (later ⇒ in front) — except a native that paints through
+        // an SDK layer: its canvas stacks ABOVE the data canvas by default, so its key must
+        // say so or the recorded order (object tree, seriesOrder reads) starts out a lie.
+        if (model.native && this.extLayers.some((l) => l.def.id === model.native!.type)) this.scene.assignIndicatorZTop(model.id);
+        else this.scene.assignIndicatorZ(model.id);
         // Legend chip prefers the compact shorttitle; the settings dialog keeps the full title.
         this.inputsUI.upsert(model.id, model.shorttitle ?? model.title, model.inputs, model.inputValues, model.paneId, {
             native: !!model.native,
@@ -2850,9 +2856,17 @@ export class NativeRenderer implements IChartRenderer {
         const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
         for (const l of this.extLayers) {
             if (!l.def.repaintOnCursor) continue;
-            l.instance.render(this.extLayerArgs(l.def.id, pane.scale, pane.bounds, nowMs));
+            const lp = this.layerPane(l.def.id) ?? pane;
+            if (lp.collapsed) continue; // blanked by the data frame; nothing to hover
+            l.instance.render(this.extLayerArgs(l.def.id, lp.scale, lp.bounds, nowMs));
             if (this.animZoom && l.instance.animating?.()) this.animator.start();
         }
+    }
+
+    /** Blank one SDK layer canvas (a collapsed host pane suppresses the layer's painting). */
+    private clearLayerCanvas(canvas: HTMLCanvasElement): void {
+        if (canvas.width === 0 || canvas.height === 0) return;
+        canvas.getContext('2d')?.clearRect(0, 0, canvas.width, canvas.height);
     }
 
     /** One frame's args for an SDK renderer layer (shared by the data + cursor paint paths). */
@@ -2874,6 +2888,10 @@ export class NativeRenderer implements IChartRenderer {
 
     /** Paint the below-data (L-1) + geometry (L0) + chrome (L1) layers from the current scene/coords. */
     private paintData(): void {
+        // Layer-canvas stacking follows the indicators' z keys — recomputed lazily here so
+        // every path that can move them (a z write, a restored config, a mount/remove, a
+        // pane move) is covered without its own call site. No-op when unchanged.
+        this.syncLayerCanvasOrder();
         this.stampScaleInvert(); // flip axes (if inverted) before any layer reads pane.scale
         this.backend.modelAlpha = this.modelAlpha;
         this.backend.candleBodyAlpha = this.candleBodyAlpha;
@@ -2903,15 +2921,26 @@ export class NativeRenderer implements IChartRenderer {
                 bounds: pane.bounds,
                 theme: this.theme,
             });
-            // SDK renderer layers: shared paint cycle, own channel data, own canvas.
+            // SDK renderer layers: shared paint cycle, own channel data, own canvas. Each
+            // paints on its OWNING indicator's pane (the volume layer's rule, generalized) —
+            // the price pane for chart-type channels and price-pane overlays alike.
             const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
             let folded: BasePaintingModulation | null = null;
             for (const l of this.extLayers) {
-                const args = this.extLayerArgs(l.def.id, pane.scale, pane.bounds, nowMs);
+                const lp: PaneNode = this.layerPane(l.def.id) ?? pane;
+                // A collapsed host pane shows its legend strip only — blank the layer for
+                // the duration (the instance isn't poked, so it can't clear itself).
+                if (lp.collapsed) {
+                    this.clearLayerCanvas(l.canvas);
+                    continue;
+                }
+                const args = this.extLayerArgs(l.def.id, lp.scale, lp.bounds, nowMs);
                 l.instance.render(args);
                 // Any mounted layer may dim/slim the base painting (chart type or overlay)
-                // — folded this same frame, applied below before the backend paints.
-                folded = foldBaseModulation(folded, l.instance.modulateBase?.(args) ?? null);
+                // — folded this same frame, applied below before the backend paints. Only
+                // layers ON the price pane get a say: one moved to its own pane no longer
+                // sits over the candles it would be dimming.
+                if (lp === pane) folded = foldBaseModulation(folded, l.instance.modulateBase?.(args) ?? null);
                 // A pulsing/fading layer keeps the animator alive; it stops itself when done.
                 if (this.animZoom && l.instance.animating?.()) this.animator.start();
             }
@@ -3122,6 +3151,13 @@ export class NativeRenderer implements IChartRenderer {
                     pane.scaleTarget = { min: 0, max: maxVol / VOLUME_PANE_FILL_FRAC };
                     pane.axisFormat = 'volume';
                 }
+            } else if (this.layerNativesOwnPane(pane, masterModels)) {
+                // An SDK-layer native moved to its own pane hits the same placeholder: its
+                // model carries no series, and its layer paints at BAR PRICES (that is what
+                // the price-pane overlay was showing). Scale the pane from the visible bars,
+                // the way the price pane does, so the layer lands where the axis says.
+                pane.scaleTarget = computePaneScale([], this.bars, true, i0, i1, dr, paneLogScale(this.scene, pane), (id) => this.scene.offsetOf(id));
+                pane.percentBaseline = this.bars[i0]?.close ?? 0;
             }
             // Strategy trade markers reserve their PIXEL headroom on the price pane, so a
             // marker stack under the lows (or above the highs) never clips at the pane edge.
@@ -3224,6 +3260,64 @@ export class NativeRenderer implements IChartRenderer {
         return null;
     }
 
+    /** The mounted native indicator that OWNS an SDK layer — the one whose type equals the
+     *  layer id (the id doubles as the data channel, so the pairing is the SDK's own
+     *  contract). Null for chart-type channels and while the owner is hidden (a hidden
+     *  indicator leaves the scene; its cleared data channel paints nothing anyway). */
+    private layerOwner(layerId: string): IndicatorModel | null {
+        for (const m of this.scene.indicators.values()) {
+            if (m.native?.type === layerId) return m;
+        }
+        return null;
+    }
+
+    /** The pane an SDK layer paints on: its owner's pane, else the price pane. */
+    private layerPane(layerId: string): PaneNode | null {
+        const owner = this.layerOwner(layerId);
+        const paneId = owner ? (owner.paneId ?? PRICE_PANE_ID) : PRICE_PANE_ID;
+        return this.scene.panes.get(paneId) ?? null;
+    }
+
+    /** The SDK layer canvases split around the data canvas, each side back-to-front:
+     *  owned layers by their owner's z key against the candles' (an indicator restacked
+     *  below the candles takes its layer canvas along), unowned by declared placement. */
+    private orderedLayerCanvases(): { below: HTMLCanvasElement[]; above: HTMLCanvasElement[] } {
+        const byId = new Map(this.extLayers.map((l) => [l.def.id, l.canvas]));
+        const { below, above } = stackLayers(
+            this.extLayers.map((l) => {
+                const owner = this.layerOwner(l.def.id);
+                return {
+                    id: l.def.id,
+                    placement: l.def.placement === 'below-data' ? 'below-data' as const : 'above-data' as const,
+                    ownerZ: owner ? this.scene.zOf(owner.id) : null,
+                };
+            }),
+            this.scene.candleZ,
+        );
+        return { below: below.map((id) => byId.get(id)!), above: above.map((id) => byId.get(id)!) };
+    }
+
+    /** The full canvas pile in paint order (layers + data/volume/vpvr) — what the DOM
+     *  stacking and the screenshot compositor must both follow. */
+    private canvasPile(): HTMLCanvasElement[] {
+        const { below, above } = this.orderedLayerCanvases();
+        return [...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above];
+    }
+
+    /** Re-slot the SDK layer canvases in the plot when the computed order changed (a z
+     *  write, a restored config, an indicator mount/remove/restack). Runs at the top of
+     *  every data frame; a no-op when the signature is unchanged. Re-inserting an
+     *  absolutely-positioned, pointer-transparent canvas repaints nothing by itself. */
+    private syncLayerCanvasOrder(): void {
+        if (this.extLayers.length === 0 || !this.plot) return;
+        const { below, above } = this.orderedLayerCanvases();
+        const sig = [...below.map((c) => this.extLayers.find((l) => l.canvas === c)!.def.id), '|', ...above.map((c) => this.extLayers.find((l) => l.canvas === c)!.def.id)].join(',');
+        if (sig === this.layerOrderSig) return;
+        this.layerOrderSig = sig;
+        for (const c of below) this.plot.insertBefore(c, this.dataCanvas);
+        for (const c of above) this.plot.insertBefore(c, this.chromeCanvas);
+    }
+
     /** True when an active volume layer is this study pane's ONLY content — so its scale should
      *  come from volume, not the empty {0,1} placeholder. (In the price pane, or alongside a real
      *  series, volume stays a bottom overlay and the master scale wins.) */
@@ -3233,6 +3327,16 @@ export class NativeRenderer implements IChartRenderer {
         if (this.nativeLayerPane('volume') !== pane) return false;
         // The volume indicator's own (series-less) model doesn't count as real content.
         return masterModels.every((m) => m.native?.type === 'volume');
+    }
+
+    /** True when this study pane's master content is only SDK-layer natives (series-less
+     *  models whose type names a mounted layer) — its scale then follows the visible bars
+     *  (see the call site). Any real master series takes over the scale as usual. */
+    private layerNativesOwnPane(pane: PaneNode, masterModels: IndicatorModel[]): boolean {
+        if (pane.kind === 'price' || masterModels.length === 0) return false;
+        return masterModels.every(
+            (m) => m.series.length === 0 && !!m.native && this.extLayers.some((l) => l.def.id === m.native!.type),
+        );
     }
 
     /** Per-pane scale state for a host UI (e.g. a price-axis context menu): the pane's pixel

--- a/src/renderers/native/core/SceneGraph.ts
+++ b/src/renderers/native/core/SceneGraph.ts
@@ -321,6 +321,13 @@ export class SceneGraph {
         if (!this.seriesZ.has(id)) this.seriesZ.set(id, this.bottomZ() - 1);
     }
 
+    /** Mount-time default for a LAYER-BACKED native (it paints on a canvas stacked above the
+     *  data canvas by default): top of the stack, so the recorded order tells the truth from
+     *  the first frame. Keeps an existing key, so a restored stack survives the remount. */
+    assignIndicatorZTop(id: string): void {
+        if (!this.seriesZ.has(id)) this.seriesZ.set(id, this.topZ() + 1);
+    }
+
     forgetIndicatorZ(id: string): void {
         this.seriesZ.delete(id);
     }

--- a/src/renderers/native/core/layerStacking.ts
+++ b/src/renderers/native/core/layerStacking.ts
@@ -1,0 +1,38 @@
+// Stacking of the SDK renderer-layer canvases against the data canvas. Model series all
+// composite inside the ONE data canvas (SceneGraph sorts them by z), so a layer canvas can
+// only slot below or above that whole canvas — this module decides which side and in what
+// order, from the z key of the indicator that OWNS the layer (the mounted native indicator
+// whose type equals the layer id — the id doubles as the data channel, so the pairing is
+// already the SDK's contract). Unowned layers (chart-type channels) keep their declared
+// placement. Pure and unit-tested; the renderer applies the result to the DOM pile and the
+// screenshot compositor.
+
+/** One mounted layer's stacking inputs. */
+export interface LayerStackEntry {
+    /** The layer id (= its data channel). */
+    id: string;
+    /** The definition's declared placement (default 'above-data'). */
+    placement: 'below-data' | 'above-data';
+    /** z key of the owning indicator, or null when no mounted indicator owns this layer. */
+    ownerZ: number | null;
+}
+
+/**
+ * Split the mounted layers around the data canvas, each side back-to-front. An owned
+ * layer sits by its owner's z against `candleZ` (below the data canvas when z < candleZ,
+ * else above — matching how a model series at that z would paint against the candles).
+ * Unowned 'below-data' layers stay at the very back; unowned 'above-data' layers sit
+ * directly over the data canvas, under any owned layer raised above it. Ties keep
+ * registration order (the sort is stable).
+ */
+export function stackLayers(entries: readonly LayerStackEntry[], candleZ: number): { below: string[]; above: string[] } {
+    const keyed = entries.map((e) => ({
+        id: e.id,
+        key: e.ownerZ ?? (e.placement === 'below-data' ? -Infinity : candleZ),
+    }));
+    keyed.sort((a, b) => a.key - b.key);
+    const below: string[] = [];
+    const above: string[] = [];
+    for (const k of keyed) (k.key < candleZ ? below : above).push(k.id);
+    return { below, above };
+}

--- a/src/renderers/native/layers.ts
+++ b/src/renderers/native/layers.ts
@@ -23,7 +23,9 @@ export interface RendererLayerArgs {
     /** Time ranges still loading (`<id>-pending` channel) — skeleton/reveal UIs. */
     pending: ReadonlyArray<readonly [number, number]>;
     coords: CoordinateSystem;
-    /** The price pane's scale + bounds. */
+    /** The scale + bounds of the pane the layer paints on: the pane of the native
+     *  indicator that owns this channel (its type equals the layer id), else the price
+     *  pane — so a layer-backed indicator moved to its own pane takes its layer along. */
     scale: PriceScale;
     bounds: PaneBounds;
     theme: VelaTheme;
@@ -95,7 +97,9 @@ export interface RendererLayerDefinition {
     /** The layer id — also its native-data channel (`setNativeData(id, …)` / `id + '-pending'`). */
     id: string;
     /** Stacking: `'below-data'` = behind the candles (reveal-under styles); `'above-data'` =
-     *  over the candles, under the chrome/axes. Default `'above-data'`. */
+     *  over the candles, under the chrome/axes. Default `'above-data'`. A layer owned by a
+     *  native indicator (its type equals the layer id) follows that indicator's z key in
+     *  the pane stacking instead (`seriesOrder` / the object tree), mounting in front. */
     placement?: 'below-data' | 'above-data';
     /** Repaint this layer when the pointer moves (hover hit-testing UIs). Off by default:
      *  pointer moves normally repaint only the crosshair overlay, not the layers. */

--- a/src/widget/symbol-picker.ts
+++ b/src/widget/symbol-picker.ts
@@ -180,6 +180,10 @@ export interface SymbolPickerOptions {
     host?: HTMLElement;
 }
 
+/** Rows rendered per page — the list GROWS by this much every time the scroll nears the
+ *  bottom, so a 13k-symbol venue browses whole without ever rendering 13k rows up front. */
+const PAGE = 100;
+
 export class SymbolPicker {
     private readonly dialog: Dialog;
     private readonly input: HTMLInputElement;
@@ -190,6 +194,7 @@ export class SymbolPicker {
     private seed = '';
     private activeTab = 'All';
     private tabs!: HTMLElement;
+    private visible = PAGE;
 
     constructor(opts: SymbolPickerOptions) {
         const doc = (opts.host ?? document.body).ownerDocument;
@@ -219,6 +224,16 @@ export class SymbolPicker {
         }
         this.list = doc.createElement('div');
         this.list.className = 'vela-sp-list';
+        // Infinite scroll: nearing the bottom grows the page and APPENDS the new rows —
+        // `filterSymbols` is a pure re-run with a larger limit whose result is a stable
+        // superset (same ranking, same order), so appended rows never reshuffle the ones
+        // already on screen. A short page (rows < visible) means the pool is exhausted.
+        this.list.addEventListener('scroll', () => {
+            if (this.rows.length < this.visible) return;
+            if (this.list.scrollTop + this.list.clientHeight < this.list.scrollHeight - 200) return;
+            this.visible += PAGE;
+            this.grow();
+        });
 
         this.dialog = new Dialog({
             title: 'Symbol Search',
@@ -299,14 +314,19 @@ export class SymbolPicker {
         });
     }
 
-    private refresh(): void {
-        const doc = this.list.ownerDocument;
+    private computeRows(): SymbolDescriptor[] {
         const TAB_TYPES: Record<string, string[]> = { Crypto: ['crypto'], Stocks: ['stock'], ETFs: ['etf'], Forex: ['forex'], Commodities: ['commodity'] };
         const pool =
             this.activeTab === 'All'
                 ? this.source()
                 : this.source().filter((s) => TAB_TYPES[this.activeTab]?.includes((s.type ?? '').toLowerCase()) || (this.activeTab === 'Crypto' && (s.type ?? '').toLowerCase() === 'futures'));
-        this.rows = filterSymbols(pool, this.input.value);
+        return filterSymbols(pool, this.input.value, this.visible);
+    }
+
+    private refresh(): void {
+        const doc = this.list.ownerDocument;
+        this.visible = PAGE; // a new query/tab starts back at one page
+        this.rows = this.computeRows();
         this.highlighted = 0;
         this.list.replaceChildren();
         if (!this.rows.length) {
@@ -316,36 +336,46 @@ export class SymbolPicker {
             this.list.appendChild(empty);
             return;
         }
-        for (const s of this.rows) {
-            const row = doc.createElement('div');
-            row.className = 'vela-sp-row';
-            row.dataset.ticker = s.ticker;
-            // The venue the user is pointing at travels with the pick — the same ticker can be
-            // listed by several providers, and dropping it would silently route to another one.
-            // The LISTING prefix wins over the provider id: it is the canonical spelling.
-            const venue = s.prefix ?? s.provider;
-            if (venue) row.dataset.venue = venue;
-            const av = tickerIconEl(doc, baseOf(s), s.ticker, 'vela-sp-avatar');
-            const main = doc.createElement('span');
-            main.className = 'vela-sp-main';
-            const t = doc.createElement('span');
-            t.className = 'vela-sp-ticker';
-            t.textContent = s.ticker;
-            const d = doc.createElement('span');
-            d.className = 'vela-sp-desc';
-            d.textContent = s.description ?? (s.type ?? '');
-            main.append(t, d);
-            row.append(av, main);
-            if (venue) {
-                const badge = doc.createElement('span');
-                badge.className = 'vela-sp-badge';
-                // Brand colors key on the PROVIDER id; the visible text is the venue label.
-                badge.dataset.p = s.provider ?? venue;
-                badge.textContent = venue;
-                row.appendChild(badge);
-            }
-            this.list.appendChild(row);
-        }
+        for (const s of this.rows) this.list.appendChild(this.rowEl(s));
         this.renderHighlight();
+    }
+
+    /** Append the page the grown `visible` just uncovered — rows already on screen stay put. */
+    private grow(): void {
+        const already = this.rows.length;
+        this.rows = this.computeRows();
+        for (const s of this.rows.slice(already)) this.list.appendChild(this.rowEl(s));
+    }
+
+    private rowEl(s: SymbolDescriptor): HTMLElement {
+        const doc = this.list.ownerDocument;
+        const row = doc.createElement('div');
+        row.className = 'vela-sp-row';
+        row.dataset.ticker = s.ticker;
+        // The venue the user is pointing at travels with the pick — the same ticker can be
+        // listed by several providers, and dropping it would silently route to another one.
+        // The LISTING prefix wins over the provider id: it is the canonical spelling.
+        const venue = s.prefix ?? s.provider;
+        if (venue) row.dataset.venue = venue;
+        const av = tickerIconEl(doc, baseOf(s), s.ticker, 'vela-sp-avatar');
+        const main = doc.createElement('span');
+        main.className = 'vela-sp-main';
+        const t = doc.createElement('span');
+        t.className = 'vela-sp-ticker';
+        t.textContent = s.ticker;
+        const d = doc.createElement('span');
+        d.className = 'vela-sp-desc';
+        d.textContent = s.description ?? (s.type ?? '');
+        main.append(t, d);
+        row.append(av, main);
+        if (venue) {
+            const badge = doc.createElement('span');
+            badge.className = 'vela-sp-badge';
+            // Brand colors key on the PROVIDER id; the visible text is the venue label.
+            badge.dataset.p = s.provider ?? venue;
+            badge.textContent = venue;
+            row.appendChild(badge);
+        }
+        return row;
     }
 }

--- a/test/layer-stacking.test.ts
+++ b/test/layer-stacking.test.ts
@@ -1,0 +1,95 @@
+// SDK layer-canvas stacking (src/renderers/native/core/layerStacking.ts): a layer owned
+// by a native indicator (its type equals the layer id) follows that indicator's z key
+// against the candles', so the object tree's restacking reaches layer-drawn indicators;
+// unowned (chart-type) layers keep their declared placement. The DOM re-slotting and the
+// painted result are exercised in the browser; the ordering rules are the unit-testable part.
+import { describe, it, expect } from 'vitest';
+import { stackLayers } from '../src/renderers/native/core/layerStacking';
+import { SceneGraph } from '../src/renderers/native/core/SceneGraph';
+
+describe('stackLayers', () => {
+    it('unowned layers keep their declared placement', () => {
+        const { below, above } = stackLayers(
+            [
+                { id: 'reveal', placement: 'below-data', ownerZ: null },
+                { id: 'grid', placement: 'above-data', ownerZ: null },
+            ],
+            0,
+        );
+        expect(below).toEqual(['reveal']);
+        expect(above).toEqual(['grid']);
+    });
+
+    it('an owned layer slots by its owner z against the candles', () => {
+        const entries = [
+            { id: 'bubbles', placement: 'above-data' as const, ownerZ: 6 },
+            { id: 'tpo', placement: 'above-data' as const, ownerZ: -2 },
+        ];
+        const { below, above } = stackLayers(entries, 5);
+        expect(below).toEqual(['tpo']); // z -2 < candleZ 5 → behind the data canvas
+        expect(above).toEqual(['bubbles']); // z 6 ≥ 5 → in front
+    });
+
+    it('owner z exactly at candleZ paints in front (matches the series rule "at/above draw in front")', () => {
+        expect(stackLayers([{ id: 'a', placement: 'above-data', ownerZ: 5 }], 5).above).toEqual(['a']);
+    });
+
+    it('orders each side by z; unowned above-data layers sit directly over the data canvas', () => {
+        const { above } = stackLayers(
+            [
+                { id: 'owned-high', placement: 'above-data', ownerZ: 9 },
+                { id: 'style-channel', placement: 'above-data', ownerZ: null }, // key = candleZ 0
+                { id: 'owned-low', placement: 'above-data', ownerZ: 3 },
+            ],
+            0,
+        );
+        expect(above).toEqual(['style-channel', 'owned-low', 'owned-high']);
+    });
+
+    it('unowned below-data layers stay at the very back, behind owned below-candle layers', () => {
+        const { below } = stackLayers(
+            [
+                { id: 'owned-back', placement: 'above-data', ownerZ: -3 },
+                { id: 'reveal', placement: 'below-data', ownerZ: null },
+            ],
+            0,
+        );
+        expect(below).toEqual(['reveal', 'owned-back']);
+    });
+
+    it('ties keep registration order (stable sort)', () => {
+        const { above } = stackLayers(
+            [
+                { id: 'first', placement: 'above-data', ownerZ: 2 },
+                { id: 'second', placement: 'above-data', ownerZ: 2 },
+            ],
+            0,
+        );
+        expect(above).toEqual(['first', 'second']);
+    });
+});
+
+describe('SceneGraph.assignIndicatorZTop', () => {
+    it('mounts at the top of the stack (above the candles and every series)', () => {
+        const scene = new SceneGraph();
+        scene.candleZ = 0;
+        scene.assignIndicatorZ('series-a'); // bottom: -1
+        scene.assignIndicatorZTop('layer-native');
+        expect(scene.zOf('layer-native')).toBeGreaterThan(scene.candleZ);
+        expect(scene.zOf('layer-native')).toBeGreaterThan(scene.zOf('series-a'));
+    });
+
+    it('keeps an existing key, so a restored stacking survives the remount', () => {
+        const scene = new SceneGraph();
+        scene.setIndicatorZ('layer-native', -7); // e.g. restored from a persisted config
+        scene.assignIndicatorZTop('layer-native');
+        expect(scene.zOf('layer-native')).toBe(-7);
+    });
+
+    it('successive mounts stack in add order, newest in front', () => {
+        const scene = new SceneGraph();
+        scene.assignIndicatorZTop('a');
+        scene.assignIndicatorZTop('b');
+        expect(scene.zOf('b')).toBeGreaterThan(scene.zOf('a'));
+    });
+});

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -160,6 +160,18 @@ describe('filterSymbols', () => {
         expect(filterSymbols(list, 'USDT', 2)).toHaveLength(2);
     });
 
+    it('a grown limit yields a stable SUPERSET — the picker appends pages without reshuffling', () => {
+        // The infinite-scroll contract: re-running with a larger limit must keep the smaller
+        // result as its exact prefix, for every query shape (empty, ranked search, scoped).
+        const wide = Array.from({ length: 250 }, (_, i) => ({ ticker: `AA${String(i).padStart(3, '0')}`, description: `Issue ${i}`, provider: 'edgx' }));
+        for (const q of ['', 'AA', 'Issue', 'edgx:']) {
+            const small = filterSymbols(wide, q, 100).map((s) => s.ticker);
+            const big = filterSymbols(wide, q, 200).map((s) => s.ticker);
+            expect(big.slice(0, small.length)).toEqual(small);
+            expect(big.length).toBeGreaterThan(small.length);
+        }
+    });
+
     describe('venue-aware search', () => {
         const venues = [
             { ticker: 'BTCUSDT', description: 'Bitcoin / TetherUS', provider: 'binance' },


### PR DESCRIPTION
### Fixed

- **Layer-drawn indicators obey the object tree.** Indicators that paint through a
  plugin renderer layer (order-flow overlays and the like) now take part in the
  chart's stacking and pane structure like any other indicator: dragging one in the
  object tree — or using Bring to front / Send to back — actually moves it in front
  of or behind the candles, moving it to another pane takes its painting along (the
  new pane scales itself to the visible bars, and collapsing it blanks the painting),
  and a fresh add is recorded at the top of the stack, which is where such overlays
  really paint — so the tree reads true from the start. Screenshots composite in the
  same order the chart shows.

- **The symbol picker browses past its first page.** The search dialog's list was
  hard-capped at 100 rows with no way to load more — on a 13k-symbol venue (US
  equities) the Stocks tab stopped mid-alphabet and everything beyond needed an
  explicit search. Scrolling near the bottom now loads the next 100 rows in place,
  repeatedly, until the pool is exhausted; the rows already on screen never
  reshuffle, and a new query or tab starts back at one page.