### PR TITLE
Snap chart canvases and candle edges to the device-pixel grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Crisp rendering on fractional display scales.** On displays with a fractional
+  zoom factor (a common Windows setting at 125% or 150%), candles, wicks,
+  gridlines, and every other chart graphic could look slightly blurred: the
+  chart's drawing surface was misaligned with the screen's physical pixels by a
+  fraction of a pixel, which smeared every edge. The surface now snaps to the
+  physical pixel grid, so edges render sharp at any display scale.
+- **Pixel-perfect candle edges.** Candle bodies and wicks now pin their tops and
+  bottoms to whole physical pixels, the same way their sides already snap. A
+  magnified screenshot shows hard one-pixel edges all around a candle instead of
+  a faint blended rim above and below the body.
+
 ## [v0.6.9]
 
 ### Added

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -163,6 +163,11 @@ export class NativeRenderer implements IChartRenderer {
     private readonly vpvrRenderer = new VpvrRenderer();
     private resizeObserver: ResizeObserver | null = null;
     private dprMedia: MediaQueryList | null = null;
+    /** Plot size in INTEGER device px, as last reported by the resize observer's
+     *  device-pixel-content-box — the browser's own statement of how many device pixels
+     *  it paints the plot into. `null` until the first report or where the box type is
+     *  unsupported (WebKit); syncSize then falls back to rounding the client rect. */
+    private plotDeviceSize: { width: number; height: number } | null = null;
 
     private readonly coords = new CoordinateSystem();
     private readonly scene = new SceneGraph();
@@ -1493,8 +1498,23 @@ export class NativeRenderer implements IChartRenderer {
             },
         });
 
-        this.resizeObserver = new ResizeObserver(() => this.resize());
+        this.resizeObserver = new ResizeObserver((entries) => {
+            for (const e of entries) {
+                if (e.target !== this.plot) continue;
+                const s = e.devicePixelContentBoxSize?.[0];
+                if (s) this.plotDeviceSize = { width: s.inlineSize, height: s.blockSize };
+            }
+            this.resize();
+        });
         this.resizeObserver.observe(this.wrapper);
+        // Also watch the plot's device-pixel box: it reports the EXACT integer device-pixel
+        // size of the box (fractional dpr and fractional layout already snapped by the
+        // browser), and it fires on zoom/dpr changes the wrapper's content-box misses.
+        try {
+            this.resizeObserver.observe(this.plot, { box: 'device-pixel-content-box' });
+        } catch {
+            // Box type unsupported (WebKit) — syncSize keeps rounding the client rect.
+        }
         this.watchDpr();
         this.syncSize();
     }
