### PR TITLE
Add declaration props to the scripting-engine port and settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to Vela, newest first.
 
 ### Added
 
+- **Declaration props: schema, overrides, and a "Properties" settings tab.** A
+  scripting engine can now expose the mutable arguments of a script's declaration
+  call (a strategy's `initial_capital`, `commission_value`, an indicator's
+  `precision`, …) as a props schema (`PreparedScript.props`, announced by
+  `capabilities.props`). Vela threads them end to end: `addIndicator(source,
+  { props })` seeds add-time overrides, the indicator handle gains `props`,
+  `setProp()` and `setProps()` (a prop change replays the whole script, like an
+  input edit), execution requests carry the merged values (`ExecutionRequest.props`,
+  `ExecutionSession.update(inputs, props?)`), and the in-chart settings dialog
+  renders them on a trailing **Properties** tab with the same live-edit /
+  Cancel / Reset-defaults semantics as inputs. Engines without props support are
+  untouched — the tab only appears when the engine publishes a schema.
+
 - **Pine label tooltips.** A label created with a `tooltip` now shows it: hover the
   label (the bubble, marker, or text) and a themed tip opens next to the cursor,
   wrapping long texts.

--- a/docs/contributing/adding-an-engine.md
+++ b/docs/contributing/adding-an-engine.md
@@ -19,10 +19,11 @@ The core owns everything downstream of the model — pane routing (overlay vs st
 An engine is a small object with four things:
 
 - **A unique language id** — e.g. `'pine'`. This is the registry key the core selects on.
-- **An honest capabilities object** — three booleans the core trusts without re-checking:
+- **An honest capabilities object** — booleans the core trusts without re-checking:
   - `streaming` — can keep a persistent incremental context alive for live ticks (vs a full re-run each time).
   - `visibleRange` — understands viewport-dependent execution (scripts that read "the left/right visible bar time").
   - `inputs` — exposes an inputs schema that drives the renderer's settings dialog.
+  - `props` (optional) — exposes a declaration-props schema (see below) and honors prop overrides on `execute`/`update`.
 - **`prepare`** — a cheap, async parse.
 - **`execute`** — the run.
 
@@ -35,6 +36,7 @@ Capability honesty matters. The core routes on these flags and does not second-g
 It resolves to:
 
 - **An inputs schema** — the typed inputs the script exposes (the renderer turns this into a settings UI).
+- **A declaration-props schema (optional)** — the *mutable arguments of the declaration call itself* (a strategy's `initial_capital`, an indicator's `precision`, …), in the same schema shape as inputs. The renderer shows them on a "Properties" settings tab. Make each entry's `defval` the **effective** default: the value the script declares, else your engine's configured default, else the language's own — the dialog opens on it and "Reset defaults" restores it.
 - **Declaration metadata** — what the script declares about itself (title, overlay vs study intent, and so on).
 - **A static `reactsToViewport` guess** — whether the source references a viewport built-in. This is a *static guess*, detected by scanning the source; it can be refined after the first real run.
 - **An opaque engine-internal token** — whatever the engine wants to read back at execute time (a parsed AST, a compiled function, a handle). The core treats it as a black box and never inspects it.
@@ -99,7 +101,7 @@ given. Instance identity belongs to the core; intra-model identity belongs to yo
 The execution session is how the core drives a running script. It exposes four levers:
 
 - **`stop()`** — tear down; stops any streaming or incremental re-execution.
-- **`update(inputs)`** — re-run (or re-stream) with merged input overrides. An input can restructure output, so this can be a structural change.
+- **`update(inputs, props?)`** — re-run (or re-stream) with merged input overrides. An input can restructure output, so this can be a structural change. When your engine advertises `props`, the second argument (when present) carries the merged declaration-prop overrides — apply both and replay; an engine without props support can ignore it.
 - **`setVisibleRange(range)`** — push a new viewport window. Re-runs viewport-dependent scripts; a no-op for everything else.
 - **`notifyBars(reason?)`** — signal that the core's bars changed. **No reason** = a live tick (forming candle or a new bar). **`'backfill'`** = older history chunks were just prepended and the load is still in progress. **`'complete'`** = the history load finished (fires exactly once per load). What to *do* about each reason is the engine's decision, not the core's — see [*History backfill*](#history-backfill-partial-bars-engine-owned-run-policy).
 - **`getContext(select?)`** *(optional)* — resolve a read-only `EngineContextSnapshot` of the run (phase, bar index, plots, variables, strategy state, trades, warnings). Implement it if your language has host-inspectable state; return **copies only** (never live references), keep it async (the bundled worker engine answers over `postMessage`), and honor `select` so callers can limit extraction. Skipping it is fine — `handle.context()` then resolves `null`, and the core's `script:run` still reports what the model carries (title, plots, cause).

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -90,9 +90,12 @@ What `addIndicator` returns. Usable immediately.
 | `id` | Stable, content-addressed identity for this indicator. |
 | `title` | Display title (overridable via the `title` option). |
 | `inputs` | The inputs parsed from the script source — each with a `key`, `title`, `type`, `defval`, and optional `min`/`max`/`step`/`options`/`group`/`inline`/`tab`/`tooltip`. Populated once the script is prepared. |
+| `props` | The script's declaration properties (a strategy's `initial_capital`, an indicator's `precision`, …) in the same schema shape as `inputs`. Empty when the engine exposes none. |
 | `visible` | Whether the indicator is currently shown. |
 | `setInput(key, value)` | Change one input by its key. Triggers a re-run (an input edit can restructure output, so this may remount the indicator). |
 | `setInputs(values)` | Change several inputs at once, keyed by input key or title. |
+| `setProp(key, value)` | Override one declaration property (e.g. `initial_capital`). A prop change replays the whole script. |
+| `setProps(values)` | Override several declaration properties at once. |
 | `setVisible(visible)` | Hide or show the indicator. Hiding suspends it — its visuals are dropped and its computation stops; showing re-runs it over the current bars. |
 | `on(event, handler)` | Per-indicator events — `ready`, `error` (`{ error }`), `alert` (`{ id, message, title?, time }`). Returns an unsubscribe function. |
 | `context(select?)` | `Promise` of a **read-only, serializable snapshot** of the engine's execution context — see [below](#capturing-what-a-script-computes). `null` when the engine lacks the capability or nothing ran yet. |

--- a/docs/user/examples.md
+++ b/docs/user/examples.md
@@ -84,7 +84,7 @@ const rsi = chart.addIndicator(
   `//@version=5
 indicator("RSI")
 plot(ta.rsi(close, input.int(14, "Length")), "RSI", color.purple)`,
-  { pane: 'new', title: 'RSI (14)' }, // AddIndicatorOptions: language / inputs / overlay / pane / title
+  { pane: 'new', title: 'RSI (14)' }, // AddIndicatorOptions: language / inputs / props / overlay / pane / title
 );
 rsi.on('ready', () => console.log(rsi.title, '→', rsi.inputs.length, 'inputs'));
 rsi.on('error', ({ error }) => console.error('RSI failed:', error.message));

--- a/docs/user/options.md
+++ b/docs/user/options.md
@@ -283,6 +283,7 @@ The optional second argument to `addIndicator(source, options)`:
 |---|---|---|
 | `language` | string | Which registered engine runs this script. Defaults to the chart's `defaultLanguage`. |
 | `inputs` | `Record<string, InputValue>` | Input overrides, keyed by input title or key. |
+| `props` | `Record<string, InputValue>` | Declaration-property overrides (a strategy's `initial_capital`, an indicator's `precision`, …), keyed like the engine's props schema. Ignored by engines without props support. |
 | `overlay` | boolean | Force overlay vs. separate pane. Default: read from `indicator(overlay=…)`. |
 | `pane` | `'price' \| 'new'` | Explicit pane placement. |
 | `title` | string | Display title override. |

--- a/src/core/IndicatorHandle.ts
+++ b/src/core/IndicatorHandle.ts
@@ -22,10 +22,18 @@ export interface IndicatorHandle {
     readonly source?: string;
     /** Inputs parsed from the Pine source (populated once the script is prepared). */
     readonly inputs: readonly InputSchema[];
+    /** Declaration-props schema (a strategy's `initial_capital`, an indicator's
+     *  `precision`, …; populated once the script is prepared). Empty when the
+     *  engine exposes none. */
+    readonly props: readonly InputSchema[];
     /** Whether the indicator is currently shown (vs hidden). Hidden indicators stop computing. */
     readonly visible: boolean;
     setInput(key: string, value: InputValue): void;
     setInputs(values: Record<string, InputValue>): void;
+    /** Override one declaration prop and re-run (a prop change replays the whole script). */
+    setProp(key: string, value: InputValue): void;
+    /** Override several declaration props at once and re-run. */
+    setProps(values: Record<string, InputValue>): void;
     /**
      * Hide or show the indicator. Hiding **suspends** it — its visuals are dropped (the legend
      * row stays, marked hidden) and its computation stops (the engine session is torn down), so a

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -175,7 +175,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         this.defaultLanguage = config.defaultLanguage;
         this.renderer.mount(container, config.theme);
         // The renderer's in-chart settings dialog reports edits here → re-run that indicator.
-        this.renderer.onInputChange((e) => this.applyInputs(e.indicatorId, { [e.key]: e.value }));
+        this.renderer.onInputChange((e) =>
+            e.kind === 'prop' ? this.applyProps(e.indicatorId, { [e.key]: e.value }) : this.applyInputs(e.indicatorId, { [e.key]: e.value }),
+        );
         // The renderer's in-chart legend ✕ reports a removal here → tear the indicator down.
         this.renderer.onRemoveIndicator((id) => this.removeIndicator(id));
         // The renderer's in-chart legend eye reports a hide/show here → suspend/resume the indicator.
@@ -1088,7 +1090,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         const title = options.title ?? 'Indicator';
         const handle = new IndicatorHandleImpl(id, title, this, source);
         this.handles.set(id, handle);
-        this.registry.add({ id, title, source, options, inputValues: { ...(options.inputs ?? {}) } });
+        this.registry.add({ id, title, source, options, inputValues: { ...(options.inputs ?? {}) }, propValues: { ...(options.props ?? {}) } });
         void this.startIndicator(id, source, options, handle);
         return handle;
     }
@@ -1113,7 +1115,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             return handle;
         }
         const inputValues = { ...descriptor.defaultInputs(), ...(options.inputs ?? {}) };
-        this.registry.add({ id, title, source: type, inputValues, native: { type, instance: descriptor.create(), descriptor } });
+        this.registry.add({ id, title, source: type, inputValues, propValues: {}, native: { type, instance: descriptor.create(), descriptor } });
         handle.setSchema(descriptor.inputsSchema());
         void this.startNativeIndicator(id, handle);
         return handle;
@@ -1175,6 +1177,21 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         record.pendingCause = 'inputs';
         if (record.session) record.session.update(record.inputValues);
         else if (record.native && !record.hidden) record.native.instance.setInputs(record.inputValues);
+    }
+
+    /** IndicatorController: re-run an indicator with merged declaration-prop overrides.
+     *  Same lifecycle as {@link applyInputs} — a prop change replays the whole script.
+     *  Script indicators only: natives have no declaration props. */
+    applyProps(id: string, values: Record<string, InputValue>): void {
+        const record = this.registry.get(id);
+        if (!record?.session) return;
+        record.propValues = { ...record.propValues, ...values };
+        // Reflect the new value in the open dialog immediately (the model arrives async).
+        if (record.renderHandle) this.renderer.setIndicatorInputs(record.renderHandle, record.inputValues, record.propValues);
+        record.pendingStructural = true;
+        if (!record.hidden) this.setLoading(record, true);
+        record.pendingCause = 'inputs';
+        record.session.update(record.inputValues, record.propValues);
     }
 
     /** IndicatorController: tear down an indicator and (if now empty) its pane. */
@@ -1355,6 +1372,10 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             for (const input of prepared.inputs) defaults[input.key] = input.defval;
             record.inputValues = { ...defaults, ...record.inputValues };
             handle.setSchema(prepared.inputs);
+            const propDefaults: Record<string, InputValue> = {};
+            for (const prop of prepared.props ?? []) propDefaults[prop.key] = prop.defval;
+            record.propValues = { ...propDefaults, ...record.propValues };
+            handle.setPropsSchema(prepared.props ?? []);
 
             // Mount a legend-only placeholder BEFORE the (possibly long) execution, so
             // the indicator appears immediately with a loading spinner instead of the
@@ -1386,6 +1407,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
                 getBars: () => this.bars,
                 fetchSeries: (sym, tf, range) => this.fetchSeries(sym, tf, range),
                 inputs: record.inputValues,
+                props: record.propValues,
                 visibleRange: this.currentVisibleRange(),
                 mode,
                 // Mid-backfill session starts (add / re-show / price-style re-execute) let the
@@ -1498,6 +1520,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             priceLines: [],
             inputs: record.prepared.inputs,
             inputValues: record.inputValues,
+            ...(record.prepared.props ? { props: record.prepared.props, propValues: record.propValues } : {}),
         };
         const paneId = this.routePane(id, model, record.options ?? {});
         this.placeModel(model, id, paneId);
@@ -1774,7 +1797,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             // Idempotent-by-id remount: refresh visuals while keeping the legend + open
             // settings dialog intact (an input change can restructure series/drawings).
             record.renderHandle = this.renderer.mountIndicator(model);
-            this.renderer.setIndicatorInputs(record.renderHandle, record.inputValues);
+            this.renderer.setIndicatorInputs(record.renderHandle, record.inputValues, record.propValues);
             record.pendingStructural = false;
         } else {
             this.renderer.updateIndicator(record.renderHandle, modelToValuePatch(model));

--- a/src/core/engine/IndicatorHandleImpl.ts
+++ b/src/core/engine/IndicatorHandleImpl.ts
@@ -8,6 +8,7 @@ import { TypedEventBus } from '../events/EventBus';
 export interface IndicatorController {
     getIndicatorContext(id: string, select?: ContextSelect): Promise<EngineContextSnapshot | null>;
     applyInputs(id: string, values: Record<string, InputValue>): void;
+    applyProps(id: string, values: Record<string, InputValue>): void;
     removeIndicator(id: string): void;
     setVisible(id: string, visible: boolean): void;
     moveIndicator(id: string, target: MoveTarget): void;
@@ -20,6 +21,7 @@ export class IndicatorHandleImpl implements IndicatorHandle {
     /** The script source (see {@link IndicatorHandle.source}); undefined for natives. */
     readonly source?: string;
     private schema: InputSchema[] = [];
+    private propsSchema: InputSchema[] = [];
     private visibleState = true;
     private readonly bus = new TypedEventBus<IndicatorEventMap>();
 
@@ -38,6 +40,10 @@ export class IndicatorHandleImpl implements IndicatorHandle {
         return this.schema;
     }
 
+    get props(): readonly InputSchema[] {
+        return this.propsSchema;
+    }
+
     get visible(): boolean {
         return this.visibleState;
     }
@@ -48,6 +54,14 @@ export class IndicatorHandleImpl implements IndicatorHandle {
 
     setInputs(values: Record<string, InputValue>): void {
         this.controller.applyInputs(this.id, values);
+    }
+
+    setProp(key: string, value: InputValue): void {
+        this.controller.applyProps(this.id, { [key]: value });
+    }
+
+    setProps(values: Record<string, InputValue>): void {
+        this.controller.applyProps(this.id, values);
     }
 
     setVisible(visible: boolean): void {
@@ -73,6 +87,10 @@ export class IndicatorHandleImpl implements IndicatorHandle {
     // ── internal (used by the orchestrator) ──────────────────────
     setSchema(schema: InputSchema[]): void {
         this.schema = schema;
+    }
+
+    setPropsSchema(schema: InputSchema[]): void {
+        this.propsSchema = schema;
     }
 
     /** Sync the public `visible` getter when the orchestrator changes visibility (API or legend eye). */

--- a/src/core/engine/IndicatorRegistry.ts
+++ b/src/core/engine/IndicatorRegistry.ts
@@ -27,6 +27,9 @@ export interface IndicatorRecord {
     model?: IndicatorModel;
     renderHandle?: IndicatorRenderHandle;
     inputValues: Record<string, InputValue>;
+    /** Declaration-prop values (effective defaults merged with user/add-time overrides).
+     *  Stays empty for engines without props support and for natives. */
+    propValues: Record<string, InputValue>;
     /** The live execution session (static or streaming) — poked on input/viewport/bar changes. */
     session?: ExecutionSession;
     /**

--- a/src/core/model/indicator.ts
+++ b/src/core/model/indicator.ts
@@ -103,4 +103,8 @@ export interface IndicatorModel {
     inputs: InputSchema[];
     /** Current input values (defaults merged with any user/add-time overrides). */
     inputValues: Record<string, InputValue>;
+    /** Declaration-props schema (the settings dialog's "Properties" tab). Absent ≡ none. */
+    props?: InputSchema[];
+    /** Current prop values (effective defaults merged with any user/add-time overrides). */
+    propValues?: Record<string, InputValue>;
 }

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -218,6 +218,10 @@ export interface AddIndicatorOptions {
     language?: string;
     /** Input overrides, keyed by input title or varId. */
     inputs?: Record<string, InputValue>;
+    /** Declaration-property overrides (a strategy's `initial_capital`, an indicator's
+     *  `precision`, …), keyed like the engine's props schema. Ignored by engines
+     *  without props support. */
+    props?: Record<string, InputValue>;
     /** Force overlay-vs-pane placement (default: read from `indicator(overlay=…)`). */
     overlay?: boolean;
     /** Explicit pane placement. */

--- a/src/core/ports/IChartRenderer.ts
+++ b/src/core/ports/IChartRenderer.ts
@@ -146,6 +146,8 @@ export interface InputChangeEvent {
     indicatorId: string;
     key: string;
     value: InputValue;
+    /** What was edited: a script input (default) or a declaration prop (the "Properties" tab). */
+    kind?: 'input' | 'prop';
 }
 
 export interface VisibleRange {
@@ -260,8 +262,9 @@ export interface IChartRenderer {
     mountIndicator(model: IndicatorModel): IndicatorRenderHandle;
     updateIndicator(handle: IndicatorRenderHandle, patch: ScenePatch): void;
     removeIndicator(handle: IndicatorRenderHandle): void;
-    /** Reflect a programmatic input change in the renderer's settings UI. */
-    setIndicatorInputs(handle: IndicatorRenderHandle, values: Record<string, InputValue>): void;
+    /** Reflect a programmatic input change in the renderer's settings UI. `props`
+     *  (when given) refreshes the declaration-prop values the same way. */
+    setIndicatorInputs(handle: IndicatorRenderHandle, values: Record<string, InputValue>, props?: Record<string, InputValue>): void;
 
     /**
      * Supply a symbol picker so the settings dialog's `input.symbol` control opens the host's own

--- a/src/core/ports/ScriptingEngine.ts
+++ b/src/core/ports/ScriptingEngine.ts
@@ -44,6 +44,14 @@ export interface PreparedScript {
     /** The language that produced this (the engine's `language`). */
     language: string;
     inputs: InputSchema[];
+    /**
+     * Declaration-property schema (a strategy's `initial_capital`, an indicator's
+     * `precision`, …) — the settings dialog renders these on a "Properties" tab.
+     * `defval` is the EFFECTIVE default: the value the script declares, else the
+     * engine's configured default, else the language's own. Absent ≡ the language
+     * has no declaration properties (`capabilities.props` false).
+     */
+    props?: InputSchema[];
     meta: IndicatorMeta;
     /**
      * Whether the script references a viewport built-in (e.g. Pine
@@ -62,6 +70,9 @@ export interface EngineCapabilities {
     visibleRange: boolean;
     /** Exposes an inputs schema (drives the renderer's settings dialog). */
     inputs: boolean;
+    /** Exposes a declaration-props schema (`PreparedScript.props`) and honors prop
+     *  overrides on `execute`/`update`. Absent ≡ false. */
+    props?: boolean;
 }
 
 /** Market context an execution needs. Vela owns the bars; this is the metadata. */
@@ -100,6 +111,9 @@ export interface ExecutionRequest {
      */
     fetchSeries?: FetchSeries;
     inputs?: Record<string, InputValue>;
+    /** Declaration-prop overrides, keyed like `PreparedScript.props`. Only meaningful
+     *  when `capabilities.props`; other engines ignore it. */
+    props?: Record<string, InputValue>;
     visibleRange?: VisibleBarRange;
     mode: 'static' | 'live';
     /**
@@ -173,8 +187,10 @@ export interface ExecutionSession {
     getContext?(select?: ContextSelect): Promise<EngineContextSnapshot | null>;
     /** Tear down (stops any streaming / incremental re-execution). */
     stop(): void;
-    /** Re-run / re-stream with merged input overrides. */
-    update(inputs: Record<string, InputValue>): void;
+    /** Re-run / re-stream with merged input overrides. `props` (when given) merges
+     *  declaration-prop overrides the same way — a props-capable engine re-runs with
+     *  both applied; others may ignore the second argument. */
+    update(inputs: Record<string, InputValue>, props?: Record<string, InputValue>): void;
     /** Update the viewport window (re-runs viewport-dependent scripts; no-op otherwise). */
     setVisibleRange(range: VisibleBarRange): void;
     /** Signal that Vela's bars changed. No reason = live tick; see {@link BarsChangeReason}. */

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1435,7 +1435,7 @@ export class NativeRenderer implements IChartRenderer {
         this.inputsUI.setLegendActions(this.legendActionsProvider);
         this.inputsUI.setLegendOverviewAction(this.legendOverviewAction);
         this.inputsUI.setOnChange((c) => {
-            for (const cb of this.inputChangeCbs) cb({ indicatorId: c.indicatorId, key: c.key, value: c.value });
+            for (const cb of this.inputChangeCbs) cb({ indicatorId: c.indicatorId, key: c.key, value: c.value, ...(c.kind ? { kind: c.kind } : {}) });
         });
         this.inputsUI.setOnRemove((id) => {
             for (const cb of this.removeIndicatorCbs) cb(id);
@@ -1933,6 +1933,7 @@ export class NativeRenderer implements IChartRenderer {
         this.inputsUI.upsert(model.id, model.shorttitle ?? model.title, model.inputs, model.inputValues, model.paneId, {
             native: !!model.native,
             ...(model.shorttitle ? { settingsTitle: model.title } : {}),
+            ...(model.props ? { props: model.props, propValues: model.propValues ?? {} } : {}),
         });
         this.syncTables(model);
         if (model.native?.type === 'volume') {
@@ -1988,8 +1989,8 @@ export class NativeRenderer implements IChartRenderer {
         this.scheduler.invalidate(InvalidateLevel.Full);
     }
 
-    setIndicatorInputs(handle: IndicatorRenderHandle, values: Record<string, InputValue>): void {
-        this.inputsUI.setValues(handle.id, values);
+    setIndicatorInputs(handle: IndicatorRenderHandle, values: Record<string, InputValue>, props?: Record<string, InputValue>): void {
+        this.inputsUI.setValues(handle.id, values, props);
     }
 
     setSymbolPicker(picker: SymbolPickerFn | null): void {

--- a/src/renderers/shared/IndicatorInputsDialog.ts
+++ b/src/renderers/shared/IndicatorInputsDialog.ts
@@ -15,6 +15,8 @@ export interface InputsUIChange {
     indicatorId: string;
     key: string;
     value: InputValue;
+    /** What was edited: a script input (default) or a declaration prop (the "Properties" tab). */
+    kind?: 'input' | 'prop';
 }
 
 /** The slice of a legend row the settings dialog needs. */
@@ -23,6 +25,21 @@ export interface IndicatorDialogRow {
     settingsTitle: string;
     inputs: InputSchema[];
     values: Record<string, InputValue>;
+    /** Declaration-props schema + values — rendered on the "Properties" tab. */
+    props: InputSchema[];
+    propValues: Record<string, InputValue>;
+}
+
+/** The settings-dialog tab hosting declaration props. */
+export const PROPS_TAB = 'Properties';
+
+/** An input decl as the dialog renders it — `prop` marks a declaration-prop entry:
+ *  reads/writes route to `row.propValues` and its commits carry `kind: 'prop'`. */
+type DialogDecl = InputSchema & { prop?: boolean };
+
+/** The value bag a decl reads from / writes to (inputs vs declaration props). */
+function bagOf(row: IndicatorDialogRow, decl: DialogDecl): Record<string, InputValue> {
+    return decl.prop ? row.propValues : row.values;
 }
 
 export interface IndicatorDialogHost {
@@ -49,6 +66,7 @@ export class IndicatorInputsDialog {
     openId: string | null = null;
     private row: IndicatorDialogRow | null = null;
     private snapshot: Record<string, InputValue> | null = null;
+    private propSnapshot: Record<string, InputValue> | null = null;
     private dialogTips: Array<() => void> = [];
     /** Re-applies every `when` gate against current values; set while the dialog is open. */
     private refreshVisibility: (() => void) | null = null;
@@ -72,10 +90,11 @@ export class IndicatorInputsDialog {
 
     open(row: IndicatorDialogRow): void {
         this.close();
-        if (row.inputs.length === 0) return;
+        if (row.inputs.length === 0 && row.props.length === 0) return;
         this.row = row;
         this.openId = row.id;
         this.snapshot = { ...row.values };
+        this.propSnapshot = { ...row.propValues };
         ensureDialogStyles();
         const t = this.host.theme();
         const border = 'var(--vela-border)';
@@ -115,6 +134,19 @@ export class IndicatorInputsDialog {
         }));
 
         const tabDefs = tabInputs(row.inputs);
+        if (row.props.length > 0) {
+            // Props always render on the trailing "Properties" tab — an engine schema
+            // carries no `tab=`, and a script input that DECLARES tab='Properties'
+            // shares the tab rather than spawning a duplicate strip label.
+            const propDecls: DialogDecl[] = row.props.map((p) => {
+                const d: DialogDecl = { ...p, prop: true };
+                delete d.tab;
+                return d;
+            });
+            const existing = tabDefs.find((t) => t.name === PROPS_TAB);
+            if (existing) existing.inputs.push(...propDecls);
+            else tabDefs.push({ name: PROPS_TAB, inputs: propDecls });
+        }
         const tabs = document.createElement('div');
         tabs.style.cssText = `display:flex;gap:12px;padding:0 20px;border-bottom:1px solid ${border};flex:0 0 auto;`;
         const tabEls: HTMLElement[] = [];
@@ -235,10 +267,11 @@ export class IndicatorInputsDialog {
         this.openId = null;
         this.row = null;
         this.snapshot = null;
+        this.propSnapshot = null;
         ui?.destroy();
     }
 
-    /** Restore every input to its open-time value (re-running the indicator), then close. */
+    /** Restore every input and prop to its open-time value (re-running the indicator), then close. */
     private revertAndClose(): void {
         const row = this.row;
         const snap = this.snapshot;
@@ -249,6 +282,17 @@ export class IndicatorInputsDialog {
                 if (row.values[inp.key] !== before) {
                     row.values[inp.key] = before;
                     this.host.onChange?.({ indicatorId: row.id, key: inp.key, value: before });
+                }
+            }
+        }
+        const propSnap = this.propSnapshot;
+        if (row && propSnap) {
+            for (const p of row.props) {
+                const snapped = propSnap[p.key];
+                const before: InputValue = snapped !== undefined ? snapped : p.defval;
+                if (row.propValues[p.key] !== before) {
+                    row.propValues[p.key] = before;
+                    this.host.onChange?.({ indicatorId: row.id, key: p.key, value: before, kind: 'prop' });
                 }
             }
         }
@@ -271,20 +315,30 @@ export class IndicatorInputsDialog {
         const row = this.row;
         if (!row) return;
         const snap = this.snapshot;
+        const propSnap = this.propSnapshot;
         for (const inp of row.inputs) {
             if (row.values[inp.key] !== inp.defval) {
                 row.values[inp.key] = inp.defval;
                 this.host.onChange?.({ indicatorId: row.id, key: inp.key, value: inp.defval });
             }
         }
+        // Props reset to their EFFECTIVE defaults (the script's declared value, else the
+        // engine's) — the schema's defval already carries that resolution.
+        for (const p of row.props) {
+            if (row.propValues[p.key] !== p.defval) {
+                row.propValues[p.key] = p.defval;
+                this.host.onChange?.({ indicatorId: row.id, key: p.key, value: p.defval, kind: 'prop' });
+            }
+        }
         this.open(row);
         if (snap) this.snapshot = snap;
+        if (propSnap) this.propSnapshot = propSnap;
     }
 
     /** Write one edit through: store it, notify the host, and re-apply the `when` gates. */
-    private commit(row: IndicatorDialogRow, key: string, value: InputValue): void {
-        row.values[key] = value;
-        this.host.onChange?.({ indicatorId: row.id, key, value });
+    private commit(row: IndicatorDialogRow, decl: DialogDecl, value: InputValue): void {
+        bagOf(row, decl)[decl.key] = value;
+        this.host.onChange?.({ indicatorId: row.id, key: decl.key, value, ...(decl.prop ? { kind: 'prop' as const } : {}) });
         this.refreshVisibility?.();
     }
 
@@ -317,7 +371,7 @@ export class IndicatorInputsDialog {
         const info = lead.tooltip ? this.infoButton(lead.tooltip) : undefined;
 
         if (lead.type === 'bool') {
-            const current = Boolean(row.values[lead.key] ?? lead.defval);
+            const current = Boolean(bagOf(row, lead)[lead.key] ?? lead.defval);
             return append(fieldRow({
                 label: nameOf(lead),
                 id,
@@ -326,7 +380,7 @@ export class IndicatorInputsDialog {
                 toggle: {
                     id,
                     checked: current,
-                    onChange: (v) => this.commit(row, lead.key, v),
+                    onChange: (v) => this.commit(row, lead, v),
                 },
             }));
         }
@@ -353,9 +407,9 @@ export class IndicatorInputsDialog {
     }
 
     /** Build the typed control for one input, committing edits live via `onChange`. */
-    private buildControl(row: IndicatorDialogRow, inp: InputSchema, id: string): HTMLElement {
-        const current = row.values[inp.key] ?? inp.defval;
-        const emit = (value: InputValue): void => this.commit(row, inp.key, value);
+    private buildControl(row: IndicatorDialogRow, inp: DialogDecl, id: string): HTMLElement {
+        const current = bagOf(row, inp)[inp.key] ?? inp.defval;
+        const emit = (value: InputValue): void => this.commit(row, inp, value);
 
         if (inp.type === 'bool') {
             return buildFieldControl({ kind: 'switch', id, checked: Boolean(current), onChange: (v) => emit(v) }).el;
@@ -367,7 +421,7 @@ export class IndicatorInputsDialog {
                 kind: 'color',
                 id,
                 theme: this.host.theme(),
-                get: () => String(row.values[inp.key] ?? inp.defval),
+                get: () => String(bagOf(row, inp)[inp.key] ?? inp.defval),
                 onChange: (v) => emit(v),
             }).el;
         }

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -52,6 +52,9 @@ interface LegendRow {
     settingsTitle: string;
     inputs: InputSchema[];
     values: Record<string, InputValue>;
+    /** Declaration-props schema + values (the settings dialog's "Properties" tab). */
+    props: InputSchema[];
+    propValues: Record<string, InputValue>;
     el: HTMLElement;
     titleEl: HTMLElement;
     statusEl: HTMLElement;
@@ -621,7 +624,7 @@ export class InputsUI {
     }
 
     /** Create or update an indicator's legend row (in the legend for its pane). */
-    upsert(id: string, title: string, inputs: InputSchema[], values: Record<string, InputValue>, paneId = 'price', opts: { native?: boolean; beta?: boolean; settingsTitle?: string } = {}): void {
+    upsert(id: string, title: string, inputs: InputSchema[], values: Record<string, InputValue>, paneId = 'price', opts: { native?: boolean; beta?: boolean; settingsTitle?: string; props?: InputSchema[]; propValues?: Record<string, InputValue> } = {}): void {
         const settingsTitle = opts.settingsTitle ?? title;
         const existing = this.rows.get(id);
         if (existing) {
@@ -629,6 +632,8 @@ export class InputsUI {
             existing.settingsTitle = settingsTitle;
             existing.inputs = inputs;
             existing.values = { ...values };
+            existing.props = opts.props ?? [];
+            existing.propValues = { ...(opts.propValues ?? {}) };
             existing.titleEl.textContent = title;
             if (existing.paneId !== paneId) { // re-routed to a different pane
                 existing.paneId = paneId;
@@ -742,7 +747,7 @@ export class InputsUI {
             controlsEl.appendChild(eye);
             eyeEl = eye;
         }
-        if (inputs.length > 0) {
+        if (inputs.length > 0 || (opts.props ?? []).length > 0) {
             const gear = document.createElement('button');
             gear.type = 'button';
             gear.setAttribute('aria-label', 'Settings');
@@ -784,7 +789,7 @@ export class InputsUI {
         el.appendChild(controlsEl);
 
         this.attach(this.legendFor(paneId), el, !!opts.native);
-        this.rows.set(id, { id, title, settingsTitle, inputs, values: { ...values }, el, titleEl, statusEl, valuesEl, plotValues: [], plotValuesKey: '', showValues: null, highlighted: false, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
+        this.rows.set(id, { id, title, settingsTitle, inputs, values: { ...values }, props: opts.props ?? [], propValues: { ...(opts.propValues ?? {}) }, el, titleEl, statusEl, valuesEl, plotValues: [], plotValuesKey: '', showValues: null, highlighted: false, paneId, hidden: false, eyeEl, controlsEl, extrasEl, native: !!opts.native });
         this.syncFoldToggle(); // 2+ indicators grow the fold chevron; a folded legend hides the new row too
     }
 
@@ -795,9 +800,11 @@ export class InputsUI {
     }
 
     /** Reflect programmatic input changes (so a re-opened dialog shows current values). */
-    setValues(id: string, values: Record<string, InputValue>): void {
+    setValues(id: string, values: Record<string, InputValue>, props?: Record<string, InputValue>): void {
         const row = this.rows.get(id);
-        if (row) row.values = { ...row.values, ...values };
+        if (!row) return;
+        row.values = { ...row.values, ...values };
+        if (props) row.propValues = { ...row.propValues, ...props };
     }
 
     /**

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -97,7 +97,10 @@ class FakeRenderer implements IChartRenderer {
     setIndicatorInputs(_h: IndicatorRenderHandle, _v: Record<string, InputValue>): void {}
     indicatorVisible = new Map<string, boolean>();
     setIndicatorVisible(h: IndicatorRenderHandle, visible: boolean): void { this.indicatorVisible.set(h.id, visible); }
-    onInputChange(_cb: (e: InputChangeEvent) => void): Unsubscribe { return () => {}; }
+    private inputChangeCb: ((e: InputChangeEvent) => void) | null = null;
+    onInputChange(cb: (e: InputChangeEvent) => void): Unsubscribe { this.inputChangeCb = cb; return () => { this.inputChangeCb = null; }; }
+    /** Test helper: simulate a settings-dialog edit (input or declaration prop). */
+    fireInputChange(e: InputChangeEvent): void { this.inputChangeCb?.(e); }
     onRemoveIndicator(cb: (id: string) => void): Unsubscribe { this.removeCb = cb; return () => { this.removeCb = null; }; }
     private toggleVisibleCb: ((id: string, visible: boolean) => void) | null = null;
     onToggleIndicatorVisible(cb: (id: string, visible: boolean) => void): Unsubscribe { this.toggleVisibleCb = cb; return () => { this.toggleVisibleCb = null; }; }
@@ -1910,6 +1913,113 @@ class ForcedOverlayEngine extends MockEngine {
     }
 }
 
+/** An engine that exposes a declaration-props schema and records what it receives. */
+class PropsEngine extends MockEngine {
+    executeProps: Array<Record<string, InputValue> | undefined> = [];
+    updates: Array<{ inputs: Record<string, InputValue>; props?: Record<string, InputValue> }> = [];
+
+    override prepare(_source: string, instanceId: string): Promise<PreparedScript> {
+        return Promise.resolve({
+            language: 'pine',
+            inputs: [{ key: 'Length', title: 'Length', type: 'int', defval: 14 }],
+            props: [
+                { key: 'initial_capital', title: 'Initial capital', type: 'float', defval: 50000 },
+                { key: 'pyramiding', title: 'Pyramiding', type: 'int', defval: 0 },
+            ],
+            meta: { title: 'Props', overlay: false },
+            reactsToViewport: false,
+            token: { instanceId, overlay: false },
+        });
+    }
+
+    override execute(req: ExecutionRequest, handlers: ExecutionHandlers): ExecutionSession {
+        const token = req.prepared.token as { instanceId: string };
+        this.executeProps.push(req.props);
+        const emit = (): void => {
+            handlers.onModel({
+                id: token.instanceId,
+                title: 'Props',
+                overlay: false,
+                paneHint: 'new',
+                series: [],
+                fills: [],
+                backgrounds: [],
+                priceLines: [],
+                inputs: req.prepared.inputs,
+                inputValues: req.inputs ?? {},
+            });
+            handlers.onDone?.();
+        };
+        emit();
+        return {
+            stop: () => {},
+            update: (inputs, props) => {
+                this.updates.push({ inputs, ...(props ? { props } : {}) });
+                emit();
+            },
+            setVisibleRange: () => {},
+            notifyBars: () => {},
+        };
+    }
+}
+
+describe('EngineOrchestrator — declaration props', () => {
+    it('merges schema defaults with add-time overrides and passes them to execute', async () => {
+        const renderer = new FakeRenderer();
+        const engine = new PropsEngine();
+        const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [engine], dataFeed: new MockDataFeed() });
+        const ind = chart.addIndicator('indicator("P")', { props: { initial_capital: 25000 } });
+        await chart.ready();
+        await flush();
+
+        // Schema defaults fill the gaps; the add-time override wins on its key.
+        expect(engine.executeProps[0]).toEqual({ initial_capital: 25000, pyramiding: 0 });
+        // The handle exposes the props schema once prepared.
+        expect(ind.props.map((p) => p.key)).toEqual(['initial_capital', 'pyramiding']);
+        chart.destroy();
+    });
+
+    it('setProps re-runs the session with merged prop overrides', async () => {
+        const renderer = new FakeRenderer();
+        const engine = new PropsEngine();
+        const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [engine], dataFeed: new MockDataFeed() });
+        const ind = chart.addIndicator('indicator("P")');
+        await chart.ready();
+        await flush();
+
+        ind.setProps({ pyramiding: 3 });
+        expect(engine.updates).toHaveLength(1);
+        expect(engine.updates[0]!.props).toEqual({ initial_capital: 50000, pyramiding: 3 });
+        // Inputs travel alongside — the session re-runs with both bags current.
+        expect(engine.updates[0]!.inputs).toEqual({ Length: 14 });
+
+        // setProp (singular) merges on top of the previous overrides.
+        ind.setProp('initial_capital', 10000);
+        expect(engine.updates[1]!.props).toEqual({ initial_capital: 10000, pyramiding: 3 });
+        chart.destroy();
+    });
+
+    it("routes a renderer 'prop' edit to the props bag and an input edit to inputs", async () => {
+        const renderer = new FakeRenderer();
+        const engine = new PropsEngine();
+        const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [engine], dataFeed: new MockDataFeed() });
+        const ind = chart.addIndicator('indicator("P")');
+        await chart.ready();
+        await flush();
+
+        renderer.fireInputChange({ indicatorId: ind.id, key: 'initial_capital', value: 75000, kind: 'prop' });
+        expect(engine.updates[0]!.props).toEqual({ initial_capital: 75000, pyramiding: 0 });
+
+        renderer.fireInputChange({ indicatorId: ind.id, key: 'Length', value: 21 });
+        expect(engine.updates[1]!.inputs).toEqual({ Length: 21 });
+        // An input edit re-runs through update(inputs) — prop overrides are not resent
+        // but stay intact for the NEXT props-driven update.
+        renderer.fireInputChange({ indicatorId: ind.id, key: 'pyramiding', value: 1, kind: 'prop' });
+        expect(engine.updates[2]!.props).toEqual({ initial_capital: 75000, pyramiding: 1 });
+        chart.destroy();
+    });
+});
+
 describe('EngineOrchestrator — force_overlay routing', () => {
     it('stamps force_overlay items with the price pane while own items keep the study pane', async () => {
         const renderer = new FakeRenderer();
@@ -1919,7 +2029,8 @@ describe('EngineOrchestrator — force_overlay routing', () => {
         await flush();
 
         // The loading placeholder mounts first (empty series); the computed model remounts last.
-        const m = renderer.mountedModels.filter((x) => x.id === ind.id).at(-1)!;
+        const mounted = renderer.mountedModels.filter((x) => x.id === ind.id);
+        const m = mounted[mounted.length - 1]!;
         const studyPane = m.paneId!;
         expect(studyPane).not.toBe('price'); // the indicator itself still routes to its own pane
 


### PR DESCRIPTION
An engine can now publish the mutable arguments of a script's declaration call (a strategy's initial_capital, an indicator's precision, ...) as a props schema: PreparedScript.props, announced by capabilities.props. The channel runs end to end:

- addIndicator(source, { props }) seeds add-time overrides;
- the indicator handle exposes props and gains setProp()/setProps() — a prop change replays the whole script, like an input edit;
- execution requests carry the merged values (ExecutionRequest.props, ExecutionSession.update(inputs, props?));
- the in-chart settings dialog renders them on a trailing "Properties" tab with the same live-edit / Cancel / Reset-defaults semantics as inputs, and now opens for a script with props but no inputs.

Engines without props support are untouched: the tab only appears when the engine publishes a schema. Docs and changelog updated.

Also fix the pre-existing typecheck break in test/orchestrator.test.ts (Array.prototype.at is not in the configured lib).