### PR TITLE
feat(renderer): categorical (or blank) value axis for layer-owned panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ All notable changes to Vela, newest first.
   new pane scales itself to the visible bars, and collapsing it blanks the painting),
   and a fresh add is recorded at the top of the stack, which is where such overlays
   really paint — so the tree reads true from the start. Screenshots composite in the
-  same order the chart shows.
+  same order the chart shows. The gridlines stay at the very back throughout: sending
+  an indicator behind the candles never hides it behind the grid.
 
 - **The symbol picker browses past its first page.** The search dialog's list was
   hard-capped at 100 rows with no way to load more — on a 13k-symbol venue (US

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Vela, newest first.
 
 ## [Unreleased]
 
+### Added
+
+- **Panes with a categorical (or blank) value axis.** A native indicator whose visuals
+  are painted entirely by a plugin renderer layer can now declare that its pane's
+  content is not value-mapped: the pane then shows no price numbers, no horizontal
+  gridlines, and no crosshair value chip — and instead of a blank axis it can label its
+  own bands (one label per row, placed at any height), the right reading for table- or
+  ribbon-style panes where a price scale would be meaningless. The labels follow the
+  indicator's settings live, and merging a regular series into the pane brings the
+  price axis back automatically.
+
 ### Fixed
 
 - **Layer-drawn indicators obey the object tree.** Indicators that paint through a

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -118,7 +118,9 @@ normal object model instead of sitting outside it:
   mounts at the top of the stack (that is where an `above-data` canvas actually paints),
   so the recorded order is honest from the first frame. Granularity is the data canvas:
   model series composite inside ONE canvas, so an owned layer sits below or above that
-  whole canvas, never between two individual plots.
+  whole canvas, never between two individual plots. The gridlines are the floor: they
+  paint on the backdrop canvas below every layer, so an indicator sent to the very back
+  still renders on top of the grid.
 - **Pane:** `args.scale`/`args.bounds` are the owner's pane — moving the indicator to
   its own pane takes the layer along. A study pane whose master content is only such
   layer natives autoscales from the visible bars (layer natives paint at bar prices), a

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -148,6 +148,21 @@ Two per-frame levers beyond the basic contract:
 Core-computed indicators (no script engine) with renderer-drawn layers — the built-in
 volume and VPVR ride this seam. See `NativeIndicator` types in `vela/plugin`.
 
+A native whose visuals come entirely from a bespoke renderer layer (its `type` equals a
+registered layer id) can override the axis of the pane it OWNS by emitting **`paneAxis`**
+on its output: such content is not value-mapped (the layer paints in pixel bands), so a
+derived price scale would label meaningless numbers. Two shapes:
+
+- `paneAxis: 'none'` — a blank axis;
+- `paneAxis: { bands: [{ frac, label }, …] }` — a **categorical axis**: each label is
+  drawn in the axis column (same typography as price ticks) at `frac` of the pane's
+  height (0 = top, 1 = bottom) — e.g. a table pane labels its rows at their centers.
+
+Either way the pane draws no price ticks, no horizontal gridlines, and no crosshair
+value chip. The override is emitted per compute, so it can follow the inputs (toggling a
+row off relabels the axis). It only holds while overriding natives are the pane's sole
+content; merging any real series into the pane brings the price axis back.
+
 ## Widget actions — `registerWidgetAction`
 
 Contribute UI as **data descriptors** (never DOM) — the widget projects them into its

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1455,6 +1455,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             overlay: d.overlay,
             paneHint: d.paneHint,
             native: { type: record.native!.type },
+            ...(out.paneAxis != null ? { paneAxis: out.paneAxis } : {}),
             series: out.series ?? [],
             fills: out.fills ?? [],
             backgrounds: out.backgrounds ?? [],

--- a/src/core/model/index.ts
+++ b/src/core/model/index.ts
@@ -39,7 +39,7 @@ export type {
     DrawingTable,
 } from './drawings';
 export type { TradeExecution } from './trades';
-export type { IndicatorMeta, PaneHint, IndicatorModel } from './indicator';
+export type { IndicatorMeta, PaneHint, PaneAxis, PaneAxisBand, IndicatorModel } from './indicator';
 export type { DirtyRange, SeriesValueDelta, ValuePatch, SchemaPatch, ScenePatch } from './patch';
 export { stableSeriesId } from './identity';
 export type { IdentifiableKind } from './identity';

--- a/src/core/model/indicator.ts
+++ b/src/core/model/indicator.ts
@@ -17,6 +17,17 @@ export interface IndicatorMeta {
 /** Where an indicator's plots are placed. */
 export type PaneHint = 'price' | 'new';
 
+/** One label of a categorical pane axis: `frac` is the label's center as a fraction of
+ *  the pane's height (0 = top, 1 = bottom). */
+export interface PaneAxisBand {
+    frac: number;
+    label: string;
+}
+
+/** A pane's value-axis override (see {@link IndicatorModel.paneAxis}): `'none'` = a
+ *  blank axis; band labels = a categorical axis, one label per content band/row. */
+export type PaneAxis = 'none' | { bands: PaneAxisBand[] };
+
 /**
  * Everything one `addIndicator()` produces — the unit the orchestrator mounts
  * on the renderer. Renderer-neutral.
@@ -39,6 +50,17 @@ export interface IndicatorModel {
      * (distinct title color) + list ordering (native indicators pin to the top).
      */
     native?: { type: string };
+    /**
+     * Value-axis override for the pane this indicator OWNS — declared by content that is
+     * not value-mapped (e.g. a bespoke renderer layer painting in pixel bands), where a
+     * derived price scale would label meaningless numbers. `'none'` leaves the axis blank;
+     * band labels place text at fractions of the pane's height (a categorical axis — one
+     * label per band/row, e.g. `frac: 0.25` centers a label in the top quarter). Either way
+     * the renderer draws no price ticks, no horizontal gridlines, and no crosshair value
+     * chip in that pane. Only honored while such indicators are the pane's sole content —
+     * any real series merged into the pane takes the scale (and its labels) back over.
+     */
+    paneAxis?: PaneAxis;
     /** Resolved pane id, filled in by the orchestrator after routing. */
     paneId?: string;
     /**

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -1,4 +1,5 @@
 import type { OHLCV } from '../model/ohlcv';
+import type { PaneAxis } from '../model/indicator';
 import type { SeriesSpec } from '../model/series';
 import type { Fill, Background, PriceLine } from '../model/scene';
 import type { DrawingLine, DrawingBox, DrawingLabel, DrawingPolyline, DrawingLinefill, DrawingTable } from '../model/drawings';
@@ -14,6 +15,13 @@ import type { DataControl } from '../DataControl';
  * columns — instead pushes its payload through the dedicated renderer seam, `pushData`.)
  */
 export interface NativeIndicatorOutput {
+    /**
+     * Value-axis override for the pane this native OWNS (see `IndicatorModel.paneAxis`):
+     * `'none'` for content that is not value-mapped, or band labels for a categorical
+     * axis. Emitted per compute, so it can follow the inputs (e.g. row toggles relabel
+     * the axis). Absent ⇒ the pane derives a scale from its content as usual.
+     */
+    paneAxis?: PaneAxis;
     series?: SeriesSpec[];
     fills?: Fill[];
     backgrounds?: Background[];

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -21,7 +21,7 @@ import type { OHLCV } from '../../core/model/ohlcv';
 import type { Millis } from '../../core/model/time';
 import type { VolumeLayerData, VpvrLayerData } from '../../core/model/volume-layers';
 import type { Pane } from '../../core/model/scene';
-import type { IndicatorModel } from '../../core/model/indicator';
+import type { IndicatorModel, PaneAxisBand } from '../../core/model/indicator';
 import type { ScenePatch } from '../../core/model/patch';
 import type { InputValue, SymbolPickerFn } from '../../core/model/inputs';
 import type { RendererDisplayOptions, NativeBackend, PriceStyle, MoveTarget, ThemeName } from '../../core/options';
@@ -3145,6 +3145,7 @@ export class NativeRenderer implements IChartRenderer {
             // 0..maxVol mapping so labels line up with the bars. Only when volume is this pane's
             // sole content (any real merged/master series takes over the scale as usual).
             pane.axisFormat = undefined;
+            pane.axisBands = undefined;
             if (this.volumeOwnsPane(pane, masterModels)) {
                 const maxVol = this.maxVisibleVolume(i0, i1);
                 if (maxVol > 0) {
@@ -3158,6 +3159,14 @@ export class NativeRenderer implements IChartRenderer {
                 // the way the price pane does, so the layer lands where the axis says.
                 pane.scaleTarget = computePaneScale([], this.bars, true, i0, i1, dr, paneLogScale(this.scene, pane), (id) => this.scene.offsetOf(id));
                 pane.percentBaseline = this.bars[i0]?.close ?? 0;
+                // Content declaring a paneAxis override is not value-mapped: no price
+                // ticks, no horizontal gridlines, no crosshair chip — and band labels
+                // (a categorical axis) draw in the price ticks' place.
+                if (masterModels.every((m) => m.paneAxis != null)) {
+                    pane.axisFormat = 'none';
+                    const banded = masterModels.find((m) => typeof m.paneAxis === 'object');
+                    pane.axisBands = banded ? (banded.paneAxis as { bands: PaneAxisBand[] }).bands : undefined;
+                }
             }
             // Strategy trade markers reserve their PIXEL headroom on the price pane, so a
             // marker stack under the lows (or above the highs) never clips at the pane edge.

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -57,6 +57,7 @@ import { mergeTradeMarkersState, tradesPriceHints, type TradeMarkerHints } from 
 import { rescaleAround, shiftScale } from './core/manualScale';
 import { resizeSplit, type PaneSplit } from './core/paneResize';
 import { type ChartConfig, CHART_CONFIG_VERSION, factoryResetConfig, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf, candleOverrideFor } from './core/chartConfig';
+import { BackdropRenderer } from './backdrop/BackdropRenderer';
 import { VolumeRenderer, VOLUME_PANE_FILL_FRAC } from './volume/VolumeRenderer';
 import { rendererLayers, foldBaseModulation, type RendererLayerArgs, type RendererLayerDefinition, type RendererLayerInstance, type BasePaintingModulation } from './layers';
 import { stackLayers } from './core/layerStacking';
@@ -135,6 +136,7 @@ export class NativeRenderer implements IChartRenderer {
     private plot!: HTMLDivElement; // the plot area (canvases + DOM overlays), inset to the right of the toolbar gutter
     private toolbarGutter = 0; // px reserved on the left for the docked drawings toolbar (0 when hidden)
     private mountContainer: HTMLElement | null = null; // the host-owned element mount() renders into
+    private backdropCanvas!: HTMLCanvasElement; // session highlights + gridlines, the pile's very bottom
     private dataCanvas!: HTMLCanvasElement;
     private volumeCanvas!: HTMLCanvasElement; // bottom-anchored volume columns above grid/candles
     private vpvrCanvas!: HTMLCanvasElement; // visible-range volume profile (above candles, right edge)
@@ -143,6 +145,7 @@ export class NativeRenderer implements IChartRenderer {
     private cursorCanvas!: HTMLCanvasElement;
     private overlayRoot!: HTMLDivElement;
     private userDrawings: UserDrawingController | null = null;
+    private readonly backdropRenderer = new BackdropRenderer();
     private readonly volumeRenderer = new VolumeRenderer();
     /** SDK renderer layers instantiated at mount ({@link registerRendererLayer}). */
     private extLayers: Array<{ def: RendererLayerDefinition; instance: RendererLayerInstance; canvas: HTMLCanvasElement }> = [];
@@ -1245,6 +1248,11 @@ export class NativeRenderer implements IChartRenderer {
         // Every DOM overlay below is a descendant, so the chrome tokens land once here.
         applyChromeTokens(this.wrapper, this.chromeTheme());
 
+        // L-2 backdrop: session highlights + gridlines, the very BOTTOM of the pile — even
+        // an SDK layer canvas slotted below the data canvas stays above the grid.
+        this.backdropCanvas = document.createElement('canvas');
+        Object.assign(this.backdropCanvas.style, { position: 'absolute', inset: '0', width: '100%', height: '100%', pointerEvents: 'none' });
+
         // L0.25 volume columns: bottom-anchored per-bar volume, ABOVE the geometry canvas so
         // grid lines and candles cannot paint over them. Transparent + pointer-transparent.
         this.volumeCanvas = document.createElement('canvas');
@@ -1293,7 +1301,7 @@ export class NativeRenderer implements IChartRenderer {
         });
         const below = this.extLayers.filter((l) => l.def.placement === 'below-data').map((l) => l.canvas);
         const above = this.extLayers.filter((l) => l.def.placement !== 'below-data').map((l) => l.canvas);
-        this.plot.append(...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above, this.chromeCanvas, this.drawingsCanvas, this.cursorCanvas, this.overlayRoot);
+        this.plot.append(this.backdropCanvas, ...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above, this.chromeCanvas, this.drawingsCanvas, this.cursorCanvas, this.overlayRoot);
         this.layerOrderSig = ''; // recomputed on the first data frame (owned layers follow their indicator's z)
         this.wrapper.appendChild(this.plot);
         this.factoryConfig = this.getConfig();
@@ -1304,6 +1312,7 @@ export class NativeRenderer implements IChartRenderer {
         container.appendChild(this.wrapper);
         this.applyBackground();
 
+        this.backdropRenderer.mount(this.backdropCanvas);
         this.volumeRenderer.mount(this.volumeCanvas);
         this.vpvrRenderer.mount(this.vpvrCanvas);
         for (const l of this.extLayers) l.instance.mount(l.canvas);
@@ -1623,6 +1632,7 @@ export class NativeRenderer implements IChartRenderer {
         this.scrollButton = null;
         for (const l of this.extLayers) l.instance.destroy?.();
         this.extLayers = [];
+        this.backdropRenderer.destroy();
         this.volumeRenderer.destroy();
         this.vpvrRenderer.destroy();
         this.backend.destroy();
@@ -2896,7 +2906,7 @@ export class NativeRenderer implements IChartRenderer {
         this.backend.modelAlpha = this.modelAlpha;
         this.backend.candleBodyAlpha = this.candleBodyAlpha;
         this.backend.candleStructureAlpha = this.candleStructureAlpha;
-        this.backend.gridAlpha = 1;
+        let gridAlpha = 1; // the backdrop's gridline opacity (layers may fade it via modulateBase)
         const candleBodyScale = 1;
         this.backend.candleBodyScale = candleBodyScale;
         const pane = this.scene.panes.get(PRICE_PANE_ID);
@@ -2947,7 +2957,7 @@ export class NativeRenderer implements IChartRenderer {
             if (folded) {
                 if (folded.candleBodyScale != null) this.backend.candleBodyScale = clamp01(folded.candleBodyScale) || 0.01;
                 if (folded.candleBodyAlpha != null) this.backend.candleBodyAlpha = clamp01(folded.candleBodyAlpha) * this.candleBodyAlpha;
-                if (folded.gridAlpha != null) this.backend.gridAlpha = clamp01(folded.gridAlpha);
+                if (folded.gridAlpha != null) gridAlpha = clamp01(folded.gridAlpha);
             }
         }
         // Live-bar easing: render the eased (gliding) OHLC for the forming bar, then restore the true
@@ -2961,6 +2971,7 @@ export class NativeRenderer implements IChartRenderer {
         // Interleave layers: the drawings whose z sits inside a pane's series stack, prepainted
         // so the backend can composite them mid-stack (under the candles, between indicators).
         this.scene.drawingSlices = this.userDrawings?.prepareSlices(this.scene.orderedPanes().map((p) => p.id)) ?? new Map();
+        this.backdropRenderer.render(this.scene, this.coords, this.theme, gridAlpha); // L-2, under every layer canvas
         this.backend.render(this.scene, this.coords, this.theme);
         this.chrome.render(this.scene, this.coords, this.theme, this.axisSurface());
         this.userDrawings?.render(); // L1.5 — above Pine drawings, below the crosshair
@@ -3306,11 +3317,11 @@ export class NativeRenderer implements IChartRenderer {
         return { below: below.map((id) => byId.get(id)!), above: above.map((id) => byId.get(id)!) };
     }
 
-    /** The full canvas pile in paint order (layers + data/volume/vpvr) — what the DOM
-     *  stacking and the screenshot compositor must both follow. */
+    /** The full canvas pile in paint order (backdrop + layers + data/volume/vpvr) — what
+     *  the DOM stacking and the screenshot compositor must both follow. */
     private canvasPile(): HTMLCanvasElement[] {
         const { below, above } = this.orderedLayerCanvases();
-        return [...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above];
+        return [this.backdropCanvas, ...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above];
     }
 
     /** Re-slot the SDK layer canvases in the plot when the computed order changed (a z
@@ -3668,6 +3679,8 @@ export class NativeRenderer implements IChartRenderer {
         const ph = h;
         this.dataCanvas.width = Math.round(pw * dpr);
         this.dataCanvas.height = Math.round(ph * dpr);
+        this.backdropCanvas.width = this.dataCanvas.width;
+        this.backdropCanvas.height = this.dataCanvas.height;
         this.volumeCanvas.width = this.dataCanvas.width;
         this.volumeCanvas.height = this.dataCanvas.height;
         for (const l of this.extLayers) { l.canvas.width = this.dataCanvas.width; l.canvas.height = this.dataCanvas.height; }

--- a/src/renderers/native/backdrop/BackdropRenderer.ts
+++ b/src/renderers/native/backdrop/BackdropRenderer.ts
@@ -1,0 +1,108 @@
+import type { VelaTheme } from '../../../core/options';
+import type { CoordinateSystem } from '../core/CoordinateSystem';
+import { percentScaleFor, type SceneGraph } from '../core/SceneGraph';
+import { paneAxisTicks, timeTicks } from '../chrome/ticks';
+import { tzOffsetMs } from '../chrome/tz';
+
+/**
+ * The backdrop layer (L-2): session highlights + the axis gridlines, on their own
+ * canvas at the very BOTTOM of the canvas pile. The grid used to be painted inside the
+ * data canvas, but SDK layer canvases can slot BELOW that canvas (an indicator
+ * restacked behind the candles takes its layer canvas along) — and nothing may ever
+ * paint under the grid. Keeping the grid on the bottom-most canvas makes that
+ * invariant structural instead of hoping every layer stays above it. Repainted on
+ * data frames only, from the same scene/coords the geometry backend reads.
+ */
+export class BackdropRenderer {
+    private canvas: HTMLCanvasElement | null = null;
+    private ctx: CanvasRenderingContext2D | null = null;
+
+    mount(canvas: HTMLCanvasElement): void {
+        this.canvas = canvas;
+        this.ctx = canvas.getContext('2d');
+    }
+
+    destroy(): void {
+        this.canvas = null;
+        this.ctx = null;
+    }
+
+    /** Paint one frame: highlight bands first, gridlines on top (the order they had inside
+     *  the data canvas). `gridAlpha` fades the gridlines as a reveal-under layer opens. */
+    render(scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme, gridAlpha: number): void {
+        const ctx = this.ctx;
+        const canvas = this.canvas;
+        if (!ctx || !canvas) return;
+
+        const dpr = coords.dpr;
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+
+        // Same gate as the geometry backend: no grid before data reaches the view.
+        const n = coords.barCount;
+        if (n === 0) return;
+        const vr = coords.visibleLogicalRange();
+        if (Math.min(n - 1, Math.ceil(vr.to)) < Math.max(0, Math.floor(vr.from))) return;
+
+        this.drawHighlights(ctx, scene, coords);
+        this.drawGrid(ctx, scene, coords, theme, coords.width, gridAlpha);
+    }
+
+    /** Renderer-owned session highlight bands: full-height (all panes), behind the grid.
+     *  Session-zone washes (pre/post-market) paint first, host highlights on top. */
+    private drawHighlights(ctx: CanvasRenderingContext2D, scene: SceneGraph, coords: CoordinateSystem): void {
+        const bands = [...scene.sessionHighlightBands(), ...scene.highlights];
+        if (bands.length === 0) return;
+        for (const band of bands) {
+            const x1 = coords.timeToX(band.from);
+            const x2 = coords.timeToX(band.to);
+            if (x2 < 0 || x1 > coords.width || x2 <= x1) continue;
+            const cx = Math.max(0, x1);
+            const cw = Math.min(coords.width, x2) - cx;
+            if (cw <= 0) continue;
+            ctx.fillStyle = band.color;
+            ctx.fillRect(cx, 0, cw, coords.height);
+        }
+    }
+
+    // ── grid ── vert/horz gate on `scene.showGrid` AND their own per-axis visibility
+    // (style); each uses its own color. Pane separators are drawn on the chrome layer
+    // (full-width, above the data) so series never overpaint them.
+    private drawGrid(ctx: CanvasRenderingContext2D, scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme, dataW: number, gridAlpha: number): void {
+        const panes = scene.orderedPanes();
+        const { gridVert, gridHorz } = scene.style;
+        const vertColor = gridVert.color ?? theme.gridColor;
+        const horzColor = gridHorz.color ?? theme.gridColor;
+        ctx.lineWidth = 1;
+        if (scene.showGrid && gridVert.visible) {
+            ctx.globalAlpha = gridAlpha; // fade the grid out as a reveal-under style opens up
+            ctx.strokeStyle = vertColor;
+            const tr = coords.visibleTimeRange();
+            const offset = tzOffsetMs((tr.from + tr.to) / 2, scene.timezone);
+            ctx.beginPath();
+            for (const tick of timeTicks(tr.from, tr.to, 8, offset)) {
+                const x = Math.round(coords.timeToX(tick.time)) + 0.5;
+                if (x < 0 || x > dataW) continue;
+                ctx.moveTo(x, 0);
+                ctx.lineTo(x, coords.height);
+            }
+            ctx.stroke();
+        }
+        for (const pane of panes) {
+            if (scene.showGrid && gridHorz.visible && !pane.collapsed) {
+                ctx.globalAlpha = gridAlpha; // fade horizontal gridlines so they don't show through fading candles
+                ctx.strokeStyle = horzColor;
+                const pct = percentScaleFor(scene, pane);
+                ctx.beginPath();
+                for (const t of paneAxisTicks(pane.scale, pane.bounds.height, pct, undefined, pane.axisFormat)) {
+                    const y = Math.round(coords.priceToY(t.price, pane.scale, pane.bounds)) + 0.5;
+                    if (y < pane.bounds.top || y > pane.bounds.top + pane.bounds.height) continue;
+                    ctx.moveTo(0, y);
+                    ctx.lineTo(dataW, y);
+                }
+                ctx.stroke();
+            }
+        }
+        ctx.globalAlpha = 1;
+    }
+}

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -849,7 +849,7 @@ export class Canvas2dBackend implements IRenderBackend {
                 ctx.strokeStyle = horzColor;
                 const pct = percentScaleFor(scene, pane);
                 ctx.beginPath();
-                for (const t of paneAxisTicks(pane.scale, pane.bounds.height, pct)) {
+                for (const t of paneAxisTicks(pane.scale, pane.bounds.height, pct, undefined, pane.axisFormat)) {
                     const y = Math.round(coords.priceToY(t.price, pane.scale, pane.bounds)) + 0.5;
                     if (y < pane.bounds.top || y > pane.bounds.top + pane.bounds.height) continue;
                     ctx.moveTo(0, y);

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -6,9 +6,6 @@ import type { SeriesSpec, LineLikeSeries, CandleSeries, LineStyle, CandleBarColo
 import { isLineLikeSeries } from '../../../core/model/series';
 import type { CoordinateSystem } from '../core/CoordinateSystem';
 import type { SceneGraph, PaneNode } from '../core/SceneGraph';
-import { paneAxisTicks, timeTicks } from '../chrome/ticks';
-import { percentScaleFor } from '../core/SceneGraph';
-import { tzOffsetMs } from '../chrome/tz';
 import { candleTier, wickWidth, candleGeometry } from './candle-lod';
 import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, effectiveCandlePaint } from '../core/chartConfig';
 import type { IRenderBackend } from './IRenderBackend';
@@ -16,19 +13,19 @@ import type { IRenderBackend } from './IRenderBackend';
 /**
  * Canvas2d GEOMETRY backend (L0) — the PRIMARY native backend and the WebGL2
  * backend's permanent fallback. Renders immediate-mode from the scene each frame,
- * culled to the visible bar range: grid, bgcolor, fills (flat/conditional/gradient),
+ * culled to the visible bar range: bgcolor, fills (flat/conditional/gradient),
  * candles, line/area/step/histogram/columns/circles/cross with per-point/per-bar
  * color, hline. Per-pane price scales are computed by the renderer BEFORE this
  * runs (it reads pane.scale). Pine drawings, axes, the current-price line, and the
  * crosshair are NOT its concern — they live on the canvas2d chrome (ChromeRenderer)
- * and cursor (CrosshairRenderer) layers above.
+ * and cursor (CrosshairRenderer) layers above; the grid + session highlights live
+ * on the backdrop canvas below (BackdropRenderer).
  */
 export class Canvas2dBackend implements IRenderBackend {
     readonly kind = 'canvas2d' as const;
     modelAlpha = 1;
     candleBodyAlpha = 1;
     candleStructureAlpha = 1;
-    gridAlpha = 1;
     candleBodyScale = 1;
     private canvas: HTMLCanvasElement | null = null;
     private ctx: CanvasRenderingContext2D | null = null;
@@ -61,10 +58,8 @@ export class Canvas2dBackend implements IRenderBackend {
         const barColorMap = mergeBarColors(scene.indicators);
         const panes = scene.orderedPanes();
 
-        // ── session highlights (very back, behind grid + data) ──
-        this.drawHighlights(ctx, scene, coords);
-        // ── grid (behind everything) ──
-        this.drawGrid(ctx, scene, coords, theme, dataW);
+        // Session highlights + the grid paint on the renderer's BACKDROP canvas, below
+        // every layer canvas (see backdrop/BackdropRenderer) — nothing to do here.
 
         // ── per-pane data (pane.scale was set by the renderer's autoscale) ──
         for (const pane of panes) {
@@ -790,23 +785,6 @@ export class Canvas2dBackend implements IRenderBackend {
         ctx.fillRect(x1, pane.bounds.top, x2 - x1, pane.bounds.height);
     }
 
-    /** Renderer-owned session highlight bands: full-height (all panes), behind grid + data.
-     *  Session-zone washes (pre/post-market) paint first, host highlights on top. */
-    private drawHighlights(ctx: CanvasRenderingContext2D, scene: SceneGraph, coords: CoordinateSystem): void {
-        const bands = [...scene.sessionHighlightBands(), ...scene.highlights];
-        if (bands.length === 0) return;
-        for (const band of bands) {
-            const x1 = coords.timeToX(band.from);
-            const x2 = coords.timeToX(band.to);
-            if (x2 < 0 || x1 > coords.width || x2 <= x1) continue;
-            const cx = Math.max(0, x1);
-            const cw = Math.min(coords.width, x2) - cx;
-            if (cw <= 0) continue;
-            ctx.fillStyle = band.color;
-            ctx.fillRect(cx, 0, cw, coords.height);
-        }
-    }
-
     private drawHline(ctx: CanvasRenderingContext2D, pl: PriceLine, pane: PaneNode, coords: CoordinateSystem, dataW: number, theme: VelaTheme): void {
         const y = Math.round(coords.priceToY(pl.price, pane.scale, pane.bounds)) + 0.5;
         if (y < pane.bounds.top || y > pane.bounds.top + pane.bounds.height) return;
@@ -818,47 +796,6 @@ export class Canvas2dBackend implements IRenderBackend {
         ctx.lineTo(dataW, y);
         ctx.stroke();
         setDash(ctx, 'solid');
-    }
-
-    // ── grid (L0, behind data) ── vert/horz gate on `scene.showGrid` AND their own
-    // per-axis visibility (style); each uses its own color. Pane separators are drawn on the
-    // chrome layer (full-width, above the data) so series never overpaint them.
-    private drawGrid(ctx: CanvasRenderingContext2D, scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme, dataW: number): void {
-        const panes = scene.orderedPanes();
-        const { gridVert, gridHorz } = scene.style;
-        const vertColor = gridVert.color ?? theme.gridColor;
-        const horzColor = gridHorz.color ?? theme.gridColor;
-        ctx.lineWidth = 1;
-        if (scene.showGrid && gridVert.visible) {
-            ctx.globalAlpha = this.gridAlpha; // fade the grid out as a reveal-under style opens up
-            ctx.strokeStyle = vertColor;
-            const tr = coords.visibleTimeRange();
-            const offset = tzOffsetMs((tr.from + tr.to) / 2, scene.timezone);
-            ctx.beginPath();
-            for (const tick of timeTicks(tr.from, tr.to, 8, offset)) {
-                const x = Math.round(coords.timeToX(tick.time)) + 0.5;
-                if (x < 0 || x > dataW) continue;
-                ctx.moveTo(x, 0);
-                ctx.lineTo(x, coords.height);
-            }
-            ctx.stroke();
-        }
-        for (const pane of panes) {
-            if (scene.showGrid && gridHorz.visible && !pane.collapsed) {
-                ctx.globalAlpha = this.gridAlpha; // fade horizontal gridlines so they don't show through fading candles
-                ctx.strokeStyle = horzColor;
-                const pct = percentScaleFor(scene, pane);
-                ctx.beginPath();
-                for (const t of paneAxisTicks(pane.scale, pane.bounds.height, pct, undefined, pane.axisFormat)) {
-                    const y = Math.round(coords.priceToY(t.price, pane.scale, pane.bounds)) + 0.5;
-                    if (y < pane.bounds.top || y > pane.bounds.top + pane.bounds.height) continue;
-                    ctx.moveTo(0, y);
-                    ctx.lineTo(dataW, y);
-                }
-                ctx.stroke();
-            }
-        }
-        ctx.globalAlpha = 1;
     }
 }
 

--- a/src/renderers/native/backend/IRenderBackend.ts
+++ b/src/renderers/native/backend/IRenderBackend.ts
@@ -5,13 +5,16 @@ import type { SceneGraph } from '../core/SceneGraph';
 /**
  * The single seam between the renderer and a drawing backend. The backend
  * consumes the retained scene + the shared coordinate system and rasterizes the
- * data layer (series, fills, bgcolor, hline, drawing geometry) plus its axes/
- * grid onto the data canvas. Two implementations sit behind it: `Canvas2dBackend`
- * (primary) and, later, `WebGL2Backend` (hand-rolled, selected when available).
+ * data layer (series, fills, bgcolor, hline, drawing geometry) onto the data
+ * canvas. Two implementations sit behind it: `Canvas2dBackend` (primary) and,
+ * later, `WebGL2Backend` (hand-rolled, selected when available).
  *
  * The crosshair is NOT the backend's concern — it's a renderer-owned overlay
  * layer (`CrosshairRenderer`) on its own canvas, repainted on the Scheduler's
- * cheap `Cursor` tier without touching the data layer.
+ * cheap `Cursor` tier without touching the data layer. Neither is the grid: it
+ * lives with the session highlights on the renderer-owned backdrop canvas
+ * (`BackdropRenderer`) at the very bottom of the pile, so SDK layer canvases
+ * stacked below the data canvas still paint above it.
  */
 export interface IRenderBackend {
     readonly kind: 'canvas2d' | 'webgl2';
@@ -24,9 +27,6 @@ export interface IRenderBackend {
     /** Opacity of the candle STRUCTURE (wicks + body border). `1` normally; fades only
      *  partway on zoom-in so the candle keeps a visible skeleton over the revealed layer. */
     candleStructureAlpha: number;
-    /** Opacity of the price/time gridlines. `1` normally; fades to `0` as a reveal-under
-     *  reveals so the grid doesn't show through the translucent candle bodies (a "grid" look). */
-    gridAlpha: number;
     /** Multiplier on the candle BODY width. `1` normally; the renderer shrinks it as a
      *  side-positioned reveal layer opens, freeing the inter-candle gap for it. */
     candleBodyScale: number;

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -6,9 +6,6 @@ import type { SeriesSpec, LineLikeSeries, CandleSeries, LineStyle, CandleBarColo
 import { isLineLikeSeries } from '../../../core/model/series';
 import type { CoordinateSystem } from '../core/CoordinateSystem';
 import type { SceneGraph, PaneNode } from '../core/SceneGraph';
-import { paneAxisTicks, timeTicks } from '../chrome/ticks';
-import { percentScaleFor } from '../core/SceneGraph';
-import { tzOffsetMs } from '../chrome/tz';
 import { candleTier, wickWidth, candleGeometry } from './candle-lod';
 import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha as cssWithAlpha, effectiveCandlePaint } from '../core/chartConfig';
 import type { IRenderBackend } from './IRenderBackend';
@@ -82,18 +79,6 @@ const DASH: Record<string, readonly [number, number] | null> = {
     dotted: [2, 3],
 };
 
-/**
- * A crisp axis-aligned hairline: a ~1-CSS-px line snapped to WHOLE DEVICE pixels — both its position
- * and its width — returned in CSS px so it maps to integer device columns/rows. Without this a 1px
- * grid line lands on a fractional device-pixel phase (different per line at non-integer dpr), and MSAA
- * spreads it across two columns at partial coverage — so lines read gray/dim and vary line-to-line.
- */
-function crispHairline(cssCenter: number, dpr: number): { pos: number; size: number } {
-    const w = Math.max(1, Math.round(dpr)); // ~1 CSS px as a whole number of device px
-    const edge = Math.round(cssCenter * dpr - w / 2); // integer device-px left/top edge
-    return { pos: edge / dpr, size: w / dpr };
-}
-
 /** Triangle-fan segment count for a round line join/cap of half-width `hw` (round enough, not over-tessellated). */
 function joinSegments(hw: number): number {
     return Math.max(6, Math.min(20, Math.round(hw * 4)));
@@ -102,8 +87,9 @@ function joinSegments(hw: number): number {
 /**
  * Hand-rolled WebGL2 GEOMETRY backend (L0). Same `IRenderBackend` seam as the
  * canvas2d backend: it consumes the retained scene + coordinate system and draws
- * grid + bgcolor + fills + candles + series + hline — everything else (axes,
- * drawings, the crosshair) stays on the canvas2d chrome/cursor layers above.
+ * bgcolor + fills + candles + series + hline — everything else stays on canvas2d
+ * layers: axes, drawings and the crosshair on the chrome/cursor layers above, the
+ * grid + session highlights on the backdrop canvas below (BackdropRenderer).
  *
  * Design: ONE per-vertex-color triangle pipeline. Every primitive decomposes into
  * colored triangles (rects, quads, line-quads, fans) in CSS-pixel space; a vertical
@@ -117,7 +103,6 @@ export class WebGL2Backend implements IRenderBackend {
     modelAlpha = 1;
     candleBodyAlpha = 1;
     candleStructureAlpha = 1;
-    gridAlpha = 1;
     candleBodyScale = 1;
     /** Set by the renderer; invoked after a context restore to request a repaint. */
     onNeedsRedraw: (() => void) | null = null;
@@ -381,15 +366,12 @@ export class WebGL2Backend implements IRenderBackend {
                     if (this.drawSliceTexture(gl, slices[si]!.canvas)) liveSlices.add(slices[si]!.canvas);
                 }
             };
-            // z-order within the batch (painter's): grid, bg, fills, then the candles +
-            // each indicator's series interleaved by `scene.candleZ`/per-indicator z, then hlines.
+            // z-order within the batch (painter's): bg, fills, then the candles + each
+            // indicator's series interleaved by `scene.candleZ`/per-indicator z, then hlines.
+            // (The grid + session highlights live on the renderer's backdrop canvas below.)
             b.alpha = 1;
-            // A collapsed pane is a legend-only strip: emit just its separator (via emitGrid), no plots.
-            if (pane.collapsed) {
-                this.emitGrid(b, coords, theme, dataW, pane, scene);
-            } else {
-                this.emitHighlights(b, scene, pane, coords);
-                this.emitGrid(b, coords, theme, dataW, pane, scene);
+            // A collapsed pane is a legend-only strip: no plots (legend + separator are chrome).
+            if (!pane.collapsed) {
                 const models = scene.orderedIndicatorsForPane(pane.id);
                 const isPrice = pane.kind === 'price';
                 // Merged (own-scale) indicators draw against their own price window inside the pane.
@@ -596,53 +578,6 @@ export class WebGL2Backend implements IRenderBackend {
     }
 
     // ── geometry emit (mirrors Canvas2dBackend, in CSS-px space) ──
-    private emitGrid(b: Batch, coords: CoordinateSystem, theme: VelaTheme, dataW: number, pane: PaneNode, scene: SceneGraph): void {
-        const top = pane.bounds.top;
-        const bot = pane.bounds.top + pane.bounds.height;
-        const { gridVert, gridHorz } = scene.style;
-        const dpr = coords.dpr;
-        b.alpha = this.gridAlpha; // fade the grid out as a reveal-under style opens (no grid through translucent candles)
-        // A collapsed pane is a legend-only strip → draw its separator but no gridlines.
-        if (scene.showGrid && gridVert.visible && !pane.collapsed) {
-            const grid = parseColor(gridVert.color ?? theme.gridColor);
-            const tr = coords.visibleTimeRange();
-            const offset = tzOffsetMs((tr.from + tr.to) / 2, scene.timezone);
-            for (const tick of timeTicks(tr.from, tr.to, 8, offset)) {
-                const x = coords.timeToX(tick.time);
-                if (x < 0 || x > dataW) continue;
-                const g = crispHairline(x, dpr); // whole-device-pixel column → crisp, uniform brightness
-                b.rect(g.pos, top, g.size, bot - top, grid);
-            }
-        }
-        if (scene.showGrid && gridHorz.visible && !pane.collapsed) {
-            const grid = parseColor(gridHorz.color ?? theme.gridColor);
-            const pct = percentScaleFor(scene, pane);
-            for (const t of paneAxisTicks(pane.scale, pane.bounds.height, pct, undefined, pane.axisFormat)) {
-                const y = coords.priceToY(t.price, pane.scale, pane.bounds);
-                if (y < top || y > bot) continue;
-                const g = crispHairline(y, dpr); // whole-device-pixel row
-                b.rect(0, g.pos, dataW, g.size, grid);
-            }
-        }
-        // Pane separators are drawn on the chrome layer (full-width, above the data), so nothing here.
-    }
-
-    /** Renderer-owned session highlight bands, clipped per-pane (scissor reconstructs full height).
-     *  Session-zone washes (pre/post-market) paint first, host highlights on top. */
-    private emitHighlights(b: Batch, scene: SceneGraph, pane: PaneNode, coords: CoordinateSystem): void {
-        const bands = [...scene.sessionHighlightBands(), ...scene.highlights];
-        if (bands.length === 0) return;
-        for (const band of bands) {
-            const x1 = coords.timeToX(band.from);
-            const x2 = coords.timeToX(band.to);
-            if (x2 < 0 || x1 > coords.width || x2 <= x1) continue;
-            const cx = Math.max(0, x1);
-            const cw = Math.min(coords.width, x2) - cx;
-            if (cw <= 0) continue;
-            b.rect(cx, pane.bounds.top, cw, pane.bounds.height, parseColor(band.color));
-        }
-    }
-
     private emitBackground(b: Batch, bg: Background, pane: PaneNode, coords: CoordinateSystem): void {
         const x1 = coords.timeToX(bg.from);
         const x2 = coords.timeToX(bg.to);

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -617,7 +617,7 @@ export class WebGL2Backend implements IRenderBackend {
         if (scene.showGrid && gridHorz.visible && !pane.collapsed) {
             const grid = parseColor(gridHorz.color ?? theme.gridColor);
             const pct = percentScaleFor(scene, pane);
-            for (const t of paneAxisTicks(pane.scale, pane.bounds.height, pct)) {
+            for (const t of paneAxisTicks(pane.scale, pane.bounds.height, pct, undefined, pane.axisFormat)) {
                 const y = coords.priceToY(t.price, pane.scale, pane.bounds);
                 if (y < top || y > bot) continue;
                 const g = crispHairline(y, dpr); // whole-device-pixel row

--- a/src/renderers/native/chrome/ChromeRenderer.ts
+++ b/src/renderers/native/chrome/ChromeRenderer.ts
@@ -245,6 +245,15 @@ export class ChromeRenderer {
                 if (y < pane.bounds.top + 6 || y > pane.bounds.top + pane.bounds.height - 4) continue;
                 ctx.fillText(t.label, dataW + 6, y);
             }
+            // A paneAxis-overridden pane labels its bands instead of prices (a
+            // categorical axis) — same column, same typography as the price ticks.
+            if (pane.axisBands) {
+                for (const b of pane.axisBands) {
+                    const y = pane.bounds.top + b.frac * pane.bounds.height;
+                    if (y < pane.bounds.top + 6 || y > pane.bounds.top + pane.bounds.height - 4) continue;
+                    ctx.fillText(b.label, dataW + 6, y);
+                }
+            }
         }
         ctx.textAlign = 'start';
     }

--- a/src/renderers/native/chrome/CrosshairRenderer.ts
+++ b/src/renderers/native/chrome/CrosshairRenderer.ts
@@ -83,7 +83,8 @@ export class CrosshairRenderer {
             }
         }
         const chipBg = cs.labelBackground ?? theme.borderColor;
-        if (pane) {
+        // An unscaled pane (axisFormat 'none') has no value axis, so no value chip either.
+        if (pane && pane.axisFormat !== 'none') {
             const price = coords.yToPrice(ch.y, pane.scale, pane.bounds);
             this.chip(ctx, dataW + 1, ch.y, formatAxisValue(pane.scale, pane.bounds.height, price, percentScaleFor(scene, pane), scene.priceMintick, pane.axisFormat), chipBg, 'left', false, theme.background);
         }
@@ -136,7 +137,7 @@ export class CrosshairRenderer {
                     break;
                 }
             }
-            if (pane) {
+            if (pane && pane.axisFormat !== 'none') {
                 this.chip(ctx, dataW + 1, ext.y, formatAxisValue(pane.scale, pane.bounds.height, ext.price, percentScaleFor(scene, pane), scene.priceMintick, pane.axisFormat), chipBg, 'left', false, theme.background);
             }
         }

--- a/src/renderers/native/chrome/ticks.ts
+++ b/src/renderers/native/chrome/ticks.ts
@@ -142,14 +142,17 @@ function trimZeros(v: number): string {
  * or index values mapped back to price; otherwise nice round prices. Linear only for
  * percent/indexed (the affine price↔percent map keeps the geometry identical to a linear
  * price axis). `format:'volume'` abbreviates the labels (K/M/B) — used for a volume-only pane.
+ * `format:'none'` yields no ticks at all — an unscaled pane (content not value-mapped) draws
+ * neither labels nor the gridlines that would ride them.
  */
 export function paneAxisTicks(
     scale: { min: number; max: number; log?: boolean },
     heightPx: number,
     pct?: PctScale,
     mintick?: number,
-    format?: 'volume',
+    format?: 'volume' | 'none',
 ): Array<{ price: number; label: string }> {
+    if (format === 'none') return [];
     if (pct) {
         const { baseline, indexed } = pct;
         const lo = Math.min(scale.min, scale.max);
@@ -170,15 +173,16 @@ export function paneAxisTicks(
 }
 
 /** Format a single price for an axis chip in the pane's mode (percent / indexed vs absolute; a
- *  volume pane abbreviates with K/M/B). */
+ *  volume pane abbreviates with K/M/B; an unscaled pane yields '' — callers skip the chip). */
 export function formatAxisValue(
     scale: { min: number; max: number; log?: boolean },
     heightPx: number,
     value: number,
     pct?: PctScale,
     mintick?: number,
-    format?: 'volume',
+    format?: 'volume' | 'none',
 ): string {
+    if (format === 'none') return '';
     if (pct) return pct.indexed ? formatIndex(toIndex(value, pct.baseline)) : formatPct(toPct(value, pct.baseline));
     if (format === 'volume') return formatCompactValue(value);
     return formatPriceLabel(scale, heightPx, value, mintick);

--- a/src/renderers/native/core/SceneGraph.ts
+++ b/src/renderers/native/core/SceneGraph.ts
@@ -2,7 +2,7 @@ import type { OHLCV } from '../../../core/model/ohlcv';
 
 import type { VolumeLayerData, VpvrLayerData } from '../../../core/model/volume-layers';
 import type { PaneKind } from '../../../core/model/scene';
-import type { IndicatorModel } from '../../../core/model/indicator';
+import type { IndicatorModel, PaneAxisBand } from '../../../core/model/indicator';
 import type { PriceStyle } from '../../../core/options';
 import type { PriceScale, PaneBounds } from './CoordinateSystem';
 import { type CandlePaintOverride, type ChartStyle, defaultChartStyle } from './chartConfig';
@@ -82,9 +82,16 @@ export interface PaneNode {
      *  height, keeping its weight so expanding restores its proportion. */
     collapsed: boolean;
     /** How this pane's axis labels read. `'volume'` (a volume indicator alone in its own
-     *  pane) abbreviates the scale with K/M/B suffixes; undefined ⇒ the default price format.
-     *  Recomputed per autoscale pass, so it clears the moment the pane's content changes. */
-    axisFormat?: 'volume';
+     *  pane) abbreviates the scale with K/M/B suffixes; `'none'` (a pane whose owning
+     *  content declares a `paneAxis` override) suppresses price ticks, horizontal
+     *  gridlines and the crosshair value chip — the content is not value-mapped.
+     *  Undefined ⇒ the default price format. Recomputed per autoscale pass, so it clears
+     *  the moment the pane's content changes. */
+    axisFormat?: 'volume' | 'none';
+    /** Categorical axis labels for a `paneAxis`-overridden pane (band labels at
+     *  fractions of the pane's height, drawn instead of price ticks). Recomputed per
+     *  autoscale pass alongside {@link axisFormat}. */
+    axisBands?: PaneAxisBand[];
     /** This STUDY pane's own axis mode — `'price'` (absolute) or `'percent'` (change vs its
      *  own `percentBaseline`). The PRICE pane instead follows the scene-level `scaleMode`
      *  (persisted chart setting), so every pane's scale is independent. Undefined ⇒ `'price'`. */

--- a/src/renderers/native/core/layerStacking.ts
+++ b/src/renderers/native/core/layerStacking.ts
@@ -23,7 +23,8 @@ export interface LayerStackEntry {
  * else above — matching how a model series at that z would paint against the candles).
  * Unowned 'below-data' layers stay at the very back; unowned 'above-data' layers sit
  * directly over the data canvas, under any owned layer raised above it. Ties keep
- * registration order (the sort is stable).
+ * registration order (the sort is stable). "The very back" is still above the grid:
+ * the backdrop canvas (highlights + gridlines) sits below every layer this orders.
  */
 export function stackLayers(entries: readonly LayerStackEntry[], candleZ: number): { below: string[]; above: string[] } {
     const keyed = entries.map((e) => ({

--- a/src/renderers/native/layers.ts
+++ b/src/renderers/native/layers.ts
@@ -99,7 +99,9 @@ export interface RendererLayerDefinition {
     /** Stacking: `'below-data'` = behind the candles (reveal-under styles); `'above-data'` =
      *  over the candles, under the chrome/axes. Default `'above-data'`. A layer owned by a
      *  native indicator (its type equals the layer id) follows that indicator's z key in
-     *  the pane stacking instead (`seriesOrder` / the object tree), mounting in front. */
+     *  the pane stacking instead (`seriesOrder` / the object tree), mounting in front.
+     *  Either way the gridlines stay BELOW every layer (they live on the backdrop canvas
+     *  at the bottom of the pile) — no stacking puts a layer behind the grid. */
     placement?: 'below-data' | 'above-data';
     /** Repaint this layer when the pointer moves (hover hit-testing UIs). Off by default:
      *  pointer moves normally repaint only the crosshair overlay, not the layers. */

--- a/test/native-anim-settle.test.ts
+++ b/test/native-anim-settle.test.ts
@@ -114,6 +114,7 @@ describe('syncSize paints synchronously while the Animator owns the frame', () =
         const canvas = () => ({ width: 0, height: 0 });
         r.wrapper = { clientWidth: 400, clientHeight: 300 };
         r.plot = { style: {} };
+        r.backdropCanvas = canvas();
         r.dataCanvas = canvas();
         r.volumeCanvas = canvas();
         r.vpvrCanvas = canvas();

--- a/test/native-axis-bundle.test.ts
+++ b/test/native-axis-bundle.test.ts
@@ -44,6 +44,15 @@ describe('percent-scale ticks + labels (item 14a)', () => {
         expect(t!.price).toBeCloseTo(100); // 0% ⇒ baseline price
     });
 
+    it("format 'none' (unscaled pane) yields no ticks and an empty chip label", () => {
+        const scale = { min: 90, max: 110 };
+        // No ticks ⇒ no axis labels and no horizontal gridlines (both ride paneAxisTicks).
+        expect(paneAxisTicks(scale, 300, undefined, undefined, 'none')).toEqual([]);
+        // 'none' wins over a percent descriptor — the pane's content is not value-mapped at all.
+        expect(paneAxisTicks(scale, 300, { baseline: 100, indexed: false }, undefined, 'none')).toEqual([]);
+        expect(formatAxisValue(scale, 300, 100, undefined, undefined, 'none')).toBe('');
+    });
+
     it('indexed-to-100 ticks are plain numbers centered on 100 at the baseline', () => {
         const ticks = paneAxisTicks({ min: 95, max: 105 }, 300, { baseline: 100, indexed: true });
         expect(ticks.length).toBeGreaterThan(0);

--- a/test/native-screenshot.test.ts
+++ b/test/native-screenshot.test.ts
@@ -44,6 +44,7 @@ function setupRenderer(): { renderer: NativeRenderer; drawn: string[]; paintedBe
 
     const renderer = new NativeRenderer();
     const r = renderer as unknown as Record<string, unknown>;
+    r.backdropCanvas = layer('backdrop');
     r.dataCanvas = layer('data');
     r.chromeCanvas = layer('chrome');
     r.drawingsCanvas = layer('drawings');
@@ -62,8 +63,9 @@ describe('NativeRenderer.screenshot() layer composition', () => {
         expect(url).toBe('data:image/png;base64,STUB');
         // The drawings layer must be present (the regression) …
         expect(drawn).toContain('drawings');
-        // … drawn after chrome so user drawings sit above Pine drawings, matching the screen.
-        expect(drawn).toEqual(['data', 'chrome', 'drawings']);
+        // … drawn after chrome so user drawings sit above Pine drawings, matching the
+        // screen — and the backdrop (grid + highlights) composites first, under everything.
+        expect(drawn).toEqual(['backdrop', 'data', 'chrome', 'drawings']);
     });
 
     it('runs a fresh paint before reading the layers back', () => {

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -501,6 +501,48 @@ describe('EngineOrchestrator', () => {
         }
     });
 
+    it("an output's paneAxis override is stamped onto the mounted model (and only then)", async () => {
+        // A layer-painting native: series-less output declaring a categorical pane axis.
+        class UnscaledNative implements NativeIndicator {
+            private ctx: NativeIndicatorContext | null = null;
+            start(ctx: NativeIndicatorContext): void { this.ctx = ctx; this.emit(); }
+            onBars(): void { this.emit(); }
+            onViewport(): void {}
+            setInputs(): void { this.emit(); }
+            suspend(): void {}
+            resume(): void { this.emit(); }
+            stop(): void {}
+            private emit(): void {
+                this.ctx?.emit({ paneAxis: { bands: [{ frac: 0.25, label: 'Top' }, { frac: 0.75, label: 'Bottom' }] } });
+            }
+        }
+        const unscaledDescriptor: NativeIndicatorDescriptor = {
+            ...testNativeDescriptor, type: 'test-unscaled', title: 'Unscaled Native', paneHint: 'new', overlay: false,
+            create: () => new UnscaledNative(),
+        };
+        registerNativeIndicator(testNativeDescriptor);
+        registerNativeIndicator(unscaledDescriptor);
+        try {
+            const renderer = new FakeRenderer();
+            const chart = new Vela({} as unknown as HTMLElement, { live: false }, { renderer, engines: [], dataFeed: new MockDataFeed() });
+            const plain = chart.addNativeIndicator('test-native');
+            const unscaled = chart.addNativeIndicator('test-unscaled');
+            await chart.ready();
+            await flush();
+
+            // The override rides the model so the renderer can relabel/suppress the pane's axis.
+            const unscaledModel = renderer.mountedModels.find((m) => m.id === unscaled.id && m.native);
+            expect(unscaledModel?.paneAxis).toEqual({ bands: [{ frac: 0.25, label: 'Top' }, { frac: 0.75, label: 'Bottom' }] });
+            expect(unscaledModel?.series).toEqual([]);
+            // An output without the override leaves the model without it (the renderer scales as usual).
+            const plainModel = renderer.mountedModels.find((m) => m.id === plain.id && m.native);
+            expect(plainModel?.paneAxis).toBeUndefined();
+        } finally {
+            unregisterNativeIndicator('test-native');
+            unregisterNativeIndicator('test-unscaled');
+        }
+    });
+
     it('native indicators sort to the TOP of inspect().indicators (even when added last)', async () => {
         registerNativeIndicator(testNativeDescriptor);
         try {


### PR DESCRIPTION
> **Draft on purpose — do not merge.** Kept as a draft so it cannot be merged until explicitly marked ready. It is also **stacked on `feat/layer-stacking-object-tree`** (it needs the generalized layer-to-pane routing) and targets that branch so the diff shows only this seam; retarget to `dev` once the base branch lands.

## Summary

- A native indicator whose visuals are painted entirely by a plugin renderer layer can now declare that the pane it owns is **not value-mapped**, by emitting `paneAxis` on its output: `'none'` for a blank axis, or `{ bands: [{ frac, label }, ...] }` for a **categorical axis** whose labels the renderer draws in the axis column (same typography as price ticks) at fractions of the pane's height.
- Either shape suppresses the pane's price ticks, horizontal gridlines, and crosshair value chip. The override is emitted per compute, so it follows the indicator's settings live; merging any real series into the pane brings the price axis back automatically.
- Generalizes the treatment the built-in volume indicator already received (`volumeOwnsPane` → K/M/B axis) into a neutral, public declaration; also fixes the backends' horizontal gridlines ignoring the pane's axis format.
- Docs (`docs/contributing/plugin-sdk.md`) and `CHANGELOG.md` updated. Additive, semver-minor.

## Test plan

- [x] `npm run typecheck` · `npm run lint` · `npm run test` (1271 passing, incl. new coverage: `paneAxisTicks`/`formatAxisValue` with `'none'`, orchestrator stamping of the output-level override) · `npm run build`
- [x] Workspace oracle suite (18/18)
- [x] Browser-verified via the first consumer (an order-flow table pane): band labels in the axis column, live relabel on row toggles, no gridlines/value chip in the pane

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native renderer paint order, autoscale/axis formatting, and both geometry backends; changes are additive for plugins but alter default stacking and grid rendering for all charts.
> 
> **Overview**
> **Categorical / blank value axes for layer-owned panes.** Native indicators whose visuals are entirely a plugin renderer layer can emit **`paneAxis`** on each compute (`'none'` or `{ bands: [{ frac, label }] }`). The orchestrator stamps it on the model; autoscale then sets **`axisFormat: 'none'`**, optional **`axisBands`**, and suppresses price ticks, horizontal gridlines, and the crosshair value chip. Band labels draw in the axis column at pane-height fractions; merging any real series into the pane restores the normal price scale.
> 
> **Grid and session highlights on a backdrop canvas.** Session washes and gridlines move from the geometry backends into **`BackdropRenderer`** on a new bottom-most canvas (`L-2`). **`gridAlpha`** from `modulateBase` applies there instead of on **`IRenderBackend`**. SDK layer canvases can sit below the data canvas without indicators sent “behind the candles” painting under the grid; screenshots composite **`backdrop` first**.
> 
> Docs (`plugin-sdk.md`) and **`CHANGELOG.md`** describe both behaviors. Tests cover `'none'` ticks/chips, orchestrator **`paneAxis`** stamping, backdrop in screenshot order, and renderer test stubs for **`backdropCanvas`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce4da3fdd87d38d5811c2d0fc8c3fdd9cef0cd4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->