### PR TITLE
fix: keep pre/post-market shading off daily and higher timeframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Pre- and post-market shading stays off daily and higher timeframes.** On an
+  extended-session chart the tint used to paint over daily, weekly, and monthly
+  candles, even though each of those bars spans whole sessions and there is
+  nothing to shade. The bands now appear only on intraday timeframes.
 - **Pre-market sunrise and post-market sunset point the right way.** The
   statusline's session badges had their chevrons inverted, so pre-market read as
   sunset and post-market as sunrise.

--- a/src/widget/session-shading.ts
+++ b/src/widget/session-shading.ts
@@ -13,6 +13,7 @@ import type { MarketSession } from '../core/options';
 import type { VisibleRange } from '../core/ports/IChartRenderer';
 import type { SymbolInfo } from '../core/ports/MarketDataFeed';
 import type { CalendarWindow } from './market-status';
+import { timeframeMs } from './timeframe';
 
 /** The `sessionZones` feature payload: `[start, end)` epoch-ms bands per phase. */
 export interface SessionZonesUpdate {
@@ -156,8 +157,9 @@ const COVER_PAD_MIN_MS = 2 * DAY_MS;
  * session spec once (symbol metadata — memoized by providers), then every range update
  * is a synchronous local expansion. Reports:
  *  - `null` — no session structure at all (continuous market / no metadata);
- *  - empty bands — sessions exist but the REGULAR tape is shown (no pre/post bars on
- *    screen to shade);
+ *  - empty bands — sessions exist but there are no pre/post bar slots to shade: the
+ *    REGULAR tape is shown, or the timeframe is daily+ (each bar aggregates whole
+ *    sessions, so a band would just tint full-day candles);
  *  - the expanded bands — the extended tape is shown. The renderer clips them to the
  *    loaded bar slots, so nothing paints before history or ahead of the current bar.
  */
@@ -167,6 +169,8 @@ export class SessionShadingTracker {
     private spec: SessionSpec | null = null;
     private ready = false;
     private session: MarketSession = 'regular';
+    /** Whether one bar is shorter than a civil day — only then do pre/post bars exist. */
+    private intraday = false;
     private covered: VisibleRange | null = null;
     /** The newest range seen — viewport moves during metadata resolution (a load's fit
      *  animation) must not be lost, so the resolution always expands the LATEST range. */
@@ -175,12 +179,14 @@ export class SessionShadingTracker {
     constructor(private readonly onZones: (zones: SessionZonesUpdate | null) => void) {}
 
     /** (Re)bind to a chart's data surface + market and expand once metadata lands. */
-    track(data: DataControl, symbol: string, opts: { session: MarketSession; range: VisibleRange }): void {
+    track(data: DataControl, symbol: string, opts: { session: MarketSession; timeframe: string; range: VisibleRange }): void {
         const my = ++this.epoch;
         this.ready = false;
         this.spec = null;
         this.covered = null;
         this.session = opts.session;
+        const tfMs = timeframeMs(opts.timeframe);
+        this.intraday = Number.isFinite(tfMs) && tfMs < DAY_MS;
         this.lastRange = opts.range;
         void data
             .symbolInfo(symbol)
@@ -214,9 +220,10 @@ export class SessionShadingTracker {
             if (force) this.onZones(null);
             return;
         }
-        if (this.session !== 'extended') {
-            // Regular tape: pre/post bars aren't on screen — bands would collapse into
-            // the inter-session gap. Keep the structure known but shade nothing.
+        if (this.session !== 'extended' || !this.intraday) {
+            // No pre/post bars on screen: the regular tape collapses those hours out of
+            // the bar axis, and a daily+ bar aggregates its whole day — either way a
+            // band would land on the wrong pixels. Keep the structure known, shade nothing.
             if (force) this.onZones({ pre: [], post: [] });
             return;
         }

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -506,7 +506,7 @@ export class ChartCell {
         const requestedSpan = Math.max(this.state.bars ?? 1000, this.rangeBars) * timeframeMs(this.state.timeframe ?? '60');
         const fallbackSpan = Number.isFinite(requestedSpan) ? Math.max(3 * 86_400_000, requestedSpan) : 3 * 86_400_000;
         const range = chart.getVisibleRange() ?? { from: now - fallbackSpan, to: now };
-        this.sessionShading.track(chart.data, symbol, { session: this.session, range });
+        this.sessionShading.track(chart.data, symbol, { session: this.session, timeframe: this.timeframe, range });
     }
 
     /** The session-shade colors live in the renderer CONFIG (persisted with it, edited

--- a/test/session-shading.test.ts
+++ b/test/session-shading.test.ts
@@ -101,7 +101,7 @@ describe('SessionShadingTracker', () => {
         const updates: Array<SessionZonesUpdate | null> = [];
         const tracker = new SessionShadingTracker((zones) => updates.push(zones));
         const monday = Date.UTC(2024, 2, 4);
-        tracker.track(data, 'AAPL', { session: 'extended', range: { from: monday, to: monday + DAY } });
+        tracker.track(data, 'AAPL', { session: 'extended', timeframe: '60', range: { from: monday, to: monday + DAY } });
         // A load's fit animation settles the viewport two weeks earlier before metadata lands.
         tracker.updateRange({ from: monday - 14 * DAY, to: monday - 13 * DAY });
         resolveSi(US_EQUITIES);
@@ -109,6 +109,33 @@ describe('SessionShadingTracker', () => {
         const zones = updates[updates.length - 1]!;
         expect(zones.pre.some(([start]) => start < monday - 13 * DAY)).toBe(true);
         tracker.stop();
+    });
+
+    it('shades nothing on daily and higher timeframes — the bars aggregate whole sessions', async () => {
+        const data = { symbolInfo: () => Promise.resolve<SymbolInfo>(US_EQUITIES) } as unknown as DataControl;
+        const monday = Date.UTC(2024, 2, 4);
+        for (const timeframe of ['1440', 'D', 'W', '43200']) {
+            const updates: Array<SessionZonesUpdate | null> = [];
+            const tracker = new SessionShadingTracker((zones) => updates.push(zones));
+            tracker.track(data, 'AAPL', { session: 'extended', timeframe, range: { from: monday, to: monday + 30 * DAY } });
+            await new Promise((r) => setTimeout(r, 0));
+            expect(updates[updates.length - 1]).toEqual({ pre: [], post: [] });
+            tracker.stop();
+        }
+    });
+
+    it('keeps shading intraday extended-session timeframes', async () => {
+        const data = { symbolInfo: () => Promise.resolve<SymbolInfo>(US_EQUITIES) } as unknown as DataControl;
+        const monday = Date.UTC(2024, 2, 4);
+        for (const timeframe of ['1', '60', '240']) {
+            const updates: Array<SessionZonesUpdate | null> = [];
+            const tracker = new SessionShadingTracker((zones) => updates.push(zones));
+            tracker.track(data, 'AAPL', { session: 'extended', timeframe, range: { from: monday, to: monday + DAY } });
+            await new Promise((r) => setTimeout(r, 0));
+            const zones = updates[updates.length - 1]!;
+            expect(zones.pre.length).toBeGreaterThan(0);
+            tracker.stop();
+        }
     });
 });
 


### PR DESCRIPTION
## Summary

- On an extended-session chart, the pre/post-market washes painted over daily, weekly, and monthly candles even though each of those bars aggregates whole sessions — there are no pre/post bar slots to shade.
- `SessionShadingTracker.track` now receives the chart's timeframe and derives an intraday flag (`timeframeMs < 1 day`); on daily+ timeframes it emits empty bands, exactly like the regular-tape branch. `ChartCell` passes its timeframe through — a timeframe switch already re-binds the tracker via `market:changed`, so no extra wiring.
- Changelog entry under `[Unreleased]` → Fixed.

## Test plan

- [x] New unit tests (failing-first): daily+ timeframes (`1440`, `D`, `W`, monthly) emit empty bands; intraday ones (`1m`, `1h`, `4h`) keep shading.
- [x] Full gate: typecheck, lint, all 1315 tests, build.
- [x] Vela oracle suite 18/20 — the 2 force-overlay failures are pre-existing (reproduce without this change) and unrelated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow visual-logic fix with unit coverage; no auth, data, or persistence changes.
> 
> **Overview**
> On an extended-session chart, pre/post-market tints no longer wash over daily, weekly, or monthly candles. Those bars already span whole sessions, so there is nothing to shade.
> 
> `SessionShadingTracker` now takes the chart timeframe and treats anything shorter than a civil day as intraday. Daily+ (or regular tape) still emits empty bands; intraday extended charts keep shading. `ChartCell` passes `this.timeframe` through on rebind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6483ffd9adb2982420f030f03fc3b23b2237afa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->