### PR TITLE
fix: hide legend callouts while the row is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Changed
+
+- **Legend callouts hide while the row is open.** Hovering or selecting an
+  indicator legend now hides its callout bubble instead of sliding it to the
+  end of the row, so the action buttons stay next to the title.
+
 ## [v0.6.9]
 
 ### Added

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -513,12 +513,12 @@ registerLegendAction({
 
 ## Legend callouts — `registerLegendCallout`
 
-A small tinted **callout bubble** with a centered icon, always visible right of an
-indicator's legend title (it trails the whole row while the hover controls are out).
-Hover shows its tooltip; when the spec carries `content`, clicking deploys a panel of
-text blocks and action buttons — below the bubble, flipping above it near the bottom
-screen edge. The classic use: a live status a user can act on (a market-session badge,
-a "new version available" notice with an Update button).
+A small tinted **callout bubble** with a centered icon, visible right of an
+indicator's legend title while the row is idle (it hides while the hover/selection
+controls are out). Hover shows its tooltip; when the spec carries `content`, clicking
+deploys a panel of text blocks and action buttons — below the bubble, flipping above
+it near the bottom screen edge. The classic use: a live status a user can act on (a
+market-session badge, a "new version available" notice with an Update button).
 
 ```ts
 import { registerLegendCallout } from 'vela/plugin';

--- a/src/core/ports/IChartRenderer.ts
+++ b/src/core/ports/IChartRenderer.ts
@@ -85,12 +85,12 @@ export interface LegendCalloutPanel {
 
 /**
  * One host-contributed legend CALLOUT, as the renderer consumes it: a small tinted
- * bubble with a centered icon, always visible beside the indicator's legend title
- * (trailing the whole row while its controls are out). When `content` is present the
- * bubble is clickable and deploys that panel — below the bubble, flipping above when
- * the bottom screen edge is too close. Pure data plus thunks, same rule as
- * {@link LegendActionView}: the shell resolves the plugin descriptor before it
- * reaches the renderer.
+ * bubble with a centered icon, visible beside the indicator's legend title while
+ * the row is idle (hidden while its hover/selection controls are out). When
+ * `content` is present the bubble is clickable and deploys that panel — below the
+ * bubble, flipping above when the bottom screen edge is too close. Pure data plus
+ * thunks, same rule as {@link LegendActionView}: the shell resolves the plugin
+ * descriptor before it reaches the renderer.
  */
 export interface LegendCalloutView {
     id: string;

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -81,8 +81,8 @@ interface LegendRow {
     controlsEl: HTMLElement;
     /** Host-contributed action buttons (inside `controlsEl`, before ✕) — rebuilt on demand. */
     extrasEl: HTMLElement;
-    /** Host-contributed callout bubbles: right of the title when idle, trailing the whole
-     *  row while the controls are out (see syncRowActions) — rebuilt on demand. */
+    /** Host-contributed callout bubbles: right of the title when idle, hidden while the
+     *  row is open (hovered/selected — see syncRowActions) — rebuilt on demand. */
     calloutsEl: HTMLElement;
     /** The live bubble instances in {@link calloutsEl} (kept so their panels die with the row). */
     callouts: CalloutBubble[];
@@ -120,6 +120,15 @@ const CLOSE_SVG = iconAt('close', LEGEND_ICON_PX);
 const FOLD_SVG = iconAt('chevron-up', LEGEND_ICON_PX);
 const UNFOLD_SVG = iconAt('chevron-down', LEGEND_ICON_PX);
 const OVERVIEW_SVG = iconAt('objects', LEGEND_ICON_PX);
+
+/**
+ * Display of a legend row's callout-bubble cluster: beside the title while idle,
+ * hidden while the row is open (hovered/selected) so the action buttons stay
+ * glued to the title.
+ */
+export function legendCalloutsDisplay(open: boolean, hasCallouts: boolean): 'inline-flex' | 'none' {
+    return !open && hasCallouts ? 'inline-flex' : 'none';
+}
 
 /**
  * Per-indicator legend chrome (title + gear + remove) as a DOM overlay on the
@@ -361,7 +370,7 @@ export class InputsUI {
         row.callouts = [];
         row.calloutsEl.replaceChildren();
         const views = this.legendCallouts?.(row.id) ?? [];
-        row.calloutsEl.style.display = views.length > 0 ? 'inline-flex' : 'none';
+        row.calloutsEl.style.display = legendCalloutsDisplay(row.highlighted, views.length > 0);
         for (const view of views) {
             const bubble = new CalloutBubble({
                 icon: view.icon,
@@ -772,7 +781,7 @@ export class InputsUI {
         }
         el.appendChild(titleWrap);
         // Contributed callout bubbles (registerLegendCallout) — a title companion while
-        // the row is idle; syncRowActions trails them after the controls when it opens.
+        // the row is idle; syncRowActions hides them while the controls are out.
         const calloutsEl = document.createElement('span');
         calloutsEl.style.cssText = `display:none;align-items:center;gap:4px;flex:none;margin-left:${LEGEND_TITLE_STATUS_GAP_PX}px;`;
         el.appendChild(calloutsEl);
@@ -966,15 +975,15 @@ export class InputsUI {
         row.controlsEl.style.display = open || row.hidden ? 'inline-flex' : 'none';
         // The status indicator steps aside while the controls are out — moved after the
         // action cluster (its title-side margin rides along) — and returns to the title's
-        // side when the row closes. The callout bubbles ride the same shuffle, trailing
-        // the whole open row ("right of the legend"), back beside the title on close.
+        // side when the row closes. Callout bubbles hide for the same window so they
+        // don't shove the buttons aside or jump to the end of the row.
         if (open) {
             row.el.appendChild(row.statusEl);
-            row.el.appendChild(row.calloutsEl);
+            for (const bubble of row.callouts) bubble.hidePanel();
         } else {
             row.el.insertBefore(row.statusEl, row.valuesEl);
-            row.el.insertBefore(row.calloutsEl, row.statusEl);
         }
+        row.calloutsEl.style.display = legendCalloutsDisplay(open, row.callouts.length > 0);
         for (const child of Array.from(row.controlsEl.children)) {
             if (!(child instanceof HTMLElement) || child === row.eyeEl) continue;
             if (child === row.extrasEl) {

--- a/src/ui/components/callout-bubble/view.ts
+++ b/src/ui/components/callout-bubble/view.ts
@@ -79,6 +79,11 @@ export class CalloutBubble {
         return this.pop?.open ?? false;
     }
 
+    /** Close the deployed panel, if any. The bubble itself stays. */
+    hidePanel(): void {
+        this.pop?.hide();
+    }
+
     destroy(): void {
         this.pop?.destroy();
         this.pop = null;

--- a/src/widget/contributions.ts
+++ b/src/widget/contributions.ts
@@ -359,10 +359,10 @@ export interface LegendCalloutSpec {
 }
 
 /**
- * A contributed LEGEND CALLOUT: a small tinted bubble with a centered icon, always
- * visible right of the indicator's legend title (trailing the whole row while its
- * hover controls are out). When the spec carries `content`, clicking the bubble
- * deploys that panel — below it, flipping above near the bottom screen edge.
+ * A contributed LEGEND CALLOUT: a small tinted bubble with a centered icon, visible
+ * right of the indicator's legend title while the row is idle (hidden while its
+ * hover/selection controls are out). When the spec carries `content`, clicking the
+ * bubble deploys that panel — below it, flipping above near the bottom screen edge.
  *
  * Unlike a legend action's static icon, a callout's whole presentation is resolved
  * per row through `callout` — return `null` to show none (the per-indicator gate),

--- a/test/legend-callouts.test.ts
+++ b/test/legend-callouts.test.ts
@@ -1,5 +1,6 @@
-// Legend callout contributions (src/widget/contributions.ts) and the callout-bubble
-// controller's pure projection rules (src/ui/components/callout-bubble/controller.ts).
+// Legend callout contributions (src/widget/contributions.ts), the callout-bubble
+// controller's pure projection rules (src/ui/components/callout-bubble/controller.ts),
+// and the legend-row display rule (src/renderers/shared/InputsUI.ts).
 // DOM-free — node env; the bubble's rendering and the deployed panel are proven in the
 // browser (the view is a thin projection over these).
 import { describe, it, expect } from 'vitest';
@@ -12,6 +13,7 @@ import {
     type LegendIndicatorInfo,
 } from '../src/widget/contributions';
 import { calloutPanelRows, closesPanel, type CalloutPanelItem } from '../src/ui/components/callout-bubble';
+import { legendCalloutsDisplay } from '../src/renderers/shared/InputsUI';
 
 describe('legend callout contributions', () => {
     it('registers, order-sorts, replaces by id, and unregisters', () => {
@@ -93,6 +95,15 @@ describe('legend callout contributions', () => {
         expect(views).toHaveLength(1);
         expect(views[0]!.content).toBeUndefined();
         unregisterLegendCallout('plain');
+    });
+});
+
+describe('legend callout row display', () => {
+    it('shows beside the title while idle and hides while the row is open', () => {
+        expect(legendCalloutsDisplay(false, true)).toBe('inline-flex');
+        expect(legendCalloutsDisplay(true, true)).toBe('none');
+        expect(legendCalloutsDisplay(false, false)).toBe('none');
+        expect(legendCalloutsDisplay(true, false)).toBe('none');
     });
 });
 


### PR DESCRIPTION
## Summary
- Hovering or selecting an indicator legend now **hides** its callout bubble instead of sliding it to the end of the row, so the eye/gear/remove controls stay next to the title.
- An open callout panel is dismissed when the row opens, so it does not float after the trigger is hidden.

## Test plan
- [x] `npm run typecheck`, `lint`, `test`, `build`
- [x] Playground: register a `registerLegendCallout`, hover an indicator title — bubble `display: none`, not the row's last child; leaving the row restores it beside the title
- [ ] Hover a legend row that has a callout and confirm the bubble disappears (does not jump right)
- [ ] Leave the row and confirm the bubble returns next to the title
- [ ] Click a clickable callout, then hover the title — the deployed panel closes with the bubble

Made with [Cursor](https://cursor.com)