@@ -3717,23 +3737,46 @@ export class NativeRenderer implements IChartRenderer {
         // The plot area is inset to the right of the toolbar gutter; the canvases fill the plot
         // sub-container (0-based), so the coordinate system / pointer coords stay unchanged.
         this.plot.style.left = `${this.toolbarGutter}px`;
-        const pw = Math.max(1, w - this.toolbarGutter);
-        const ph = h;
-        this.dataCanvas.width = Math.round(pw * dpr);
-        this.dataCanvas.height = Math.round(ph * dpr);
-        this.backdropCanvas.width = this.dataCanvas.width;
-        this.backdropCanvas.height = this.dataCanvas.height;
-        this.volumeCanvas.width = this.dataCanvas.width;
-        this.volumeCanvas.height = this.dataCanvas.height;
-        for (const l of this.extLayers) { l.canvas.width = this.dataCanvas.width; l.canvas.height = this.dataCanvas.height; }
-        this.vpvrCanvas.width = this.dataCanvas.width;
-        this.vpvrCanvas.height = this.dataCanvas.height;
-        this.chromeCanvas.width = this.dataCanvas.width;
-        this.chromeCanvas.height = this.dataCanvas.height;
-        this.drawingsCanvas.width = this.dataCanvas.width;
-        this.drawingsCanvas.height = this.dataCanvas.height;
-        this.cursorCanvas.width = this.dataCanvas.width;
-        this.cursorCanvas.height = this.dataCanvas.height;
+        // Size the pile from the plot's REAL box, not client sizes: clientWidth/Height are
+        // integer-rounded, and on fractional-dpr displays (Windows 125%/150%) a backing store
+        // rounded from them covers a different number of device pixels than the box it is
+        // displayed in — the compositor then resamples the whole bitmap and every
+        // device-snapped edge feathers by ~1px.
+        const rect = this.plot.getBoundingClientRect();
+        let bw = Math.max(1, Math.round(rect.width * dpr));
+        let bh = Math.max(1, Math.round(rect.height * dpr));
+        // Prefer the observer-reported device-pixel size when it describes the CURRENT box
+        // (within 1 device px of the rect — the browser's snapping can differ from plain
+        // rounding by up to a pixel, which is exactly why its report wins). A stale report
+        // (e.g. right after the toolbar gutter moved the plot) is rejected; the observer
+        // fires again with the fresh box and re-syncs.
+        const dev = this.plotDeviceSize;
+        if (dev && Math.abs(dev.width - rect.width * dpr) <= 1 && Math.abs(dev.height - rect.height * dpr) <= 1) {
+            bw = Math.max(1, dev.width);
+            bh = Math.max(1, dev.height);
+        }
+        // Bitmap px == device px: each canvas gets an explicit CSS size derived from its
+        // backing store, so nothing is rescaled at composite time. The box's fractional
+        // device OFFSET is left alone on purpose: the compositor pixel-snaps a layer's
+        // layout position by itself, but an explicit sub-pixel translate becomes part of
+        // the composite matrix and RESAMPLES the texture — a half-device-pixel translate
+        // blends every horizontal edge 50/50 (measured, not theory). Never "compensate".
+        const pw = bw / dpr;
+        const ph = bh / dpr;
+        const size = (canvas: HTMLCanvasElement): void => {
+            canvas.width = bw;
+            canvas.height = bh;
+            canvas.style.width = `${pw}px`;
+            canvas.style.height = `${ph}px`;
+        };
+        size(this.dataCanvas);
+        size(this.backdropCanvas);
+        size(this.volumeCanvas);
+        for (const l of this.extLayers) size(l.canvas);
+        size(this.vpvrCanvas);
+        size(this.chromeCanvas);
+        size(this.drawingsCanvas);
+        size(this.cursorCanvas);
         // Reserve strips for the price axis (right) + time axis (bottom); the
         // data area drives the coordinate transform so series sit clear of them.
         this.coords.setSize(Math.max(1, pw - this.rightAxisW), Math.max(1, ph - TIME_AXIS_H), dpr);

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -6,7 +6,7 @@ import type { SeriesSpec, LineLikeSeries, CandleSeries, LineStyle, CandleBarColo
 import { isLineLikeSeries } from '../../../core/model/series';
 import type { CoordinateSystem } from '../core/CoordinateSystem';
 import type { SceneGraph, PaneNode } from '../core/SceneGraph';
-import { candleTier, wickWidth, candleGeometry } from './candle-lod';
+import { candleTier, wickWidth, candleGeometry, snapY } from './candle-lod';
 import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, effectiveCandlePaint } from '../core/chartConfig';
 import type { IRenderBackend } from './IRenderBackend';
 
@@ -444,16 +444,18 @@ export class Canvas2dBackend implements IRenderBackend {
             if (drawBody) {
                 const oY = coords.priceToY(b.open, pane.scale, pane.bounds);
                 const cY = coords.priceToY(b.close, pane.scale, pane.bounds);
-                top = Math.min(oY, cY);
-                bodyH = Math.max(1, Math.abs(cY - oY));
+                // Both edges snapped to the device grid so the horizontal edges rasterize
+                // crisp (no blended rim); a doji keeps a visible 1-device-px body.
+                top = snapY(Math.min(oY, cY), coords.dpr);
+                bodyH = Math.max(1 / coords.dpr, snapY(Math.max(oY, cY), coords.dpr) - top);
             }
             if (cs.wickVisible) {
                 // barcolor() recolors only the BODY (TV semantics): the wick keeps the
                 // direction color while a body is drawn. At stick-only zoom the stick IS
                 // the candle, so it keeps the barcolor tint.
                 const wick = (up ? cs.wickUpColor : cs.wickDownColor) ?? (drawBody ? dir : color);
-                const hY = coords.priceToY(b.high, pane.scale, pane.bounds);
-                const lY = coords.priceToY(b.low, pane.scale, pane.bounds);
+                const hY = snapY(coords.priceToY(b.high, pane.scale, pane.bounds), coords.dpr);
+                const lY = snapY(coords.priceToY(b.low, pane.scale, pane.bounds), coords.dpr);
                 ctx.globalAlpha = this.candleStructureAlpha;
                 ctx.strokeStyle = wick;
                 ctx.lineWidth = g.wickW;

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -6,7 +6,7 @@ import type { SeriesSpec, LineLikeSeries, CandleSeries, LineStyle, CandleBarColo
 import { isLineLikeSeries } from '../../../core/model/series';
 import type { CoordinateSystem } from '../core/CoordinateSystem';
 import type { SceneGraph, PaneNode } from '../core/SceneGraph';
-import { candleTier, wickWidth, candleGeometry } from './candle-lod';
+import { candleTier, wickWidth, candleGeometry, snapY } from './candle-lod';
 import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha as cssWithAlpha, effectiveCandlePaint } from '../core/chartConfig';
 import type { IRenderBackend } from './IRenderBackend';
 import { Batch, type RGBA } from './gl/Batch';
@@ -871,12 +871,14 @@ export class WebGL2Backend implements IRenderBackend {
             if (drawBody) {
                 const oY = coords.priceToY(bar.open, pane.scale, pane.bounds);
                 const cY = coords.priceToY(bar.close, pane.scale, pane.bounds);
-                bodyTop = Math.min(oY, cY);
-                bodyH = Math.max(1, Math.abs(cY - oY));
+                // Both edges snapped to the device grid so the horizontal edges rasterize
+                // crisp (no blended rim); a doji keeps a visible 1-device-px body.
+                bodyTop = snapY(Math.min(oY, cY), coords.dpr);
+                bodyH = Math.max(1 / coords.dpr, snapY(Math.max(oY, cY), coords.dpr) - bodyTop);
             }
             if (cs.wickVisible) {
-                const hY = coords.priceToY(bar.high, pane.scale, pane.bounds);
-                const lY = coords.priceToY(bar.low, pane.scale, pane.bounds);
+                const hY = snapY(coords.priceToY(bar.high, pane.scale, pane.bounds), coords.dpr);
+                const lY = snapY(coords.priceToY(bar.low, pane.scale, pane.bounds), coords.dpr);
                 b.alpha = this.candleStructureAlpha;
                 // barcolor() recolors only the BODY (TV semantics): the wick keeps the
                 // direction color while a body is drawn. At stick-only zoom the stick IS

--- a/src/renderers/native/backend/candle-lod.ts
+++ b/src/renderers/native/backend/candle-lod.ts
@@ -36,6 +36,18 @@ export function candleTier(spacing: number): CandleTier {
     return 'full';
 }
 
+/**
+ * Snap a CSS-px Y coordinate to the device-pixel grid — the vertical counterpart of
+ * candleGeometry's X snapping, applied to candle body tops/bottoms and wick ends.
+ * An edge on a whole device pixel rasterizes as one hard step; a fractional one
+ * leaves a blended anti-aliasing row that reads as a darker rim on the body. The
+ * cost is up to half a device pixel of true position — invisible at any zoom.
+ * Shared by both backends so canvas2d and WebGL2 land candles on the same rows.
+ */
+export function snapY(yCss: number, dpr: number): number {
+    return Math.round(yCss * dpr) / dpr;
+}
+
 /** Wick + body layout of one candle, in CSS px, with every edge on the device-pixel grid. */
 export interface CandleGeometry {
     /** Wick left edge / width. */

--- a/test/candle-snap-y.test.ts
+++ b/test/candle-snap-y.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { snapY, candleGeometry } from '../src/renderers/native/backend/candle-lod';
+
+/**
+ * Vertical device-grid snapping for candle geometry — the counterpart of
+ * candleGeometry's X snapping. Body tops/bottoms and wick ends must land on whole
+ * device pixels at ANY dpr, or the rasterizer leaves a blended anti-aliasing row
+ * that reads as a darker rim along the candle body.
+ */
+
+describe('snapY lands CSS-px Y coordinates on the device-pixel grid', () => {
+    it('produces whole device pixels at fractional dpr', () => {
+        for (const y of [311.3, 38.8, 0.49, 662.01, 99.999]) {
+            for (const dpr of [1, 1.25, 1.5, 2, 2.625]) {
+                const dev = snapY(y, dpr) * dpr;
+                expect(dev, `y=${y} dpr=${dpr}`).toBeCloseTo(Math.round(dev), 9);
+            }
+        }
+    });
+
+    it('moves a coordinate by at most half a device pixel', () => {
+        for (const y of [311.3, 38.8, 0.49, 662.01]) {
+            for (const dpr of [1, 1.25, 1.5, 2]) {
+                expect(Math.abs(snapY(y, dpr) - y)).toBeLessThanOrEqual(0.5 / dpr + 1e-9);
+            }
+        }
+    });
+
+    it('keeps an already-snapped coordinate unchanged', () => {
+        expect(snapY(311.2, 1.25)).toBe(311.2); // 311.2 × 1.25 = 389 exactly
+        expect(snapY(48, 1.25)).toBe(48); // 60 device px
+    });
+
+    it('agrees with candleGeometry: snapped edges share the same 1/dpr lattice', () => {
+        // A wick rect spanning snapY(hY)..snapY(lY) at candleGeometry's wickX must be
+        // an exact integer-device rect — the invariant both backends rely on.
+        const dpr = 1.25;
+        const g = candleGeometry(415.37, 9, dpr);
+        const topDev = snapY(123.456, dpr) * dpr;
+        const leftDev = g.wickX * dpr;
+        expect(topDev).toBeCloseTo(Math.round(topDev), 9);
+        expect(leftDev).toBeCloseTo(Math.round(leftDev), 9);
+    });
+});

--- a/test/native-anim-settle.test.ts
+++ b/test/native-anim-settle.test.ts
@@ -111,9 +111,9 @@ describe('syncSize paints synchronously while the Animator owns the frame', () =
         (globalThis as { window?: unknown }).window = { devicePixelRatio: 1 };
         const { r, paints } = setup();
         let flushes = 0;
-        const canvas = () => ({ width: 0, height: 0 });
+        const canvas = () => ({ width: 0, height: 0, style: {} });
         r.wrapper = { clientWidth: 400, clientHeight: 300 };
-        r.plot = { style: {} };
+        r.plot = { style: {}, getBoundingClientRect: () => ({ left: 0, top: 0, width: 400, height: 300 }) };
         r.backdropCanvas = canvas();
         r.dataCanvas = canvas();
         r.volumeCanvas = canvas();

--- a/test/native-canvas-device-grid.test.ts
+++ b/test/native-canvas-device-grid.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+
+/**
+ * Device-pixel alignment of the canvas pile — regression guard for the "feathered
+ * candles" bug on fractional-dpr displays (Windows 125%/150%).
+ *
+ * `clientWidth`/`clientHeight` are integer-rounded, so a backing store sized from them
+ * (`round(client × dpr)`) can cover a DIFFERENT number of device pixels than the
+ * fractional box the canvas is displayed in — the compositor then resamples the whole
+ * bitmap, and every device-snapped edge (candle bodies, wicks, gridlines) smears by
+ * ~1px. `syncSize` must therefore size the backing store from the plot's REAL box
+ * (preferring the resize observer's device-pixel-content-box report when it has one)
+ * and pin each canvas's CSS size to `backing / dpr`, so bitmap px == device px.
+ *
+ * The box's fractional device OFFSET is deliberately NOT compensated: the compositor
+ * pixel-snaps a layer's layout position by itself, while an explicit sub-pixel
+ * translate joins the composite matrix and resamples the texture — blending every
+ * horizontal edge 50/50 (measured in a real browser). syncSize must never write a
+ * transform.
+ *
+ * The scenario below is the measured real-world case: dpr 1.25, plot box
+ * 1441.6 × 661.6 CSS px at (44, 38.8). Same node-env stubbing technique as
+ * native-anim-settle.test.ts.
+ */
+
+type AnyRenderer = Record<string, any>;
+
+const RECT = { left: 44, top: 38.8, width: 1441.6, height: 661.6 };
+
+function setup(): { r: AnyRenderer } {
+    (globalThis as { window?: unknown }).window = { devicePixelRatio: 1.25 };
+    const renderer = new NativeRenderer();
+    const r = renderer as unknown as AnyRenderer;
+    const canvas = () => ({ width: 0, height: 0, style: {} });
+    r.wrapper = { clientWidth: 1486, clientHeight: 662 };
+    r.plot = { style: {}, getBoundingClientRect: () => RECT };
+    r.backdropCanvas = canvas();
+    r.dataCanvas = canvas();
+    r.volumeCanvas = canvas();
+    r.vpvrCanvas = canvas();
+    r.chromeCanvas = canvas();
+    r.drawingsCanvas = canvas();
+    r.cursorCanvas = canvas();
+    r.extLayers = [{ def: { id: 'x', placement: 'above-data' }, instance: {}, canvas: canvas() }];
+    r.layoutPanes = () => {};
+    r.didInitialFit = true;
+    r.scheduler = { flushNow: () => {} };
+    r.animator = { active: false };
+    return { r };
+}
+
+describe('syncSize pins the canvas pile to the device-pixel grid', () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    afterEach(() => { (globalThis as { window?: unknown }).window = originalWindow; });
+
+    it('sizes the backing store from the real (fractional) plot box, not client sizes', () => {
+        const { r } = setup();
+        r.syncSize();
+        // 1441.6 × 1.25 = 1802 exactly — clientWidth would have rounded to 1442 → 1803.
+        expect(r.dataCanvas.width).toBe(1802);
+        expect(r.dataCanvas.height).toBe(827);
+    });
+
+    it('pins each canvas CSS size to backing / dpr so bitmap px == device px', () => {
+        const { r } = setup();
+        r.syncSize();
+        expect(r.dataCanvas.style.width).toBe('1441.6px');
+        expect(r.dataCanvas.style.height).toBe('661.6px');
+    });
+
+    it('never writes a transform — offset snapping belongs to the compositor', () => {
+        const { r } = setup();
+        r.syncSize();
+        // An explicit sub-pixel translate would join the composite matrix and resample
+        // the texture (50/50-blended horizontal edges); the layout offset is left alone.
+        expect(r.dataCanvas.style.transform).toBeUndefined();
+    });
+
+    it('applies the same geometry to every canvas in the pile', () => {
+        const { r } = setup();
+        r.syncSize();
+        for (const c of [r.backdropCanvas, r.volumeCanvas, r.vpvrCanvas, r.chromeCanvas, r.drawingsCanvas, r.cursorCanvas, r.extLayers[0].canvas]) {
+            expect(c.width).toBe(1802);
+            expect(c.height).toBe(827);
+            expect(c.style.width).toBe('1441.6px');
+        }
+    });
+
+    it('feeds the coordinate system the exact CSS size of the aligned canvases', () => {
+        const { r } = setup();
+        r.syncSize();
+        expect(r.coords.width + r.rightAxisW).toBeCloseTo(1441.6, 9);
+        expect(r.coords.dpr).toBe(1.25);
+    });
+
+    it('prefers the observer-reported device-pixel box over the rounded rect', () => {
+        const { r } = setup();
+        // The browser's own snapping may land one device px off plain rounding
+        // (rect × dpr = 1802) — its report is the truth and must win.
+        r.plotDeviceSize = { width: 1801, height: 827 };
+        r.syncSize();
+        expect(r.dataCanvas.width).toBe(1801);
+        expect(r.dataCanvas.style.width).toBe('1440.8px');
+    });
+
+    it('rejects a stale device-pixel report that no longer describes the box', () => {
+        const { r } = setup();
+        // As after the toolbar gutter moved the plot: the stashed report is for the OLD
+        // box (off by far more than snapping can explain) — fall back to the rect.
+        r.plotDeviceSize = { width: 1700, height: 827 };
+        r.syncSize();
+        expect(r.dataCanvas.width).toBe(1802);
+        expect(r.dataCanvas.style.width).toBe('1441.6px');
+    });
+});


### PR DESCRIPTION
## Summary

- **Backing stores sized from the plot box's real device-pixel size.** `syncSize` previously used integer `clientWidth`/`clientHeight` × dpr, which on fractional display scales (Windows 125%/150%) produced a bitmap covering a different number of device pixels than the box it was displayed in — the compositor rescaled the whole canvas pile and every edge feathered by ~1px. The pile is now sized from `getBoundingClientRect()`, preferring the browser's own `device-pixel-content-box` report from the resize observer when available (with a staleness guard), and each canvas gets an explicit CSS size of `backing / dpr` so bitmap pixels map 1:1 to device pixels.
- **Candle tops/bottoms snap to whole device pixels.** Body top/bottom and wick ends now snap to the device grid (shared `snapY` in `candle-lod.ts`, both backends), the vertical counterpart of the existing `candleGeometry` X snapping — no more blended anti-aliasing row above/below candle bodies. A doji keeps a crisp one-device-pixel body.
- **The box's fractional device offset is deliberately NOT compensated.** The compositor pixel-snaps layer positions itself; an explicit sub-pixel translate joins the composite matrix and resamples the texture (measured: it blends every horizontal edge 50/50). A test pins that `syncSize` never writes a transform.

## Verification

- Four-way gate green: typecheck · lint · test (includes three new suites: device-grid sizing, observer prefer/reject, `snapY` lattice) · build.
- Browser-verified at dpr 1.25: device-resolution scanlines show pure single-step transitions on all candle edges (sides, tops, bottoms); wick renders as exactly 2 pure-color device pixels. Self-healing verified by forcing a fractional host width — backing re-snapped to the browser-reported device size.
- Oracle suites: vela 22/22, vela-pro 11/11.

## Test plan

- [ ] `npm run test` (1364 passing, incl. `native-canvas-device-grid`, `candle-snap-y`)
- [ ] On a 125%/150% Windows display: zoom into candles, screenshot, magnify — edges should be hard single-pixel steps with no translucent rim
- [ ] Resize the window / change browser zoom / move between monitors with different scaling — chart re-sharpens without reload

Made with [Cursor](https://cursor.com)