### PR TITLE
fix: keep a maximized pane's legend below the status line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ All notable changes to Vela, newest first.
 - **Pre-market sunrise and post-market sunset point the right way.** The
   statusline's session badges had their chevrons inverted, so pre-market read as
   sunset and post-market as sunrise.
+- **A maximized pane's legend stays clear of the status line.** Maximizing an
+  indicator pane moved its legend to the top of the chart, where it merged with
+  the symbol status line. The legend now stacks below the status line, the same
+  way the price pane's legend always has.
 
 ## [v0.6.8]
 

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -23,6 +23,12 @@ export {
     type InputTab,
 } from './IndicatorInputsDialog';
 
+/** Marker attribute published on the legend container whose pane sits at the plot's top
+ *  edge — the price pane normally, or a maximized study pane filling the plot. Host
+ *  overlays anchored to the plot's top-left (the widget status line) key on it to shift
+ *  the colliding legend below themselves, whichever pane owns the top. */
+export const LEGEND_AT_TOP_ATTR = 'data-vela-pane-at-top';
+
 /** A pane as the legend move UI sees it (id + label + vertical bounds, top-to-bottom order). */
 export interface LegendPaneView {
     id: string;
@@ -514,6 +520,9 @@ export class InputsUI {
 
     private positionLegend(lg: HTMLElement, paneId: string): void {
         const bounds = this.paneBoundsOf ? this.paneBoundsOf(paneId) : { top: 0, height: Infinity };
+        // Publish whether this legend's pane sits at the very top of the plot (see
+        // LEGEND_AT_TOP_ATTR) — the price pane normally, or a maximized study pane filling it.
+        lg.toggleAttribute(LEGEND_AT_TOP_ATTR, bounds.top === 0);
         // A pane hidden by a maximize elsewhere collapses to ~0 height — hide its legend entirely
         // (a collapsed strip keeps a small height, so its title still shows). Titles switched
         // off (the settings toggle) hide every pane's container the same way. Restore to 'flex'

--- a/src/widget/statusline.ts
+++ b/src/widget/statusline.ts
@@ -11,6 +11,7 @@ import { fmtPrice, fmtChange, decimalsFor } from './format';
 import { timeframeLabel } from './timeframe';
 import { tickerIconEl } from './symbol-icon';
 import { parseSymbol } from '../data/ProviderRegistry';
+import { LEGEND_AT_TOP_ATTR } from '../renderers/shared/InputsUI';
 
 const STYLE_ID = 'vela-widget-statusline';
 const CSS = `
@@ -89,12 +90,15 @@ const CSS = `
  * these are the pre-ink fallbacks only. */
 .vela-statusline .vela-sl-change[data-dir='up'] { color: var(--vela-up); }
 .vela-statusline .vela-sl-change[data-dir='down'] { color: var(--vela-down); }
-/* Stack the renderer's PRICE-pane legend below the status line (study panes stay put).
- * The renderer sets the legend's inline top — shift with a transform, don't fight it.
- * Scoped to hosts that actually CARRY a status line (the marker class set by the
- * Statusline constructor) — the stylesheet is document-global, so a bare container
- * class here would shift every chart on the page, including statusline-less ones. */
-.vela-has-statusline [data-vela-pane='price'] { transform: translateY(26px); }
+/* Stack the TOP pane's legend below the status line (lower study panes stay put).
+ * The renderer marks whichever legend sits at the plot's top edge — the price pane
+ * normally, or a maximized study pane filling the plot — so the legend never merges
+ * with the status line whichever pane owns the top. The renderer sets the legend's
+ * inline top — shift with a transform, don't fight it. Scoped to hosts that actually
+ * CARRY a status line (the marker class set by the Statusline constructor) — the
+ * stylesheet is document-global, so a bare attribute selector here would shift every
+ * chart on the page, including statusline-less ones. */
+.vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(26px); }
 /* Mobile: two-line chip — logo / symbol / meta / market status on one aligned row, the
  * bar change on the next. Full O/H/L/C stays hidden (too dense on a phone-width plot).
  * GRID, not a wrapping flexbox: an absolutely positioned wrapping flex container sizes
@@ -130,7 +134,7 @@ const CSS = `
     font-size: var(--vela-font-size-sm);
     line-height: 1.2;
 }
-[data-layout='mobile'] .vela-has-statusline [data-vela-pane='price'] { transform: translateY(40px); }
+[data-layout='mobile'] .vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(40px); }
 /* FIT mode (multi-chart cells — see setFitMode): the line never wraps; segments that
  * don't fit are HIDDEN by fit() (change first, then meta, then the market badge), so
  * overflow:hidden only guards the transient between a resize and the next measure.
@@ -147,7 +151,7 @@ const CSS = `
     padding-left: 0;
 }
 /* One row again — the mobile two-line shift doesn't apply in fit mode. */
-[data-layout='mobile'] .vela-sl-fit-host.vela-has-statusline [data-vela-pane='price'] { transform: translateY(26px); }
+[data-layout='mobile'] .vela-sl-fit-host.vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(26px); }
 `;
 
 interface BarLike {


### PR DESCRIPTION
## Summary

- Maximizing a sub-pane indicator (double-click or the pane's expand button) moves its pane to the top of the plot, where its legend landed on top of the symbol status line and the two merged into unreadable text.
- The legend layer now publishes a `data-vela-pane-at-top` marker on whichever pane's legend sits at the plot's top edge (the price pane normally, or a maximized study pane), and the status line's stylesheet shifts that marked legend below itself instead of shifting only the price pane's legend. The attribute name is shared as an exported constant so the two sides cannot drift apart.
- Adds a changelog entry under `[Unreleased]` → `Fixed`.

## Verification

- Reproduced pre-fix in the playground: with an RSI sub-pane maximized, the legend rect measured identical to the status line band (overlap confirmed by bounding rects).
- Post-fix: the maximized study legend carries the marker + 26px shift and sits fully below the status line; un-maximizing restores the split with the price legend shifted and the study legend back at its pane top, unshifted.
- Gate: lint, tests (1342 passed), build all green. `npm run typecheck` fails on dev with 5 pre-existing errors in `test/orchestrator.test.ts` (unrelated to this change; identical on a clean checkout).
- Oracle suite `oracle-tests/vela`: 18/22 — the same 4 scenarios fail on a clean dev build (force-overlay counts, plot arguments, tables), unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only CSS/DOM marker change for legend vs status line overlap; no auth, data, or rendering pipeline impact.
> 
> **Overview**
> Maximizing a study pane no longer stacks its legend on top of the symbol status line.
> 
> The legend layer now marks whichever pane sits at the plot’s top edge (`data-vela-pane-at-top`), and the status line CSS shifts that legend down instead of only the price pane’s. Desktop, mobile, and fit-mode offsets stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a8367fc0d4a0428b5d8f57336e646e28c67fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->