### PR TITLE
feat: route force_overlay model content to the price pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Vela, newest first.
 
 ## [Unreleased]
 
+### Added
+
+- **`force_overlay` content joins the price pane.** Model elements flagged
+  `force_overlay` — value series, plotted candles and bars, fills, backgrounds,
+  markers, and tables, like the drawing objects before them — now render on the
+  price pane even when their indicator occupies its own pane, and they share the
+  price scale (the pane's autoscale folds them in). `chart.inspect()` reports a
+  `forcedOverlay` count per indicator so the routing is verifiable.
+
 ### Fixed
 
 - **Pre-market sunrise and post-market sunset point the right way.** The

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1804,16 +1804,19 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
     private placeModel(model: IndicatorModel, id: string, paneId: string): void {
         model.id = id;
         model.paneId = paneId;
-        for (const series of model.series) series.paneId = paneId;
-        for (const fill of model.fills) fill.paneId = paneId;
-        for (const bg of model.backgrounds) bg.paneId = paneId;
+        // A `force_overlay` item (overlay: true) renders on the price pane regardless of
+        // where its indicator routed — stamp it 'price' so the model tells the truth.
+        const paneOf = (item: { overlay?: boolean }): string => (item.overlay === true ? 'price' : paneId);
+        for (const series of model.series) series.paneId = paneOf(series);
+        for (const fill of model.fills) fill.paneId = paneOf(fill);
+        for (const bg of model.backgrounds) bg.paneId = paneOf(bg);
         for (const line of model.priceLines) line.paneId = paneId;
-        if (model.lines) for (const ln of model.lines) ln.paneId = paneId;
-        if (model.boxes) for (const bx of model.boxes) bx.paneId = paneId;
-        if (model.labels) for (const lb of model.labels) lb.paneId = paneId;
-        if (model.polylines) for (const pl of model.polylines) pl.paneId = paneId;
-        if (model.linefills) for (const lf of model.linefills) lf.paneId = paneId;
-        if (model.tables) for (const tb of model.tables) tb.paneId = paneId;
+        if (model.lines) for (const ln of model.lines) ln.paneId = paneOf(ln);
+        if (model.boxes) for (const bx of model.boxes) bx.paneId = paneOf(bx);
+        if (model.labels) for (const lb of model.labels) lb.paneId = paneOf(lb);
+        if (model.polylines) for (const pl of model.polylines) pl.paneId = paneOf(pl);
+        if (model.linefills) for (const lf of model.linefills) lf.paneId = paneOf(lf);
+        if (model.tables) for (const tb of model.tables) tb.paneId = paneOf(tb);
     }
 
     /** Throttled (1/s per indicator) 'context:changed' — streamed models re-emit per tick,

--- a/src/core/engine/inspect.ts
+++ b/src/core/engine/inspect.ts
@@ -28,6 +28,8 @@ export interface IndicatorSummary {
     barColors: number;
     trades: number;
     inputs: number;
+    /** Elements flagged `force_overlay` (routed to the price pane), across every kind. */
+    forcedOverlay: number;
 }
 
 /** A snapshot of everything the Vela core has generated for the mounted indicators. */
@@ -48,6 +50,7 @@ export interface SceneInspection {
         tables: number;
         barColors: number;
         trades: number;
+        forcedOverlay: number;
     };
 }
 
@@ -55,6 +58,11 @@ export interface SceneInspection {
 export function summarizeModel(model: IndicatorModel): IndicatorSummary {
     const series: Record<string, number> = {};
     for (const s of model.series) series[s.kind] = (series[s.kind] ?? 0) + 1;
+    const countOverlay = (items?: ReadonlyArray<{ overlay?: boolean }>): number => items?.filter((i) => i.overlay === true).length ?? 0;
+    const forcedOverlay =
+        countOverlay(model.series) + countOverlay(model.fills) + countOverlay(model.backgrounds) +
+        countOverlay(model.lines) + countOverlay(model.boxes) + countOverlay(model.labels) +
+        countOverlay(model.polylines) + countOverlay(model.linefills) + countOverlay(model.tables);
     return {
         id: model.id,
         title: model.title,
@@ -75,6 +83,7 @@ export function summarizeModel(model: IndicatorModel): IndicatorSummary {
         barColors: model.barColors?.length ?? 0,
         trades: model.trades?.length ?? 0,
         inputs: model.inputs.length,
+        forcedOverlay,
     };
 }
 
@@ -98,6 +107,7 @@ export function inspectModels(models: IndicatorModel[]): SceneInspection {
             tables: sum((s) => s.tables),
             barColors: sum((s) => s.barColors),
             trades: sum((s) => s.trades),
+            forcedOverlay: sum((s) => s.forcedOverlay),
         },
     };
 }

