### PR TITLE
feat(indicator): add "Reset defaults" button to indicator settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **Reset an indicator's settings to its defaults.** The indicator settings dialog
+  gained a "Reset defaults" button on the left of its footer: one click restores
+  every input to the value the indicator declares, re-running it immediately — the
+  same affordance the chart settings dialog already offers. A reset is still
+  cancelable: Cancel keeps reverting the whole session to the values the dialog
+  opened with.
 - **Shell-routed indicator adds for plugins.** The contribution context gained
   `ctx.addIndicator({ name, script, language? })` and `ctx.addNativeIndicator(type)`:
   unlike the raw `chart.addIndicator` / `chart.addNativeIndicator`, additions made

--- a/src/renderers/shared/IndicatorInputsDialog.ts
+++ b/src/renderers/shared/IndicatorInputsDialog.ts
@@ -39,7 +39,8 @@ const SOURCES = ['close', 'open', 'high', 'low', 'hl2', 'hlc3', 'ohlc4', 'volume
 
 /**
  * Indicator settings dialog — tabbed live-edit form opened from the legend gear.
- * Cancel reverts to the open-time snapshot; Ok / × / backdrop / Esc keep live edits.
+ * Cancel reverts to the open-time snapshot; Ok / × / backdrop / Esc keep live edits;
+ * Reset defaults restores every input's declared `defval` (still cancelable).
  */
 export class IndicatorInputsDialog {
     private dialog: HTMLElement | null = null;
@@ -95,11 +96,15 @@ export class IndicatorInputsDialog {
             closeOnEscape: false,
             footer: (foot) => {
                 foot.append(
+                    this.resetAction(),
                     this.dialogButton('Cancel', false, () => this.revertAndClose()),
                     this.dialogButton('Ok', true, () => this.close()),
                 );
             },
-            onOpenChange: (open) => { if (!open) this.close(); },
+            // Stale-guard: destroying a dialog fires its machine's onOpenChange(false)
+            // asynchronously — after a reset rebuild that notification must not close
+            // the replacement dialog.
+            onOpenChange: (open) => { if (!open && this.uiDialog === ui) this.close(); },
         });
         applyChromeTokens(ui.panel, t);
         ui.panel.style.colorScheme = this.isDarkTheme() ? 'dark' : 'light';
@@ -248,6 +253,32 @@ export class IndicatorInputsDialog {
             }
         }
         this.close();
+    }
+
+    /** The footer's reset button — same chip as Cancel, pinned to the LEFT edge
+     *  (`margin-right:auto` against the footer's flex-end keeps Cancel/Ok right). */
+    private resetAction(): HTMLButtonElement {
+        const b = this.dialogButton('Reset defaults', false, () => this.resetToDefaults());
+        b.style.marginRight = 'auto';
+        return b;
+    }
+
+    /** Restore every input to its declared default (re-running the indicator), then
+     *  re-open the form so each control re-reads the restored values — the same
+     *  rebuild-after-reset move as the chart-settings dialog. The open-time snapshot
+     *  survives the rebuild, so Cancel after a reset still reverts the whole session. */
+    private resetToDefaults(): void {
+        const row = this.row;
+        if (!row) return;
+        const snap = this.snapshot;
+        for (const inp of row.inputs) {
+            if (row.values[inp.key] !== inp.defval) {
+                row.values[inp.key] = inp.defval;
+                this.host.onChange?.({ indicatorId: row.id, key: inp.key, value: inp.defval });
+            }
+        }
+        this.open(row);
+        if (snap) this.snapshot = snap;
     }
 
     /** Write one edit through: store it, notify the host, and re-apply the `when` gates. */


### PR DESCRIPTION
- Introduced a "Reset defaults" button in the indicator settings dialog, allowing users to restore all inputs to their declared default values with a single click. This action re-runs the indicator immediately and is cancelable, preserving the session's open-time snapshot. Updated documentation to reflect this new feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only dialog footer and live-edit restore path; no auth, persistence, or data-handling changes. A small close-on-rebuild race is explicitly guarded.
> 
> **Overview**
> Adds a **Reset defaults** button to the indicator settings dialog, matching the chart settings footer.
> 
> One click writes every input back to its declared `defval` (re-running the indicator) and rebuilds the form. The open-time snapshot is kept, so **Cancel** still undoes the whole session including a reset. `onOpenChange` is guarded so destroying the old dialog during that rebuild does not close the replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e3af262c8c758f75f53173ff27323f640c70759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->