### PR TITLE
fix: reflect symbol and timeframe picks in the chrome instantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Symbol and timeframe picks show instantly.** Choosing a new symbol or
+  timeframe now updates the topbar, status line, and watermark the moment the
+  pick is made instead of after the new market's bars finish loading — on a
+  slow connection the loading chart carries the name you picked rather than
+  the old market's.
 - **Pre-market sunrise and post-market sunset point the right way.** The
   statusline's session badges had their chevrons inverted, so pre-market read as
   sunset and post-market as sunrise.

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -438,23 +438,36 @@ export class ChartCell {
         // (the shared topbar gear opens the ACTIVE cell's dialog).
         this.pushSettingsSections();
 
-        // The ONE bookkeeping seam: every market change — cell setters, sync links, or
-        // host code calling chart.setMarket directly — lands here and updates the cell
+        // The committed bookkeeping seam: every market change — cell setters, sync links,
+        // or host code calling chart.setMarket directly — lands here and updates the cell
         // state + overlays, then notifies the workspace (chrome projection, retention).
+        // The cell setters ALSO project optimistically before the load (see projectMarket);
+        // this pass re-runs idempotently and adds the data-dependent bookkeeping.
         this.offMarket = this.inner.on('market:changed', ({ symbol, timeframe }) => {
-            this.state.symbol = symbol;
-            this.state.provider = parseSymbol(symbol).provider ?? undefined;
-            this.state.timeframe = timeframe;
-            this.state.session = normalizeSession(this.inner?.market.session);
-            this.watermark?.update(symbol, timeframe);
-            this.statusline?.setSymbol(symbol);
-            this.statusline?.setMeta(timeframe, this.inner?.data.displayPrefix(symbol) ?? this.state.provider ?? '');
-            if (this.inner) this.statusline?.onChart(this.inner); // drop the old market's resting OHLC
+            this.projectMarket(symbol, timeframe);
             this.refreshNativeCatalog(); // per-symbol support flags may differ
             this.refreshSessionAvailable(); // the new symbol may (not) have sessions
             if (this.inner) this.marketStatus?.track(this.inner.data, symbol); // …and its own market clock
             this.deps.onMarketChanged(this.id);
         });
+    }
+
+    /**
+     * Project a market identity into the cell state and its display overlays (watermark,
+     * statusline), WITHOUT the data-dependent bookkeeping. Runs twice per user pick: once
+     * optimistically from the cell setters — the labels reflect the pick immediately, not
+     * after the bars load — and again from `market:changed` (the committed pass, and the
+     * only pass for host `chart.setMarket` calls). Idempotent, so the double run converges.
+     */
+    private projectMarket(symbol: string, timeframe: string): void {
+        this.state.symbol = symbol;
+        this.state.provider = parseSymbol(symbol).provider ?? undefined;
+        this.state.timeframe = timeframe;
+        this.state.session = normalizeSession(this.inner?.market.session);
+        this.watermark?.update(symbol, timeframe);
+        this.statusline?.setSymbol(symbol);
+        this.statusline?.setMeta(timeframe, this.inner?.data.displayPrefix(symbol) ?? this.state.provider ?? '');
+        if (this.inner) this.statusline?.onChart(this.inner); // drop the old market's resting OHLC
     }
 
     /**
@@ -714,11 +727,15 @@ export class ChartCell {
         return this.instances.length + this.nativeCatalog.filter((n) => n.present).length;
     }
 
-    /** Switch this cell's market in place (the chart instance survives). */
+    /** Switch this cell's market in place (the chart instance survives). The projection
+     *  is OPTIMISTIC — labels and chrome show the pick before the bars load; it follows
+     *  the setMarket call so the statusline reads the already-blanked chart. */
     setSymbol(symbol: string): void {
         if (!this.inner || symbol === this.symbol) return;
         this.unresolvedToasted = null; // a re-picked symbol gets a fresh verdict
         void this.inner.setMarket({ symbol });
+        this.projectMarket(symbol, this.timeframe);
+        this.deps.onMarketChanged(this.id);
     }
 
     setTimeframe(timeframe: string): void {
@@ -727,6 +744,8 @@ export class ChartCell {
         this.activeRangeId = null;
         this.rangeBars = 0;
         void this.inner.setMarket({ timeframe, bars: this.state.bars });
+        this.projectMarket(this.symbol, timeframe);
+        this.deps.onMarketChanged(this.id);
     }
 
     /** Applied live (renderer feature) — no reload. */


### PR DESCRIPTION
## Summary

- Switching the symbol or timeframe from the UI (topbar menu/chips, symbol search, mobile drawer, plugin contexts, sync links) now updates the topbar, statusline, watermark and mobile bar **the moment the pick is made**, instead of only after the new market''s bars finish loading. On a slow connection the loading chart carries the picked name rather than the old market''s.
- Implementation: the chrome labels hung solely off `market:changed`, which the engine emits after awaiting the data load. `ChartCell.setSymbol`/`setTimeframe` — the seam every UI pick routes through — now project the picked identity into the cell state and display overlays optimistically. `market:changed` remains the committed pass: it re-runs the same (idempotent) projection and keeps the data-dependent bookkeeping (native catalog, session availability, market clock). No public API change; the core''s `setMarket`/`market:changed` contract is untouched.
- Changelog entry added under `[Unreleased]` → `Fixed`.

## Test plan

- [x] Gate: `typecheck` · `lint` · `test` (1313 tests) · `build` — all green on this branch.
- [x] Browser proof in the playground with real Binance data and all fetches artificially delayed by 3s: mutation-observer timing logs show the timeframe label flipped to the pick at the same millisecond the data fetch *started* (3.7s before it returned), and likewise for a symbol pick through the search dialog; the committed pass converged after the load with the chart, statusline and indicators correct.
- [x] Oracle suites: `vela-pro` 11/11 passed against the rebuilt Vela; `vela` 20/22 — the two `forcedOverlay` failures are pre-existing (`force_overlay` is not implemented in the current Vela-pinets checkout) and unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI timing only: overlay projection is idempotent and the public setMarket / market:changed contract is unchanged. Extra onMarketChanged notifies are expected and converge after load.
> 
> **Overview**
> Symbol and timeframe picks now update the topbar, status line, and watermark **as soon as the user chooses them**, instead of waiting for the new market’s bars to finish loading. On a slow connection the loading chart already carries the picked name.
> 
> `ChartCell.setSymbol` / `setTimeframe` project the new identity into cell state and overlays (and notify the workspace) right after `setMarket`. The existing `market:changed` handler still runs as the committed pass: it re-applies the same idempotent `projectMarket` and keeps data-dependent bookkeeping (native catalog, session availability, market clock). Direct host `chart.setMarket` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80ecb8cca4cd2637a243a50191857c34ed50bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->