### PR TITLE
fix: show a script's compact shorttitle in the legend and settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to Vela, newest first.
   price scale (the pane's autoscale folds them in). `chart.inspect()` reports a
   `forcedOverlay` count per indicator so the routing is verifiable.
 
+### Changed
+
+- **The settings dialog shows the indicator's compact name.** An indicator that
+  declares a short title (Pine `shorttitle`) now shows it in the settings-dialog
+  header as well as the legend chip, so the two always match. While a script is
+  still loading, its legend row identifies it by the full title and swaps to the
+  compact name with the first computed result.
+
 ### Fixed
 
 - **Label `textalign` works on bubble styles.** Multi-line text inside a label

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1489,6 +1489,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         const meta = record.prepared.meta;
         const model: IndicatorModel = {
             id,
+            // Deliberately the FULL title, never a shorttitle: while the script loads the
+            // legend identifies it by its full name; the compact shorttitle arrives with
+            // the first computed model and takes over from there.
             title: record.options?.title ?? meta.title,
             overlay: meta.overlay,
             paneHint: meta.overlay ? 'price' : 'new',

--- a/src/core/model/indicator.ts
+++ b/src/core/model/indicator.ts
@@ -38,8 +38,9 @@ export interface IndicatorModel {
     /** Full display name (settings dialog, object tree, inspect). */
     title: string;
     /**
-     * Compact legend label when the full {@link title} is too long for the chip.
-     * Absent ⇒ the legend uses {@link title}. Mirrors Pine `indicator(..., shorttitle=)`.
+     * Compact label the legend chip and the settings dialog show instead of the full
+     * {@link title}. Absent ⇒ both use {@link title}. Mirrors Pine
+     * `indicator(..., shorttitle=)`.
      */
     shorttitle?: string;
     overlay: boolean;

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -91,8 +91,8 @@ export interface NativeIndicatorDescriptor {
     /** Full display name (picker, settings header, handle title). */
     readonly title: string;
     /**
-     * Compact name for the on-chart legend chip. Absent ⇒ {@link title}. The picker and
-     * settings dialog keep the full title either way.
+     * Compact name for the on-chart legend chip and the settings-dialog header.
+     * Absent ⇒ {@link title}. The picker keeps the full title either way.
      */
     readonly shortTitle?: string;
     readonly paneHint: 'price' | 'new';

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1929,10 +1929,10 @@ export class NativeRenderer implements IChartRenderer {
         // say so or the recorded order (object tree, seriesOrder reads) starts out a lie.
         if (model.native && this.extLayers.some((l) => l.def.id === model.native!.type)) this.scene.assignIndicatorZTop(model.id);
         else this.scene.assignIndicatorZ(model.id);
-        // Legend chip prefers the compact shorttitle; the settings dialog keeps the full title.
+        // The legend chip and the settings dialog both show the compact shorttitle when
+        // declared; the full title stays on the picker, object tree and inspect().
         this.inputsUI.upsert(model.id, model.shorttitle ?? model.title, model.inputs, model.inputValues, model.paneId, {
             native: !!model.native,
-            ...(model.shorttitle ? { settingsTitle: model.title } : {}),
         });
         this.syncTables(model);
         if (model.native?.type === 'volume') {

--- a/src/renderers/shared/IndicatorInputsDialog.ts
+++ b/src/renderers/shared/IndicatorInputsDialog.ts
@@ -20,7 +20,8 @@ export interface InputsUIChange {
 /** The slice of a legend row the settings dialog needs. */
 export interface IndicatorDialogRow {
     id: string;
-    settingsTitle: string;
+    /** Dialog header — the same compact text the legend chip shows. */
+    title: string;
     inputs: InputSchema[];
     values: Record<string, InputValue>;
 }
@@ -84,7 +85,7 @@ export class IndicatorInputsDialog {
 
         const ui = new Dialog({
             host,
-            title: row.settingsTitle,
+            title: row.title,
             // Non-modal: live-edit dialog — a modal machine locks pointer events on the
             // whole body, killing the chart and the body-portaled popovers.
             modal: false,

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -46,10 +46,8 @@ export interface LegendPlotValue {
 
 interface LegendRow {
     id: string;
-    /** Legend chip text (may be a compact shorttitle). */
+    /** Display text for the legend chip AND the settings-dialog header (may be a compact shorttitle). */
     title: string;
-    /** Settings-dialog header; falls back to {@link title} when unset. */
-    settingsTitle: string;
     inputs: InputSchema[];
     values: Record<string, InputValue>;
     el: HTMLElement;
@@ -621,12 +619,10 @@ export class InputsUI {
     }
 
     /** Create or update an indicator's legend row (in the legend for its pane). */
-    upsert(id: string, title: string, inputs: InputSchema[], values: Record<string, InputValue>, paneId = 'price', opts: { native?: boolean; beta?: boolean; settingsTitle?: string } = {}): void {
-        const settingsTitle = opts.settingsTitle ?? title;
+    upsert(id: string, title: string, inputs: InputSchema[], values: Record<string, InputValue>, paneId = 'price', opts: { native?: boolean; beta?: boolean } = {}): void {
         const existing = this.rows.get(id);
         if (existing) {
             existing.title = title;
-            existing.settingsTitle = settingsTitle;
             existing.inputs = inputs;
             existing.values = { ...values };
             existing.titleEl.textContent = title;
@@ -784,7 +780,7 @@ export class InputsUI {
         el.appendChild(controlsEl);
 
         this.attach(this.legendFor(paneId), el, !!opts.native);
-        this.rows.set(id, { id, title, settingsTitle, inputs, values: { ...values }, el, titleEl, statusEl, valuesEl, plotValues: [], plotValuesKey: '', showValues: null, highlighted: false, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
+        this.rows.set(id, { id, title, inputs, values: { ...values }, el, titleEl, statusEl, valuesEl, plotValues: [], plotValuesKey: '', showValues: null, highlighted: false, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
         this.syncFoldToggle(); // 2+ indicators grow the fold chevron; a folded legend hides the new row too
     }
 

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -209,6 +209,8 @@ class MockEngine implements ScriptingEngine {
     policyA = false;
     /** Test knob: emit a strategy-style trade-execution pair with every model. */
     emitTrades = false;
+    /** Test knob: prepare-time meta declares this compact shorttitle. */
+    declareShortTitle: string | undefined;
     runCount: Record<string, number> = {};
     lastVisibleRange: Record<string, VisibleBarRange | undefined> = {};
     streamStarts: Record<string, number> = {};
@@ -221,7 +223,7 @@ class MockEngine implements ScriptingEngine {
         return Promise.resolve({
             language: 'pine',
             inputs: [{ key: 'Length', title: 'Length', type: 'int', defval: 14 }],
-            meta: { title: 'Mock', overlay },
+            meta: { title: 'Mock', overlay, ...(this.declareShortTitle ? { shorttitle: this.declareShortTitle } : {}) },
             reactsToViewport,
             token: { instanceId, overlay },
         });
@@ -1094,6 +1096,8 @@ class DeferredEngine extends MockEngine {
     }
     /** When set, emitted models carry THIS overlay flag (to diverge from the prepare-time guess). */
     emitOverlay: boolean | undefined;
+    /** When set, emitted models carry THIS compact shorttitle. */
+    emitShortTitle: string | undefined;
     /** Release every deferred execution (the "compute finished" moment). */
     finish(): void {
         const run = this.pending;
@@ -1110,6 +1114,7 @@ class DeferredEngine extends MockEngine {
     private deferredModel(id: string, overlay: boolean): IndicatorModel {
         return {
             id, title: 'Mock', overlay, paneHint: overlay ? 'price' : 'new',
+            ...(this.emitShortTitle ? { shorttitle: this.emitShortTitle } : {}),
             series: [{ id: `${id}:line:mock#0`, title: 'Mock', paneId: 'unrouted', kind: 'line', points: [{ time: 1, value: 1 }], style: { color: '#fff', width: 1, lineStyle: 'solid' } }],
             fills: [], backgrounds: [], priceLines: [], inputs: [], inputValues: {},
         };
@@ -1152,6 +1157,32 @@ describe('EngineOrchestrator — loading placeholder + legend status', () => {
         expect(added).toEqual([ind.id]);
         expect(chart.inspect().indicators).toHaveLength(1);
         expect(renderer.removed).toHaveLength(0);
+    });
+
+    it('keeps the FULL title while loading; the shorttitle arrives with the first computed model', async () => {
+        const renderer = new FakeRenderer();
+        const engine = new DeferredEngine();
+        engine.declareShortTitle = 'MK'; // prepare-time meta already declares the compact name…
+        engine.emitShortTitle = 'MK'; // …and the computed model carries it
+        const chart = new Vela({} as unknown as HTMLElement, { live: false }, { renderer, engines: [engine], dataFeed: new MockDataFeed() });
+
+        const ind = chart.addIndicator('//@version=5\nindicator("Slow", "MK")\nplot(close)');
+        await chart.ready();
+        await flush();
+
+        // Loading: the placeholder identifies the script by its full name — never the shorttitle.
+        const placeholder = renderer.mountedModels.find((m) => m.id === ind.id);
+        expect(placeholder?.title).toBe('Mock');
+        expect(placeholder?.shorttitle).toBeUndefined();
+
+        engine.finish();
+        await flush();
+
+        // Loaded: the computed remount carries the compact name (legend + settings dialog swap to it).
+        const last = renderer.mountedModels[renderer.mountedModels.length - 1];
+        expect(last?.id).toBe(ind.id);
+        expect(last?.title).toBe('Mock');
+        expect(last?.shorttitle).toBe('MK');
     });
 
     it('re-routes to the right pane when the computed overlay differs from the prepare-time guess', async () => {
@@ -1919,7 +1950,8 @@ describe('EngineOrchestrator — force_overlay routing', () => {
         await flush();
 
         // The loading placeholder mounts first (empty series); the computed model remounts last.
-        const m = renderer.mountedModels.filter((x) => x.id === ind.id).at(-1)!;
+        const mounted = renderer.mountedModels.filter((x) => x.id === ind.id);
+        const m = mounted[mounted.length - 1]!;
         const studyPane = m.paneId!;
         expect(studyPane).not.toBe('price'); // the indicator itself still routes to its own pane
 


### PR DESCRIPTION
## Summary

- A script indicator's compact `shorttitle` now drives the **settings-dialog header** as well as the legend chip, so the two always match; the full title stays on the picker, object tree and `inspect()`.
- The **loading placeholder deliberately keeps the full title**: while a script is still computing, its legend row identifies it by the full name, and the compact shorttitle swaps in with the first computed model. A targeted orchestrator test pins both halves of that contract.
- Removes the now-dead `settingsTitle` plumbing (`InputsUI` / `IndicatorInputsDialog` internal only, not public API).
- Also restores `npm run typecheck` on dev: the merged force_overlay test used `Array.at(-1)`, which the es2020 lib target does not carry.

Pairs with LuxAlgo/Vela-pinets#18, which makes the Pine engine carry `shorttitle` into the model (Vela's legend already consumed it; the settings dialog now does too).

## Validation

- Full gate green: typecheck · lint · test (1343, incl. the new placeholder/shorttitle test) · build.
- Browser probe on the Vela-pinets playground, sampling the legend DOM every 20 ms while a deliberately slow script loads: no row during prepare → **full title** while computing → **shorttitle** once loaded; settings dialog header reads the shorttitle (`vela-dialog-title`).
- Oracle suites: `vela` 20/22 — the two failures are the `forcedOverlay` scenarios, which need the separate Vela-pinets `feat/force-overlay` branch and fail identically without this change; `vela-pro` 11/11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI labeling and internal dialog plumbing only; no auth, data, or execution-path changes. A new orchestrator test covers the loading vs loaded title contract.
> 
> **Overview**
> The settings dialog header now uses the same compact `shorttitle` as the legend chip, so the two always match. The picker, object tree, and `inspect()` still keep the full title.
> 
> While a script is loading, the legend placeholder **deliberately uses the full title**; the compact name arrives with the first computed model. Dead `settingsTitle` plumbing is removed from `InputsUI` / `IndicatorInputsDialog`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9c7f4680c24ba78bcfcddca4c050ab4b3fb7037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->