--- a/src/core/model/drawings.ts
+++ b/src/core/model/drawings.ts
@@ -221,4 +221,6 @@ export interface DrawingTable {
     cells: Array<Array<TableCell | null>>;
     /** Merged-cell regions (`table.merge_cells`); origin spans, others are dropped. */
     merges: TableMerge[];
+    /** `force_overlay` → anchor to the price pane regardless of the indicator's pane. */
+    overlay?: boolean;
 }

--- a/src/core/model/scene.ts
+++ b/src/core/model/scene.ts
@@ -36,6 +36,8 @@ export interface Fill {
     colors?: Array<string | null>;
     /** Per-bar vertical gradient (gradient-fill overload), aligned by index. */
     gradient?: Array<FillGradientStop | null>;
+    /** `force_overlay` → render on the price pane regardless of the indicator's pane. */
+    overlay?: boolean;
 }
 
 /** A vertical background tint over a time span (Pine `bgcolor()` / session bands). */
@@ -47,6 +49,8 @@ export interface Background {
     /** Exclusive end, epoch ms. */
     to: Millis;
     color: string;
+    /** `force_overlay` → render on the price pane regardless of the indicator's pane. */
+    overlay?: boolean;
 }
 
 /** A horizontal price line (Pine `hline()`). */

--- a/src/core/model/series.ts
+++ b/src/core/model/series.ts
@@ -65,6 +65,8 @@ interface SeriesBase {
     /** Declared draw-order intent; the renderer owns final z-ordering. */
     zOrder?: number;
     visible?: boolean;
+    /** `force_overlay` → render on the price pane regardless of the indicator's pane. */
+    overlay?: boolean;
 }
 
 export interface LineLikeSeries extends SeriesBase {

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -52,7 +52,7 @@ import type { Projector, SnapMode } from '../../core/drawings';
 import type { IDrawingsRendererPort } from '../../core/drawings';
 import { formatPriceLabel } from './chrome/ticks';
 import { zonedDate } from './chrome/tz';
-import { computePaneScale, expandScaleByPixels } from './core/autoscale';
+import { computePaneScale, expandScaleByPixels, overlaySeriesRange } from './core/autoscale';
 import { mergeTradeMarkersState, tradesPriceHints, type TradeMarkerHints } from '../shared/trade-markers';
 import { rescaleAround, shiftScale } from './core/manualScale';
 import { resizeSplit, type PaneSplit } from './core/paneResize';
@@ -3152,7 +3152,13 @@ export class NativeRenderer implements IChartRenderer {
             const masterModels = models.filter((m) => m.ownScale !== true);
             // User drawings do not expand the scale (placing one in the empty margin
             // must not yank the window to follow the cursor). Pine drawings still fold in.
-            const dr = this.chrome.paneDrawingsRange(masterModels, this.scene, pane === pricePane, vr);
+            let dr = this.chrome.paneDrawingsRange(masterModels, this.scene, pane === pricePane, vr);
+            // force_overlay series render on the price pane whatever pane their indicator
+            // owns — fold their visible range in here (their own pane excludes them).
+            if (pane === pricePane) {
+                const or = overlaySeriesRange(this.scene.indicators.values(), i0, i1, (id) => this.scene.offsetOf(id));
+                if (or) dr = dr ? { min: Math.min(dr.min, or.min), max: Math.max(dr.max, or.max) } : or;
+            }
             // Hidden candles drop out of the price pane's autoscale, so overlay indicators fill the pane.
             const includeCandles = pane.kind === 'price' && !this.scene.candlesHidden;
             // Each pane logs (or not) on its OWN flag — the price pane from the scene setting,
@@ -3479,6 +3485,7 @@ export class NativeRenderer implements IChartRenderer {
         for (const m of models) {
             const off = this.scene.offsetOf(m.id);
             for (const s of m.series) {
+                if (s.overlay === true) continue; // renders on the price pane, not this one
                 if (isLineLikeSeries(s)) {
                     const v = s.points[i0 - off]?.value;
                     if (v != null && Number.isFinite(v)) return v;

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -82,9 +82,18 @@ export class Canvas2dBackend implements IRenderBackend {
             };
 
             // Behind everything: backgrounds + fills (kept under the candle/series layers).
+            // Own (non-force_overlay) content on each model's pane; force_overlay content
+            // on the price pane against its MASTER scale, whatever pane the indicator owns
+            // (Pine semantics — mirrors the chrome's overlay-drawing routing).
             ctx.globalAlpha = this.modelAlpha; // indicator models fade in after the intro; candles stay opaque
-            for (const m of models) for (const bg of m.backgrounds) this.drawBackground(ctx, bg, pane, coords);
-            for (const m of models) for (const f of m.fills) this.drawFill(ctx, m, f, effPane(m), coords, i0, i1, scene.offsetOf(m.id));
+            for (const m of models) for (const bg of m.backgrounds) if (bg.overlay !== true) this.drawBackground(ctx, bg, pane, coords);
+            for (const m of models) for (const f of m.fills) if (f.overlay !== true) this.drawFill(ctx, m, f, effPane(m), coords, i0, i1, scene.offsetOf(m.id));
+            if (isPrice) {
+                for (const m of scene.indicators.values()) {
+                    for (const bg of m.backgrounds) if (bg.overlay === true) this.drawBackground(ctx, bg, pane, coords);
+                    for (const f of m.fills) if (f.overlay === true) this.drawFill(ctx, m, f, pane, coords, i0, i1, scene.offsetOf(m.id));
+                }
+            }
 
             // User-drawing interleave layers, prepainted by the renderer: each composites just
             // before the series carrying its `beforeZ`, so a drawing can sit under the candles
@@ -114,7 +123,7 @@ export class Canvas2dBackend implements IRenderBackend {
                 // Model data is index-aligned from the model's ANCHOR bar (offset 0 = whole-chart).
                 const off = scene.offsetOf(m.id);
                 const mp = effPane(m);
-                for (const s of m.series) this.drawSeries(ctx, s, mp, coords, i0, i1, theme, off);
+                for (const s of m.series) if (s.overlay !== true) this.drawSeries(ctx, s, mp, coords, i0, i1, theme, off);
             }
             if (drawCandles && !candleDrawn) {
                 drawSlicesUpTo(scene.candleZ);
@@ -122,6 +131,16 @@ export class Canvas2dBackend implements IRenderBackend {
                 this.drawPriceSeries(ctx, scene, i0, i1, coords, pane, theme, barColorMap, dataW);
             }
             drawSlicesUpTo(Infinity); // layers bound to a hidden/removed series still paint, at the stack top
+
+            // force_overlay series from EVERY indicator paint on the price pane, at the top
+            // of its series stack, against the master price scale.
+            if (isPrice) {
+                ctx.globalAlpha = this.modelAlpha;
+                for (const m of scene.indicators.values()) {
+                    const off = scene.offsetOf(m.id);
+                    for (const s of m.series) if (s.overlay === true) this.drawSeries(ctx, s, pane, coords, i0, i1, theme, off);
+                }
+            }
 
             // On top: price lines.
             ctx.globalAlpha = this.modelAlpha;

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -380,8 +380,17 @@ export class WebGL2Backend implements IRenderBackend {
                     return sc === pane.scale ? pane : { ...pane, scale: sc };
                 };
                 b.alpha = this.modelAlpha; // indicator models fade in after the intro; candles/grid stay opaque
-                for (const m of models) for (const bgSpan of m.backgrounds) this.emitBackground(b, bgSpan, pane, coords);
-                for (const m of models) for (const f of m.fills) this.emitFill(b, m, f, effPane(m), coords, i0, i1, scene.offsetOf(m.id));
+                // Own (non-force_overlay) content on each model's pane; force_overlay content
+                // on the price pane against its MASTER scale, whatever pane the indicator owns
+                // (Pine semantics — mirrors the chrome's overlay-drawing routing).
+                for (const m of models) for (const bgSpan of m.backgrounds) if (bgSpan.overlay !== true) this.emitBackground(b, bgSpan, pane, coords);
+                for (const m of models) for (const f of m.fills) if (f.overlay !== true) this.emitFill(b, m, f, effPane(m), coords, i0, i1, scene.offsetOf(m.id));
+                if (isPrice) {
+                    for (const m of scene.indicators.values()) {
+                        for (const bgSpan of m.backgrounds) if (bgSpan.overlay === true) this.emitBackground(b, bgSpan, pane, coords);
+                        for (const f of m.fills) if (f.overlay === true) this.emitFill(b, m, f, pane, coords, i0, i1, scene.offsetOf(m.id));
+                    }
+                }
                 // When the price is hidden, the candle layer is skipped entirely (overlays still draw).
                 const drawCandles = isPrice && !scene.candlesHidden;
                 let candleDrawn = false;
@@ -397,7 +406,7 @@ export class WebGL2Backend implements IRenderBackend {
                     // Model data is index-aligned from the model's ANCHOR bar (offset 0 = whole-chart).
                     const off = scene.offsetOf(m.id);
                     const mp = effPane(m);
-                    for (const s of m.series) this.emitSeries(b, s, mp, coords, i0, i1, theme, off);
+                    for (const s of m.series) if (s.overlay !== true) this.emitSeries(b, s, mp, coords, i0, i1, theme, off);
                 }
                 if (drawCandles && !candleDrawn) {
                     drawSlicesUpTo(scene.candleZ);
@@ -406,6 +415,14 @@ export class WebGL2Backend implements IRenderBackend {
                 }
                 drawSlicesUpTo(Infinity); // layers bound to a hidden/removed series still paint, at the stack top
                 b.alpha = this.modelAlpha;
+                // force_overlay series from EVERY indicator paint on the price pane, at the top
+                // of its series stack, against the master price scale.
+                if (isPrice) {
+                    for (const m of scene.indicators.values()) {
+                        const off = scene.offsetOf(m.id);
+                        for (const s of m.series) if (s.overlay === true) this.emitSeries(b, s, pane, coords, i0, i1, theme, off);
+                    }
+                }
                 for (const m of models) { const mp = effPane(m); for (const pl of m.priceLines) this.emitHline(b, pl, mp, coords, dataW, theme); }
                 b.alpha = 1;
             }
@@ -458,7 +475,7 @@ export class WebGL2Backend implements IRenderBackend {
         for (const pane of scene.orderedPanes()) {
             const b = this.glowBatch;
             b.reset();
-            this.emitGlowSources(b, scene.indicatorsForPane(pane.id), pane, coords, i0, i1, (id) => scene.offsetOf(id));
+            this.emitGlowSources(b, scene, pane, coords, i0, i1);
             if (b.vertexCount === 0) continue;
             const topH = Math.round(pane.bounds.top * dpr * 0.5);
             const botH = Math.round((pane.bounds.top + pane.bounds.height) * dpr * 0.5);
@@ -533,15 +550,23 @@ export class WebGL2Backend implements IRenderBackend {
         return true;
     }
 
-    /** The "neon" elements that glow: line/area/step lines + point markers (not candles/fills/bars). */
-    private emitGlowSources(b: Batch, models: IndicatorModel[], pane: PaneNode, coords: CoordinateSystem, i0: number, i1: number, offsetOf: (id: string) => number = () => 0): void {
-        for (const m of models) {
-            const off = offsetOf(m.id);
-            for (const s of m.series) {
-                if (!isLineLikeSeries(s) || s.visible === false) continue;
-                if (s.kind === 'histogram' || s.kind === 'columns') continue;
-                if (s.kind === 'circles' || s.kind === 'cross') this.emitPointMarkers(b, s, pane, coords, i0, i1, off);
-                else this.emitPolyline(b, s, pane, coords, i0, i1, s.kind === 'step', off);
+    /** The "neon" elements that glow: line/area/step lines + point markers (not candles/fills/bars).
+     *  Routing mirrors the main pass: own series per pane, force_overlay series on the price pane. */
+    private emitGlowSources(b: Batch, scene: SceneGraph, pane: PaneNode, coords: CoordinateSystem, i0: number, i1: number): void {
+        const emitOne = (s: SeriesSpec, off: number): void => {
+            if (!isLineLikeSeries(s) || s.visible === false) return;
+            if (s.kind === 'histogram' || s.kind === 'columns') return;
+            if (s.kind === 'circles' || s.kind === 'cross') this.emitPointMarkers(b, s, pane, coords, i0, i1, off);
+            else this.emitPolyline(b, s, pane, coords, i0, i1, s.kind === 'step', off);
+        };
+        for (const m of scene.indicatorsForPane(pane.id)) {
+            const off = scene.offsetOf(m.id);
+            for (const s of m.series) if (s.overlay !== true) emitOne(s, off);
+        }
+        if (pane.kind === 'price') {
+            for (const m of scene.indicators.values()) {
+                const off = scene.offsetOf(m.id);
+                for (const s of m.series) if (s.overlay === true) emitOne(s, off);
             }
         }
     }

--- a/src/renderers/native/core/autoscale.ts
+++ b/src/renderers/native/core/autoscale.ts
@@ -1,5 +1,6 @@
 import type { OHLCV } from '../../../core/model/ohlcv';
 import type { IndicatorModel } from '../../../core/model/indicator';
+import type { SeriesSpec } from '../../../core/model/series';
 import { isLineLikeSeries } from '../../../core/model/series';
 import type { PriceScale } from './CoordinateSystem';
 
@@ -47,23 +48,10 @@ export function computePaneScale(
     for (const model of models) {
         const off = offsetOf(model.id);
         for (const s of model.series) {
-            if (s.kind === 'candle' || s.kind === 'bar') {
-                for (let i = i0; i <= i1; i += 1) {
-                    const b = s.bars[i - off];
-                    if (b) {
-                        consider(b.high);
-                        consider(b.low);
-                    }
-                }
-            } else if (isLineLikeSeries(s)) {
-                // Hidden (display.none / na) series are NOT skipped — like LWC they
-                // stay on the price scale so a fill anchored to them stays in view.
-                for (let i = i0; i <= i1; i += 1) consider(s.points[i - off]?.value);
-                // Histogram/columns grow from their base (default 0) — include it so
-                // an all-positive plot autoscales from a visible zero line.
-                if (s.kind === 'histogram' || s.kind === 'columns') consider(s.style?.base ?? 0);
-                else if (s.style?.base != null) consider(s.style.base);
-            }
+            // force_overlay series render (and scale) on the PRICE pane, not their own —
+            // the price pane folds them back in via overlaySeriesRange.
+            if (s.overlay === true) continue;
+            considerSeries(s, i0, i1, off, consider);
         }
         for (const pl of model.priceLines) consider(pl.price);
     }
@@ -88,6 +76,53 @@ export function computePaneScale(
     }
     const span = max - min;
     return { min: min - span * MARGIN_BOTTOM, max: max + span * MARGIN_TOP };
+}
+
+/** Fold one series' visible values (bars or points + base) into `consider`. */
+function considerSeries(s: SeriesSpec, i0: number, i1: number, off: number, consider: (v: number | null | undefined) => void): void {
+    if (s.kind === 'candle' || s.kind === 'bar') {
+        for (let i = i0; i <= i1; i += 1) {
+            const b = s.bars[i - off];
+            if (b) {
+                consider(b.high);
+                consider(b.low);
+            }
+        }
+    } else if (isLineLikeSeries(s)) {
+        // Hidden (display.none / na) series are NOT skipped — like LWC they
+        // stay on the price scale so a fill anchored to them stays in view.
+        for (let i = i0; i <= i1; i += 1) consider(s.points[i - off]?.value);
+        // Histogram/columns grow from their base (default 0) — include it so
+        // an all-positive plot autoscales from a visible zero line.
+        if (s.kind === 'histogram' || s.kind === 'columns') consider(s.style?.base ?? 0);
+        else if (s.style?.base != null) consider(s.style.base);
+    }
+}
+
+/**
+ * Visible range of the `force_overlay` series across the given models — these render
+ * on the PRICE pane (whatever pane their indicator routed to), so the price pane's
+ * autoscale folds them in the way it folds force_overlay drawings. Null when none.
+ */
+export function overlaySeriesRange(
+    models: Iterable<IndicatorModel>,
+    i0: number,
+    i1: number,
+    offsetOf: (id: string) => number = () => 0,
+): { min: number; max: number } | null {
+    let min = Infinity;
+    let max = -Infinity;
+    const consider = (v: number | null | undefined): void => {
+        if (v != null && Number.isFinite(v)) {
+            if (v < min) min = v;
+            if (v > max) max = v;
+        }
+    };
+    for (const model of models) {
+        const off = offsetOf(model.id);
+        for (const s of model.series) if (s.overlay === true) considerSeries(s, i0, i1, off, consider);
+    }
+    return min === Infinity ? null : { min, max };
 }
 
 /**

--- a/test/force-overlay-scale.test.ts
+++ b/test/force-overlay-scale.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { computePaneScale, overlaySeriesRange } from '../src/renderers/native/core/autoscale';
+import type { IndicatorModel } from '../src/core/model/indicator';
+import type { SeriesPoint } from '../src/core/model/series';
+
+/**
+ * force_overlay series live on the PRICE pane's scale: their own pane's autoscale
+ * skips them, and overlaySeriesRange hands their visible range to the price pane.
+ */
+
+function points(values: number[]): SeriesPoint[] {
+    return values.map((v, i) => ({ time: 1_700_000_000_000 + i * 60_000, value: v }));
+}
+
+function studyModel(): IndicatorModel {
+    return {
+        id: 'st', title: 'Study', overlay: false, paneHint: 'new', paneId: 'pane-st',
+        series: [
+            { id: 'st:own', title: 'own', paneId: 'pane-st', kind: 'line', points: points([10, 20, 15]), style: { color: '#fff', width: 1, lineStyle: 'solid' } },
+            { id: 'st:forced', title: 'forced', paneId: 'price', kind: 'line', points: points([1000, 2000, 1500]), overlay: true, style: { color: '#0f0', width: 1, lineStyle: 'solid' } },
+        ],
+        fills: [], backgrounds: [], priceLines: [], inputs: [], inputValues: {},
+    };
+}
+
+describe('autoscale — force_overlay series routing', () => {
+    it('computePaneScale skips overlay series (the study window fits its own plots only)', () => {
+        const scale = computePaneScale([studyModel()], [], false, 0, 2);
+        // The forced series' 1000..2000 values must NOT stretch the study window.
+        expect(scale.max).toBeLessThan(1000);
+        expect(scale.min).toBeLessThanOrEqual(10);
+    });
+
+    it('overlaySeriesRange returns exactly the overlay series range (for the price pane fold)', () => {
+        expect(overlaySeriesRange([studyModel()], 0, 2)).toEqual({ min: 1000, max: 2000 });
+    });
+
+    it('overlaySeriesRange is null when nothing is flagged', () => {
+        const m = studyModel();
+        for (const s of m.series) s.overlay = undefined;
+        expect(overlaySeriesRange([m], 0, 2)).toBeNull();
+    });
+
+    it('overlaySeriesRange honors the visible window and per-model anchor offset', () => {
+        // Anchor offset 1: the model's index 0 is the chart's bar 1.
+        expect(overlaySeriesRange([studyModel()], 1, 1, () => 1)).toEqual({ min: 1000, max: 1000 });
+    });
+});

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -31,6 +31,7 @@ import { registerChartType, unregisterChartType, type SeriesDataEngineHost } fro
 import type { BarTransform } from '../src/core/price-styles/BarTransform';
 import type { NativeIndicator, NativeIndicatorContext, NativeIndicatorDescriptor } from '../src/core/native-indicators/NativeIndicator';
 import type { Pane } from '../src/core/model/scene';
+import type { DrawingLine } from '../src/core/model/drawings';
 import type { IndicatorModel } from '../src/core/model/indicator';
 import type { ScenePatch } from '../src/core/model/patch';
 import type { InputValue } from '../src/core/model/inputs';
@@ -1859,6 +1860,84 @@ describe('chart.runScript — execute and receive the run', () => {
         expect(result.run).toBeNull();
         expect(result.error?.message).toBe('compile blew up');
         expect(chart.indicators()).toHaveLength(0);
+        chart.destroy();
+    });
+});
+
+/** A study engine whose model carries `force_overlay`-flagged items next to own ones. */
+class ForcedOverlayEngine extends MockEngine {
+    override execute(req: ExecutionRequest, handlers: ExecutionHandlers): ExecutionSession {
+        const token = req.prepared.token as { instanceId: string };
+        const id = token.instanceId;
+        const bars = req.getBars?.() ?? req.bars;
+        const points = bars.map((b) => ({ time: b.time, value: b.close }));
+        const line = (name: string, overlay: boolean): DrawingLine => ({
+            id: `${id}:line-drawing:${name}`, paneId: 'unrouted', xloc: 'bar_time',
+            x1: bars[0]!.time, y1: 100, x2: bars[1]!.time, y2: 101, extend: 'none',
+            invisible: false, width: 1, style: 'solid', arrowLeft: false, arrowRight: false, overlay,
+        });
+        handlers.onModel({
+            id, title: 'Mock', overlay: false, paneHint: 'new',
+            series: [
+                { id: `${id}:line:own#0`, title: 'own', paneId: 'unrouted', kind: 'line', points, style: { color: '#fff', width: 1, lineStyle: 'solid' } },
+                { id: `${id}:line:forced#0`, title: 'forced', paneId: 'unrouted', kind: 'line', points, overlay: true, style: { color: '#0f0', width: 1, lineStyle: 'solid' } },
+            ],
+            fills: [],
+            backgrounds: [{ id: `${id}:bg#0`, paneId: 'unrouted', from: bars[0]!.time, to: bars[1]!.time, color: '#123456', overlay: true }],
+            priceLines: [],
+            lines: [line('own', false), line('forced', true)],
+            boxes: [
+                { id: `${id}:box:own`, paneId: 'unrouted', xloc: 'bar_time', left: bars[0]!.time, top: 105, right: bars[1]!.time, bottom: 95, extend: 'none', borderWidth: 1, borderStyle: 'solid', textSize: 'auto', hAlign: 'center', vAlign: 'center', wrap: false, fontFamily: 'default', bold: false, italic: false, overlay: false },
+                { id: `${id}:box:forced`, paneId: 'unrouted', xloc: 'bar_time', left: bars[0]!.time, top: 105, right: bars[1]!.time, bottom: 95, extend: 'none', borderWidth: 1, borderStyle: 'solid', textSize: 'auto', hAlign: 'center', vAlign: 'center', wrap: false, fontFamily: 'default', bold: false, italic: false, overlay: true },
+            ],
+            labels: [
+                { id: `${id}:label:own`, paneId: 'unrouted', xloc: 'bar_time', x: bars[0]!.time, y: 100, yloc: 'price', style: 'label_down', size: 'normal', textAlign: 'center', fontFamily: 'default', overlay: false },
+                { id: `${id}:label:forced`, paneId: 'unrouted', xloc: 'bar_time', x: bars[0]!.time, y: 100, yloc: 'price', style: 'label_down', size: 'normal', textAlign: 'center', fontFamily: 'default', overlay: true },
+            ],
+            polylines: [
+                { id: `${id}:poly:own`, paneId: 'unrouted', points: [{ xloc: 'bar_time', x: bars[0]!.time, price: 100 }, { xloc: 'bar_time', x: bars[1]!.time, price: 101 }], curved: false, closed: false, lineWidth: 1, lineStyle: 'solid', arrowLeft: false, arrowRight: false, overlay: false },
+                { id: `${id}:poly:forced`, paneId: 'unrouted', points: [{ xloc: 'bar_time', x: bars[0]!.time, price: 100 }, { xloc: 'bar_time', x: bars[1]!.time, price: 101 }], curved: false, closed: false, lineWidth: 1, lineStyle: 'solid', arrowLeft: false, arrowRight: false, overlay: true },
+            ],
+            linefills: [
+                { id: `${id}:lf:own`, paneId: 'unrouted', line1: line('lf-own-a', false), line2: line('lf-own-b', false), color: '#123456', overlay: false },
+                { id: `${id}:lf:forced`, paneId: 'unrouted', line1: line('lf-forced-a', true), line2: line('lf-forced-b', true), color: '#654321', overlay: true },
+            ],
+            tables: [{ id: `${id}:tb#0`, paneId: 'unrouted', position: 'top_right', columns: 1, rows: 1, frameWidth: 0, borderWidth: 0, cells: [[null]], merges: [], overlay: true }],
+            inputs: [], inputValues: {},
+        });
+        handlers.onDone?.();
+        return { stop: () => {}, update: () => {}, setVisibleRange: () => {}, notifyBars: () => {} };
+    }
+}
+
+describe('EngineOrchestrator — force_overlay routing', () => {
+    it('stamps force_overlay items with the price pane while own items keep the study pane', async () => {
+        const renderer = new FakeRenderer();
+        const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [new ForcedOverlayEngine()], dataFeed: new MockDataFeed() });
+        const ind = chart.addIndicator('//@version=5\nindicator("Study")\nplot(close)');
+        await chart.ready();
+        await flush();
+
+        // The loading placeholder mounts first (empty series); the computed model remounts last.
+        const m = renderer.mountedModels.filter((x) => x.id === ind.id).at(-1)!;
+        const studyPane = m.paneId!;
+        expect(studyPane).not.toBe('price'); // the indicator itself still routes to its own pane
+
+        expect(m.series.find((s) => s.title === 'own')?.paneId).toBe(studyPane);
+        expect(m.series.find((s) => s.title === 'forced')?.paneId).toBe('price');
+        expect(m.backgrounds[0]?.paneId).toBe('price');
+        expect(m.tables?.[0]?.paneId).toBe('price');
+        // Every drawing kind: the forced instance routes to price, the own one stays put.
+        for (const kind of ['lines', 'boxes', 'labels', 'polylines', 'linefills'] as const) {
+            const items = m[kind]!;
+            expect(items.find((d) => d.id.endsWith(':own'))?.paneId).toBe(studyPane);
+            expect(items.find((d) => d.id.endsWith(':forced'))?.paneId).toBe('price');
+        }
+
+        // The deterministic oracle signal: inspect() counts the flagged items.
+        const summary = chart.inspect().indicators.find((s) => s.id === ind.id)!;
+        // forced series + background + table + one of each drawing kind (line, box, label, polyline, linefill)
+        expect(summary.forcedOverlay).toBe(8);
         chart.destroy();
     });
 });


### PR DESCRIPTION
## Summary

- Model elements flagged `overlay` (Pine `force_overlay`) — value series, plotted candles/bars, fills, backgrounds, and tables, like the drawing objects before them — now render on the **price pane** even when their indicator occupies its own pane. This is the Vela half of making `force_overlay` work for the series-level Pine functions; the engine half (mapping the flag into the model) lands in the companion Vela-pinets PR.
- Additive public-model change: optional `overlay?: boolean` on `SeriesSpec`, `Fill`, `Background`, and `DrawingTable` (the drawing models already carried it). No breaking impact — absent means today's behavior.

## How it works

- `EngineOrchestrator.placeModel` stamps flagged items with the `price` pane id, so the model tells the truth to any renderer (tables anchor by their own pane id and need nothing else). Live-tick value patches are built after stamping, so streamed updates keep the routing.
- Autoscale: flagged series are excluded from their own pane's window; a new `overlaySeriesRange` folds their visible range into the price pane's window — mirroring how force_overlay drawings already folded in. Study-pane percent baselines skip them too.
- Both geometry backends (canvas2d and WebGL2, including the WebGL2 glow pass) paint flagged series, backgrounds, and fills on the price pane against its master scale, at the top of its series stack. Own content is untouched.
- `chart.inspect()` gains a `forcedOverlay` count per indicator (and in totals) as the deterministic verification signal.

## Test plan

- [x] New unit tests: orchestrator pane stamping for every element kind (series, background, fill-carrying drawings, line/box/label/polyline/linefill/table) + pure autoscale routing (`test/force-overlay-scale.test.ts`).
- [x] Full gate: typecheck, lint, 1318 tests, build.
- [x] Workspace oracle suite: 20/20 scenarios including two new force_overlay scenarios (series + drawings), passing on both canvas2d and WebGL2; Vela-pro suite 11/11 against this build.
- [x] Real-browser proof on live data through the Vela-pinets worker-engine playground (forced MA/markers/washes on the price pane, oscillator alone in the study pane).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pane routing, autoscale, and both canvas/WebGL paint paths, so overlay plots can change study vs price windows if the overlay flag is wrong.
> 
> **Overview**
> **force_overlay** now applies to plots, not just drawings. Series, candles/bars, fills, backgrounds, and tables flagged `overlay: true` render on the **price pane** (master scale) while the indicator itself can stay in its own pane.
> 
> `placeModel` stamps those items with pane id `price`. Autoscale skips them on the study pane and folds their range into the price pane via `overlaySeriesRange`. Canvas2d and WebGL2 (including glow) paint flagged content on the price pane at the top of the series stack.
> 
> `chart.inspect()` adds a `forcedOverlay` count. Optional `overlay` on series/fill/background/table is additive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce113c3f02a236ed9c838cb423485e94ff4006b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->