### PR TITLE
fix: let barcolor() candles obey the border visibility setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **`barcolor()` respects the candle border setting.** A candle tinted by
+  `barcolor()` no longer gets a forced outline in the up/down direction color:
+  with borders disabled the tinted body renders flat, and with borders enabled an
+  unconfigured border color follows the tint instead of the direction color, so
+  heatmap-style recoloring reads as one solid hue. Explicitly configured border
+  colors still apply.
 - **Label `textalign` works on bubble styles.** Multi-line text inside a label
   bubble now aligns left, center, or right as asked; it was always centered.
 - **Pine tables render with Pine's sizing and visibility rules.** An allocated

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -477,11 +477,13 @@ export class Canvas2dBackend implements IRenderBackend {
                     ctx.fillStyle = color;
                     ctx.fillRect(g.bodyX, top, g.bodyW, bodyH);
                 }
-                // A barcolored body always gets a border in the direction color (TV
-                // semantics) — that's what keeps the tinted candle readable.
-                if (cs.borderVisible || bc || (fading && cs.bodyVisible)) {
+                // The border strictly follows its visibility setting — barcolor() never
+                // forces one. An unconfigured border color inherits the body color, so a
+                // barcolored body gets a matching tinted border, not a direction-colored
+                // outline.
+                if (cs.borderVisible || (fading && cs.bodyVisible)) {
                     ctx.globalAlpha = this.candleStructureAlpha;
-                    ctx.strokeStyle = cs.borderVisible || bc ? ((up ? cs.borderUpColor : cs.borderDownColor) ?? dir) : color;
+                    ctx.strokeStyle = cs.borderVisible ? ((up ? cs.borderUpColor : cs.borderDownColor) ?? color) : color;
                     ctx.lineWidth = 1;
                     // Inset by half the stroke so the border lands on whole pixels
                     // (crisp) and stays inside the body's snapped footprint.

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -896,11 +896,13 @@ export class WebGL2Backend implements IRenderBackend {
                     b.alpha = this.candleBodyAlpha;
                     b.rect(g.bodyX, bodyTop, g.bodyW, bodyH, c);
                 }
-                // A barcolored body always gets a border in the direction color (TV
-                // semantics) — that's what keeps the tinted candle readable.
-                if (cs.borderVisible || bc || (fading && cs.bodyVisible)) {
+                // The border strictly follows its visibility setting — barcolor() never
+                // forces one. An unconfigured border color inherits the body color, so a
+                // barcolored body gets a matching tinted border, not a direction-colored
+                // outline.
+                if (cs.borderVisible || (fading && cs.bodyVisible)) {
                     b.alpha = this.candleStructureAlpha;
-                    const bord = cs.borderVisible || bc ? parseColor((isUp ? cs.borderUpColor : cs.borderDownColor) ?? dir) : c;
+                    const bord = cs.borderVisible ? parseColor((isUp ? cs.borderUpColor : cs.borderDownColor) ?? bodyColorStr) : c;
                     // Inset by half the stroke so the border stays inside the body's
                     // snapped footprint (mirrors the canvas2d backend).
                     const bw = Math.max(0, g.bodyW - 1);

--- a/test/native-barcolor-candles.test.ts
+++ b/test/native-barcolor-candles.test.ts
@@ -6,10 +6,13 @@ import type { IndicatorModel } from '../src/core/model/indicator';
 import type { VelaTheme } from '../src/core/options';
 
 /**
- * barcolor() recolors only the candle BODY (TV semantics): the wick and a forced
- * border keep the direction (up/down) color so the tint stays readable. These
- * tests drive the canvas2d backend with a recording 2d context and assert which
- * colors each candle part is painted with.
+ * barcolor() recolors only the candle BODY (TV semantics): the wick keeps the
+ * direction (up/down) color. The border strictly follows the border-visibility
+ * setting — a barcolor never forces one — and when visible with no explicit
+ * border color configured it inherits the body color (so a tinted body gets a
+ * matching tinted border, not a direction-colored outline). These tests drive
+ * the canvas2d backend with a recording 2d context and assert which colors each
+ * candle part is painted with.
  */
 
 const THEME: VelaTheme = {
@@ -48,8 +51,16 @@ function recordingCtx(): { ctx: CanvasRenderingContext2D; ops: Array<{ op: strin
     return { ctx, ops };
 }
 
-/** One-candle scene (up candle by default), optionally barcolored. */
-function paint(barColor?: string, bar = { time: 0, open: 100, high: 106, low: 99, close: 105 }): Array<{ op: string; style: string }> {
+interface PaintOptions {
+    barColor?: string;
+    bar?: { time: number; open: number; high: number; low: number; close: number };
+    borderVisible?: boolean;
+    borderUpColor?: string;
+}
+
+/** One-candle scene (up candle by default), optionally barcolored / bordered. */
+function paint(opts: PaintOptions = {}): Array<{ op: string; style: string }> {
+    const bar = opts.bar ?? { time: 0, open: 100, high: 106, low: 99, close: 105 };
     const backend = new Canvas2dBackend();
     const { ctx, ops } = recordingCtx();
     const canvas = { width: 300, height: 100, getContext: () => ctx } as unknown as HTMLCanvasElement;
@@ -58,14 +69,16 @@ function paint(barColor?: string, bar = { time: 0, open: 100, high: 106, low: 99
     const scene = new SceneGraph();
     scene.bars = [bar];
     scene.showGrid = false; // isolate the candle ops
+    if (opts.borderVisible !== undefined) scene.style.candle.borderVisible = opts.borderVisible;
+    if (opts.borderUpColor !== undefined) scene.style.candle.borderUpColor = opts.borderUpColor;
     const pane = scene.ensurePane('price', 'price', 0, 3);
     pane.bounds = { top: 0, height: 100 };
     pane.scale = { min: 95, max: 110 };
-    if (barColor !== undefined) {
+    if (opts.barColor !== undefined) {
         const model = {
             id: 'ind', title: 'I', overlay: true, paneId: 'price',
             series: [], fills: [], backgrounds: [], priceLines: [],
-            barColors: [{ time: bar.time, color: barColor }],
+            barColors: [{ time: bar.time, color: opts.barColor }],
             inputs: [], inputValues: {},
         } as unknown as IndicatorModel;
         scene.indicators.set(model.id, model);
@@ -79,7 +92,7 @@ function paint(barColor?: string, bar = { time: 0, open: 100, high: 106, low: 99
     return ops;
 }
 
-describe('canvas2d candles — barcolor() body tint keeps direction wick + border', () => {
+describe('canvas2d candles — barcolor() tints the body, the border follows its setting', () => {
     it('plain candle: body + wick in the direction color, no border (borders default off)', () => {
         const ops = paint();
         expect(ops).toEqual([
@@ -88,48 +101,42 @@ describe('canvas2d candles — barcolor() body tint keeps direction wick + borde
         ]);
     });
 
-    it('barcolored candle: tinted body, wick AND forced border stay the direction color', () => {
-        const ops = paint('#123456');
+    it('barcolored candle with borders off: tinted body, direction wick, NO border', () => {
+        const ops = paint({ barColor: '#123456' });
         expect(ops).toEqual([
             { op: 'stroke', style: THEME.upColor }, // wick — NOT the barcolor
             { op: 'fill', style: '#123456' }, // body — the barcolor
-            { op: 'stroke', style: THEME.upColor }, // border — forced by the barcolor
         ]);
     });
 
-    it('barcolored down candle keeps the down direction color for wick + border', () => {
-        const ops = paint('#123456', { time: 0, open: 105, high: 106, low: 99, close: 100 });
+    it('barcolored down candle with borders off: tinted body, down-direction wick, NO border', () => {
+        const ops = paint({ barColor: '#123456', bar: { time: 0, open: 105, high: 106, low: 99, close: 100 } });
         expect(ops).toEqual([
             { op: 'stroke', style: THEME.downColor },
             { op: 'fill', style: '#123456' },
-            { op: 'stroke', style: THEME.downColor },
         ]);
     });
 
-    it('configured border colors win over the direction fallback on barcolored candles', () => {
-        const backend = new Canvas2dBackend();
-        const { ctx, ops } = recordingCtx();
-        const canvas = { width: 300, height: 100, getContext: () => ctx } as unknown as HTMLCanvasElement;
-        backend.mount(canvas);
-        const scene = new SceneGraph();
-        scene.bars = [{ time: 0, open: 100, high: 106, low: 99, close: 105 }];
-        scene.showGrid = false;
-        scene.style.candle.borderUpColor = '#ABCDEF';
-        const pane = scene.ensurePane('price', 'price', 0, 3);
-        pane.bounds = { top: 0, height: 100 };
-        pane.scale = { min: 95, max: 110 };
-        const model = {
-            id: 'ind', title: 'I', overlay: true, paneId: 'price',
-            series: [], fills: [], backgrounds: [], priceLines: [],
-            barColors: [{ time: 0, color: '#123456' }],
-            inputs: [], inputValues: {},
-        } as unknown as IndicatorModel;
-        scene.indicators.set(model.id, model);
-        scene.assignIndicatorZ(model.id);
-        const coords = new CoordinateSystem();
-        coords.setSize(300, 100, 1);
-        coords.setBars([0]);
-        backend.render(scene, coords, THEME);
+    it('plain candle with borders on: border falls back to the direction color', () => {
+        const ops = paint({ borderVisible: true });
+        expect(ops).toEqual([
+            { op: 'stroke', style: THEME.upColor }, // wick
+            { op: 'fill', style: THEME.upColor }, // body
+            { op: 'stroke', style: THEME.upColor }, // border
+        ]);
+    });
+
+    it('barcolored candle with borders on: the unconfigured border inherits the barcolored body', () => {
+        const ops = paint({ barColor: '#123456', borderVisible: true });
+        expect(ops).toEqual([
+            { op: 'stroke', style: THEME.upColor }, // wick — direction color
+            { op: 'fill', style: '#123456' }, // body — the barcolor
+            { op: 'stroke', style: '#123456' }, // border — inherits the body (barcolor)
+        ]);
+    });
+
+    it('configured border colors win over the body-inherit fallback on barcolored candles', () => {
+        const ops = paint({ barColor: '#123456', borderVisible: true, borderUpColor: '#ABCDEF' });
         expect(ops[ops.length - 1]).toEqual({ op: 'stroke', style: '#ABCDEF' }); // border honors the configured color
     });
 });

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1919,7 +1919,8 @@ describe('EngineOrchestrator — force_overlay routing', () => {
         await flush();
 
         // The loading placeholder mounts first (empty series); the computed model remounts last.
-        const m = renderer.mountedModels.filter((x) => x.id === ind.id).at(-1)!;
+        const mounted = renderer.mountedModels.filter((x) => x.id === ind.id);
+        const m = mounted[mounted.length - 1]!;
         const studyPane = m.paneId!;
         expect(studyPane).not.toBe('price'); // the indicator itself still routes to its own pane
 


### PR DESCRIPTION
## Summary

- `barcolor()` no longer forces a border on the candles it tints. Previously both render backends stroked a 1px outline in the up/down direction color around every barcolored body even when candle borders were disabled in the settings, so heatmap-style recoloring (e.g. gradient candle scripts) showed a green/red outline that reintroduced the direction signal the tint was meant to replace.
- The border now strictly follows its visibility setting. When borders are enabled and no explicit border color is configured, the border inherits the body color — a barcolored body gets a matching tinted border instead of a direction-colored outline, per the documented `null ⇒ inherit the body color` contract. Explicitly configured border colors still win. Plain candles are unchanged in every combination.
- Rewrote `test/native-barcolor-candles.test.ts` (it pinned the old forced-border behavior) into six cases covering borders on/off × plain/barcolored × configured border colors.
- Also fixes a pre-existing typecheck failure on `dev`: `test/orchestrator.test.ts` used `Array.at()`, which the configured TS `lib` target does not include; replaced with index access.

## Test plan

- [x] `npm run typecheck` · `npm run lint` · `npm run test` (1344 passed) · `npm run build` all green on this branch
- [x] Unit tests: 3 of the 6 rewritten barcolor cases fail without the fix, all pass with it
- [x] Browser proof on the Vela-pinets playground with a gradient-heatmap Pine script: borders disabled → flat tinted bodies (no outline); borders enabled → border follows the tint; toggled live via renderer config
- [x] Workspace oracle suite (`oracle-tests/vela`): Barcolor Regime Recoloring scenario passes; the two force-overlay failures reproduce identically without this change (pre-existing on the current branch combination, unrelated)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rendering-only candle border color/visibility change with updated unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> `barcolor()` no longer forces a direction-colored outline on tinted candles. Borders now follow the visibility setting: off means a flat tinted body; on with no explicit border color inherits the body tint so heatmap recoloring stays one hue. Configured border colors still win.
> 
> The same logic is applied in both Canvas2d and WebGL2 candle drawing. Tests cover borders on/off × plain/barcolored × explicit border color. Also replaces `Array.at()` in `orchestrator.test.ts` so typecheck matches the TS lib target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd13ca1798f9db2072f7ed5ed8a29e782108b90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->