### PR TITLE
fix: let the Cursor button exit measure and eraser modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **The Cursor button leaves the ruler and eraser.** Clicking Cursor on the drawing
+  toolbar now returns to the regular pointer even while the measure ruler or the
+  eraser is active; before, those modes stayed on and the click appeared to do
+  nothing.
+
 ## [v0.6.9]
 
 ### Added

--- a/src/renderers/native/drawings/DrawingToolbar.ts
+++ b/src/renderers/native/drawings/DrawingToolbar.ts
@@ -204,7 +204,7 @@ export class DrawingToolbar {
         this.root.replaceChildren();
         this.groupCells.clear();
         this.groupIcons.clear();
-        this.cursorBtn = this.makeButton(CURSOR_ICON, 'Cursor', () => this.onArm(null));
+        this.cursorBtn = this.makeButton(CURSOR_ICON, 'Cursor', () => this.onCursorClick());
         this.root.appendChild(this.cursorBtn);
         if (this.def.groups.length > 0) this.root.appendChild(this.divider());
         for (const g of this.def.groups) {
@@ -318,6 +318,15 @@ export class DrawingToolbar {
         this.magnetCell = cell;
         this.magnetIcon = icon;
         return cell;
+    }
+
+    /** Cursor returns to select/idle: an active measure/eraser mode exits through its own
+     *  toggle callback (disarming a tool via `onArm(null)` alone can't — the host treats a
+     *  null arm as a no-op side effect of entering those modes), then the tool disarms. */
+    private onCursorClick(): void {
+        if (this.measureActive) this.onMeasure();
+        if (this.eraserActive) this.onEraser();
+        this.onArm(null);
     }
 
     /** Clicking the icon arms the group's last-used tool (it does NOT open the flyout). */


### PR DESCRIPTION
## Summary
- Clicking **Cursor** on the drawing toolbar while the measure ruler or the eraser was active did nothing: the button only cleared the armed drawing tool, and while a mode is on there is no armed tool to clear, so the mode stayed stuck.
- The Cursor click now also exits an active measure/eraser mode through the toolbar's own toggle callbacks before disarming, so both hosts of the bar — the in-chart docked toolbar and the workspace's shared bar — return to select/idle in one click. (The exit could not live in the arm-null path itself: entering measure/eraser emits an arm-null as a side effect, which would have made the modes self-cancel.)
- Changelog entry added under `[Unreleased]` (the bug ships in v0.6.9).

## Verification
- Reproduced pre-fix in the playground (both the docked in-chart bar and the workspace shared bar): with the ruler or eraser armed, clicking Cursor left the mode on.
- Post-fix, browser-verified on both bars: Cursor exits measure and eraser (button highlight AND `chart.drawings.getMode()` return to idle/null), measure↔eraser mutual exclusion still works, and arming/disarming drawing tools is unchanged.
- Gate: typecheck, lint, test (1353 passed), build — all green. Oracle suites: vela 22/22, vela-pro 11/11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized toolbar click-handler change with documented rationale; drawing UX only, no auth or data paths.
> 
> **Overview**
> **Cursor on the drawing toolbar now returns to the normal pointer when measure or eraser is active.** Previously the button only called `onArm(null)`, which clears an armed drawing tool; with ruler or eraser on there is no armed tool, so the click looked like a no-op and those modes stayed highlighted.
> 
> The handler is **`onCursorClick`**: it toggles off measure and eraser through the same callbacks as their toolbar buttons (needed because exiting those modes cannot live only in the arm-null path—entering them already emits arm-null as a side effect), then disarms any drawing tool. Cursor active state in `highlight()` already treats idle as no armed tool and neither measure nor eraser active.
> 
> Changelog documents the fix under **`[Unreleased]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a68faf30ae5ad12b41a6f4881abfe8a202f2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->