### PR TITLE
Make indicator fills, drawings, and tables follow the object-tree stacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Changed
+
+- **Restacking an indicator now moves everything it paints.** Reordering an
+  indicator from the object tree (or `seriesOrder`) repositions the whole
+  indicator as one unit — plots, fills, lines, boxes, labels, markers, polylines,
+  linefills, and tables — instead of only its plots. Fills paint at the
+  indicator's own slot (a band raised above the price now tints over the
+  candles), drawings and tables follow their indicator through the stack, and —
+  since new indicators start under the price series — a fresh script's drawings
+  begin behind the candles until you restack it. Tables are painted on the chart
+  canvas now, so they obey the same order and appear in chart screenshots; cell
+  tooltips keep working. Pine `bgcolor()` stays behind everything and
+  `barcolor()` stays with the candles, as before.
+
 ## [v0.6.9]
 
 ### Added

--- a/docs/contributing/adding-a-renderer.md
+++ b/docs/contributing/adding-a-renderer.md
@@ -176,7 +176,7 @@ Beyond painting, the renderer owns **presentation chrome** and **coordinate/time
 
 - The per-indicator **legend**.
 - The **settings dialog** for editing inputs (and the input-change events it raises).
-- **Table dashboards** drawn as an overlay.
+- **Table dashboards** (the native renderer paints them into its canvas stack so they follow the indicator's draw order; the shared DOM table overlay remains available for renderers that prefer an overlay).
 - The **coordinate and time resolution** for drawings — converting the model's canonical epoch-millisecond timestamps and prices into screen positions.
 
 ### Reuse the shared, backend-neutral building blocks

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -404,7 +404,9 @@ they work from the very first keystroke, before any click.
   header carries its reorder/collapse/maximize controls. Rows are also draggable — onto a pane to
   move an item there, onto the band between two panes to open a new one, or to any slot in a
   pane's column to set draw order, a drawing under the candles or between two indicators included
-  — with a ghost label and a drop hint while the drag is live. Drawings can be multi-selected
+  — with a ghost label and a drop hint while the drag is live. An indicator's row carries
+  everything the indicator paints: its plots, fills, script drawings and tables all move through
+  the stack together. Drawings can be multi-selected
   (Ctrl/Cmd-click) and bundled into a named group that hides, locks, deletes and drags as one
   block; groups live for as long as the chart and are not persisted. Kept in sync with the
   chart's events.

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -31,7 +31,6 @@ import { isLineLikeSeries } from '../../core/model/series';
 import { InputsUI, type LegendPlotValue } from '../shared/InputsUI';
 import { PaneControls } from './chrome/PaneControls';
 import { AxisScaleButtons, type AxisScaleView } from './chrome/AxisScaleButtons';
-import { TableOverlay } from '../shared/TableOverlay';
 import { NATIVE_CAPABILITIES, supportsWebGL2 } from './capabilities';
 import { WebGL2Backend } from './backend/WebGL2Backend';
 import { CoordinateSystem, type PaneBounds, type PriceScale } from './core/CoordinateSystem';
@@ -49,6 +48,7 @@ import { AXIS_MASTER_W, AXIS_MERGED_W } from './chrome/axisLayout';
 import { CrosshairRenderer } from './chrome/CrosshairRenderer';
 import { SettingsDialog } from './chrome/SettingsDialog';
 import { UserDrawingController } from './drawings/UserDrawingController';
+import { IndicatorDrawingSlices, mergeSlices } from './drawings/IndicatorDrawingSlices';
 import { createProjector } from './drawings/Projector';
 import type { Projector, SnapMode } from '../../core/drawings';
 import type { IDrawingsRendererPort } from '../../core/drawings';
@@ -170,6 +170,8 @@ export class NativeRenderer implements IChartRenderer {
     private backendMode: NativeBackend = 'auto';
     private glowAmount = 0; // WebGL2 neon-glow intensity (canvas2d ignores it)
     private readonly chrome = new ChromeRenderer();
+    /** Prepaints each indicator's Pine drawings into interleave slices at the model's z. */
+    private readonly indicatorSlices = new IndicatorDrawingSlices();
     /** Hover tooltips for Pine labels (canvas hit-rects collected by the chrome layer). */
     private labelTooltip: LabelTooltip | null = null;
     private readonly crosshairLayer = new CrosshairRenderer();
@@ -305,7 +307,6 @@ export class NativeRenderer implements IChartRenderer {
     private readonly toggleVisibleCbs = new Set<(id: string, visible: boolean) => void>();
     private readonly moveIndicatorCbs = new Set<(id: string, target: MoveTarget) => void>();
     private readonly priceStyleCbs = new Set<(style: PriceStyle) => void>();
-    private readonly tableOverlays = new Map<string, TableOverlay>();
 
     constructor(opts?: RendererDisplayOptions) {
         if (opts) {
@@ -584,9 +585,8 @@ export class NativeRenderer implements IChartRenderer {
      * hidden) on clear so a re-show picks up the current theme.
      */
     setLoading(loading: boolean): void {
-        // Tables are the one series-independent content: corner-anchored DOM, so an emptied
-        // chart doesn't take them along — hide them for the load, restore with the bars.
-        for (const overlay of this.tableOverlays.values()) overlay.setVisible(!loading);
+        // Tables need no special handling here: they paint through the interleave slices,
+        // and the backend paints nothing on an emptied (bar-less) chart.
         if (!loading || !this.wrapper) {
             this.loadingEl?.remove();
             this.loadingEl = null;
@@ -1386,9 +1386,10 @@ export class NativeRenderer implements IChartRenderer {
         this.plot.addEventListener('pointerleave', this.onScrollProximityLeave);
 
         // Pine label tooltips: hover a label that carries one and a themed tip opens.
+        // The hit-rects are collected by the slice prepainter (drawings paint there now).
         this.labelTooltip = new LabelTooltip(this.plot, {
             theme: () => this.chromeTheme(),
-            lookup: (x, y) => this.chrome.labelTooltipAt(x, y),
+            lookup: (x, y) => this.indicatorSlices.labelTooltipAt(x, y),
         });
 
         // User-drawings layer (paints L1.5 plus the interleave layers the geometry backend
@@ -1632,8 +1633,6 @@ export class NativeRenderer implements IChartRenderer {
         this.inputsUI?.destroy();
         this.paneControls?.destroy();
         this.axisScaleButtons?.destroy();
-        for (const overlay of this.tableOverlays.values()) overlay.destroy();
-        this.tableOverlays.clear();
         this.resizeObserver?.disconnect();
         this.resizeObserver = null;
         this.dprMedia?.removeEventListener('change', this.onDprChange);
@@ -1779,7 +1778,6 @@ export class NativeRenderer implements IChartRenderer {
     ensurePane(pane: Pane): void {
         this.scene.ensurePane(pane.id, pane.kind, pane.order, pane.heightWeight ?? (pane.kind === 'price' ? 3 : 1));
         this.layoutPanes();
-        this.repositionTables();
         // A new pane changes the count, so the lone price pane's maximize button appears.
         this.paneControls?.refresh();
         this.scheduler.invalidate(InvalidateLevel.Full);
@@ -1804,10 +1802,8 @@ export class NativeRenderer implements IChartRenderer {
         if (!model.ownScale) this.scene.dropIndicatorScale(handle.id);
         this.inputsUI.setPane(handle.id, paneId);
         this.refreshAnchorOffset(model);
-        this.syncTables(model); // re-anchor any table overlay to the new pane
         this.refreshAxisWidth();
         this.layoutPanes();
-        this.repositionTables();
         this.paneControls?.refresh();
         this.scheduler.invalidate(InvalidateLevel.Full);
     }
@@ -1815,7 +1811,6 @@ export class NativeRenderer implements IChartRenderer {
     orderPanes(orderedIds: string[]): void {
         this.scene.orderPanes(orderedIds);
         this.layoutPanes();
-        this.repositionTables();
         this.paneControls?.refresh();
         this.scheduler.invalidate(InvalidateLevel.Full);
     }
@@ -1825,7 +1820,6 @@ export class NativeRenderer implements IChartRenderer {
         if (!pane || pane.collapsed === collapsed) return;
         pane.collapsed = collapsed;
         this.layoutPanes();
-        this.repositionTables();
         this.paneControls?.refresh();
         this.scheduler.invalidate(InvalidateLevel.Full);
     }
@@ -1834,7 +1828,6 @@ export class NativeRenderer implements IChartRenderer {
         if (paneId !== null && !this.scene.panes.has(paneId)) paneId = null;
         this.maximizedPaneId = paneId;
         this.layoutPanes();
-        this.repositionTables();
         this.paneControls?.refresh();
         this.scheduler.invalidate(InvalidateLevel.Full);
     }
@@ -1939,7 +1932,6 @@ export class NativeRenderer implements IChartRenderer {
             native: !!model.native,
             ...(model.props ? { props: model.props, propValues: model.propValues ?? {} } : {}),
         });
-        this.syncTables(model);
         if (model.native?.type === 'volume') {
             this.volumeActive = true; // the volume layer follows the indicator's presence
             this.volumeHidden = false;
@@ -1966,7 +1958,6 @@ export class NativeRenderer implements IChartRenderer {
             }
         }
         applyPatch(model, patch);
-        this.syncTables(model);
         this.scheduler.invalidate(InvalidateLevel.Light);
     }
 
@@ -1986,8 +1977,6 @@ export class NativeRenderer implements IChartRenderer {
         this.scene.forgetAnchorOffset(handle.id);
         this.scene.dropIndicatorScale(handle.id);
         this.inputsUI.remove(handle.id);
-        this.tableOverlays.get(handle.id)?.destroy();
-        this.tableOverlays.delete(handle.id);
         this.refreshAxisWidth();
         this.paneControls?.refresh();
         this.scheduler.invalidate(InvalidateLevel.Full);
@@ -2040,8 +2029,6 @@ export class NativeRenderer implements IChartRenderer {
         }
         if (!visible) {
             this.scene.indicators.delete(handle.id); // keep the z key (forgetIndicatorZ NOT called) so show preserves order
-            this.tableOverlays.get(handle.id)?.destroy();
-            this.tableOverlays.delete(handle.id);
         }
         this.inputsUI.setVisible(handle.id, visible);
         this.scheduler.invalidate(InvalidateLevel.Full);
@@ -2562,7 +2549,6 @@ export class NativeRenderer implements IChartRenderer {
     /** Relayout + repaint + refresh the hover buttons after a collapse/maximize/order change. */
     private afterPaneLayoutChange(): void {
         this.layoutPanes();
-        this.repositionTables();
         this.paneControls?.refresh();
         this.scheduler.invalidate(InvalidateLevel.Full);
     }
@@ -2650,7 +2636,6 @@ export class NativeRenderer implements IChartRenderer {
         above.heightWeight = next.above;
         below.heightWeight = next.below;
         this.layoutPanes();
-        this.repositionTables();
         this.scheduler.invalidate(InvalidateLevel.Full);
     }
 
@@ -2666,7 +2651,6 @@ export class NativeRenderer implements IChartRenderer {
         above.heightWeight = half;
         below.heightWeight = half;
         this.layoutPanes();
-        this.repositionTables();
         this.scheduler.invalidate(InvalidateLevel.Full);
     }
 
@@ -3003,9 +2987,13 @@ export class NativeRenderer implements IChartRenderer {
             && (liveActual.high !== this.liveEaseHigh || liveActual.low !== this.liveEaseLow || liveActual.close !== this.liveEaseClose);
         if (easeLive && liveActual) this.bars[li] = { ...liveActual, high: this.liveEaseHigh, low: this.liveEaseLow, close: this.liveEaseClose };
 
-        // Interleave layers: the drawings whose z sits inside a pane's series stack, prepainted
-        // so the backend can composite them mid-stack (under the candles, between indicators).
-        this.scene.drawingSlices = this.userDrawings?.prepareSlices(this.scene.orderedPanes().map((p) => p.id)) ?? new Map();
+        // Interleave layers: each indicator's Pine drawings at that indicator's z slot, plus
+        // the user drawings whose z sits inside a pane's series stack — prepainted so the
+        // backend can composite them mid-stack (under the candles, between indicators).
+        this.scene.drawingSlices = mergeSlices(
+            this.indicatorSlices.prepare(this.scene, this.coords, this.theme, this.dataCanvas),
+            this.userDrawings?.prepareSlices(this.scene.orderedPanes().map((p) => p.id)) ?? new Map(),
+        );
         this.backdropRenderer.render(this.scene, this.coords, this.theme, gridAlpha); // L-2, under every layer canvas
         this.backend.render(this.scene, this.coords, this.theme);
         this.chrome.render(this.scene, this.coords, this.theme, this.axisSurface());
@@ -3529,29 +3517,6 @@ export class NativeRenderer implements IChartRenderer {
         return maxVol;
     }
 
-    /** Create/update/destroy an indicator's DOM table overlay (anchored off real pane geometry). */
-    private syncTables(model: IndicatorModel): void {
-        const tables = model.tables ?? [];
-        let overlay = this.tableOverlays.get(model.id);
-        if (tables.length === 0) {
-            if (overlay) {
-                overlay.destroy();
-                this.tableOverlays.delete(model.id);
-            }
-            return;
-        }
-        if (!overlay) {
-            overlay = new TableOverlay(this.plot, this.theme, (id) => this.paneBoundsFor(id));
-            overlay.setVisible(this.loadingEl === null); // born mid-load ⇒ born hidden
-            this.tableOverlays.set(model.id, overlay);
-        }
-        overlay.update(tables);
-    }
-
-    private repositionTables(): void {
-        for (const overlay of this.tableOverlays.values()) overlay.reposition();
-    }
-
     private layoutPanes(): void {
         const panes = this.scene.orderedPanes();
         const dataHeight = this.coords.height;
@@ -3741,7 +3706,6 @@ export class NativeRenderer implements IChartRenderer {
         // bar/price, so drop it (LWC hides the crosshair until the next move).
         this.scene.crosshair = null;
         this.layoutPanes();
-        this.repositionTables();
         this.userDrawings?.onResize(); // dismiss the settings popup on a resize
         if (!this.didInitialFit && this.coords.barCount > 0) {
             this.fitContent();

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -81,17 +81,16 @@ export class Canvas2dBackend implements IRenderBackend {
                 return sc === pane.scale ? pane : { ...pane, scale: sc };
             };
 
-            // Behind everything: backgrounds + fills (kept under the candle/series layers).
-            // Own (non-force_overlay) content on each model's pane; force_overlay content
-            // on the price pane against its MASTER scale, whatever pane the indicator owns
-            // (Pine semantics — mirrors the chrome's overlay-drawing routing).
+            // Behind everything: bgcolor spans — Pine keeps the background under every
+            // layer regardless of stacking. Own (non-force_overlay) spans on each model's
+            // pane; force_overlay spans on the price pane, whatever pane the indicator
+            // owns (Pine semantics — mirrors the chrome's overlay-drawing routing).
+            // Fills are NOT here: they paint inside the z loop at their model's slot.
             ctx.globalAlpha = this.modelAlpha; // indicator models fade in after the intro; candles stay opaque
             for (const m of models) for (const bg of m.backgrounds) if (bg.overlay !== true) this.drawBackground(ctx, bg, pane, coords);
-            for (const m of models) for (const f of m.fills) if (f.overlay !== true) this.drawFill(ctx, m, f, effPane(m), coords, i0, i1, scene.offsetOf(m.id));
             if (isPrice) {
                 for (const m of scene.indicators.values()) {
                     for (const bg of m.backgrounds) if (bg.overlay === true) this.drawBackground(ctx, bg, pane, coords);
-                    for (const f of m.fills) if (f.overlay === true) this.drawFill(ctx, m, f, pane, coords, i0, i1, scene.offsetOf(m.id));
                 }
             }
 
@@ -123,6 +122,10 @@ export class Canvas2dBackend implements IRenderBackend {
                 // Model data is index-aligned from the model's ANCHOR bar (offset 0 = whole-chart).
                 const off = scene.offsetOf(m.id);
                 const mp = effPane(m);
+                // Fills paint at the model's z slot, under its own series — a band between
+                // two plots sits behind the plot lines, and the whole model moves as one
+                // unit when its object-tree row is reordered.
+                for (const f of m.fills) if (f.overlay !== true) this.drawFill(ctx, m, f, mp, coords, i0, i1, off);
                 for (const s of m.series) if (s.overlay !== true) this.drawSeries(ctx, s, mp, coords, i0, i1, theme, off);
             }
             if (drawCandles && !candleDrawn) {
@@ -130,17 +133,24 @@ export class Canvas2dBackend implements IRenderBackend {
                 ctx.globalAlpha = this.candleStructureAlpha;
                 this.drawPriceSeries(ctx, scene, i0, i1, coords, pane, theme, barColorMap, dataW);
             }
-            drawSlicesUpTo(Infinity); // layers bound to a hidden/removed series still paint, at the stack top
-
-            // force_overlay series from EVERY indicator paint on the price pane, at the top
-            // of its series stack, against the master price scale.
+            // force_overlay content from EVERY indicator paints on the price pane, at the
+            // top of its series stack, against the master price scale — fills first so a
+            // forced band still sits under the forced plot lines.
             if (isPrice) {
                 ctx.globalAlpha = this.modelAlpha;
+                for (const m of scene.indicators.values()) {
+                    const off = scene.offsetOf(m.id);
+                    for (const f of m.fills) if (f.overlay === true) this.drawFill(ctx, m, f, pane, coords, i0, i1, off);
+                }
                 for (const m of scene.indicators.values()) {
                     const off = scene.offsetOf(m.id);
                     for (const s of m.series) if (s.overlay === true) this.drawSeries(ctx, s, pane, coords, i0, i1, theme, off);
                 }
             }
+            // Stack-top slices: the topmost indicator's drawings, force_overlay drawings,
+            // and layers bound to a hidden/removed series — above the forced series too,
+            // since drawings always paint over their own plots.
+            drawSlicesUpTo(Infinity);
 
             // On top: price lines.
             ctx.globalAlpha = this.modelAlpha;

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -366,8 +366,8 @@ export class WebGL2Backend implements IRenderBackend {
                     if (this.drawSliceTexture(gl, slices[si]!.canvas)) liveSlices.add(slices[si]!.canvas);
                 }
             };
-            // z-order within the batch (painter's): bg, fills, then the candles + each
-            // indicator's series interleaved by `scene.candleZ`/per-indicator z, then hlines.
+            // z-order within the batch (painter's): bg, then the candles + each indicator's
+            // fills + series interleaved by `scene.candleZ`/per-indicator z, then hlines.
             // (The grid + session highlights live on the renderer's backdrop canvas below.)
             b.alpha = 1;
             // A collapsed pane is a legend-only strip: no plots (legend + separator are chrome).
@@ -380,15 +380,15 @@ export class WebGL2Backend implements IRenderBackend {
                     return sc === pane.scale ? pane : { ...pane, scale: sc };
                 };
                 b.alpha = this.modelAlpha; // indicator models fade in after the intro; candles/grid stay opaque
-                // Own (non-force_overlay) content on each model's pane; force_overlay content
-                // on the price pane against its MASTER scale, whatever pane the indicator owns
-                // (Pine semantics — mirrors the chrome's overlay-drawing routing).
+                // Behind everything: bgcolor spans — Pine keeps the background under every
+                // layer regardless of stacking. Own (non-force_overlay) spans on each
+                // model's pane; force_overlay spans on the price pane (Pine semantics —
+                // mirrors the chrome's overlay-drawing routing). Fills are NOT here: they
+                // paint inside the z loop at their model's slot.
                 for (const m of models) for (const bgSpan of m.backgrounds) if (bgSpan.overlay !== true) this.emitBackground(b, bgSpan, pane, coords);
-                for (const m of models) for (const f of m.fills) if (f.overlay !== true) this.emitFill(b, m, f, effPane(m), coords, i0, i1, scene.offsetOf(m.id));
                 if (isPrice) {
                     for (const m of scene.indicators.values()) {
                         for (const bgSpan of m.backgrounds) if (bgSpan.overlay === true) this.emitBackground(b, bgSpan, pane, coords);
-                        for (const f of m.fills) if (f.overlay === true) this.emitFill(b, m, f, pane, coords, i0, i1, scene.offsetOf(m.id));
                     }
                 }
                 // When the price is hidden, the candle layer is skipped entirely (overlays still draw).
@@ -406,6 +406,10 @@ export class WebGL2Backend implements IRenderBackend {
                     // Model data is index-aligned from the model's ANCHOR bar (offset 0 = whole-chart).
                     const off = scene.offsetOf(m.id);
                     const mp = effPane(m);
+                    // Fills paint at the model's z slot, under its own series — a band between
+                    // two plots sits behind the plot lines, and the whole model moves as one
+                    // unit when its object-tree row is reordered.
+                    for (const f of m.fills) if (f.overlay !== true) this.emitFill(b, m, f, mp, coords, i0, i1, off);
                     for (const s of m.series) if (s.overlay !== true) this.emitSeries(b, s, mp, coords, i0, i1, theme, off);
                 }
                 if (drawCandles && !candleDrawn) {
@@ -413,16 +417,24 @@ export class WebGL2Backend implements IRenderBackend {
                     b.alpha = this.candleStructureAlpha;
                     this.emitPriceSeries(b, scene, i0, i1, coords, pane, theme, barColorMap, dataW);
                 }
-                drawSlicesUpTo(Infinity); // layers bound to a hidden/removed series still paint, at the stack top
                 b.alpha = this.modelAlpha;
-                // force_overlay series from EVERY indicator paint on the price pane, at the top
-                // of its series stack, against the master price scale.
+                // force_overlay content from EVERY indicator paints on the price pane, at the
+                // top of its series stack, against the master price scale — fills first so a
+                // forced band still sits under the forced plot lines.
                 if (isPrice) {
+                    for (const m of scene.indicators.values()) {
+                        const off = scene.offsetOf(m.id);
+                        for (const f of m.fills) if (f.overlay === true) this.emitFill(b, m, f, pane, coords, i0, i1, off);
+                    }
                     for (const m of scene.indicators.values()) {
                         const off = scene.offsetOf(m.id);
                         for (const s of m.series) if (s.overlay === true) this.emitSeries(b, s, pane, coords, i0, i1, theme, off);
                     }
                 }
+                // Stack-top slices: the topmost indicator's drawings, force_overlay drawings,
+                // and layers bound to a hidden/removed series — above the forced series too,
+                // since drawings always paint over their own plots.
+                drawSlicesUpTo(Infinity);
                 for (const m of models) { const mp = effPane(m); for (const pl of m.priceLines) this.emitHline(b, pl, mp, coords, dataW, theme); }
                 b.alpha = 1;
             }

--- a/src/renderers/native/capabilities.ts
+++ b/src/renderers/native/capabilities.ts
@@ -18,7 +18,7 @@ export const NATIVE_CAPABILITIES: RendererCapabilities = {
     drawings: true,
     userDrawings: true, // interactive drawing tools (toolbar + hit-test + handles)
     drawingDepth: true, // drawings share the series' z space (backend-composited interleave layers)
-    tables: true, // reuses the DOM TableOverlay
+    tables: true, // canvas-painted into the owning indicator's interleave slice
     trades: true, // strategy order-fill markers (arrows + labels + fill-price ticks)
     inputsUI: true, // reuses the DOM InputsUI
 };

--- a/src/renderers/native/chrome/ChromeRenderer.ts
+++ b/src/renderers/native/chrome/ChromeRenderer.ts
@@ -7,7 +7,7 @@ import type { SceneGraph, PaneNode } from '../core/SceneGraph';
 import { percentScaleFor } from '../core/SceneGraph';
 // Re-exported so existing importers (crosshair) can keep sourcing it from here.
 export { percentScaleFor } from '../core/SceneGraph';
-import { DrawingSceneRenderer, type DrawingSet, type LabelTipRegion } from '../../shared/DrawingSceneRenderer';
+import { DrawingSceneRenderer, modelDrawingSet, type DrawingSet } from '../../shared/DrawingSceneRenderer';
 import { renderTradeMarkers } from '../../shared/trade-markers';
 import type { TradeExecution } from '../../../core/model/trades';
 import { paneAxisTicks, formatAxisValue, timeTicks } from './ticks';
@@ -18,25 +18,20 @@ import { tzOffsetMs } from './tz';
 
 /**
  * Renderer-owned chrome layer (canvas2d) on its own canvas, stacked above the
- * geometry layer (L0) and below the cursor layer (L2). It draws the things the
- * geometry backend can't (or shouldn't): Pine drawings (geometry + text TOGETHER,
- * preserving creation-order z-order), the per-pane price axes + labels, the time
- * axis + labels, and the current-price line + chip.
- *
- * It is ALWAYS canvas2d and independent of the geometry backend (canvas2d now,
- * WebGL2 later) — the GPU path never has to rasterize text. It also owns the
- * shared DrawingSceneRenderer, so it computes the drawing price-range that folds
- * into autoscale (`paneDrawingsRange`).
+ * geometry layer (L0) and below the cursor layer (L2). It draws the per-pane price
+ * axes + labels, the time axis + labels, the current-price line + chip, and the
+ * strategy trade markers. Pine drawings do NOT paint here: they prepaint into
+ * interleave slices (IndicatorDrawingSlices) the geometry backend composites at
+ * their model's z slot — this layer only keeps the shared DrawingSceneRenderer to
+ * compute the drawing price-range that folds into autoscale (`paneDrawingsRange`).
  */
 export class ChromeRenderer {
     private canvas: HTMLCanvasElement | null = null;
     private ctx: CanvasRenderingContext2D | null = null;
     // The color for axis tick labels — the host-passed surface text, set each frame in render().
     private axisTextColor = DARK_THEME.textColor;
-    // Shared Pine-drawing renderer (line/box/label/polyline/linefill); widthCache persists.
+    // Shared Pine-drawing renderer, used here for autoscale geometry only; widthCache persists.
     private readonly drawScene = new DrawingSceneRenderer({ timeToLogical: () => 0, barAt: () => null, theme: {} as VelaTheme });
-    // Tooltip hit-rects of every label drawn this frame, in plot coords (rebuilt per render).
-    private labelTips: LabelTipRegion[] = [];
 
     mount(canvas: HTMLCanvasElement): void {
         this.canvas = canvas;
@@ -62,8 +57,8 @@ export class ChromeRenderer {
      */
     paneDrawingsRange(ownModels: IndicatorModel[], scene: SceneGraph, isPricePane: boolean, vr: { from: number; to: number }): { min: number; max: number } | null {
         let dr: { min: number; max: number } | null = null;
-        for (const m of ownModels) dr = unionRange(dr, this.drawingsRange(this.ownDrawings(m), vr, scene.offsetOf(m.id)));
-        if (isPricePane) for (const m of scene.indicators.values()) dr = unionRange(dr, this.drawingsRange(this.overlayDrawings(m), vr, scene.offsetOf(m.id)));
+        for (const m of ownModels) dr = unionRange(dr, this.drawingsRange(modelDrawingSet(m, false), vr, scene.offsetOf(m.id)));
+        if (isPricePane) for (const m of scene.indicators.values()) dr = unionRange(dr, this.drawingsRange(modelDrawingSet(m, true), vr, scene.offsetOf(m.id)));
         return dr;
     }
 
@@ -84,7 +79,6 @@ export class ChromeRenderer {
         // The gutters (and their labels) use the surface the host passes (the live chart
         // background); everything data-side keeps the live theme.
         this.axisTextColor = surface?.textColor ?? theme.textColor;
-        this.labelTips = [];
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
         ctx.clearRect(0, 0, fullW, fullH);
         // Paint the price-axis (right) + time-axis (bottom) gutters opaquely so drawings or
@@ -110,20 +104,8 @@ export class ChromeRenderer {
         }
         const pricePane = panes.find((p) => p.kind === 'price') ?? null;
 
-        // ── Pine drawings — above series. Own drawings on each model's pane;
-        //    force_overlay drawings on the price pane (Pine semantics). A merged (own-scale)
-        //    indicator's drawings follow its own scale column. ──
-        for (const pane of panes) {
-            if (pane.collapsed) continue; // collapsed strip: legend only, no drawings/plots
-            for (const m of scene.indicatorsForPane(pane.id)) {
-                const sc = scene.scaleFor(m, pane);
-                const mp = sc === pane.scale ? pane : { ...pane, scale: sc };
-                this.renderDrawings(ctx, coords, this.ownDrawings(m), mp, dataW, scene.offsetOf(m.id));
-            }
-        }
-        if (pricePane) {
-            for (const m of scene.indicators.values()) this.renderDrawings(ctx, coords, this.overlayDrawings(m), pricePane, dataW, scene.offsetOf(m.id));
-        }
+        // Pine drawings paint through the interleave slices at their model's z slot
+        // (IndicatorDrawingSlices), NOT here — the chrome stays axes + markers + chips.
 
         // ── Strategy trade markers — always the PRICE pane, whatever pane the strategy's
         //    plots landed on (a fill price only means something on the price scale), above
@@ -145,27 +127,6 @@ export class ChromeRenderer {
     destroy(): void {
         this.canvas = null;
         this.ctx = null;
-    }
-
-    // ── Pine-drawing helpers (own vs force_overlay routing) ──
-    private ownDrawings(m: IndicatorModel): DrawingSet {
-        return {
-            lines: (m.lines ?? []).filter((d) => !d.overlay),
-            boxes: (m.boxes ?? []).filter((d) => !d.overlay),
-            labels: (m.labels ?? []).filter((d) => !d.overlay),
-            polylines: (m.polylines ?? []).filter((d) => !d.overlay),
-            linefills: (m.linefills ?? []).filter((d) => !d.overlay),
-        };
-    }
-
-    private overlayDrawings(m: IndicatorModel): DrawingSet {
-        return {
-            lines: (m.lines ?? []).filter((d) => d.overlay),
-            boxes: (m.boxes ?? []).filter((d) => d.overlay),
-            labels: (m.labels ?? []).filter((d) => d.overlay),
-            polylines: (m.polylines ?? []).filter((d) => d.overlay),
-            linefills: (m.linefills ?? []).filter((d) => d.overlay),
-        };
     }
 
     private drawingsRange(set: DrawingSet, vr: { from: number; to: number }, indexOffset = 0): { min: number; max: number } | null {
@@ -209,37 +170,6 @@ export class ChromeRenderer {
             Math.max(1.5, coords.bodySpacing() * 0.4),
         );
         ctx.restore();
-    }
-
-    private renderDrawings(ctx: CanvasRenderingContext2D, coords: CoordinateSystem, set: DrawingSet, pane: PaneNode, dataW: number, indexOffset = 0): void {
-        this.drawScene.setSet(set, indexOffset);
-        if (this.drawScene.isEmpty()) return;
-        ctx.save();
-        ctx.translate(0, pane.bounds.top); // pane-relative space (drawings use [0, H])
-        ctx.beginPath();
-        ctx.rect(0, 0, dataW, pane.bounds.height);
-        ctx.clip();
-        this.drawScene.render(
-            ctx,
-            dataW,
-            pane.bounds.height,
-            (l) => coords.logicalToX(l),
-            (price) => coords.priceToY(price, pane.scale, pane.bounds) - pane.bounds.top,
-        );
-        ctx.restore();
-        // Collect this set's label tooltip rects, shifted from pane space into plot space.
-        for (const r of this.drawScene.labelTipRegions()) {
-            this.labelTips.push({ ...r, top: r.top + pane.bounds.top, bottom: r.bottom + pane.bounds.top });
-        }
-    }
-
-    /** Tooltip of the topmost label under a plot-space point, or null. Fed by the last render. */
-    labelTooltipAt(x: number, y: number): string | null {
-        for (let i = this.labelTips.length - 1; i >= 0; i -= 1) {
-            const r = this.labelTips[i]!;
-            if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return r.text;
-        }
-        return null;
     }
 
     // ── axes ──

--- a/src/renderers/native/core/SceneGraph.ts
+++ b/src/renderers/native/core/SceneGraph.ts
@@ -43,10 +43,12 @@ export interface PctScale {
 }
 
 /**
- * One raster layer of user drawings interleaved into a pane's series stack: a prepainted
- * plot-sized canvas the backend composites (drawImage / textured quad) immediately BEFORE
- * the series whose z key is `beforeZ` — so its drawings sit under that series and every
- * series above it, but over everything painted earlier (grid, fills, lower series).
+ * One raster layer of drawings interleaved into a pane's series stack — user drawings
+ * slotted by their own z, or an indicator's Pine drawings slotted at their model's z: a
+ * prepainted plot-sized canvas the backend composites (drawImage / textured quad)
+ * immediately BEFORE the series whose z key is `beforeZ` — so its drawings sit under
+ * that series and every series above it, but over everything painted earlier (grid,
+ * fills, lower series).
  */
 export interface DrawingSlice {
     /** The z key of the series this layer paints in front of the grid but behind. */
@@ -200,9 +202,10 @@ export class SceneGraph {
      *  so each indicator arrives behind the candles (and behind older indicators);
      *  `setIndicatorZ`/`bringToFront`/`sendToBack` change it. */
     private readonly seriesZ = new Map<string, number>();
-    /** Per-pane raster layers of user drawings interleaved into the series stack — each is a
+    /** Per-pane raster layers of drawings interleaved into the series stack (each
+     *  indicator's Pine drawings at its model's z, plus in-stack user drawings) — each a
      *  prepainted canvas the backend composites just before the series carrying `beforeZ`.
-     *  Rebuilt by the renderer per data frame; empty when every drawing sits over the stack. */
+     *  Rebuilt by the renderer per data frame. */
     drawingSlices: ReadonlyMap<string, ReadonlyArray<DrawingSlice>> = new Map();
     /** Per-model index offset: the chart bar index of the model's `anchorTime` — its
      *  index-aligned payloads (dense series arrays, `bar_index` drawings) count from that

--- a/src/renderers/native/drawings/IndicatorDrawingSlices.ts
+++ b/src/renderers/native/drawings/IndicatorDrawingSlices.ts
@@ -1,0 +1,184 @@
+import type { VelaTheme } from '../../../core/options';
+import type { DrawingTable } from '../../../core/model/drawings';
+import type { CoordinateSystem } from '../core/CoordinateSystem';
+import type { SceneGraph, PaneNode, DrawingSlice } from '../core/SceneGraph';
+import {
+    DrawingSceneRenderer,
+    modelDrawingSet,
+    drawingSetEmpty,
+    type DrawingSet,
+    type LabelTipRegion,
+} from '../../shared/DrawingSceneRenderer';
+import { paintTable } from '../../shared/TableCanvasRenderer';
+
+/**
+ * The slice key for an indicator's drawings: the first series boundary STRICTLY above
+ * the model's z — the drawings composite above the model's own series (a tie in
+ * `sliceKeyFor` terms would put them under it) but below the next slot — or Infinity
+ * when the model tops its pane's stack (composited above the force_overlay series).
+ */
+export function indicatorSliceKey(z: number, boundaries: readonly number[]): number {
+    return boundaries.find((b) => b > z) ?? Infinity;
+}
+
+/** One model's contribution to a slice canvas: its drawing set + tables painted against
+ *  a pane (whose `scale` is already the model's effective one) at its index offset. */
+interface SliceEntry {
+    set: DrawingSet;
+    tables: DrawingTable[];
+    pane: PaneNode;
+    indexOffset: number;
+}
+
+/**
+ * Prepaints each indicator's Pine drawings (line/box/label/polyline/linefill) AND its
+ * tables into interleave-layer canvases the geometry backend composites into the
+ * pane's series stack — the same {@link DrawingSlice} contract user drawings ride.
+ * Keyed at the first series boundary STRICTLY ABOVE the owning model's z, they paint
+ * over the model's own series but under everything stacked higher (candles included),
+ * so the whole model moves as one unit when its object-tree row is reordered.
+ * force_overlay content paints on the price pane above its whole stack (`Infinity`),
+ * mirroring where force_overlay series paint.
+ *
+ * Also collects the label + table-cell tooltip hit-rects (plot space) each frame —
+ * painting moved off the chrome canvas / DOM, so the tooltip lookup lives here now.
+ */
+export class IndicatorDrawingSlices {
+    private readonly drawScene = new DrawingSceneRenderer({ timeToLogical: () => 0, barAt: () => null, theme: {} as VelaTheme });
+    /** Slice canvas cache, keyed `paneId|beforeZ` — same lifecycle as the user-drawing cache. */
+    private readonly sliceCache = new Map<string, HTMLCanvasElement>();
+    /** Tooltip hit-rects of every label drawn this frame, in plot coords (rebuilt per prepare). */
+    private tips: LabelTipRegion[] = [];
+
+    /**
+     * Rebuild the per-indicator drawing slices for this data frame. `ref` is the data
+     * canvas the slices must match pixel-for-pixel (the backend composites them 1:1).
+     * Runs from the renderer's data paint, just before the backend composites the scene.
+     */
+    prepare(scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme, ref: HTMLCanvasElement): Map<string, DrawingSlice[]> {
+        this.tips = [];
+        const out = new Map<string, DrawingSlice[]>();
+        if (ref.width === 0 || ref.height === 0) {
+            this.sliceCache.clear();
+            return out;
+        }
+        this.drawScene.setDeps({
+            timeToLogical: (ms) => coords.timeToLogical(ms),
+            barAt: (logical) => {
+                const b = scene.bars[Math.round(logical)];
+                return b ? { high: b.high, low: b.low } : null;
+            },
+            theme,
+        });
+        const dpr = coords.dpr;
+        const dataW = coords.width;
+
+        // Bucket the models' drawing sets by `paneId|beforeZ`. Own models iterate in
+        // ascending z (their relative stacking inside a shared canvas), force_overlay
+        // sets append last — they paint over the price pane's whole pile, as before.
+        const buckets = new Map<string, { paneId: string; beforeZ: number; entries: SliceEntry[] }>();
+        const add = (paneId: string, beforeZ: number, entry: SliceEntry): void => {
+            const key = `${paneId}|${beforeZ}`;
+            const bucket = buckets.get(key);
+            if (bucket) bucket.entries.push(entry);
+            else buckets.set(key, { paneId, beforeZ, entries: [entry] });
+        };
+        for (const pane of scene.orderedPanes()) {
+            if (pane.collapsed) continue; // collapsed strip: legend only, no drawings
+            const boundaries = scene.seriesBoundaries(pane.id);
+            for (const m of scene.orderedIndicatorsForPane(pane.id)) {
+                const set = modelDrawingSet(m, false);
+                const tables = (m.tables ?? []).filter((t) => !t.overlay);
+                if (drawingSetEmpty(set) && tables.length === 0) continue;
+                // A merged (own-scale) indicator's drawings follow its own scale column.
+                const sc = scene.scaleFor(m, pane);
+                const mp = sc === pane.scale ? pane : { ...pane, scale: sc };
+                const beforeZ = indicatorSliceKey(scene.zOf(m.id), boundaries);
+                add(pane.id, beforeZ, { set, tables, pane: mp, indexOffset: scene.offsetOf(m.id) });
+            }
+            if (pane.kind === 'price') {
+                for (const m of scene.indicators.values()) {
+                    const set = modelDrawingSet(m, true);
+                    const tables = (m.tables ?? []).filter((t) => t.overlay === true);
+                    if (drawingSetEmpty(set) && tables.length === 0) continue;
+                    add(pane.id, Infinity, { set, tables, pane, indexOffset: scene.offsetOf(m.id) });
+                }
+            }
+        }
+
+        for (const [key, { paneId, beforeZ, entries }] of buckets) {
+            let canvas = this.sliceCache.get(key);
+            if (!canvas) {
+                canvas = document.createElement('canvas');
+                this.sliceCache.set(key, canvas);
+            }
+            if (canvas.width !== ref.width || canvas.height !== ref.height) {
+                canvas.width = ref.width;
+                canvas.height = ref.height;
+            }
+            const ctx = canvas.getContext('2d');
+            if (!ctx) continue;
+            ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+            ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+            for (const e of entries) this.paintEntry(ctx, e, coords, dataW, theme);
+            const slices = out.get(paneId) ?? [];
+            slices.push({ beforeZ, canvas });
+            out.set(paneId, slices);
+        }
+        for (const key of [...this.sliceCache.keys()]) if (!buckets.has(key)) this.sliceCache.delete(key); // drop stale layers
+        for (const slices of out.values()) slices.sort((a, b) => a.beforeZ - b.beforeZ);
+        return out;
+    }
+
+    private paintEntry(ctx: CanvasRenderingContext2D, e: SliceEntry, coords: CoordinateSystem, dataW: number, theme: VelaTheme): void {
+        const { pane } = e;
+        const paneTips: LabelTipRegion[] = [];
+        ctx.save();
+        ctx.translate(0, pane.bounds.top); // pane-relative space (drawings use [0, H])
+        ctx.beginPath();
+        ctx.rect(0, 0, dataW, pane.bounds.height);
+        ctx.clip();
+        this.drawScene.setSet(e.set, e.indexOffset);
+        this.drawScene.render(
+            ctx,
+            dataW,
+            pane.bounds.height,
+            (l) => coords.logicalToX(l),
+            (price) => coords.priceToY(price, pane.scale, pane.bounds) - pane.bounds.top,
+        );
+        paneTips.push(...this.drawScene.labelTipRegions());
+        // Tables paint over the model's other drawings — the pane-corner dashboard reads
+        // above its own lines/labels, as the DOM overlay used to.
+        for (const t of e.tables) paintTable(ctx, t, { paneHeight: pane.bounds.height, plotWidth: dataW, theme }, paneTips);
+        ctx.restore();
+        // Collect this entry's tooltip rects, shifted from pane space into plot space.
+        for (const r of paneTips) {
+            this.tips.push({ ...r, top: r.top + pane.bounds.top, bottom: r.bottom + pane.bounds.top });
+        }
+    }
+
+    /** Tooltip of the topmost label or table cell under a plot-space point, or null. Fed by the last prepare. */
+    labelTooltipAt(x: number, y: number): string | null {
+        for (let i = this.tips.length - 1; i >= 0; i -= 1) {
+            const r = this.tips[i]!;
+            if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return r.text;
+        }
+        return null;
+    }
+}
+
+/**
+ * Merge the indicator slices with the user-drawing slices into one per-pane, z-sorted
+ * list for the backend. On a shared `beforeZ` the indicator content composites first
+ * (user drawings stay on top of engine output at the same slot).
+ */
+export function mergeSlices(
+    indicator: ReadonlyMap<string, DrawingSlice[]>,
+    user: ReadonlyMap<string, ReadonlyArray<DrawingSlice>>,
+): ReadonlyMap<string, DrawingSlice[]> {
+    const out = new Map<string, DrawingSlice[]>();
+    for (const [paneId, slices] of indicator) out.set(paneId, [...slices]);
+    for (const [paneId, slices] of user) out.set(paneId, [...(out.get(paneId) ?? []), ...slices]);
+    for (const slices of out.values()) slices.sort((a, b) => a.beforeZ - b.beforeZ); // stable: ties keep indicator-first
+    return out;
+}

--- a/src/renderers/shared/DrawingSceneRenderer.ts
+++ b/src/renderers/shared/DrawingSceneRenderer.ts
@@ -38,6 +38,34 @@ export interface DrawingPriceRange {
 
 export const EMPTY_DRAWING_SET: DrawingSet = { lines: [], boxes: [], labels: [], polylines: [], linefills: [] };
 
+/** A model shape carrying optional Pine drawing arrays (structurally `IndicatorModel`). */
+export interface DrawingSetSource {
+    lines?: DrawingLine[];
+    boxes?: DrawingBox[];
+    labels?: DrawingLabel[];
+    polylines?: DrawingPolyline[];
+    linefills?: DrawingLinefill[];
+}
+
+/** A model's Pine drawings routed ONE way: its own pane (`overlay` false) or forced onto
+ *  the price pane (`overlay` true, Pine's `force_overlay`) — every consumer of a model's
+ *  drawings splits along this same seam. */
+export function modelDrawingSet(m: DrawingSetSource, overlay: boolean): DrawingSet {
+    const want = (d: { overlay?: boolean }): boolean => Boolean(d.overlay) === overlay;
+    return {
+        lines: (m.lines ?? []).filter(want),
+        boxes: (m.boxes ?? []).filter(want),
+        labels: (m.labels ?? []).filter(want),
+        polylines: (m.polylines ?? []).filter(want),
+        linefills: (m.linefills ?? []).filter(want),
+    };
+}
+
+/** True when the set draws nothing at all. */
+export function drawingSetEmpty(s: DrawingSet): boolean {
+    return !s.lines.length && !s.boxes.length && !s.labels.length && !s.polylines.length && !s.linefills.length;
+}
+
 /** Hover hit-rect of one rendered label that carries a tooltip (canvas coords of the last render). */
 export interface LabelTipRegion {
     left: number;

--- a/src/renderers/shared/TableCanvasRenderer.ts
+++ b/src/renderers/shared/TableCanvasRenderer.ts
@@ -1,0 +1,209 @@
+import type { DrawingTable, TableCell, TablePosition } from '../../core/model/drawings';
+import type { VelaTheme } from '../../core/options';
+import { fontPxOf, tableHasContent, mergeRenderPlan } from './TableOverlay';
+import type { LabelTipRegion } from './DrawingSceneRenderer';
+
+// Mirrors the DOM TableOverlay's box model: 2px 6px cell padding, a 6px anchor
+// margin, and the browser's default ~1.2 line height for `white-space: pre` text.
+const PAD_X = 6;
+const PAD_Y = 2;
+const MARGIN = 6;
+const LINE_HEIGHT = 1.2;
+
+/** Geometry the painter anchors against — all in PANE-RELATIVE pixels
+ *  (the caller's ctx is translated to the pane's top and clipped to it). */
+export interface TablePaintArgs {
+    paneHeight: number;
+    /** Plot-area width (excludes the right price-axis strip) — Pine cell widths are percents of it. */
+    plotWidth: number;
+    theme: VelaTheme;
+}
+
+interface CellBox {
+    cell: TableCell;
+    r: number;
+    c: number;
+    cs: number;
+    rs: number;
+}
+
+interface TableLayout {
+    colW: number[];
+    rowH: number[];
+    w: number;
+    h: number;
+    boxes: CellBox[];
+}
+
+/**
+ * Paints one Pine `table.new` onto a canvas, mirroring the DOM TableOverlay's
+ * layout semantics (nine-position pane anchoring past the axis, auto/percent cell
+ * sizing, merges, collapsed borders, outer frame, bold/italic/mono, `\n` line
+ * breaks without wrapping). Painting on canvas is what lets a table ride its
+ * indicator's interleave slice and follow the object-tree stacking; cell tooltips
+ * survive as hit-rects appended to `tips` (pane space — the caller shifts them).
+ */
+export function paintTable(ctx: CanvasRenderingContext2D, t: DrawingTable, args: TablePaintArgs, tips: LabelTipRegion[]): void {
+    if (!tableHasContent(t)) return;
+    const layout = layoutTable(ctx, t, args);
+    if (!layout || layout.w <= 0 || layout.h <= 0) return;
+
+    const fw = t.frameColor && t.frameWidth > 0 ? t.frameWidth : 0;
+    const { x, y } = anchorOrigin(t.position, layout.w + 2 * fw, layout.h + 2 * fw, args);
+    const x0 = x + fw;
+    const y0 = y + fw;
+
+    // Table background behind every cell, then the outer frame stroke around it.
+    if (t.bgColor) {
+        ctx.fillStyle = t.bgColor;
+        ctx.fillRect(x0, y0, layout.w, layout.h);
+    }
+    if (fw > 0 && t.frameColor) {
+        ctx.strokeStyle = t.frameColor;
+        ctx.lineWidth = fw;
+        ctx.strokeRect(x + fw / 2, y + fw / 2, layout.w + fw, layout.h + fw);
+    }
+
+    // Column/row pixel origins (prefix sums).
+    const colX: number[] = [0];
+    for (const w of layout.colW) colX.push(colX[colX.length - 1]! + w);
+    const rowY: number[] = [0];
+    for (const h of layout.rowH) rowY.push(rowY[rowY.length - 1]! + h);
+
+    // Cell backgrounds + text.
+    const prevBaseline = ctx.textBaseline;
+    const prevAlign = ctx.textAlign;
+    ctx.textBaseline = 'middle';
+    for (const box of layout.boxes) {
+        const rx = x0 + colX[box.c]!;
+        const ry = y0 + rowY[box.r]!;
+        const rw = colX[box.c + box.cs]! - colX[box.c]!;
+        const rh = rowY[box.r + box.rs]! - rowY[box.r]!;
+        const cell = box.cell;
+        if (cell.bgColor) {
+            ctx.fillStyle = cell.bgColor;
+            ctx.fillRect(rx, ry, rw, rh);
+        }
+        const text = cell.text ?? '';
+        if (text.length > 0) {
+            const px = fontPxOf(cell.textSize);
+            ctx.font = cellFont(cell, px, args.theme);
+            ctx.fillStyle = cell.textColor ?? args.theme.textColor;
+            const lines = text.split('\n');
+            const blockH = lines.length * px * LINE_HEIGHT;
+            const blockTop = cell.vAlign === 'top' ? ry + PAD_Y : cell.vAlign === 'bottom' ? ry + rh - PAD_Y - blockH : ry + (rh - blockH) / 2;
+            const tx = cell.hAlign === 'left' ? rx + PAD_X : cell.hAlign === 'right' ? rx + rw - PAD_X : rx + rw / 2;
+            ctx.textAlign = cell.hAlign;
+            lines.forEach((line, i) => ctx.fillText(line, tx, blockTop + (i + 0.5) * px * LINE_HEIGHT));
+        }
+        if (cell.tooltip) tips.push({ left: rx, top: ry, right: rx + rw, bottom: ry + rh, text: cell.tooltip });
+    }
+    ctx.textBaseline = prevBaseline;
+    ctx.textAlign = prevAlign;
+
+    // Collapsed cell borders: each grid edge stroked ONCE (adjacent cells share
+    // theirs), so translucent border colors don't double up on inner lines.
+    if (t.borderColor && t.borderWidth > 0) {
+        ctx.strokeStyle = t.borderColor;
+        ctx.lineWidth = t.borderWidth;
+        const seen = new Set<string>();
+        ctx.beginPath();
+        const edge = (ax: number, ay: number, bx: number, by: number): void => {
+            const key = `${ax},${ay},${bx},${by}`;
+            if (seen.has(key)) return;
+            seen.add(key);
+            ctx.moveTo(ax, ay);
+            ctx.lineTo(bx, by);
+        };
+        for (const box of layout.boxes) {
+            const l = Math.round(x0 + colX[box.c]!);
+            const r = Math.round(x0 + colX[box.c + box.cs]!);
+            const tp = Math.round(y0 + rowY[box.r]!);
+            const bt = Math.round(y0 + rowY[box.r + box.rs]!);
+            edge(l, tp, r, tp);
+            edge(l, bt, r, bt);
+            edge(l, tp, l, bt);
+            edge(r, tp, r, bt);
+        }
+        ctx.stroke();
+    }
+}
+
+/** DOM-table auto layout, approximated: content-sized columns/rows (explicit percent
+ *  sizes act as minimums, like a `width` on a `pre` cell), spans distributing their
+ *  deficit evenly, and never-set cells occupying no space. */
+function layoutTable(ctx: CanvasRenderingContext2D, t: DrawingTable, args: TablePaintArgs): TableLayout | null {
+    const { span, omit } = mergeRenderPlan(t);
+    const colW = new Array<number>(t.columns).fill(0);
+    const rowH = new Array<number>(t.rows).fill(0);
+    const boxes: CellBox[] = [];
+    for (let r = 0; r < t.rows; r += 1) {
+        for (let c = 0; c < t.columns; c += 1) {
+            if (omit.has(`${r}:${c}`)) continue;
+            const cell = t.cells[r]?.[c];
+            if (cell == null) continue; // never set via table.cell() → occupies no space
+            const sp = span.get(`${r}:${c}`);
+            boxes.push({ cell, r, c, cs: Math.min(sp?.cs ?? 1, t.columns - c), rs: Math.min(sp?.rs ?? 1, t.rows - r) });
+        }
+    }
+    if (boxes.length === 0) return null;
+
+    const sizeOf = (cell: TableCell): { w: number; h: number } => {
+        const px = fontPxOf(cell.textSize);
+        ctx.font = cellFont(cell, px, args.theme);
+        const lines = (cell.text ?? '').split('\n');
+        let maxW = 0;
+        for (const line of lines) maxW = Math.max(maxW, ctx.measureText(line).width);
+        let w = Math.ceil(maxW) + 2 * PAD_X;
+        let h = Math.ceil(lines.length * px * LINE_HEIGHT) + 2 * PAD_Y;
+        if (cell.width) w = Math.max(w, (cell.width / 100) * args.plotWidth);
+        if (cell.height) h = Math.max(h, (cell.height / 100) * args.paneHeight);
+        return { w, h };
+    };
+
+    // Pass 1: non-spanning cells size their own column/row.
+    const spanning: Array<{ box: CellBox; w: number; h: number }> = [];
+    for (const box of boxes) {
+        const { w, h } = sizeOf(box.cell);
+        if (box.cs === 1) colW[box.c] = Math.max(colW[box.c]!, w);
+        if (box.rs === 1) rowH[box.r] = Math.max(rowH[box.r]!, h);
+        if (box.cs > 1 || box.rs > 1) spanning.push({ box, w, h });
+    }
+    // Pass 2: a span wider/taller than its tracks spreads the deficit evenly.
+    for (const { box, w, h } of spanning) {
+        if (box.cs > 1) {
+            let sum = 0;
+            for (let c = box.c; c < box.c + box.cs; c += 1) sum += colW[c]!;
+            if (w > sum) for (let c = box.c; c < box.c + box.cs; c += 1) colW[c]! += (w - sum) / box.cs;
+        }
+        if (box.rs > 1) {
+            let sum = 0;
+            for (let r = box.r; r < box.r + box.rs; r += 1) sum += rowH[r]!;
+            if (h > sum) for (let r = box.r; r < box.r + box.rs; r += 1) rowH[r]! += (h - sum) / box.rs;
+        }
+    }
+    let w = 0;
+    for (const cw of colW) w += cw;
+    let h = 0;
+    for (const rh of rowH) h += rh;
+    return { colW, rowH, w, h, boxes };
+}
+
+/** Top-left of the table's OUTER box (frame included) for a Pine `position.*` anchor —
+ *  the same 6px margins and axis-clearing insets the DOM overlay computes. */
+function anchorOrigin(position: TablePosition, totalW: number, totalH: number, args: TablePaintArgs): { x: number; y: number } {
+    let y: number;
+    if (position.startsWith('top')) y = MARGIN;
+    else if (position.startsWith('bottom')) y = args.paneHeight - MARGIN - totalH;
+    else y = args.paneHeight / 2 - totalH / 2;
+    let x: number;
+    if (position.endsWith('left')) x = MARGIN;
+    else if (position.endsWith('right')) x = args.plotWidth - MARGIN - totalW;
+    else x = args.plotWidth / 2 - totalW / 2;
+    return { x, y };
+}
+
+function cellFont(cell: TableCell, px: number, theme: VelaTheme): string {
+    const family = cell.fontFamily === 'monospace' ? 'monospace' : theme.fontFamily || 'sans-serif';
+    return `${cell.italic ? 'italic ' : ''}${cell.bold ? 'bold ' : ''}${px}px ${family}`;
+}

--- a/test/indicator-drawing-slices.test.ts
+++ b/test/indicator-drawing-slices.test.ts
@@ -1,0 +1,67 @@
+// Indicator drawings following the object tree (src/renderers/native/drawings/
+// IndicatorDrawingSlices.ts): an indicator's Pine drawings prepaint into an interleave
+// slice keyed just ABOVE the model's z, so they ride the model's row through the pane
+// stack — under the candles when the row sits under the candles. The painted result is
+// exercised in the browser; the keying + merge rules are the unit-testable part.
+import { describe, it, expect } from 'vitest';
+import { indicatorSliceKey, mergeSlices } from '../src/renderers/native/drawings/IndicatorDrawingSlices';
+import { sliceKeyFor } from '../src/renderers/native/drawings/UserDrawingController';
+import { SceneGraph, type DrawingSlice } from '../src/renderers/native/core/SceneGraph';
+
+const canvas = (tag: string): HTMLCanvasElement => ({ tag }) as unknown as HTMLCanvasElement;
+
+describe('indicatorSliceKey', () => {
+    it('a model under the candles keys AT the candle boundary: over its own series, under the candles', () => {
+        // Default mount: candles z 0, indicator z -1 → boundaries [-1, 0].
+        expect(indicatorSliceKey(-1, [-1, 0])).toBe(0);
+    });
+
+    it('a model raised above the candles keys past every boundary: over the whole stack', () => {
+        expect(indicatorSliceKey(1, [0, 1])).toBe(Infinity);
+    });
+
+    it('a model between two others keys at the next series up', () => {
+        expect(indicatorSliceKey(-2, [-2, -1, 0])).toBe(-1);
+    });
+
+    it('never keys at the model own z — that would composite the drawings UNDER its own series', () => {
+        // sliceKeyFor (user drawings) pins a tie under the series; the indicator key must not.
+        expect(sliceKeyFor(-1, [-1, 0])).toBe(-1);
+        expect(indicatorSliceKey(-1, [-1, 0])).toBeGreaterThan(-1);
+    });
+
+    it('follows a reorder end to end through SceneGraph z keys', () => {
+        const scene = new SceneGraph();
+        scene.candleZ = 0;
+        scene.assignIndicatorZ('pine'); // mounts at the bottom: z -1
+        const below = indicatorSliceKey(scene.zOf('pine'), [scene.zOf('pine'), scene.candleZ].sort((a, b) => a - b));
+        expect(below).toBe(scene.candleZ); // drawings composite under the candles
+        scene.bringIndicatorToFront('pine'); // the object tree drags the row above Candles
+        const above = indicatorSliceKey(scene.zOf('pine'), [scene.zOf('pine'), scene.candleZ].sort((a, b) => a - b));
+        expect(above).toBe(Infinity); // drawings composite over the whole stack
+    });
+});
+
+describe('mergeSlices', () => {
+    it('merges both sources per pane, sorted by beforeZ', () => {
+        const ind = new Map<string, DrawingSlice[]>([['price', [{ beforeZ: 5, canvas: canvas('i5') }]]]);
+        const usr = new Map<string, DrawingSlice[]>([['price', [{ beforeZ: 0, canvas: canvas('u0') }]]]);
+        const merged = mergeSlices(ind, usr).get('price')!;
+        expect(merged.map((s) => s.beforeZ)).toEqual([0, 5]);
+    });
+
+    it('on a shared key the indicator slice composites first (user drawings stay on top)', () => {
+        const ind = new Map<string, DrawingSlice[]>([['price', [{ beforeZ: 0, canvas: canvas('ind') }]]]);
+        const usr = new Map<string, DrawingSlice[]>([['price', [{ beforeZ: 0, canvas: canvas('usr') }]]]);
+        const merged = mergeSlices(ind, usr).get('price')!;
+        expect(merged.map((s) => (s.canvas as unknown as { tag: string }).tag)).toEqual(['ind', 'usr']);
+    });
+
+    it('keeps panes that only one source contributes to', () => {
+        const ind = new Map<string, DrawingSlice[]>([['study-1', [{ beforeZ: -2, canvas: canvas('i') }]]]);
+        const usr = new Map<string, DrawingSlice[]>([['price', [{ beforeZ: 1, canvas: canvas('u') }]]]);
+        const merged = mergeSlices(ind, usr);
+        expect(merged.get('study-1')!.length).toBe(1);
+        expect(merged.get('price')!.length).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

- Restacking an indicator from the object tree (or `seriesOrder`) now moves **everything** it paints as one unit — plots, fills, `line.new`/`box.new`/`label.new`/`polyline.new`/`linefill.new` drawings, `plotshape`/`plotchar`/`plotarrow` markers, and `table.new` dashboards. Previously only the plots followed the row: fills were pinned behind the candles and drawings/tables always painted on top.
- Fills now paint at their model's z slot in both geometry backends (Canvas2d + WebGL2); Pine drawings prepaint into per-indicator interleave slices (the same mechanism user-drawing depth rides) composited just above the model's own series; `force_overlay` content keeps painting above the price pane's stack.
- Tables are rasterized onto the chart canvas (new `TableCanvasRenderer` mirroring the DOM overlay's layout: nine-position anchoring, auto/percent sizing, merges, collapsed borders, frame, bold/italic/mono). They now obey the stacking, appear in `screenshot()`, and keep cell tooltips through the same hover-tip path as label tooltips.
- Intentionally unchanged: `bgcolor()` stays behind everything, `barcolor()` stays with the candle layer, price lines stay on top.
- Visible default change: new indicators mount under the price series, so a fresh script's drawings/tables now genuinely start behind the candles until restacked — matching what the object tree has always displayed.

## Test plan

- [x] `typecheck` / `lint` / `test` / `build` all green (8 new unit tests pin the slice keying and merge rules)
- [x] Oracle scenario suite: 22/22 on canvas2d and 22/22 on WebGL2; table/box/marker/force_overlay renders visually reviewed
- [x] Playground probe: one `seriesOrder` write moves plot + fill + line + box + label + markers + table above/below the candles together; label tooltip verified through the relocated hit-rects
- [x] Vela-pro oracle suite 11/11 against the rebuilt package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to native renderer z-order and compositing (both backends, tables, tooltips); visual regressions are possible though unit tests cover slice keying/merge rules.
> 
> **Overview**
> **Restacking an indicator in the object tree (or via `seriesOrder`) now moves everything that indicator paints as one unit** — plots, fills, Pine drawings, tables, and markers — instead of only the plot series.
> 
> **Fills** no longer paint in a global “behind everything” pass; both **Canvas2d** and **WebGL2** backends draw them at the indicator’s **z slot** (under that model’s series, above lower stack layers). **`bgcolor()`** stays behind the stack; **`barcolor()`** and price lines are unchanged.
> 
> **Pine drawings** move off the chrome canvas into new **`IndicatorDrawingSlices`**: per-indicator prepaint canvases merged with user-drawing slices and composited mid-stack at a `beforeZ` keyed just above the model’s z. **Tables** drop the native renderer’s DOM **`TableOverlay`** in favor of **`TableCanvasRenderer`**, painted in the same slices so they follow draw order and appear in screenshots; label/table tooltips use hit-rects from the slice prepainter.
> 
> Shared helpers **`modelDrawingSet`** / **`drawingSetEmpty`** centralize own vs `force_overlay` routing; docs and changelog describe the object-tree behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea4e38769d5d30424b21c150a7228af9311f4f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->