### PR TITLE
fix: point pre-market sunrise and post-market sunset the right way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Pre-market sunrise and post-market sunset point the right way.** The
+  statusline's session badges had their chevrons inverted, so pre-market read as
+  sunset and post-market as sunrise.
+
 ## [v0.6.8]
 
 ### Added

--- a/src/core/icons.ts
+++ b/src/core/icons.ts
@@ -110,11 +110,11 @@ registerIcon(
 );
 registerIcon(
     'market-pre',
-    svg24('<path d="M12 2v8"/><path d="m4.93 10.93 1.41 1.41"/><path d="M2 18h2"/><path d="M20 18h2"/><path d="m19.07 10.93-1.41 1.41"/><path d="M22 22H2"/><path d="m16 6-4 4-4-4"/><path d="M16 18a4 4 0 0 0-8 0"/>'),
+    svg24('<path d="M12 2v8"/><path d="m4.93 10.93 1.41 1.41"/><path d="M2 18h2"/><path d="M20 18h2"/><path d="m19.07 10.93-1.41 1.41"/><path d="M22 22H2"/><path d="m8 6 4-4 4 4"/><path d="M16 18a4 4 0 0 0-8 0"/>'),
 );
 registerIcon(
     'market-post',
-    svg24('<path d="M12 10V2"/><path d="m4.93 10.93 1.41 1.41"/><path d="M2 18h2"/><path d="M20 18h2"/><path d="m19.07 10.93-1.41 1.41"/><path d="M22 22H2"/><path d="m16 18-4-4-4 4"/><path d="M16 6a4 4 0 0 0-8 0"/>'),
+    svg24('<path d="M12 10V2"/><path d="m4.93 10.93 1.41 1.41"/><path d="M2 18h2"/><path d="M20 18h2"/><path d="m19.07 10.93-1.41 1.41"/><path d="M22 22H2"/><path d="m16 14-4 4-4-4"/><path d="M16 6a4 4 0 0 0-8 0"/>'),
 );
 registerIcon('market-closed', svg24('<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>'));
 registerIcon(

--- a/test/icons.test.ts
+++ b/test/icons.test.ts
@@ -80,7 +80,28 @@ describe('icon registry', () => {
         // Duplicate attributes: the first wins, so the px size overrides the `1em` default.
         expect(attr(iconAt('check', 13), 'width')).toBe('13');
     });
+
+    it('points the pre-market sunrise up and the post-market sunset down', () => {
+        // The statusline badge is 12px: the chevron is what tells sunrise from sunset.
+        // First relative dy of the 3-vertex chevron: negative = tip above the wings.
+        expect(chevronTip('market-pre')).toBe('up');
+        expect(chevronTip('market-post')).toBe('down');
+    });
 });
+
+/** The 3-vertex relative chevron (`m x y dx dy dx dy`) that marks sunrise vs sunset. */
+function chevronTip(id: string): 'up' | 'down' {
+    const svg = iconMarkup(id);
+    expect(svg, `missing icon: ${id}`).toBeTruthy();
+    for (const m of svg!.matchAll(/<path d="([^"]+)"/g)) {
+        const d = m[1] ?? '';
+        if (d[0] !== 'm' && d[0] !== 'M') continue;
+        const nums = d.slice(1).match(/-?[\d.]+/g)?.map(Number) ?? [];
+        if (nums.length !== 6) continue;
+        return nums[3]! < 0 ? 'up' : 'down';
+    }
+    throw new Error(`${id} has no 3-vertex chevron`);
+}
 
 describe('icon conventions', () => {
     const registered = [...CHROME_ICONS, ...TOOL_ICONS].map((id) => [id, iconMarkup(id)!] as const);


### PR DESCRIPTION
## Summary
- The statusline pre-market sunrise and post-market sunset badges had inverted chevrons, so each session read as the other.
- The glyphs now point up for pre-market and down for post-market, with a unit test pinning the direction.

## Test plan
- [x] `npm run typecheck` / `lint` / `test` / `build`
- [x] Icon test asserts pre-market chevron up and post-market chevron down
- [ ] Spot-check the statusline badge on an equities symbol during pre- and post-market

Made with [Cursor](https://cursor.com)