### PR TITLE
fix: render Pine labels with their full text styling and tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,18 @@ All notable changes to Vela, newest first.
 
 ## [Unreleased]
 
+### Added
+
+- **Pine label tooltips.** A label created with a `tooltip` now shows it: hover the
+  label (the bubble, marker, or text) and a themed tip opens next to the cursor,
+  wrapping long texts.
+- **Bold and italic label text.** Labels accept the same bold/italic text
+  formatting boxes already support, applied to bubble and plain text styles alike.
+
 ### Fixed
 
+- **Label `textalign` works on bubble styles.** Multi-line text inside a label
+  bubble now aligns left, center, or right as asked; it was always centered.
 - **Pine tables render with Pine's sizing and visibility rules.** An allocated
   table whose cells were never set no longer paints as an empty grid — it
   occupies no space until content arrives, and unused rows and columns of a

--- a/src/core/model/drawings.ts
+++ b/src/core/model/drawings.ts
@@ -124,6 +124,9 @@ export interface DrawingLabel {
     textAlign: BoxHAlign;
     tooltip?: string;
     fontFamily: BoxFontFamily;
+    /** Pine `text_formatting` — bold/italic text, matching the box text options. */
+    bold?: boolean;
+    italic?: boolean;
     /** na bubble/marker color → render text only (no bubble/shape fill). */
     noFill?: boolean;
     /** `force_overlay` → render on the price pane regardless of the indicator's pane. */

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -43,6 +43,7 @@ import { clampBarSpacing, defaultViewport, MIN_BAR_SPACING, MAX_BAR_SPACING, typ
 import { Canvas2dBackend } from './backend/Canvas2dBackend';
 import type { IRenderBackend } from './backend/IRenderBackend';
 import { ChromeRenderer } from './chrome/ChromeRenderer';
+import { LabelTooltip } from './chrome/LabelTooltip';
 import { AXIS_MASTER_W, AXIS_MERGED_W } from './chrome/axisLayout';
 import { CrosshairRenderer } from './chrome/CrosshairRenderer';
 import { SettingsDialog } from './chrome/SettingsDialog';
@@ -168,6 +169,8 @@ export class NativeRenderer implements IChartRenderer {
     private backendMode: NativeBackend = 'auto';
     private glowAmount = 0; // WebGL2 neon-glow intensity (canvas2d ignores it)
     private readonly chrome = new ChromeRenderer();
+    /** Hover tooltips for Pine labels (canvas hit-rects collected by the chrome layer). */
+    private labelTooltip: LabelTooltip | null = null;
     private readonly crosshairLayer = new CrosshairRenderer();
     private scheduler!: Scheduler;
     /** 1 Hz repaint pump so the price-axis countdown-to-bar-close ticks; null when off. */
@@ -1379,6 +1382,12 @@ export class NativeRenderer implements IChartRenderer {
         this.plot.addEventListener('pointermove', this.onScrollProximityMove);
         this.plot.addEventListener('pointerleave', this.onScrollProximityLeave);
 
+        // Pine label tooltips: hover a label that carries one and a themed tip opens.
+        this.labelTooltip = new LabelTooltip(this.plot, {
+            theme: () => this.chromeTheme(),
+            lookup: (x, y) => this.chrome.labelTooltipAt(x, y),
+        });
+
         // User-drawings layer (paints L1.5 plus the interleave layers the geometry backend
         // composites into the series stack, and owns the interaction/settings popup). It
         // implements the IDrawingsRendererPort the core DrawingController drives.
@@ -1633,6 +1642,8 @@ export class NativeRenderer implements IChartRenderer {
         this.settingsButton = null;
         this.plot?.removeEventListener('pointermove', this.onScrollProximityMove);
         this.plot?.removeEventListener('pointerleave', this.onScrollProximityLeave);
+        this.labelTooltip?.destroy();
+        this.labelTooltip = null;
         this.scrollButton?.remove();
         this.scrollButton = null;
         for (const l of this.extLayers) l.instance.destroy?.();

--- a/src/renderers/native/chrome/ChromeRenderer.ts
+++ b/src/renderers/native/chrome/ChromeRenderer.ts
@@ -7,7 +7,7 @@ import type { SceneGraph, PaneNode } from '../core/SceneGraph';
 import { percentScaleFor } from '../core/SceneGraph';
 // Re-exported so existing importers (crosshair) can keep sourcing it from here.
 export { percentScaleFor } from '../core/SceneGraph';
-import { DrawingSceneRenderer, type DrawingSet } from '../../shared/DrawingSceneRenderer';
+import { DrawingSceneRenderer, type DrawingSet, type LabelTipRegion } from '../../shared/DrawingSceneRenderer';
 import { renderTradeMarkers } from '../../shared/trade-markers';
 import type { TradeExecution } from '../../../core/model/trades';
 import { paneAxisTicks, formatAxisValue, timeTicks } from './ticks';
@@ -35,6 +35,8 @@ export class ChromeRenderer {
     private axisTextColor = DARK_THEME.textColor;
     // Shared Pine-drawing renderer (line/box/label/polyline/linefill); widthCache persists.
     private readonly drawScene = new DrawingSceneRenderer({ timeToLogical: () => 0, barAt: () => null, theme: {} as VelaTheme });
+    // Tooltip hit-rects of every label drawn this frame, in plot coords (rebuilt per render).
+    private labelTips: LabelTipRegion[] = [];
 
     mount(canvas: HTMLCanvasElement): void {
         this.canvas = canvas;
@@ -82,6 +84,7 @@ export class ChromeRenderer {
         // The gutters (and their labels) use the surface the host passes (the live chart
         // background); everything data-side keeps the live theme.
         this.axisTextColor = surface?.textColor ?? theme.textColor;
+        this.labelTips = [];
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
         ctx.clearRect(0, 0, fullW, fullH);
         // Paint the price-axis (right) + time-axis (bottom) gutters opaquely so drawings or
@@ -224,6 +227,19 @@ export class ChromeRenderer {
             (price) => coords.priceToY(price, pane.scale, pane.bounds) - pane.bounds.top,
         );
         ctx.restore();
+        // Collect this set's label tooltip rects, shifted from pane space into plot space.
+        for (const r of this.drawScene.labelTipRegions()) {
+            this.labelTips.push({ ...r, top: r.top + pane.bounds.top, bottom: r.bottom + pane.bounds.top });
+        }
+    }
+
+    /** Tooltip of the topmost label under a plot-space point, or null. Fed by the last render. */
+    labelTooltipAt(x: number, y: number): string | null {
+        for (let i = this.labelTips.length - 1; i >= 0; i -= 1) {
+            const r = this.labelTips[i]!;
+            if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return r.text;
+        }
+        return null;
     }
 
     // ── axes ──

--- a/src/renderers/native/chrome/LabelTooltip.ts
+++ b/src/renderers/native/chrome/LabelTooltip.ts
@@ -1,0 +1,88 @@
+// Hover tooltips for Pine labels (`label.new(..., tooltip=...)`). Labels are canvas
+// pixels, not DOM anchors, so the chrome-tooltip helper doesn't apply: this tracks the
+// pointer on the plot, hit-tests the label rects the chrome layer collected while
+// painting, and shows a themed tip near the cursor after a short hover. The tip carries
+// its own tokens (like the rest of the in-chart chrome) so it works on a bare chart.
+import type { VelaTheme } from '../../../core/options';
+import { applyChromeTokens } from '../../shared/theme-tokens';
+
+export interface LabelTooltipDeps {
+    /** Live theme — read at open time, so a theme switch never shows a stale tip. */
+    theme: () => VelaTheme;
+    /** Tooltip text under a plot-space point (the chrome layer's label hit-rects). */
+    lookup: (x: number, y: number) => string | null;
+}
+
+const HOVER_DELAY_MS = 350;
+
+export class LabelTooltip {
+    private tip: HTMLElement | null = null;
+    private timer: number | null = null;
+    /** Text of the currently open OR armed tip — dedupes moves inside one label. */
+    private current: string | null = null;
+
+    constructor(
+        private readonly plot: HTMLElement,
+        private readonly deps: LabelTooltipDeps,
+    ) {
+        plot.addEventListener('pointermove', this.onMove);
+        plot.addEventListener('pointerleave', this.onLeave);
+        plot.addEventListener('pointerdown', this.onLeave);
+    }
+
+    destroy(): void {
+        this.plot.removeEventListener('pointermove', this.onMove);
+        this.plot.removeEventListener('pointerleave', this.onLeave);
+        this.plot.removeEventListener('pointerdown', this.onLeave);
+        this.clear();
+    }
+
+    private readonly onMove = (e: PointerEvent): void => {
+        if (e.pointerType !== 'mouse') return; // a tap has no hover to follow (see chrome-tooltip)
+        const rect = this.plot.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        const text = this.deps.lookup(x, y);
+        if (!text) {
+            this.clear();
+            return;
+        }
+        if (text === this.current) return; // still inside the same label
+        this.clear();
+        this.current = text;
+        this.timer = window.setTimeout(() => this.show(text, x, y), HOVER_DELAY_MS);
+    };
+
+    private readonly onLeave = (): void => {
+        this.clear();
+    };
+
+    private show(text: string, x: number, y: number): void {
+        const doc = this.plot.ownerDocument;
+        const tip = doc.createElement('div');
+        tip.textContent = text;
+        tip.style.cssText =
+            'position:absolute;z-index:var(--vela-z-tooltip);pointer-events:none;' +
+            'background:var(--vela-bg);border:1px solid var(--vela-border);color:var(--vela-fg);' +
+            'border-radius:var(--vela-radius-md);padding:4px 9px;box-shadow:var(--vela-shadow);' +
+            'font:var(--vela-font-size-md) var(--vela-font);max-width:260px;';
+        applyChromeTokens(tip, this.deps.theme());
+        this.plot.appendChild(tip);
+        // Below-right of the cursor, clamped so the tip never spills out of the plot.
+        const pw = this.plot.clientWidth;
+        const ph = this.plot.clientHeight;
+        tip.style.left = `${Math.max(0, Math.min(x + 12, pw - tip.offsetWidth - 4))}px`;
+        tip.style.top = `${Math.max(0, Math.min(y + 16, ph - tip.offsetHeight - 4))}px`;
+        this.tip = tip;
+    }
+
+    private clear(): void {
+        if (this.timer !== null) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+        this.tip?.remove();
+        this.tip = null;
+        this.current = null;
+    }
+}

--- a/src/renderers/shared/DrawingSceneRenderer.ts
+++ b/src/renderers/shared/DrawingSceneRenderer.ts
@@ -38,6 +38,15 @@ export interface DrawingPriceRange {
 
 export const EMPTY_DRAWING_SET: DrawingSet = { lines: [], boxes: [], labels: [], polylines: [], linefills: [] };
 
+/** Hover hit-rect of one rendered label that carries a tooltip (canvas coords of the last render). */
+export interface LabelTipRegion {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+    text: string;
+}
+
 function fontSizePx(size: BoxTextSize): number {
     return size === 'auto' ? 12 : namedFontSize(size);
 }
@@ -53,6 +62,8 @@ function fontSizePx(size: BoxTextSize): number {
 export class DrawingSceneRenderer {
     /** measureText width cache, keyed by `${font} ${text}`, persists across frames. */
     private readonly widthCache = new Map<string, number>();
+    /** Tooltip hit-rects captured while drawing the CURRENT set (rebuilt per render). */
+    private tipRegions: LabelTipRegion[] = [];
     /**
      * Index offset of the CURRENT set's model: its `xloc:'bar_index'` coordinates count
      * from the model's anchor bar, so they shift by this to land on chart logical indices.
@@ -81,8 +92,14 @@ export class DrawingSceneRenderer {
         return !s.lines.length && !s.boxes.length && !s.labels.length && !s.polylines.length && !s.linefills.length;
     }
 
+    /** Tooltip hit-rects of the labels drawn by the LAST `render` call (same coords as `ctx`). */
+    labelTipRegions(): readonly LabelTipRegion[] {
+        return this.tipRegions;
+    }
+
     /** Draw the whole set into `ctx` using the supplied coordinate closures. */
     render(ctx: CanvasRenderingContext2D, W: number, H: number, xOf: (l: number) => number, yOf: (p: number) => number | null): void {
+        this.tipRegions = [];
         if (this.isEmpty()) return;
         ctx.save();
         this.drawLinefills(ctx, W, H, xOf, yOf);
@@ -465,14 +482,38 @@ export class DrawingSceneRenderer {
             if (this.isPointShape(lb.style)) {
                 if (!lb.noFill) this.drawLabelShape(ctx, lb.style, px, py, fontPx, color);
                 if (lb.text) this.drawLabelText(ctx, lb, px, py + fontPx, fontPx);
+                if (lb.tooltip) {
+                    const r = Math.max(4, fontPx * 0.6) + 3;
+                    this.tipRegions.push({ left: px - r, top: py - r, right: px + r, bottom: py + r, text: lb.tooltip });
+                }
             } else if (lb.style === 'none' || lb.style === 'text_outline') {
-                if (lb.text) this.drawLabelText(ctx, lb, px, py, fontPx, lb.style === 'text_outline');
+                if (lb.text) {
+                    this.drawLabelText(ctx, lb, px, py, fontPx, lb.style === 'text_outline');
+                    if (lb.tooltip) this.tipRegions.push(this.textRegion(ctx, lb, px, py, fontPx, lb.tooltip));
+                }
             } else {
                 // noFill (na color) keeps the bubble style's geometry — drawBubble
                 // places the text as if the bubble were there and skips the fill.
-                this.drawBubble(ctx, lb, px, py, fontPx, color);
+                const r = this.drawBubble(ctx, lb, px, py, fontPx, color);
+                if (lb.tooltip) this.tipRegions.push({ left: r.x, top: r.y, right: r.x + r.w, bottom: r.y + r.h, text: lb.tooltip });
             }
         }
+    }
+
+    /** Canvas font for a label's text — family + Pine `text_formatting` (bold/italic). */
+    private labelFont(lb: DrawingLabel, fontPx: number): string {
+        const family = lb.fontFamily === 'monospace' ? 'monospace' : this.deps.theme.fontFamily || 'sans-serif';
+        return `${lb.italic ? 'italic ' : ''}${lb.bold ? 'bold ' : ''}${fontPx}px ${family}`;
+    }
+
+    /** Hover rect of a text-only label (style none/text_outline/noFill), centered like drawLabelText. */
+    private textRegion(ctx: CanvasRenderingContext2D, lb: DrawingLabel, cx: number, cy: number, fontPx: number, text: string): LabelTipRegion {
+        const font = this.labelFont(lb, fontPx);
+        const lines = (lb.text ?? '').split('\n');
+        const w = Math.max(1, ...lines.map((l) => this.measure(ctx, font, l)));
+        const h = fontPx * 1.25 * lines.length;
+        const left = lb.textAlign === 'left' ? cx : lb.textAlign === 'right' ? cx - w : cx - w / 2;
+        return { left, top: cy - h / 2, right: left + w, bottom: cy + h / 2, text };
     }
 
     private isPointShape(style: DrawingLabel['style']): boolean {
@@ -494,8 +535,7 @@ export class DrawingSceneRenderer {
     }
 
     private drawLabelText(ctx: CanvasRenderingContext2D, lb: DrawingLabel, cx: number, cy: number, fontPx: number, outline = false): void {
-        const family = lb.fontFamily === 'monospace' ? 'monospace' : this.deps.theme.fontFamily || 'sans-serif';
-        ctx.font = `${fontPx}px ${family}`;
+        ctx.font = this.labelFont(lb, fontPx);
         ctx.textAlign = lb.textAlign === 'left' ? 'left' : lb.textAlign === 'right' ? 'right' : 'center';
         ctx.textBaseline = 'middle';
         const lines = lb.text!.split('\n');
@@ -577,9 +617,9 @@ export class DrawingSceneRenderer {
         }
     }
 
-    private drawBubble(ctx: CanvasRenderingContext2D, lb: DrawingLabel, px: number, py: number, fontPx: number, color: string): void {
-        const family = lb.fontFamily === 'monospace' ? 'monospace' : this.deps.theme.fontFamily || 'sans-serif';
-        ctx.font = `${fontPx}px ${family}`;
+    /** Draw a bubble label; returns the bubble body rect (for tooltip hit-testing). */
+    private drawBubble(ctx: CanvasRenderingContext2D, lb: DrawingLabel, px: number, py: number, fontPx: number, color: string): { x: number; y: number; w: number; h: number } {
+        ctx.font = this.labelFont(lb, fontPx);
         const lines = (lb.text ?? '').split('\n');
         const padX = 6;
         const padY = 4;
@@ -645,11 +685,23 @@ export class DrawingSceneRenderer {
             // With no bubble behind it, contrast-of-bubble is meaningless — fall
             // back to the theme's text color (same default as bare label text).
             ctx.fillStyle = lb.textColor ?? (lb.noFill ? this.deps.theme.textColor : contrastColor(color));
-            ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
+            // Pine `textalign` aligns the LINES inside the bubble (the bubble itself stays put).
+            let tx: number;
+            if (lb.textAlign === 'left') {
+                ctx.textAlign = 'left';
+                tx = bx + padX;
+            } else if (lb.textAlign === 'right') {
+                ctx.textAlign = 'right';
+                tx = bx + w - padX;
+            } else {
+                ctx.textAlign = 'center';
+                tx = bx + w / 2;
+            }
             const startY = by + padY + lineH / 2;
-            for (let i = 0; i < lines.length; i += 1) ctx.fillText(lines[i]!, bx + w / 2, startY + i * lineH);
+            for (let i = 0; i < lines.length; i += 1) ctx.fillText(lines[i]!, tx, startY + i * lineH);
         }
+        return { x: bx, y: by, w, h };
     }
 
     private roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {

--- a/test/drawing-scene-labels.test.ts
+++ b/test/drawing-scene-labels.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { DrawingSceneRenderer, EMPTY_DRAWING_SET, type DrawingSet } from '../src/renderers/shared/DrawingSceneRenderer';
+import type { DrawingLabel } from '../src/core/model/drawings';
+import type { VelaTheme } from '../src/core/options';
+
+// One label at logical 100 / price 100; identity coordinate closures keep the math legible.
+const xOf = (l: number): number => l;
+const yOf = (p: number): number => p;
+
+const theme = { fontFamily: 'sans-serif', textColor: '#ddd' } as VelaTheme;
+
+function label(over: Partial<DrawingLabel>): DrawingLabel {
+    return {
+        id: 'l1',
+        paneId: 'price',
+        xloc: 'bar_index',
+        x: 100,
+        y: 100,
+        yloc: 'price',
+        text: 'AB',
+        style: 'label_down',
+        size: 'normal', // 14px → lineH 17.5
+        textAlign: 'center',
+        fontFamily: 'default',
+        ...over,
+    };
+}
+
+function setOf(labels: DrawingLabel[]): DrawingSet {
+    return { ...EMPTY_DRAWING_SET, labels };
+}
+
+/** Records every fillText with the font/textAlign active at call time. */
+function recordingCtx() {
+    const texts: Array<{ text: string; x: number; y: number; font: string; align: string }> = [];
+    let font = '';
+    let align = 'start';
+    const ctx = {
+        set font(v: string) {
+            font = v;
+        },
+        get font(): string {
+            return font;
+        },
+        set textAlign(v: string) {
+            align = v;
+        },
+        get textAlign(): string {
+            return align;
+        },
+        fillStyle: '',
+        strokeStyle: '',
+        lineWidth: 1,
+        textBaseline: 'alphabetic',
+        save() {},
+        restore() {},
+        beginPath() {},
+        closePath() {},
+        moveTo() {},
+        lineTo() {},
+        arcTo() {},
+        arc() {},
+        rect() {},
+        clip() {},
+        fill() {},
+        stroke() {},
+        fillRect() {},
+        strokeRect() {},
+        setLineDash() {},
+        strokeText() {},
+        fillText(text: string, x: number, y: number) {
+            texts.push({ text, x, y, font, align });
+        },
+        measureText: () => ({ width: 10 }),
+    };
+    return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
+}
+
+function paint(labels: DrawingLabel[]) {
+    const scene = new DrawingSceneRenderer({ timeToLogical: (ms) => ms, barAt: () => null, theme }, setOf(labels));
+    const rec = recordingCtx();
+    scene.render(rec.ctx, 800, 400, xOf, yOf);
+    return { scene, texts: rec.texts };
+}
+
+// Bubble geometry at the defaults: text width 10 → w = 22 (padX 6), h = 25.5 (lineH 17.5 + padY 8),
+// label_down at (100, 100) → body rect left 89, top 67.5.
+const BUBBLE = { left: 89, right: 111, top: 67.5, bottom: 93 };
+
+describe('bubble labels — textalign', () => {
+    it('centers by default', () => {
+        const { texts } = paint([label({})]);
+        expect(texts).toHaveLength(1);
+        expect(texts[0]!.align).toBe('center');
+        expect(texts[0]!.x).toBe(100);
+    });
+
+    it('left-aligns lines against the bubble padding', () => {
+        const { texts } = paint([label({ textAlign: 'left' })]);
+        expect(texts[0]!.align).toBe('left');
+        expect(texts[0]!.x).toBe(BUBBLE.left + 6);
+    });
+
+    it('right-aligns lines against the bubble padding', () => {
+        const { texts } = paint([label({ textAlign: 'right' })]);
+        expect(texts[0]!.align).toBe('right');
+        expect(texts[0]!.x).toBe(BUBBLE.right - 6);
+    });
+});
+
+describe('labels — text_formatting (bold/italic)', () => {
+    it('plain labels keep the plain font', () => {
+        const { texts } = paint([label({})]);
+        expect(texts[0]!.font).toBe('14px sans-serif');
+    });
+
+    it('bold and italic reach the bubble font', () => {
+        const { texts } = paint([label({ bold: true, italic: true })]);
+        expect(texts[0]!.font).toBe('italic bold 14px sans-serif');
+    });
+
+    it('bold reaches text-only labels too', () => {
+        const { texts } = paint([label({ style: 'none', bold: true })]);
+        expect(texts[0]!.font).toBe('bold 14px sans-serif');
+    });
+});
+
+describe('labels — tooltip hit regions', () => {
+    it('a bubble with a tooltip exposes its body rect', () => {
+        const { scene } = paint([label({ tooltip: 'hello' })]);
+        const regions = scene.labelTipRegions();
+        expect(regions).toHaveLength(1);
+        expect(regions[0]).toEqual({ ...BUBBLE, text: 'hello' });
+    });
+
+    it('point shapes expose a square around the marker', () => {
+        const { scene } = paint([label({ style: 'circle', tooltip: 'dot' })]);
+        const r = scene.labelTipRegions()[0]!;
+        // r = max(4, 14*0.6) + 3 = 11.4 around (100, 100)
+        expect(r.left).toBeCloseTo(88.6);
+        expect(r.right).toBeCloseTo(111.4);
+        expect(r.top).toBeCloseTo(88.6);
+        expect(r.bottom).toBeCloseTo(111.4);
+        expect(r.text).toBe('dot');
+    });
+
+    it('text-only labels expose the text block, honoring textalign', () => {
+        const { scene } = paint([label({ style: 'none', textAlign: 'left', tooltip: 'txt' })]);
+        const r = scene.labelTipRegions()[0]!;
+        expect(r.left).toBe(100); // left-aligned text starts at the anchor
+        expect(r.right).toBe(110);
+        expect(r.text).toBe('txt');
+    });
+
+    it('labels without a tooltip contribute nothing, and regions reset per render', () => {
+        const { scene } = paint([label({})]);
+        expect(scene.labelTipRegions()).toHaveLength(0);
+        // Re-render with a tooltip-carrying set, then again without: stale regions must not survive.
+        const rec = recordingCtx();
+        scene.setSet(setOf([label({ tooltip: 'x' })]));
+        scene.render(rec.ctx, 800, 400, xOf, yOf);
+        expect(scene.labelTipRegions()).toHaveLength(1);
+        scene.setSet(setOf([label({})]));
+        scene.render(rec.ctx, 800, 400, xOf, yOf);
+        expect(scene.labelTipRegions()).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary

Three label rendering gaps, fixed at the renderer/model level (the Pine-engine side lands separately in Vela-pinets):

- **`textalign` now works on bubble styles.** `drawBubble` hard-coded `ctx.textAlign = 'center'`; multi-line text inside a label bubble now aligns left/center/right per the model's `textAlign`, with the bubble itself staying put (Pine semantics).
- **Bold/italic label text.** `DrawingLabel` gains optional `bold`/`italic` (the same fields `DrawingBox` already had), and the drawing renderer applies the font variant to bubble and plain text styles alike. Additive model change — existing consumers are unaffected.
- **Label tooltips render.** The model always carried `DrawingLabel.tooltip`, but nothing ever showed it. The shared drawing renderer now collects a hover hit-rect for every label drawn with a tooltip (bubble body, marker square, or text block), the chrome layer shifts them into plot space per frame, and a new `LabelTooltip` chrome component tracks the pointer and opens a themed, cursor-anchored tip after a short hover (mouse only, cleared on leave/press — same conventions as `chrome-tooltip`).

## Test plan

- [x] New `test/drawing-scene-labels.test.ts` (10 tests): bubble textalign left/center/right, bold/italic reaching the canvas font, tooltip hit-rects for all three label render paths, and per-render region reset.
- [x] Full gate: typecheck, lint, test (110 files / 1335 tests), build.
- [x] Browser proof on the Vela-pinets playground (real worker engine): left/right-aligned bubbles, bold+italic, monospace-bold labels render as asked; hovering the tooltip-carrying label opens the themed tip.
- [x] Workspace oracle suites: vela 20/22 (the 2 failures are the pre-existing `force-overlay` scenarios waiting on #73, unrelated), vela-pro 11/11.

## Notes

- Stacked on #76 (`fix/table-fidelity`) — merge #75 → #76 → this.
- Companion PR in Vela-pinets maps Pine's `text_formatting` onto the new `bold`/`italic` fields and patches the missing PineTS label setters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Pine drawing paint plus native pointer hover chrome. Additive model fields and hit-testing are low-severity but sit on a hot render/input path.
> 
> **Overview**
> Pine labels now match the rest of drawing text styling, and a `tooltip` on a label actually shows on hover.
> 
> **Bubble `textalign`** no longer ignores left/right: lines align inside the bubble while the bubble stays anchored. **Bold/italic** land on `DrawingLabel` (same optional fields boxes already had) and feed the canvas font for bubble, marker, and text-only styles.
> 
> Hovering a tooltip-carrying label opens a themed, cursor-anchored tip (mouse only, delayed, cleared on leave/press). The shared drawing renderer records hit-rects per paint; chrome maps them into plot space and `LabelTooltip` hit-tests them. Covered by new drawing-scene tests for alignment, font variants, and region reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f85ad8a4a963a1513997c821a4c8ae4ec56492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->