### PR TITLE
fix: render Pine tables with Pine's sizing and visibility rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Pine tables render with Pine's sizing and visibility rules.** An allocated
+  table whose cells were never set no longer paints as an empty grid — it
+  occupies no space until content arrives, and unused rows and columns of a
+  partially filled table collapse instead of padding the layout. Cell text no
+  longer wraps, so unicode sparklines and `━━━` divider rows stay on one line.
+  A cell's `width`/`height` percentages now size the cell against the pane, an
+  integer `text_size` renders at exactly that pixel size, and bold/italic cell
+  formatting is honored. The table frame draws as a clean outer stroke around
+  the table instead of an inset line that cell backgrounds could cover, and the
+  origin cell of a merged region always paints — repeated `table.merge_cells`
+  calls from a running script used to blank the merged title row.
 - **A label with an `na` color keeps its style's placement.** A Pine label whose
   bubble color is `na` used to draw its text centered on the anchor no matter
   which style it declared, so `label.style_label_up` read like

--- a/src/core/model/drawings.ts
+++ b/src/core/model/drawings.ts
@@ -188,12 +188,19 @@ export interface TableCell {
     bgColor?: string;
     hAlign: BoxHAlign;
     vAlign: BoxVAlign;
-    textSize: BoxTextSize;
+    /** A named size, or Pine's integer `text_size` as a raw pixel value. */
+    textSize: BoxTextSize | number;
     fontFamily: BoxFontFamily;
     tooltip?: string;
     bold: boolean;
     italic: boolean;
-    /** A non-origin cell absorbed by a `table.merge_cells` region → not rendered. */
+    /** Cell width as a percent of the pane's width (absent/0 = size to content). */
+    width?: number;
+    /** Cell height as a percent of the pane's height (absent/0 = size to content). */
+    height?: number;
+    /** A non-origin cell absorbed by a `table.merge_cells` region → not rendered.
+     *  Engines may also (spuriously) stamp this on the merge ORIGIN — renderers must
+     *  resolve visibility against `DrawingTable.merges`, not this flag alone. */
     merged?: boolean;
 }
 

--- a/src/renderers/shared/TableOverlay.ts
+++ b/src/renderers/shared/TableOverlay.ts
@@ -1,4 +1,4 @@
-import type { DrawingTable, BoxTextSize, TablePosition } from '../../core/model/drawings';
+import type { DrawingTable, TableCell, BoxTextSize, TablePosition } from '../../core/model/drawings';
 import type { VelaTheme } from '../../core/options';
 
 const SIZE_PX: Record<BoxTextSize, number> = {
@@ -9,6 +9,57 @@ const SIZE_PX: Record<BoxTextSize, number> = {
     large: 16,
     huge: 20,
 };
+
+/** Font size in px: a Pine integer `text_size` passes through as-is. */
+export function fontPxOf(size: TableCell['textSize']): number {
+    if (typeof size === 'number') return size > 0 ? size : SIZE_PX.auto;
+    return SIZE_PX[size] ?? SIZE_PX.auto;
+}
+
+/**
+ * True when at least one cell was actually set via `table.cell()`. A merely
+ * allocated table (`table.new` with rows × columns of nulls, or only
+ * merge-absorbed stubs) occupies no space in Pine — it must not paint, not
+ * even its background or frame.
+ */
+export function tableHasContent(t: DrawingTable): boolean {
+    return t.cells.some((row) => row?.some((c) => c != null && !c.merged));
+}
+
+/** How each merge region renders: the origin spans, the absorbed cells are omitted. */
+export interface MergeRenderPlan {
+    /** Origin key (`row:col`) → col/row spans. */
+    span: Map<string, { cs: number; rs: number }>;
+    /** Cells to omit entirely (absorbed by a merge region). */
+    omit: Set<string>;
+}
+
+/**
+ * Resolve merge regions to spans + omissions. Defensive on two engine quirks:
+ * duplicate merge records are idempotent, and a `merged` flag stamped on the
+ * ORIGIN cell never omits it — only genuinely absorbed cells are omitted
+ * (region members other than the origin, plus stray `merged`-flagged cells
+ * whose region record is missing).
+ */
+export function mergeRenderPlan(t: DrawingTable): MergeRenderPlan {
+    const span = new Map<string, { cs: number; rs: number }>();
+    const omit = new Set<string>();
+    for (const m of t.merges) {
+        span.set(`${m.startRow}:${m.startCol}`, { cs: m.endCol - m.startCol + 1, rs: m.endRow - m.startRow + 1 });
+        for (let r = m.startRow; r <= m.endRow; r += 1) {
+            for (let c = m.startCol; c <= m.endCol; c += 1) {
+                if (r !== m.startRow || c !== m.startCol) omit.add(`${r}:${c}`);
+            }
+        }
+    }
+    for (let r = 0; r < t.rows; r += 1) {
+        for (let c = 0; c < t.columns; c += 1) {
+            if (t.cells[r]?.[c]?.merged && !span.has(`${r}:${c}`)) omit.add(`${r}:${c}`);
+        }
+    }
+    for (const key of span.keys()) omit.delete(key);
+    return { span, omit };
+}
 
 /**
  * Renders Pine `table.new` objects as DOM overlays anchored to the chart corners.
@@ -44,7 +95,9 @@ export class TableOverlay {
     update(tables: DrawingTable[]): void {
         this.lastTables = tables;
         this.root.replaceChildren();
-        for (const t of tables) this.root.appendChild(this.renderTable(t));
+        for (const t of tables) {
+            if (tableHasContent(t)) this.root.appendChild(this.renderTable(t));
+        }
     }
 
     /** Re-render at the current pane geometry — after layout settles or on resize. */
@@ -63,43 +116,44 @@ export class TableOverlay {
     }
 
     private renderTable(t: DrawingTable): HTMLElement {
+        const b = this.paneBounds(t.paneId);
         const wrap = document.createElement('div');
         wrap.style.position = 'absolute';
-        this.anchor(wrap, t.position, this.paneBounds(t.paneId));
+        // Frame as the wrapper's border: an OUTER stroke around the table's outline,
+        // never covered by cell backgrounds (an inset shadow on the table would be).
+        if (t.frameColor && t.frameWidth > 0) wrap.style.border = `${t.frameWidth}px solid ${t.frameColor}`;
+        this.anchor(wrap, t.position, b);
 
         const table = document.createElement('table');
         Object.assign(table.style, {
             borderCollapse: 'collapse',
             background: t.bgColor ?? 'transparent',
             fontFamily: this.theme.fontFamily || 'sans-serif',
-            // Frame as an inset shadow (not a `border`) so it stays independent of the
-            // collapsed cell borders even when frame_width != border_width.
-            boxShadow: t.frameColor && t.frameWidth > 0 ? `inset 0 0 0 ${t.frameWidth}px ${t.frameColor}` : 'none',
             border: 'none',
             tableLayout: 'auto',
             // Re-enable pointer events on the table only (root is none) so cell tooltips work.
             pointerEvents: 'auto',
         } satisfies Partial<CSSStyleDeclaration>);
 
-        // Merged regions: the origin cell spans; the absorbed cells are not emitted.
-        const span = new Map<string, { cs: number; rs: number }>();
-        const skip = new Set<string>();
-        for (const m of t.merges) {
-            span.set(`${m.startRow}:${m.startCol}`, { cs: m.endCol - m.startCol + 1, rs: m.endRow - m.startRow + 1 });
-            for (let r = m.startRow; r <= m.endRow; r += 1) {
-                for (let c = m.startCol; c <= m.endCol; c += 1) {
-                    if (r !== m.startRow || c !== m.startCol) skip.add(`${r}:${c}`);
-                }
-            }
-        }
+        const { span, omit } = mergeRenderPlan(t);
+        // Pine cell width/height are percents of the pane's plot area.
+        const plotW = Math.max(0, (this.root.clientWidth || this.container.clientWidth) - b.rightAxis);
+        const paneH = b.height;
 
         const cellBorder = t.borderColor && t.borderWidth > 0 ? `${t.borderWidth}px solid ${t.borderColor}` : 'none';
         for (let r = 0; r < t.rows; r += 1) {
             const tr = document.createElement('tr');
             for (let c = 0; c < t.columns; c += 1) {
+                if (omit.has(`${r}:${c}`)) continue; // absorbed by a merge
                 const cell = t.cells[r]?.[c] ?? null;
-                if (skip.has(`${r}:${c}`) || cell?.merged) continue; // absorbed by a merge
                 const td = document.createElement('td');
+                if (cell === null) {
+                    // Never set via table.cell() → occupies no space: an unused
+                    // row/column collapses instead of painting an empty grid.
+                    Object.assign(td.style, { padding: '0', border: 'none' } satisfies Partial<CSSStyleDeclaration>);
+                    tr.appendChild(td);
+                    continue;
+                }
                 const sp = span.get(`${r}:${c}`);
                 if (sp) {
                     if (sp.cs > 1) td.colSpan = sp.cs;
@@ -108,18 +162,22 @@ export class TableOverlay {
                 Object.assign(td.style, {
                     border: cellBorder,
                     padding: '2px 6px',
-                    background: cell?.bgColor ?? 'transparent',
-                    color: cell?.textColor ?? this.theme.textColor,
-                    textAlign: cell?.hAlign ?? 'center',
-                    verticalAlign: cell?.vAlign === 'top' ? 'top' : cell?.vAlign === 'bottom' ? 'bottom' : 'middle',
-                    fontSize: `${SIZE_PX[cell?.textSize ?? 'normal']}px`,
-                    fontFamily: cell?.fontFamily === 'monospace' ? 'monospace' : 'inherit',
-                    fontWeight: cell?.bold ? 'bold' : 'normal',
-                    fontStyle: cell?.italic ? 'italic' : 'normal',
-                    whiteSpace: 'pre-line',
+                    background: cell.bgColor ?? 'transparent',
+                    color: cell.textColor ?? this.theme.textColor,
+                    textAlign: cell.hAlign,
+                    verticalAlign: cell.vAlign === 'top' ? 'top' : cell.vAlign === 'bottom' ? 'bottom' : 'middle',
+                    fontSize: `${fontPxOf(cell.textSize)}px`,
+                    fontFamily: cell.fontFamily === 'monospace' ? 'monospace' : 'inherit',
+                    fontWeight: cell.bold ? 'bold' : 'normal',
+                    fontStyle: cell.italic ? 'italic' : 'normal',
+                    // Pine cell text never wraps; `\n` still breaks lines. Wrapping
+                    // used to collapse unicode sparklines and ━━━ dividers.
+                    whiteSpace: 'pre',
                 } satisfies Partial<CSSStyleDeclaration>);
-                if (cell?.tooltip) td.title = cell.tooltip;
-                td.textContent = cell?.text ?? '';
+                if (cell.width) td.style.width = `${(cell.width / 100) * plotW}px`;
+                if (cell.height) td.style.height = `${(cell.height / 100) * paneH}px`;
+                if (cell.tooltip) td.title = cell.tooltip;
+                td.textContent = cell.text ?? '';
                 tr.appendChild(td);
             }
             table.appendChild(tr);

--- a/test/table-overlay-plan.test.ts
+++ b/test/table-overlay-plan.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { fontPxOf, tableHasContent, mergeRenderPlan } from '../src/renderers/shared/TableOverlay';
+import type { DrawingTable, TableCell } from '../src/core/model/drawings';
+
+function cell(over: Partial<TableCell> = {}): TableCell {
+    return { hAlign: 'center', vAlign: 'center', textSize: 'normal', fontFamily: 'default', bold: false, italic: false, ...over };
+}
+
+function tableOf(cells: Array<Array<TableCell | null>>, merges: DrawingTable['merges'] = []): DrawingTable {
+    return {
+        id: 't',
+        paneId: 'price',
+        position: 'top_right',
+        columns: cells[0]?.length ?? 0,
+        rows: cells.length,
+        frameWidth: 0,
+        borderWidth: 0,
+        cells,
+        merges,
+    };
+}
+
+describe('TableOverlay · fontPxOf', () => {
+    it('passes an integer Pine text_size through as raw pixels', () => {
+        expect(fontPxOf(14)).toBe(14);
+        expect(fontPxOf(23)).toBe(23);
+    });
+
+    it('maps named sizes and treats 0/auto as the auto size', () => {
+        expect(fontPxOf('large')).toBe(16);
+        expect(fontPxOf('auto')).toBe(13);
+        expect(fontPxOf(0)).toBe(13);
+    });
+});
+
+describe('TableOverlay · tableHasContent', () => {
+    it('an allocated-but-never-filled table has no content', () => {
+        expect(tableHasContent(tableOf([[null, null], [null, null]]))).toBe(false);
+    });
+
+    it('a single set cell makes the table render', () => {
+        expect(tableHasContent(tableOf([[null, cell({ text: 'x' })], [null, null]]))).toBe(true);
+        // A set cell with no text (bgcolor-only) still counts.
+        expect(tableHasContent(tableOf([[cell({ bgColor: '#ff0000' })]]))).toBe(true);
+    });
+
+    it('merge-absorbed stubs alone do not count as content', () => {
+        expect(tableHasContent(tableOf([[cell({ merged: true }), cell({ merged: true })]]))).toBe(false);
+    });
+});
+
+describe('TableOverlay · mergeRenderPlan', () => {
+    it('origin spans, absorbed cells are omitted', () => {
+        const t = tableOf([[cell({ text: 'T' }), cell(), cell()]], [{ startRow: 0, startCol: 0, endRow: 0, endCol: 2 }]);
+        const { span, omit } = mergeRenderPlan(t);
+        expect(span.get('0:0')).toEqual({ cs: 3, rs: 1 });
+        expect(omit.has('0:0')).toBe(false);
+        expect(omit.has('0:1')).toBe(true);
+        expect(omit.has('0:2')).toBe(true);
+    });
+
+    it('never omits the origin, even when the engine stamped `merged` on it', () => {
+        // Repeated `table.merge_cells` in PineTS marks the ORIGIN cell `_merged`
+        // (self-parent forwarding) — the merged title row must still paint.
+        const t = tableOf(
+            [[cell({ text: 'T', merged: true }), cell({ merged: true }), cell({ merged: true })]],
+            [{ startRow: 0, startCol: 0, endRow: 0, endCol: 2 }],
+        );
+        const { omit } = mergeRenderPlan(t);
+        expect(omit.has('0:0')).toBe(false);
+        expect(omit.has('0:1')).toBe(true);
+    });
+
+    it('duplicate merge records are idempotent', () => {
+        const m = { startRow: 0, startCol: 0, endRow: 1, endCol: 1 };
+        const t = tableOf([[cell({ text: 'T' }), cell()], [cell(), cell()]], [m, { ...m }, { ...m }]);
+        const { span, omit } = mergeRenderPlan(t);
+        expect(span.size).toBe(1);
+        expect(omit).toEqual(new Set(['0:1', '1:0', '1:1']));
+    });
+
+    it('a stray absorbed stub without its merge record is still omitted', () => {
+        const t = tableOf([[cell({ text: 'a' }), cell({ merged: true })]]);
+        const { omit } = mergeRenderPlan(t);
+        expect(omit.has('0:1')).toBe(true);
+        expect(omit.has('0:0')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Stacked on #75 (`fix/na-colors`) — only the last commit is new here.

- An allocated table whose cells were never set (`var t = table.new(...)` with no `table.cell`) no longer paints as an empty grid: it occupies no space until content arrives, and unset cells/rows/columns of a partially filled table collapse instead of padding the layout.
- Merge visibility is resolved from the table's merge regions, never from the per-cell `merged` flag alone: the merge ORIGIN always paints (engines can spuriously stamp it as absorbed when `table.merge_cells` runs every bar), only absorbed cells are omitted, and duplicate merge records are idempotent.
- The table frame draws as an outer stroke around the table instead of an inset shadow that cell backgrounds covered.
- Cell text no longer wraps (`white-space: pre`), so unicode sparklines and `━━━` divider rows stay on one line.
- `TableCell` gains `width`/`height` (percent of the pane, resolved against real pane geometry and refreshed on resize) and accepts an integer `textSize` rendered at exactly that pixel value.

Pairs with the Vela-pinets PR that maps these cell fields out of PineTS.

## Test plan

- [x] `npm run typecheck` / `lint` / `test` (1325, incl. 9 new for the overlay's pure helpers) / `build`
- [x] Workspace oracle suite 20/22 — new `table-args` scenario passes; the two failures are the known unrelated `force-overlay` scenarios (feature lives on its own branch); the existing merged-header table scenario renders identically

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer-only table overlay and model-field tweaks; no auth, data, or engine execution changes. Visual regressions on Pine tables are the main risk.
> 
> **Overview**
> Pine `table.new` overlays now follow Pine’s layout rules instead of painting empty grids and wrapping cell text.
> 
> Empty allocated tables occupy no space until a cell is set; unset rows/columns collapse. Merge visibility is resolved from merge regions so the origin always paints even when the engine stamps `merged` on it (repeated `table.merge_cells`). Cell `width`/`height` are pane percents, integer `text_size` is raw pixels, text does not wrap (`white-space: pre`), and the frame is an outer border rather than an inset shadow that cell fills covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 525378711c36fe3d82a216de3c35130466938b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->