### PR TITLE
Multi-chart view controls: drag/reorder, maximize, zoom, reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@ All notable changes to Vela, newest first.
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- **Crisp rendering on fractional display scales.** On displays with a fractional
-  zoom factor (a common Windows setting at 125% or 150%), candles, wicks,
-  gridlines, and every other chart graphic could look slightly blurred: the
-  chart's drawing surface was misaligned with the screen's physical pixels by a
-  fraction of a pixel, which smeared every edge. The surface now snaps to the
-  physical pixel grid, so edges render sharp at any display scale.
-- **Pixel-perfect candle edges.** Candle bodies and wicks now pin their tops and
-  bottoms to whole physical pixels, the same way their sides already snap. A
-  magnified screenshot shows hard one-pixel edges all around a candle instead of
-  a faint blended rim above and below the body.
+- **Per-chart view controls in the multi-chart workspace.** Rest the cursor near
+  the bottom center of any chart and a small cluster of buttons appears — the
+  same reveal as the jump-to-latest button: zoom out, zoom in, maximize, and
+  reset. Maximize expands that one chart over the whole grid; the other charts
+  keep everything and return instantly with the restore button (switching
+  layouts restores too). Reset re-enables automatic price scaling and frames
+  the full history, like the context menu's "Reset view". Hosts can drive the
+  same expansion from code with `maximizeCell(id)` (and `null` to restore),
+  read it back via `maximizedCell`, and listen for the `cell:maximized` event.
+
 ### Changed
 
 - **Restacking an indicator now moves everything it paints.** Reordering an
@@ -29,6 +29,25 @@ All notable changes to Vela, newest first.
   canvas now, so they obey the same order and appear in chart screenshots; cell
   tooltips keep working. Pine `bgcolor()` stays behind everything and
   `barcolor()` stays with the candles, as before.
+
+### Fixed
+
+- **The attribution mark stays clear of collapsed panes in a workspace.** In the
+  multi-chart workspace (and the single-chart shell built on it), collapsing an
+  indicator pane at the bottom of the bottom-left chart left the shared
+  attribution mark sitting on top of the collapsed strip's legend row. The mark
+  now climbs above collapsed strips — the same behavior a standalone chart's own
+  mark always had — and follows the maximized chart while one covers the grid.
+- **Crisp rendering on fractional display scales.** On displays with a fractional
+  zoom factor (a common Windows setting at 125% or 150%), candles, wicks,
+  gridlines, and every other chart graphic could look slightly blurred: the
+  chart's drawing surface was misaligned with the screen's physical pixels by a
+  fraction of a pixel, which smeared every edge. The surface now snaps to the
+  physical pixel grid, so edges render sharp at any display scale.
+- **Pixel-perfect candle edges.** Candle bodies and wicks now pin their tops and
+  bottoms to whole physical pixels, the same way their sides already snap. A
+  magnified screenshot shows hard one-pixel edges all around a candle instead of
+  a faint blended rim above and below the body.
 
 ## [v0.6.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,28 @@ All notable changes to Vela, newest first.
 
 - **Per-chart view controls in the multi-chart workspace.** Rest the cursor near
   the bottom center of any chart and a small cluster of buttons appears — the
-  same reveal as the jump-to-latest button: zoom out, zoom in, maximize, and
-  reset. Maximize expands that one chart over the whole grid; the other charts
-  keep everything and return instantly with the restore button (switching
-  layouts restores too). Reset re-enables automatic price scaling and frames
-  the full history, like the context menu's "Reset view". Hosts can drive the
-  same expansion from code with `maximizeCell(id)` (and `null` to restore),
-  read it back via `maximizedCell`, and listen for the `cell:maximized` event.
+  same reveal as the jump-to-latest button: a drag handle, zoom out, zoom in,
+  maximize, and reset. The drag handle moves the chart within the grid — hold
+  it, sweep onto another chart (a dashed ring previews the target), and release
+  to trade places. Maximize expands that one chart over the whole grid; the
+  other charts keep everything and return instantly with the restore button
+  (switching layouts restores too). Reset re-enables automatic price scaling
+  and frames the full history, like the context menu's "Reset view". On mobile
+  the hover cluster stays out of the way (as do the per-pane hover buttons) —
+  the bottom bar gains a maximize stop instead, which isolates the current
+  chart and lights up as an inverse chip whenever that chart covers the grid
+  or one of its panes is maximized (a double-tap does that); pressing it while
+  lit restores the view. Hosts can drive the same moves from code with
+  `maximizeCell(id)` (and `null` to restore), `maximizedCell`,
+  `swapCells(a, b)`, and the `cell:maximized` event.
 
 ### Changed
 
+- **A maximized pane now shows its state.** While a pane is maximized, its
+  restore button at the top-right reads as a lit chip (white on the dark theme,
+  dark on the light one) and stays visible without hovering — the same
+  affordance a collapsed pane's expand chip already had — so an isolated pane
+  is recognizable at a glance.
 - **Restacking an indicator now moves everything it paints.** Reordering an
   indicator from the object tree (or `seriesOrder`) repositions the whole
   indicator as one unit — plots, fills, lines, boxes, labels, markers, polylines,

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -100,7 +100,9 @@ ws.setLayout('8');       // cells diff BY IDENTITY; identities past the new size
 // Shrinking never pools the ACTIVE chart: if its slot would leave the layout, it
 // moves into the last surviving slot instead (the other cells keep their order).
 ws.setTheme('light');    // re-skins the shared chrome + EVERY cell live (also reachable from any cell's chart settings → Canvas → Theme)
-ws.on('cell:active' | 'layout:changed' | 'cell:created' | 'cell:destroyed' | 'state:changed', cb);
+ws.maximizeCell('sol');  // one cell over the whole grid (null restores) — pure presentation,
+ws.maximizedCell;        //  the other cells keep everything; layout/state changes restore
+ws.on('cell:active' | 'layout:changed' | 'cell:maximized' | 'cell:created' | 'cell:destroyed' | 'state:changed', cb);
 ```
 
 **Rule of thumb:** hold the cell (or its identity), read `cell.chart` at the point of
@@ -122,6 +124,14 @@ handed to `ws.setLayout(...)`.
 
 Splitters between cells resize the grid tracks (double-click a divider for an even
 split).
+
+Each cell also carries its own **view controls**: rest the cursor near the bottom
+center of a chart (the same reveal as the jump-to-latest button) and a small cluster
+appears — zoom out, zoom in, maximize, and reset. Maximize is `maximizeCell` behind a
+button: that one chart takes the whole grid, restore (or a layout switch) brings the
+grid back, and nothing about the hidden charts is lost. Reset re-enables auto price
+scaling and frames the full history — the context menu's "Reset view". On single-cell
+grids the maximize button stays away; zoom and reset remain.
 
 ## Sync links
 

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -102,6 +102,7 @@ ws.setLayout('8');       // cells diff BY IDENTITY; identities past the new size
 ws.setTheme('light');    // re-skins the shared chrome + EVERY cell live (also reachable from any cell's chart settings → Canvas → Theme)
 ws.maximizeCell('sol');  // one cell over the whole grid (null restores) — pure presentation,
 ws.maximizedCell;        //  the other cells keep everything; layout/state changes restore
+ws.swapCells('btc', 'eth'); // the two cells trade SLOTS (arrangement only — cells untouched)
 ws.on('cell:active' | 'layout:changed' | 'cell:maximized' | 'cell:created' | 'cell:destroyed' | 'state:changed', cb);
 ```
 
@@ -127,11 +128,22 @@ split).
 
 Each cell also carries its own **view controls**: rest the cursor near the bottom
 center of a chart (the same reveal as the jump-to-latest button) and a small cluster
-appears — zoom out, zoom in, maximize, and reset. Maximize is `maximizeCell` behind a
-button: that one chart takes the whole grid, restore (or a layout switch) brings the
-grid back, and nothing about the hidden charts is lost. Reset re-enables auto price
-scaling and frames the full history — the context menu's "Reset view". On single-cell
-grids the maximize button stays away; zoom and reset remain.
+appears — a drag handle, zoom out, zoom in, maximize, and reset. The drag handle
+(the dotted grip at the left) moves the chart within the grid: hold it, sweep onto
+another chart — a dashed ring previews the target — and release to trade slots
+(`swapCells` behind a gesture; releasing anywhere else cancels). Maximize is
+`maximizeCell` behind a button: that one chart takes the whole grid, restore (or a
+layout switch) brings the grid back, and nothing about the hidden charts is lost.
+Reset re-enables auto price scaling and frames the full history — the context menu's
+"Reset view". On single-cell grids the drag handle and maximize stay away; zoom and
+reset remain.
+
+On **mobile** the hover clusters don't apply (no cursor to reveal them — the per-pane
+hover buttons stay away too, though a collapsed pane keeps its expand chip). The
+mobile bottom bar carries a **maximize stop** instead: one tap isolates the current
+chart over the grid, and the stop lights up as an inverse chip whenever something is
+isolated — the chart itself, or a pane inside it (a double-tap in the plot maximizes
+a pane). Tapping the lit stop restores the view.
 
 ## Sync links
 

--- a/src/core/icons.ts
+++ b/src/core/icons.ts
@@ -149,6 +149,8 @@ registerIcon('folder-plus', S('<path d="M1.6 4.4a1 1 0 0 1 1-1h2.7l1.3 1.7h6.8a1
 registerIcon('folder-minus', S('<path d="M1.6 4.4a1 1 0 0 1 1-1h2.7l1.3 1.7h6.8a1 1 0 0 1 1 1v6.5a1 1 0 0 1-1 1h-10.8a1 1 0 0 1-1-1z"/><path d="M6.2 9.4h3.6"/>'));
 registerIcon('collapse', S('<path d="M3 8h10"/>'));
 registerIcon('expand', S('<rect x="2.2" y="2.2" width="11.6" height="11.6" rx="1.4"/><path d="M8 5.4v5.2M5.4 8h5.2"/>'));
+registerIcon('plus', S('<path d="M8 2.8v10.4M2.8 8h10.4"/>'));
+registerIcon('minus', S('<path d="M2.8 8h10.4"/>'));
 registerIcon('maximize', S('<path d="M2.5 6V3a.5.5 0 0 1 .5-.5h3M10 2.5h3a.5.5 0 0 1 .5.5v3M13.5 10v3a.5.5 0 0 1-.5.5h-3M6 13.5H3a.5.5 0 0 1-.5-.5v-3"/>'));
 registerIcon('restore', S('<path d="M6.2 2.5v3.7H2.5M9.8 13.5V9.8h3.7M13.5 6.2H9.8V2.5M2.5 9.8h3.7v3.7"/>'));
 registerIcon('star', S('<path d="M8 2.2l1.75 3.55 3.9.55-2.8 2.75.65 3.9L8 11.1l-3.5 1.85.65-3.9-2.8-2.75 3.9-.55z"/>'));
@@ -156,7 +158,7 @@ registerIcon('star-filled', S('<path d="M8 2.2l1.75 3.55 3.9.55-2.8 2.75.65 3.9L
 registerIcon('grip', S('<circle cx="6" cy="3.5" r="1"/><circle cx="10" cy="3.5" r="1"/><circle cx="6" cy="8" r="1"/><circle cx="10" cy="8" r="1"/><circle cx="6" cy="12.5" r="1"/><circle cx="10" cy="12.5" r="1"/>', 'fill="currentColor" stroke="none"'));
 registerIcon('kebab', S('<circle cx="8" cy="3.2" r="1.2"/><circle cx="8" cy="8" r="1.2"/><circle cx="8" cy="12.8" r="1.2"/>', 'fill="currentColor" stroke="none"'));
 registerIcon('burger', S('<path d="M2.5 4.5h11M2.5 8h11M2.5 11.5h11"/>'));
-registerIcon('reset', S('<rect x="6" y="6" width="4" height="4" rx="0.8"/><path d="M2.2 8a5.8 5.8 0 1 0 1.9-4.3L2.2 5.3"/><path d="M2.2 2.2v3.1h3.1"/>'));
+registerIcon('reset', S('<path d="M2 8a6 6 0 1 0 6-6 6.5 6.5 0 0 0-4.5 1.83L2 5.33"/><path d="M2 2v3.33h3.33"/>'));
 
 // ── pane chrome (stack order, collapse, maximize) ──
 registerIcon('pane-collapse', S('<path d="M2.6 9.4h4v4M13.4 6.6h-4v-4"/><path d="m9.4 6.6 4.2-4.2M2.4 13.6l4.2-4.2"/>'));

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1681,6 +1681,7 @@ export class NativeRenderer implements IChartRenderer {
         this.attributionEl = null;
         this.mountContainer?.style.removeProperty('--vela-toolbar-gutter');
         this.mountContainer?.style.removeProperty('--vela-scale-gutter');
+        this.mountContainer?.style.removeProperty('--vela-bottom-gutter');
         this.mountContainer?.style.removeProperty('--vela-price-pane-top');
         this.mountContainer?.style.removeProperty('--vela-price-pane-bottom');
         this.mountContainer = null;
@@ -3592,6 +3593,11 @@ export class NativeRenderer implements IChartRenderer {
             : dataHeight;
         // Extra collapsed strips below that pane push the button up by exactly their height.
         this.scrollBtnBottomPx = SCROLL_BTN_BOTTOM + Math.max(0, dataHeight - paneBottom);
+        // Publish the same inset as `--vela-bottom-gutter` (time axis + collapsed strips
+        // below the lowest open pane) beside the left/right gutters, so host overlays
+        // anchored to the plot's bottom edge (the workspace's shared attribution mark)
+        // climb over collapsed strips exactly like the renderer's own bottom chrome.
+        this.mountContainer?.style.setProperty('--vela-bottom-gutter', `${TIME_AXIS_H + Math.max(0, dataHeight - paneBottom)}px`);
         // Clear the whole scale gutter (wider when merged own-scale columns are present), not just
         // the single master column — otherwise the button lands inside a multi-column scale.
         this.scrollBtnRightPx = this.rightAxisW + SCROLL_BTN_RIGHT_INSET;

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1488,6 +1488,8 @@ export class NativeRenderer implements IChartRenderer {
                 this.emitPaneAction({ type: 'maximize', paneId, maximized });
             },
         });
+        // Honor a layout mode pushed before mount — mobile keeps the hover clusters away.
+        this.paneControls.setSuspended(this.layoutMode === 'mobile');
 
         this.axisScaleButtons = new AxisScaleButtons(this.plot, theme, {
             panes: () => this.axisScaleViews(),
@@ -2101,6 +2103,9 @@ export class NativeRenderer implements IChartRenderer {
         this.userDrawings?.setLayoutMode(mode);
         this.settingsDialog?.setLayoutMode(mode);
         this.inputsUI?.setLayoutMode(mode);
+        // Hover clusters need a cursor — mobile suppresses them (collapsed panes keep
+        // their expand chips; the shell's own chrome covers pane/chart maximize).
+        this.paneControls?.setSuspended(mode === 'mobile');
         if (this.scrollButton) {
             // A finger needs a larger target than a cursor.
             const px = mode === 'mobile' ? SCROLL_BTN_SIZE_TOUCH : SCROLL_BTN_SIZE;

--- a/src/renderers/native/chrome/PaneControls.ts
+++ b/src/renderers/native/chrome/PaneControls.ts
@@ -67,6 +67,9 @@ export class PaneControls {
     private readonly root: HTMLDivElement;
     private readonly clusters = new Map<string, HTMLDivElement>();
     private hoverPaneId: string | null = null;
+    /** Mobile: hover clusters are meaningless without a cursor — suppressed; a
+     *  collapsed pane's standalone expand chip stays (the only way back up). */
+    private suspended = false;
 
     constructor(private readonly plot: HTMLElement, private theme: VelaTheme, private readonly deps: PaneControlsDeps) {
         ensureStyles();
@@ -83,6 +86,7 @@ export class PaneControls {
 
     /** Reveal the cluster for the pane under the cursor, resolved from the pointer's y in the plot. */
     private readonly onPlotMove = (e: PointerEvent): void => {
+        if (this.suspended) return;
         const rect = this.plot.getBoundingClientRect();
         const y = e.clientY - rect.top;
         let hit: string | null = null;
@@ -146,7 +150,12 @@ export class PaneControls {
         // a lone price pane can't be "expanded", so it gets no button (and thus no cluster).
         if (p.count > 1) {
             cluster.appendChild(
-                this.button(p.maximized ? ICONS.restore : ICONS.maximize, p.maximized ? 'Restore pane' : 'Maximize pane', false, () => this.deps.onToggleMaximize(p.id), { role: 'maximize' }),
+                this.button(p.maximized ? ICONS.restore : ICONS.maximize, p.maximized ? 'Restore pane' : 'Maximize pane', false, () => this.deps.onToggleMaximize(p.id), {
+                    role: 'maximize',
+                    // Same inverse-chip treatment as the collapsed pane's expand toggle: the
+                    // maximized state must read as an active state, not just a swapped glyph.
+                    selected: p.maximized,
+                }),
             );
         }
     }
@@ -190,8 +199,12 @@ export class PaneControls {
             const hovered = id === this.hoverPaneId;
             // An empty cluster (e.g. a lone price pane with no maximize) never shows.
             const hasButtons = cluster.children.length > 0;
-            // A collapsed pane keeps its cluster visible so the expand chip is always reachable.
-            const visible = hasButtons && (hovered || p.collapsed) && p.height > 8;
+            // STATE chips stay visible without hover: a collapsed pane's expand chip (always —
+            // it is the only way back up, mobile included) and a MAXIMIZED pane's restore chip
+            // (desktop only — mobile's own chrome reflects that state), so the isolation state
+            // reads at a glance instead of only under the cursor.
+            const stateChipRole = p.collapsed ? 'collapse' : !this.suspended && p.maximized ? 'maximize' : null;
+            const visible = hasButtons && (hovered || stateChipRole != null) && p.height > 8;
             cluster.style.right = `${rightPx}px`;
             // Center the cluster inside the ~26px collapsed strip (24 = cluster height incl. padding).
             cluster.style.top = p.collapsed
@@ -199,15 +212,15 @@ export class PaneControls {
                 : `${p.top + 4}px`;
             cluster.style.display = visible ? 'flex' : 'none';
             if (!visible) continue;
-            // Without hover only the expand chip shows, standalone: drop the dark pill so the white
+            // Without hover only the state chip shows, standalone: drop the dark pill so the white
             // chip reads on its own. Its siblings stay laid out (visibility:hidden, not display:none)
-            // so the expand chip keeps the exact slot it occupies once the full cluster reveals on hover.
-            const soloExpand = p.collapsed && !hovered;
-            cluster.style.background = soloExpand ? 'transparent' : CLUSTER_PILL;
+            // so the chip keeps the exact slot it occupies once the full cluster reveals on hover.
+            const soloChip = stateChipRole != null && !hovered;
+            cluster.style.background = soloChip ? 'transparent' : CLUSTER_PILL;
             for (const child of cluster.children) {
                 const btn = child as HTMLElement;
                 btn.style.display = 'inline-flex';
-                btn.style.visibility = soloExpand && btn.dataset.role !== 'collapse' ? 'hidden' : 'visible';
+                btn.style.visibility = soloChip && btn.dataset.role !== stateChipRole ? 'hidden' : 'visible';
             }
         }
     }
@@ -216,6 +229,15 @@ export class PaneControls {
     setHoverPane(paneId: string | null): void {
         if (this.hoverPaneId === paneId) return;
         this.hoverPaneId = paneId;
+        this.reposition();
+    }
+
+    /** Mobile suppression: no hover clusters (touch has no cursor; the shell's own
+     *  chrome covers maximize), while collapsed panes keep their expand chips. */
+    setSuspended(on: boolean): void {
+        if (on === this.suspended) return;
+        this.suspended = on;
+        if (on) this.hoverPaneId = null;
         this.reposition();
     }
 

--- a/src/renderers/native/chrome/PaneControls.ts
+++ b/src/renderers/native/chrome/PaneControls.ts
@@ -39,7 +39,7 @@ const ICON_PX = 12;
 
 /** The cluster's scrim pill. It floats over CHART CONTENT (candles of any color), not over a
  *  panel, so it stays a neutral darkening rather than a themed surface. */
-const CLUSTER_PILL = 'rgba(0,0,0,0.28)';
+const CLUSTER_PILL = 'rgba(0,0,0,0.65)';
 
 /** Hover/active states as CSS, so they can never lag behind a pointer or drift from the
  *  tokens (the buttons only carry their per-instance color/opacity inline). */

--- a/src/widget/cell-controls.ts
+++ b/src/widget/cell-controls.ts
@@ -1,7 +1,8 @@
 // Per-cell view controls — a hover cluster pinned to the bottom-center of a workspace
-// cell: zoom out / zoom in / maximize-or-restore / reset view. Revealed by cursor
-// proximity, the same affordance as the renderer's scroll-to-realtime button, and
-// styled like the pane clusters (a neutral scrim pill over chart content).
+// cell: a drag handle to move the chart within the grid, zoom out / zoom in,
+// maximize-or-restore, and reset view. Revealed by cursor proximity, the same
+// affordance as the renderer's scroll-to-realtime button, and styled like the pane
+// clusters (a neutral scrim pill over chart content).
 import { icon } from '../core/icons';
 import { injectStyles } from '../ui/styles';
 import { Glider, ZOOM_IN, ZOOM_OUT } from './glide';
@@ -28,6 +29,8 @@ const CSS = `
 .vela-cc-btn svg{display:block;}
 .vela-cc-btn:hover{background:var(--vela-active);color:var(--vela-fg-bright);}
 .vela-cc-on,.vela-cc-on:hover{background:var(--vela-selected-bg);color:var(--vela-selected-fg);}
+.vela-cc-grip{cursor:grab;touch-action:none;}
+.vela-cc-grip:active{cursor:grabbing;}
 `;
 
 /**
@@ -45,23 +48,38 @@ export interface CellControlsDeps {
     chart(): Vela | null;
     /** Reset the cell's view — the context menu's "Reset view" action. */
     reset(): void;
-    /** Whether maximize applies at all (multi-cell grids only — a lone chart has
-     *  nothing to trade space with, same rule as the pane cluster's maximize). */
-    canMaximize(): boolean;
+    /** Whether the grid holds more than one cell — gates maximize (a lone chart has
+     *  nothing to trade space with, same rule as the pane cluster's maximize) and
+     *  the drag handle (nowhere to move to). */
+    multiCell(): boolean;
     /** Is THIS cell the maximized one? */
     isMaximized(): boolean;
     toggleMaximize(): void;
+    /** Hit-test for the drag handle: the OTHER live cell under a viewport point
+     *  (null over this cell, the chrome, or outside the grid). */
+    dragTargetAt(x: number, y: number): string | null;
+    /** Live highlight of the would-be drop cell while a grip drag is underway
+     *  (null clears — also called on cancel). */
+    previewDrop(id: string | null): void;
+    /** Commit a grip drag: this cell and `targetId` trade slots. */
+    dropOn(targetId: string): void;
 }
 
 /**
  * Owns the cluster DOM inside one cell host. Zooming eases through its own
  * {@link Glider} on THIS cell's chart (the buttons act on the cell they live in,
- * whatever the active cell is); maximize/reset route to the deps.
+ * whatever the active cell is); maximize/reset/drag route to the deps.
  */
 export class CellControls {
     private readonly root: HTMLDivElement;
     private readonly glider: Glider;
     private near = false;
+    /** A grip drag is underway — the proximity reveal must not hide the cluster
+     *  while captured pointer moves sweep across the whole grid. */
+    private dragging = false;
+    /** Mobile: the proximity reveal is meaningless without a cursor — the mobile
+     *  bar's maximize stop replaces the cluster. */
+    private suspended = false;
 
     constructor(
         private readonly host: HTMLElement,
@@ -91,13 +109,17 @@ export class CellControls {
         this.refresh();
     }
 
-    /** Rebuild the buttons (the maximize gate or the maximized state changed). */
+    /** Rebuild the buttons (the multi-cell gate or the maximized state changed). */
     refresh(): void {
         this.root.textContent = '';
+        const multi = this.deps.multiCell();
+        const maximized = multi && this.deps.isMaximized();
+        // The drag handle only exists when there is somewhere to move to: never on a
+        // single-cell grid, and not while this chart covers the grid.
+        if (multi && !maximized) this.root.appendChild(this.makeGrip());
         this.root.appendChild(this.button('minus', 'Zoom out', () => this.glider.zoom(ZOOM_OUT)));
         this.root.appendChild(this.button('plus', 'Zoom in', () => this.glider.zoom(ZOOM_IN)));
-        if (this.deps.canMaximize()) {
-            const maximized = this.deps.isMaximized();
+        if (multi) {
             this.root.appendChild(
                 this.button(maximized ? 'restore' : 'maximize', maximized ? 'Restore layout' : 'Maximize chart', () => this.deps.toggleMaximize(), {
                     // The maximized state reads as an inverse chip (white-on-dark, dark-on-light),
@@ -128,12 +150,67 @@ export class CellControls {
         return b;
     }
 
+    /** The drag handle (2×3 dot grip): press and drag onto another cell to trade
+     *  slots with it. The preview highlight follows the pointer; releasing outside
+     *  any other cell cancels. */
+    private makeGrip(): HTMLButtonElement {
+        const b = this.host.ownerDocument.createElement('button');
+        b.type = 'button';
+        b.title = 'Drag to move chart';
+        b.setAttribute('aria-label', 'Drag to move chart');
+        b.className = 'vela-cc-btn vela-cc-grip';
+        b.innerHTML = icon('grip');
+        b.addEventListener('pointerdown', (e) => this.onGripDown(b, e));
+        return b;
+    }
+
+    private onGripDown(btn: HTMLButtonElement, e: PointerEvent): void {
+        if (e.button !== 0 && e.pointerType === 'mouse') return;
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+            btn.setPointerCapture(e.pointerId);
+        } catch {
+            // a synthetic/already-released pointer can't be captured — the move/up pair below still works
+        }
+        this.dragging = true;
+        let target: string | null = null;
+        const move = (ev: PointerEvent): void => {
+            target = this.deps.dragTargetAt(ev.clientX, ev.clientY);
+            this.deps.previewDrop(target);
+        };
+        const finish = (commit: boolean) => (): void => {
+            this.dragging = false;
+            this.deps.previewDrop(null);
+            btn.removeEventListener('pointermove', move);
+            btn.removeEventListener('pointerup', onUp);
+            btn.removeEventListener('pointercancel', onCancel);
+            if (commit && target != null) this.deps.dropOn(target);
+        };
+        const onUp = finish(true);
+        const onCancel = finish(false);
+        btn.addEventListener('pointermove', move);
+        btn.addEventListener('pointerup', onUp);
+        btn.addEventListener('pointercancel', onCancel);
+    }
+
+    /** Mobile flips the cluster off entirely (and hides it if currently revealed). */
+    setSuspended(on: boolean): void {
+        this.suspended = on;
+        if (on) this.setNear(false);
+    }
+
     private readonly onHostMove = (e: PointerEvent): void => {
+        if (this.suspended) return;
+        if (this.dragging) return; // captured drag moves sweep the grid — keep the cluster up
         const rect = this.host.getBoundingClientRect();
         this.setNear(nearBottomCenter(e.clientX - rect.left, e.clientY - rect.top, rect.width, rect.height));
     };
 
-    private readonly onHostLeave = (): void => this.setNear(false);
+    private readonly onHostLeave = (): void => {
+        if (this.dragging) return;
+        this.setNear(false);
+    };
 
     private setNear(near: boolean): void {
         if (near === this.near) return;

--- a/src/widget/cell-controls.ts
+++ b/src/widget/cell-controls.ts
@@ -1,0 +1,150 @@
+// Per-cell view controls — a hover cluster pinned to the bottom-center of a workspace
+// cell: zoom out / zoom in / maximize-or-restore / reset view. Revealed by cursor
+// proximity, the same affordance as the renderer's scroll-to-realtime button, and
+// styled like the pane clusters (a neutral scrim pill over chart content).
+import { icon } from '../core/icons';
+import { injectStyles } from '../ui/styles';
+import { Glider, ZOOM_IN, ZOOM_OUT } from './glide';
+import type { Vela } from '../Vela';
+
+/** Cursor distance (px, from the cluster center) that reveals the cluster —
+ *  mirrors the scroll-to-realtime button's proximity radius. */
+export const CELL_CONTROLS_PROXIMITY_PX = 120;
+
+/** px the renderer reserves for a time axis (mirrors NativeRenderer's TIME_AXIS_H). */
+const TIME_AXIS_H = 22;
+/** Cluster bottom inset — above the time axis, level with the scroll button. */
+const CONTROLS_BOTTOM_PX = TIME_AXIS_H + 12;
+/** Cluster height incl. padding (20px buttons + 2px padding each side). */
+const CLUSTER_H = 24;
+
+/** The cluster's scrim pill — floats over chart content, so a neutral darkening
+ *  rather than a themed surface (same value as the pane clusters). */
+const CLUSTER_PILL = 'rgba(0,0,0,0.65)';
+
+const STYLE_ID = 'vela-cell-controls';
+const CSS = `
+.vela-cc-btn{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;padding:0;border:none;border-radius:var(--vela-radius-sm);background:transparent;line-height:0;font-size:12px;color:var(--vela-fg-muted);cursor:pointer;}
+.vela-cc-btn svg{display:block;}
+.vela-cc-btn:hover{background:var(--vela-active);color:var(--vela-fg-bright);}
+.vela-cc-on,.vela-cc-on:hover{background:var(--vela-selected-bg);color:var(--vela-selected-fg);}
+`;
+
+/**
+ * Is the pointer near the cluster's resting spot (bottom-center of the cell)? PURE —
+ * `x`/`y` are cell-local coordinates, `width`/`height` the cell's size.
+ */
+export function nearBottomCenter(x: number, y: number, width: number, height: number, proximityPx = CELL_CONTROLS_PROXIMITY_PX): boolean {
+    const cx = width / 2;
+    const cy = height - CONTROLS_BOTTOM_PX - CLUSTER_H / 2;
+    return Math.hypot(x - cx, y - cy) <= proximityPx;
+}
+
+export interface CellControlsDeps {
+    /** The cell's LIVE chart (null once the cell is destroyed). */
+    chart(): Vela | null;
+    /** Reset the cell's view — the context menu's "Reset view" action. */
+    reset(): void;
+    /** Whether maximize applies at all (multi-cell grids only — a lone chart has
+     *  nothing to trade space with, same rule as the pane cluster's maximize). */
+    canMaximize(): boolean;
+    /** Is THIS cell the maximized one? */
+    isMaximized(): boolean;
+    toggleMaximize(): void;
+}
+
+/**
+ * Owns the cluster DOM inside one cell host. Zooming eases through its own
+ * {@link Glider} on THIS cell's chart (the buttons act on the cell they live in,
+ * whatever the active cell is); maximize/reset route to the deps.
+ */
+export class CellControls {
+    private readonly root: HTMLDivElement;
+    private readonly glider: Glider;
+    private near = false;
+
+    constructor(
+        private readonly host: HTMLElement,
+        private readonly deps: CellControlsDeps,
+    ) {
+        injectStyles(STYLE_ID, CSS, host.ownerDocument);
+        this.glider = new Glider(deps.chart);
+        this.root = host.ownerDocument.createElement('div');
+        Object.assign(this.root.style, {
+            position: 'absolute',
+            left: '50%',
+            bottom: `${CONTROLS_BOTTOM_PX}px`,
+            transform: 'translateX(-50%)',
+            zIndex: '6',
+            display: 'none', // revealed by cursor proximity (onHostMove)
+            gap: '2px',
+            padding: '2px',
+            borderRadius: 'var(--vela-radius-md)',
+            background: CLUSTER_PILL,
+            pointerEvents: 'auto',
+        });
+        // Hover on the HOST (not a canvas child) so moving the cursor onto the cluster —
+        // a host child above the canvases — keeps it revealed instead of hiding it.
+        this.host.addEventListener('pointermove', this.onHostMove);
+        this.host.addEventListener('pointerleave', this.onHostLeave);
+        this.host.appendChild(this.root);
+        this.refresh();
+    }
+
+    /** Rebuild the buttons (the maximize gate or the maximized state changed). */
+    refresh(): void {
+        this.root.textContent = '';
+        this.root.appendChild(this.button('minus', 'Zoom out', () => this.glider.zoom(ZOOM_OUT)));
+        this.root.appendChild(this.button('plus', 'Zoom in', () => this.glider.zoom(ZOOM_IN)));
+        if (this.deps.canMaximize()) {
+            const maximized = this.deps.isMaximized();
+            this.root.appendChild(
+                this.button(maximized ? 'restore' : 'maximize', maximized ? 'Restore layout' : 'Maximize chart', () => this.deps.toggleMaximize(), {
+                    // The maximized state reads as an inverse chip (white-on-dark, dark-on-light),
+                    // the same active-state affordance as a collapsed pane's expand button.
+                    selected: maximized,
+                }),
+            );
+        }
+        this.root.appendChild(
+            this.button('reset', 'Reset chart', () => {
+                this.glider.stop(); // a running zoom glide must not fight the reset
+                this.deps.reset();
+            }),
+        );
+    }
+
+    private button(iconId: string, title: string, onClick: () => void, opts: { selected?: boolean } = {}): HTMLButtonElement {
+        const b = this.host.ownerDocument.createElement('button');
+        b.type = 'button';
+        b.title = title;
+        b.setAttribute('aria-label', title);
+        b.className = opts.selected === true ? 'vela-cc-btn vela-cc-on' : 'vela-cc-btn';
+        b.innerHTML = icon(iconId);
+        b.addEventListener('click', (e) => {
+            e.stopPropagation();
+            onClick();
+        });
+        return b;
+    }
+
+    private readonly onHostMove = (e: PointerEvent): void => {
+        const rect = this.host.getBoundingClientRect();
+        this.setNear(nearBottomCenter(e.clientX - rect.left, e.clientY - rect.top, rect.width, rect.height));
+    };
+
+    private readonly onHostLeave = (): void => this.setNear(false);
+
+    private setNear(near: boolean): void {
+        if (near === this.near) return;
+        this.near = near;
+        this.root.style.display = near ? 'flex' : 'none';
+    }
+
+    destroy(): void {
+        this.glider.stop();
+        this.host.removeEventListener('pointermove', this.onHostMove);
+        this.host.removeEventListener('pointerleave', this.onHostLeave);
+        this.root.remove();
+    }
+}

--- a/src/widget/mobile-bar.ts
+++ b/src/widget/mobile-bar.ts
@@ -43,6 +43,9 @@ const CSS = `
 }
 .vela-mb-item:active { background: var(--vela-hover); }
 .vela-mb-item .vela-icon { font-size: 18px; width: 18px; height: 18px; }
+/* A lit stop (the maximize toggle while something is isolated): the inverse
+   "selected" chip — white on the dark theme, dark on the light one. */
+.vela-mb-item.vela-mb-on, .vela-mb-item.vela-mb-on:active { background: var(--vela-selected-bg); color: var(--vela-selected-fg); }
 /* Left-aligned contributed actions get their own stops (the built-in indicators
    slot) — the wrapper is layout-transparent so each stop flexes like a sibling. */
 .vela-mb-actions { display: contents; }
@@ -70,6 +73,10 @@ export interface MobileBarOptions {
     onIndicatorsClick?: () => void;
     /** Omitted ⇒ no drawings stop (the shell disabled user drawings — `drawings: false`). */
     onDrawingsClick?: () => void;
+    /** Omitted ⇒ no maximize stop (single-chart shells — nothing to isolate). The
+     *  workspace passes a toggle that isolates the active chart over the grid;
+     *  {@link setMaximizeActive} lights the stop while something is isolated. */
+    onMaximizeClick?: () => void;
     onMoreClick: () => void;
     onSettingsClick: () => void;
     /** Live widget context — left-aligned contributed actions (`align: 'left'`)
@@ -81,6 +88,8 @@ export class MobileBar {
     readonly el: HTMLElement;
     private readonly symbolEl: HTMLElement;
     private readonly tfEl: HTMLElement;
+    /** The maximize toggle stop (null when the shell has nothing to isolate). */
+    private readonly maxEl: HTMLButtonElement | null;
     /** Left-aligned contributed actions — filled by {@link renderActions}. */
     private readonly actionsHost: HTMLElement;
     private readonly opts: MobileBarOptions;
@@ -111,10 +120,12 @@ export class MobileBar {
         this.actionsHost.className = 'vela-mb-actions';
         const onDrawings = opts.onDrawingsClick;
         const drawings = onDrawings ? item('vela-mb-drawings', 'Drawings', onDrawings, 'pen') : null;
+        const onMaximize = opts.onMaximizeClick;
+        this.maxEl = onMaximize ? item('vela-mb-maximize', 'Maximize chart', onMaximize, 'maximize') : null;
         const more = item('vela-mb-more', 'More', opts.onMoreClick, 'kebab');
         const settings = item('vela-mb-settings', 'Chart settings', opts.onSettingsClick, 'gear');
 
-        this.el.append(this.symbolEl, this.tfEl, ...(indicators ? [indicators] : []), this.actionsHost, ...(drawings ? [drawings] : []), more, settings);
+        this.el.append(this.symbolEl, this.tfEl, ...(indicators ? [indicators] : []), this.actionsHost, ...(drawings ? [drawings] : []), ...(this.maxEl ? [this.maxEl] : []), more, settings);
         host.appendChild(this.el);
         this.renderActions();
     }
@@ -150,6 +161,15 @@ export class MobileBar {
 
     setTimeframe(tf: string): void {
         this.tfEl.textContent = timeframeLabel(tf);
+    }
+
+    /** Light the maximize stop while something is isolated (a chart over the grid,
+     *  or a maximized pane inside the active chart) — inverse chip + restore glyph. */
+    setMaximizeActive(on: boolean): void {
+        if (!this.maxEl) return;
+        this.maxEl.classList.toggle('vela-mb-on', on);
+        this.maxEl.setAttribute('aria-label', on ? 'Restore layout' : 'Maximize chart');
+        this.maxEl.replaceChildren(iconEl(on ? 'restore' : 'maximize', this.el.ownerDocument));
     }
 
     destroy(): void {

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -20,6 +20,7 @@ import { MarketStatusTracker } from '../widget/market-status';
 import { SessionShadingTracker } from '../widget/session-shading';
 import { timeframeMs } from '../widget/timeframe';
 import { Watermark } from '../widget/watermark';
+import { CellControls } from '../widget/cell-controls';
 import { ChartContextMenu } from '../widget/context-menu';
 import { WidgetHistory } from '../widget/history';
 import type { RangePreset } from '../widget/bottombar';
@@ -144,6 +145,12 @@ export interface CellDeps {
     manifestSettled(): boolean;
     /** Report a pointer-down/focus in this cell (the workspace sets it active). */
     activate(id: string): void;
+    /** Whether the cell clusters offer maximize at all (multi-cell grids only). */
+    canMaximize(): boolean;
+    /** Is this cell the one the workspace currently maximizes over the grid? */
+    isMaximized(id: string): boolean;
+    /** Maximize this cell over the whole grid, or restore the grid when it already is. */
+    toggleMaximize(id: string): void;
     /** The cell's market changed in place (chrome/retention refresh upstream). */
     onMarketChanged(id: string): void;
     /** The cell's price style changed in place (topbar icon/menu refresh upstream). */
@@ -190,6 +197,8 @@ export class ChartCell {
     /** Keeps the pre/post-market shading on the symbol's real calendar (see {@link SessionShadingTracker}). */
     private readonly sessionShading = new SessionShadingTracker((zones) => this.inner?.renderer.set('sessionZones', zones));
     private readonly watermark: Watermark | null;
+    /** Bottom-center hover cluster: zoom in/out, maximize/restore, reset view. */
+    private readonly cellControls: CellControls;
     private readonly contextMenu: ChartContextMenu;
     private readonly offMarket: () => void;
     /** The cell's durable market state — the seed vocabulary plus the venue mirror the
@@ -371,11 +380,15 @@ export class ChartCell {
             if (this.inner && this.state.symbol) this.marketStatus?.track(this.inner.data, this.state.symbol);
         });
         this.syncStatuslineColors();
+        this.cellControls = new CellControls(this.host, {
+            chart: () => this.inner,
+            reset: () => this.resetView(),
+            canMaximize: () => deps.canMaximize(),
+            isMaximized: () => deps.isMaximized(id),
+            toggleMaximize: () => deps.toggleMaximize(id),
+        });
         this.contextMenu = new ChartContextMenu(this.host, {
-            resetView: () => {
-                this.inner?.renderer.set('autoScale', true);
-                this.inner?.setVisibleRangePreset('ALL');
-            },
+            resetView: () => this.resetView(),
             timezone: () => this.deps.timezone(),
             setTimezone: (zone) => this.deps.setTimezone(zone),
             // Right-clicking activates the cell first (capture-phase pointerdown), so the
@@ -802,6 +815,18 @@ export class ChartCell {
         }
     }
 
+    /** Reset this cell's view: re-enable auto scale and frame the full history —
+     *  the same action the chart context menu offers. */
+    resetView(): void {
+        this.inner?.renderer.set('autoScale', true);
+        this.inner?.setVisibleRangePreset('ALL');
+    }
+
+    /** Rebuild the view-controls cluster (the maximize gate or state changed). */
+    refreshControls(): void {
+        this.cellControls.refresh();
+    }
+
     /** Make this cell the active one and put keyboard focus on its chart surface. */
     focus(): void {
         this.deps.activate(this.id);
@@ -1151,6 +1176,7 @@ export class ChartCell {
     destroy(): void {
         this.destroyed = true;
         this.offMarket();
+        this.cellControls.destroy();
         this.contextMenu.destroy();
         this.history.destroy();
         this.marketStatus?.stop();

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -145,12 +145,19 @@ export interface CellDeps {
     manifestSettled(): boolean;
     /** Report a pointer-down/focus in this cell (the workspace sets it active). */
     activate(id: string): void;
-    /** Whether the cell clusters offer maximize at all (multi-cell grids only). */
-    canMaximize(): boolean;
+    /** Whether the grid holds more than one cell — gates the cluster's maximize
+     *  button and its drag handle (a lone chart has neither use). */
+    multiCell(): boolean;
     /** Is this cell the one the workspace currently maximizes over the grid? */
     isMaximized(id: string): boolean;
     /** Maximize this cell over the whole grid, or restore the grid when it already is. */
     toggleMaximize(id: string): void;
+    /** Drag-handle hit-test: the OTHER live cell under a viewport point (never `id`). */
+    cellDragTarget(id: string, x: number, y: number): string | null;
+    /** Live drop-target highlight while a grip drag is underway (null clears). */
+    previewDropTarget(id: string | null): void;
+    /** Commit a grip drag: the two cells trade slots in the grid. */
+    dropCell(id: string, targetId: string): void;
     /** The cell's market changed in place (chrome/retention refresh upstream). */
     onMarketChanged(id: string): void;
     /** The cell's price style changed in place (topbar icon/menu refresh upstream). */
@@ -197,7 +204,7 @@ export class ChartCell {
     /** Keeps the pre/post-market shading on the symbol's real calendar (see {@link SessionShadingTracker}). */
     private readonly sessionShading = new SessionShadingTracker((zones) => this.inner?.renderer.set('sessionZones', zones));
     private readonly watermark: Watermark | null;
-    /** Bottom-center hover cluster: zoom in/out, maximize/restore, reset view. */
+    /** Bottom-center hover cluster: drag handle, zoom in/out, maximize/restore, reset view. */
     private readonly cellControls: CellControls;
     private readonly contextMenu: ChartContextMenu;
     private readonly offMarket: () => void;
@@ -383,9 +390,12 @@ export class ChartCell {
         this.cellControls = new CellControls(this.host, {
             chart: () => this.inner,
             reset: () => this.resetView(),
-            canMaximize: () => deps.canMaximize(),
+            multiCell: () => deps.multiCell(),
             isMaximized: () => deps.isMaximized(id),
             toggleMaximize: () => deps.toggleMaximize(id),
+            dragTargetAt: (x, y) => deps.cellDragTarget(id, x, y),
+            previewDrop: (target) => deps.previewDropTarget(target),
+            dropOn: (target) => deps.dropCell(id, target),
         });
         this.contextMenu = new ChartContextMenu(this.host, {
             resetView: () => this.resetView(),
@@ -825,6 +835,11 @@ export class ChartCell {
     /** Rebuild the view-controls cluster (the maximize gate or state changed). */
     refreshControls(): void {
         this.cellControls.refresh();
+    }
+
+    /** Mobile flips the per-cell cluster off (the shell's mobile bar replaces it). */
+    setControlsSuspended(on: boolean): void {
+        this.cellControls.setSuspended(on);
     }
 
     /** Make this cell the active one and put keyboard focus on its chart surface. */

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -134,6 +134,8 @@ export interface WorkspaceEventMap extends Record<string, unknown> {
     'script:run': WorkspaceScriptRun;
     /** The grid switched layouts (cells created/destroyed/restored around it). */
     'layout:changed': { layout: string };
+    /** A cell was maximized over the whole grid, or the grid restored (`id: null`). */
+    'cell:maximized': { id: string | null };
     'cell:created': { id: string };
     'cell:destroyed': { id: string };
     /** The persistable state changed (debounced ~500ms) — re-pull `getState()` if you
@@ -175,6 +177,10 @@ const CSS = `
 /* Mobile: the docked drawing-toolbar column would eat a phone-width grid — the shell's
    drawings drawer + on-chart pill replace it (same policy as the widget's in-chart bar). */
 [data-layout='mobile'] .vela-ws-toolbar { display: none; }
+/* A maximized cell owns the whole grid: the splitter strips have no seams to grab and
+   the active ring would just outline the only visible chart — both are noise here. */
+.vela-ws-grid[data-maximized='1'] .vela-ws-splitter { display: none; }
+.vela-ws-grid[data-maximized='1'] .vela-cell[data-active='1']::after { display: none; }
 `;
 
 /** Grid glyph for the topbar layout dropdown (stroke follows the button color). */
@@ -224,6 +230,9 @@ export class VelaWorkspace {
      *  slots beyond the list get auto identities. Grows, never reorders. */
     private order: string[] = [];
     private activeId: string | null = null;
+    /** The cell maximized over the whole grid (null = normal grid). TRANSIENT view
+     *  state — never persisted; any structural change (layout, applyState) restores. */
+    private maximizedId: string | null = null;
     private cellBackend: NativeBackend = 'auto';
     /** `layout: false` — the grid is pinned to the one-cell layout, the layout picker
      *  and sync switches never render, and `setLayout` no-ops. */
@@ -513,7 +522,11 @@ export class VelaWorkspace {
         // follows the app-wide default a plugin may have set for the attribution corner
         // (`registerRendererDefaults({ attribution })`): the cells read it through their
         // renderer, and the grid reads it here, so one setting covers every surface
-        // instead of leaving this mark behind as the one a host cannot reach.
+        // instead of leaving this mark behind as the one a host cannot reach. It LIVES
+        // inside the bottom-left cell (mountAttributionMark): the offsets ride that
+        // cell's renderer-published gutters, so the mark climbs above collapsed pane
+        // strips exactly like a lone chart's own mark instead of sitting on a strip's
+        // legend row.
         const attribution = rendererDefaults().attribution;
         if (attribution !== false) {
             const background = resolveTheme(opts.theme).background;
@@ -521,8 +534,12 @@ export class VelaWorkspace {
                 typeof attribution === 'string' && attribution.trim()
                     ? createCustomMark(doc, attribution, background)
                     : createAttributionMark(doc, background);
-            Object.assign(mark.style, { left: '12px', bottom: `${TIME_AXIS_H + 10}px`, zIndex: '11' });
-            this.gridEl.appendChild(mark);
+            Object.assign(mark.style, {
+                left: 'calc(var(--vela-toolbar-gutter, 0px) + 12px)',
+                bottom: `calc(var(--vela-bottom-gutter, ${TIME_AXIS_H}px) + 10px)`,
+                zIndex: '11',
+            });
+            this.gridEl.appendChild(mark); // pre-cells fallback host; re-parented by mountAttributionMark
             this.attributionMark = mark; // kept so a live theme swap re-inks it
         }
 
@@ -875,7 +892,9 @@ export class VelaWorkspace {
             this.pool.clear();
             for (const { id, ...cs } of st.charts.slice(liveCount)) this.pool.set(id, cs);
             this.order = st.charts.map((c) => c.id);
+            this.maximizedId = null; // documents describe the full grid — restore before re-applying
             this.applyGrid(); // re-assert the restored track sizes on the unchanged grid
+            this.refreshCellControls();
             const nextActive = st.activeCellId && this.cellsById.has(st.activeCellId) ? st.activeCellId : (this.order[0] ?? null);
             if (nextActive === this.activeId) this.projectActiveCell();
             else this.setActiveCell(nextActive);
@@ -905,6 +924,7 @@ export class VelaWorkspace {
         const def = this.monoLayout ? null : ensureLayout(st.layout); // mono: grid stays pinned to '1'
         if (def) this.def = def;
         this.cellBackend = this.backendFor(this.def);
+        this.maximizedId = null; // ditto — the rebuilt grid starts unmaximized
         this.applyGrid();
         this.buildCells();
         this.syncCellPresentation();
@@ -977,6 +997,7 @@ export class VelaWorkspace {
     setLayout(layout: string | LayoutDefinition): void {
         if (this.destroyed) return;
         if (this.monoLayout) return; // single-chart mode — the grid is pinned to '1'
+        this.maximizedId = null; // a maximized cell is presentation — a layout switch restores first
         const next = this.resolveLayout(layout);
         const nextBackend = this.backendFor(next);
         const rebuildAll = nextBackend !== this.cellBackend;
@@ -1003,6 +1024,7 @@ export class VelaWorkspace {
         this.buildCells();
         this.alignNewCellStyles(preexisting);
         this.syncCellPresentation();
+        this.refreshCellControls(); // the maximize gate follows the cell count
         this.topbar.setLayout(next.id);
         const nextActive = activeAfterLayout(this.activeId, this.order.slice(0, next.cells.length));
         if (nextActive === this.activeId) this.projectActiveCell(); // same slot, maybe a rebuilt cell
@@ -1010,6 +1032,29 @@ export class VelaWorkspace {
         this.refreshRetention();
         this.events.emit('layout:changed', { layout: next.id });
         this.markStateDirty();
+    }
+
+    /** The identity of the cell maximized over the whole grid, or null. */
+    get maximizedCell(): string | null {
+        return this.maximizedId;
+    }
+
+    /**
+     * Maximize one cell over the whole grid, or restore the layout with `null`. Pure
+     * presentation: the other cells stay alive underneath — charts, subscriptions and
+     * state untouched — so restoring is instant. The maximized cell becomes the active
+     * one. Transient view state (also reachable from each cell's bottom-center view
+     * cluster): switching layouts or applying a state document restores the grid.
+     */
+    maximizeCell(id: string | null): void {
+        if (this.destroyed) return;
+        if (id != null && (!this.cellsById.has(id) || this.def.cells.length <= 1)) return;
+        if (id === this.maximizedId) return;
+        this.maximizedId = id;
+        if (id) this.setActiveCell(id);
+        this.applyGrid(); // re-derives the slot geometry, then overlays the maximize presentation
+        this.refreshCellControls();
+        this.events.emit('cell:maximized', { id });
     }
 
     resize(): void {
@@ -1189,7 +1234,56 @@ export class VelaWorkspace {
             const host = this.cellsById.get(this.order[i] ?? '')?.host;
             if (host) host.style.gridArea = perCell[slot.id]?.gridArea ?? '';
         }
+        this.applyMaximizePresentation();
+        this.mountAttributionMark(); // the bottom-left host may have changed (layout/maximize)
         this.splitters.layout();
+    }
+
+    /** Overlay the maximize presentation on the freshly applied grid: EVERY cell spans
+     *  the full track grid — the maximized one on top, the siblings invisible beneath
+     *  it (their charts stay alive — restoring is instant). The siblings must span too:
+     *  left in their slots they would auto-flow into implicit zero-height rows, whose
+     *  gaps steal height from the maximized cell and collapse their renderers to 0.
+     *  The splitter strips and the active ring hide via the `data-maximized` rules. */
+    private applyMaximizePresentation(): void {
+        const maxId = this.maximizedId;
+        if (maxId) this.gridEl.dataset.maximized = '1';
+        else delete this.gridEl.dataset.maximized;
+        for (const [id, cell] of this.cellsById) {
+            const style = cell.host.style;
+            // applyGrid just re-derived each slot's own gridArea — only override while maximized.
+            if (maxId) style.gridArea = '1 / 1 / -1 / -1';
+            style.zIndex = maxId && id === maxId ? '5' : '';
+            style.visibility = maxId && id !== maxId ? 'hidden' : '';
+        }
+    }
+
+    /** Rebuild every cell's view cluster (the maximize gate or state changed). */
+    private refreshCellControls(): void {
+        for (const cell of this.cellsById.values()) cell.refreshControls();
+    }
+
+    /** The cell whose bottom-left corner the grid's attribution mark floats in — the
+     *  maximized cell while one covers the grid, else the bottom-left slot's cell. */
+    private bottomLeftCell(): ChartCell | undefined {
+        if (this.maximizedId) return this.cellsById.get(this.maximizedId);
+        const grid = occupancyGrid(this.def);
+        const slot = grid[grid.length - 1]?.[0];
+        const idx = this.def.cells.findIndex((c) => (c.area ?? c.id) === slot);
+        return this.cellsById.get(this.order[idx >= 0 ? idx : 0] ?? '');
+    }
+
+    /** Keep the shared attribution mark inside the BOTTOM-LEFT visible cell: its
+     *  offsets ride that cell's renderer-published `--vela-bottom-gutter` /
+     *  `--vela-toolbar-gutter`, so collapsed pane strips push the mark up without any
+     *  bookkeeping here. Re-run after anything that changes which host that is
+     *  (layout switch, maximize, cell rebuild); a destroyed host drops the mark from
+     *  the DOM, and this re-mount brings it back. */
+    private mountAttributionMark(): void {
+        const mark = this.attributionMark;
+        if (!mark) return;
+        const host = this.bottomLeftCell()?.host ?? this.gridEl;
+        if (mark.parentElement !== host) host.appendChild(mark);
     }
 
     /** Create the cells the current layout wants but don't exist yet (pool-first).
@@ -1223,6 +1317,9 @@ export class VelaWorkspace {
                 setTimezone: (zone) => this.setTimezone(zone),
                 context: () => this.context(),
                 activate: (id) => this.setActiveCell(id),
+                canMaximize: () => !this.monoLayout && this.def.cells.length > 1,
+                isMaximized: (id) => this.maximizedId === id,
+                toggleMaximize: (id) => this.maximizeCell(this.maximizedId === id ? null : id),
                 onMarketChanged: (id) => this.onCellMarketChanged(id),
                 onPriceStyleChanged: (id) => this.onCellPriceStyleChanged(id),
                 onIndicatorsChanged: (id) => this.onCellIndicatorsChanged(id),
@@ -1257,6 +1354,7 @@ export class VelaWorkspace {
             const host = this.cellsById.get(this.order[i] ?? '')?.host;
             if (host) this.gridEl.appendChild(host);
         }
+        this.mountAttributionMark(); // fresh hosts exist now — (re)claim the bottom-left one
     }
 
     /** Per-cell chart subscriptions (trigger ② — the chart instance is stable for the

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -181,6 +181,17 @@ const CSS = `
    the active ring would just outline the only visible chart — both are noise here. */
 .vela-ws-grid[data-maximized='1'] .vela-ws-splitter { display: none; }
 .vela-ws-grid[data-maximized='1'] .vela-cell[data-active='1']::after { display: none; }
+/* Drop-target preview while a cell's drag handle is held: a dashed ring + the same
+   soft wash the splitter hover uses, over the chart, inert to the pointer. */
+.vela-cell[data-drop-target='1']::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border: 2px dashed var(--vela-fg-bright);
+    background: var(--vela-separator-hover-band);
+    pointer-events: none;
+    z-index: 11;
+}
 `;
 
 /** Grid glyph for the topbar layout dropdown (stroke follows the button color). */
@@ -624,6 +635,9 @@ export class VelaWorkspace {
                           : {}),
                       getContext: () => this.context(),
                       ...(this.drawingsEnabled ? { onDrawingsClick: () => this.openDrawingsDrawer() } : {}),
+                      // Multi-chart only: the stop that isolates the ACTIVE chart (the
+                      // per-cell hover cluster has no cursor to reveal it on mobile).
+                      ...(this.monoLayout ? {} : { onMaximizeClick: () => this.toggleMobileMaximize() }),
                       onMoreClick: () => this.openMoreDrawer(),
                       onSettingsClick: () => this.active.chart.renderer.openSettings(),
                   })
@@ -892,7 +906,7 @@ export class VelaWorkspace {
             this.pool.clear();
             for (const { id, ...cs } of st.charts.slice(liveCount)) this.pool.set(id, cs);
             this.order = st.charts.map((c) => c.id);
-            this.maximizedId = null; // documents describe the full grid — restore before re-applying
+            this.clearMaximized(); // documents describe the full grid — restore before re-applying
             this.applyGrid(); // re-assert the restored track sizes on the unchanged grid
             this.refreshCellControls();
             const nextActive = st.activeCellId && this.cellsById.has(st.activeCellId) ? st.activeCellId : (this.order[0] ?? null);
@@ -924,7 +938,7 @@ export class VelaWorkspace {
         const def = this.monoLayout ? null : ensureLayout(st.layout); // mono: grid stays pinned to '1'
         if (def) this.def = def;
         this.cellBackend = this.backendFor(this.def);
-        this.maximizedId = null; // ditto — the rebuilt grid starts unmaximized
+        this.clearMaximized(); // ditto — the rebuilt grid starts unmaximized
         this.applyGrid();
         this.buildCells();
         this.syncCellPresentation();
@@ -997,7 +1011,7 @@ export class VelaWorkspace {
     setLayout(layout: string | LayoutDefinition): void {
         if (this.destroyed) return;
         if (this.monoLayout) return; // single-chart mode — the grid is pinned to '1'
-        this.maximizedId = null; // a maximized cell is presentation — a layout switch restores first
+        this.clearMaximized(); // a maximized cell is presentation — a layout switch restores first
         const next = this.resolveLayout(layout);
         const nextBackend = this.backendFor(next);
         const rebuildAll = nextBackend !== this.cellBackend;
@@ -1054,7 +1068,52 @@ export class VelaWorkspace {
         if (id) this.setActiveCell(id);
         this.applyGrid(); // re-derives the slot geometry, then overlays the maximize presentation
         this.refreshCellControls();
+        this.syncMobileMaximize();
         this.events.emit('cell:maximized', { id });
+    }
+
+    /** The mobile bar's maximize stop: one press isolates the ACTIVE chart over the
+     *  grid; while something is already isolated — the chart, or a pane inside it
+     *  (mobile's double-tap) — the press restores that instead. Every branch re-syncs
+     *  the stop on its own (`maximizeCell` directly, `panes.maximize` via its
+     *  synchronous `pane:changed`). */
+    private toggleMobileMaximize(): void {
+        const cell = this.activeId ? this.cellsById.get(this.activeId) : undefined;
+        if (!cell) return;
+        if (this.maximizedId) this.maximizeCell(null);
+        else if (cell.chart.panes.list().some((p) => p.maximized)) cell.chart.panes.maximize(null);
+        else this.maximizeCell(cell.id);
+    }
+
+    /** Keep the mobile bar's maximize stop truthful: lit (inverse chip, restore
+     *  glyph) while the active chart covers the grid OR one of its panes is
+     *  maximized — the state a double-tap toggles is otherwise invisible on mobile. */
+    private syncMobileMaximize(): void {
+        if (!this.mobileBar) return;
+        const cell = this.activeId ? this.cellsById.get(this.activeId) : undefined;
+        const paneMax = cell ? cell.chart.panes.list().some((p) => p.maximized) : false;
+        this.mobileBar.setMaximizeActive(this.maximizedId != null || paneMax);
+    }
+
+    /**
+     * Trade the SLOTS of two live cells — the grid arrangement changes, the cells
+     * themselves (charts, indicators, drawings, the active flag) stay untouched.
+     * What each cell's drag handle commits; also callable directly by hosts.
+     */
+    swapCells(a: string, b: string): void {
+        if (this.destroyed || a === b) return;
+        const i = this.order.indexOf(a);
+        const j = this.order.indexOf(b);
+        if (i < 0 || j < 0 || !this.cellsById.has(a) || !this.cellsById.has(b)) return;
+        [this.order[i], this.order[j]] = [this.order[j]!, this.order[i]!];
+        // Auto-flow layouts place row-major by CHILD order — re-append the hosts in
+        // the new slot order (area layouts re-key their gridArea in applyGrid).
+        for (const [k] of this.def.cells.entries()) {
+            const host = this.cellsById.get(this.order[k] ?? '')?.host;
+            if (host) this.gridEl.appendChild(host);
+        }
+        this.applyGrid();
+        this.markStateDirty();
     }
 
     resize(): void {
@@ -1130,6 +1189,7 @@ export class VelaWorkspace {
         this.mobileBar?.renderActions();
         this.mobileBar?.setSymbol(cell.symbol);
         this.mobileBar?.setTimeframe(cell.timeframe);
+        this.syncMobileMaximize(); // the new active cell may hold a maximized pane
         this.drawingPill?.onChart(cell.chart); // the pill mirrors the ACTIVE cell's tool state
         const pushHistory = (): void => this.topbar.setHistoryState(cell.history.canUndo, cell.history.canRedo);
         this.historyUnsub?.();
@@ -1263,6 +1323,35 @@ export class VelaWorkspace {
         for (const cell of this.cellsById.values()) cell.refreshControls();
     }
 
+    /** Drop the transient maximize on a structural change (layout switch, state
+     *  document) — WITH the event, so hosts tracking `cell:maximized` never drift
+     *  from `maximizedCell`. The caller's own grid re-apply paints the restore. */
+    private clearMaximized(): void {
+        if (this.maximizedId == null) return;
+        this.maximizedId = null;
+        this.events.emit('cell:maximized', { id: null });
+    }
+
+    /** The live cell under a viewport point, excluding `excludeId` and any host a
+     *  maximize has hidden — the drag handle's hit-test. */
+    private cellAtPoint(x: number, y: number, excludeId: string): string | null {
+        for (const [id, cell] of this.cellsById) {
+            if (id === excludeId || cell.host.style.visibility === 'hidden') continue;
+            const r = cell.host.getBoundingClientRect();
+            if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return id;
+        }
+        return null;
+    }
+
+    /** Mark one cell as the live drop target of a grip drag (null clears all) —
+     *  the `data-drop-target` stylesheet rule paints the dashed preview ring. */
+    private setDropTarget(id: string | null): void {
+        for (const [cid, cell] of this.cellsById) {
+            if (cid === id) cell.host.dataset.dropTarget = '1';
+            else delete cell.host.dataset.dropTarget;
+        }
+    }
+
     /** The cell whose bottom-left corner the grid's attribution mark floats in — the
      *  maximized cell while one covers the grid, else the bottom-left slot's cell. */
     private bottomLeftCell(): ChartCell | undefined {
@@ -1317,9 +1406,12 @@ export class VelaWorkspace {
                 setTimezone: (zone) => this.setTimezone(zone),
                 context: () => this.context(),
                 activate: (id) => this.setActiveCell(id),
-                canMaximize: () => !this.monoLayout && this.def.cells.length > 1,
+                multiCell: () => !this.monoLayout && this.def.cells.length > 1,
                 isMaximized: (id) => this.maximizedId === id,
                 toggleMaximize: (id) => this.maximizeCell(this.maximizedId === id ? null : id),
+                cellDragTarget: (id, x, y) => this.cellAtPoint(x, y, id),
+                previewDropTarget: (target) => this.setDropTarget(target),
+                dropCell: (id, target) => this.swapCells(id, target),
                 onMarketChanged: (id) => this.onCellMarketChanged(id),
                 onPriceStyleChanged: (id) => this.onCellPriceStyleChanged(id),
                 onIndicatorsChanged: (id) => this.onCellIndicatorsChanged(id),
@@ -1337,6 +1429,7 @@ export class VelaWorkspace {
             // A fresh renderer starts desktop — push the live mode so touch gestures,
             // fullscreen dialogs and the scroll-button sizing apply from the first frame.
             cell.chart.renderer.setLayoutMode(this.layoutCtl.current);
+            cell.setControlsSuspended(this.layoutCtl.current === 'mobile');
             // The shared star set is a workspace pref — every newborn cell inherits it
             // silently (equal-set idempotence keeps the favorites event from echoing).
             if (this.favs.length > 0) cell.chart.drawings.setFavorites(this.favs as never[]);
@@ -1443,6 +1536,11 @@ export class VelaWorkspace {
         // A theme picked in ONE cell (its settings dialog's Canvas → Theme) re-skins the
         // WHOLE workspace — shared chrome plus every other cell.
         chart.on('theme:changed', (t) => this.setTheme(t));
+        // Pane collapse/maximize in the ACTIVE cell (double-tap on mobile, API) —
+        // keep the mobile bar's maximize stop truthful.
+        chart.on('pane:changed', () => {
+            if (cell.id === this.activeId) this.syncMobileMaximize();
+        });
         // Mobile: long-press an axis strip → timezone / price-scale sheet (desktop keeps
         // the right-click menu). The press's own pointerdown already activated the cell.
         chart.renderer.onAxisLongPress((e) => {
@@ -1796,6 +1894,7 @@ export class VelaWorkspace {
         for (const cell of this.cellsById.values()) {
             cell.chart.renderer.closeDialogs();
             cell.chart.renderer.setLayoutMode(mode);
+            cell.setControlsSuspended(mode === 'mobile'); // the mobile bar's maximize stop replaces the cluster
         }
         this.syncCellPresentation(); // the legend's overview override is mode-scoped
     }

--- a/test/cell-controls.test.ts
+++ b/test/cell-controls.test.ts
@@ -1,0 +1,205 @@
+// The per-cell view cluster (src/widget/cell-controls.ts): the proximity reveal (pure),
+// the button set and its maximize gating, and the actions' routing. Node env — the DOM
+// is a MINIMAL stub (element tree, listeners, inline style); real rendering and the
+// workspace's maximize presentation are proven in the browser.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { CellControls, nearBottomCenter, CELL_CONTROLS_PROXIMITY_PX, type CellControlsDeps } from '../src/widget/cell-controls';
+import type { Vela } from '../src/Vela';
+
+interface StubEl {
+    tagName: string;
+    className: string;
+    title: string;
+    type: string;
+    innerHTML: string;
+    textContent: string;
+    style: Record<string, string>;
+    children: StubEl[];
+    parent: StubEl | null;
+    ownerDocument: unknown;
+    listeners: Map<string, Array<(e: unknown) => void>>;
+    appendChild(node: StubEl): StubEl;
+    setAttribute(name: string, value: string): void;
+    addEventListener(type: string, fn: (e: unknown) => void): void;
+    removeEventListener(type: string, fn: (e: unknown) => void): void;
+    getBoundingClientRect(): { left: number; top: number; width: number; height: number };
+    remove(): void;
+    fire(type: string, event?: Record<string, unknown>): void;
+}
+
+function makeEl(doc: unknown, tagName: string): StubEl {
+    let text = '';
+    const el: StubEl = {
+        tagName,
+        className: '',
+        title: '',
+        type: '',
+        innerHTML: '',
+        get textContent() {
+            return text;
+        },
+        // The component clears the cluster via `textContent = ''` — mirror the DOM's
+        // child-dropping semantics, which is what refresh() relies on.
+        set textContent(v: string) {
+            text = v;
+            el.children.length = 0;
+        },
+        style: {},
+        children: [],
+        parent: null,
+        ownerDocument: doc,
+        listeners: new Map(),
+        appendChild(node) {
+            node.parent = el;
+            el.children.push(node);
+            return node;
+        },
+        setAttribute() {},
+        addEventListener(t, fn) {
+            const list = el.listeners.get(t) ?? [];
+            list.push(fn);
+            el.listeners.set(t, list);
+        },
+        removeEventListener(t, fn) {
+            const list = el.listeners.get(t) ?? [];
+            el.listeners.set(t, list.filter((f) => f !== fn));
+        },
+        getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 600 }),
+        remove() {
+            if (el.parent) el.parent.children = el.parent.children.filter((c) => c !== el);
+            el.parent = null;
+        },
+        fire(t, event = {}) {
+            for (const fn of el.listeners.get(t) ?? []) fn({ stopPropagation: () => {}, ...event });
+        },
+    };
+    return el;
+}
+
+function makeHost(): StubEl {
+    const doc = { createElement: (tag: string) => makeEl(doc, tag) };
+    return makeEl(doc, 'div');
+}
+
+function makeDeps(over: Partial<CellControlsDeps> = {}): CellControlsDeps {
+    return {
+        chart: () => null,
+        reset: () => {},
+        canMaximize: () => true,
+        isMaximized: () => false,
+        toggleMaximize: () => {},
+        ...over,
+    };
+}
+
+const cluster = (host: StubEl): StubEl => host.children[0]!;
+const titles = (host: StubEl): string[] => cluster(host).children.map((b) => b.title);
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('nearBottomCenter (pure)', () => {
+    it('is true at the cluster spot and within the proximity radius', () => {
+        // 800×600 cell: the cluster centers at (400, 600 − 34 − 12) = (400, 554).
+        expect(nearBottomCenter(400, 554, 800, 600)).toBe(true);
+        expect(nearBottomCenter(400 + CELL_CONTROLS_PROXIMITY_PX, 554, 800, 600)).toBe(true); // radius inclusive
+        expect(nearBottomCenter(400, 554 - CELL_CONTROLS_PROXIMITY_PX, 800, 600)).toBe(true);
+    });
+
+    it('is false away from the bottom-center', () => {
+        expect(nearBottomCenter(400, 300, 800, 600)).toBe(false); // middle of the plot
+        expect(nearBottomCenter(20, 580, 800, 600)).toBe(false); // bottom-LEFT corner
+        expect(nearBottomCenter(780, 580, 800, 600)).toBe(false); // bottom-RIGHT (scroll button's home)
+        expect(nearBottomCenter(400, 20, 800, 600)).toBe(false); // top-center
+    });
+
+    it('scales with the cell size — the spot follows the cell, not the viewport', () => {
+        expect(nearBottomCenter(200, 254, 400, 300)).toBe(true); // half-size cell, its own bottom-center
+        expect(nearBottomCenter(400, 554, 400, 300)).toBe(false); // the big cell's spot is outside a small cell
+    });
+});
+
+describe('CellControls — button set and gating', () => {
+    it('builds zoom out / zoom in / maximize / reset when maximize applies', () => {
+        const host = makeHost();
+        new CellControls(host as never, makeDeps());
+        expect(titles(host)).toEqual(['Zoom out', 'Zoom in', 'Maximize chart', 'Reset chart']);
+    });
+
+    it('drops the maximize button on single-cell grids (no space to trade)', () => {
+        const host = makeHost();
+        new CellControls(host as never, makeDeps({ canMaximize: () => false }));
+        expect(titles(host)).toEqual(['Zoom out', 'Zoom in', 'Reset chart']);
+    });
+
+    it('refresh() flips maximize to restore for the maximized cell', () => {
+        const host = makeHost();
+        let maximized = false;
+        const controls = new CellControls(host as never, makeDeps({ isMaximized: () => maximized }));
+        expect(cluster(host).children[2]!.className).toBe('vela-cc-btn'); // resting state — no chip
+        maximized = true;
+        controls.refresh();
+        expect(titles(host)).toEqual(['Zoom out', 'Zoom in', 'Restore layout', 'Reset chart']);
+        // The maximized state reads as the inverse "selected" chip (the collapsed-pane idiom).
+        expect(cluster(host).children[2]!.className).toBe('vela-cc-btn vela-cc-on');
+    });
+});
+
+describe('CellControls — proximity reveal', () => {
+    it('starts hidden, shows near the bottom-center, hides when the pointer leaves', () => {
+        const host = makeHost();
+        new CellControls(host as never, makeDeps());
+        expect(cluster(host).style.display).toBe('none');
+        host.fire('pointermove', { clientX: 400, clientY: 554 });
+        expect(cluster(host).style.display).toBe('flex');
+        host.fire('pointermove', { clientX: 400, clientY: 100 });
+        expect(cluster(host).style.display).toBe('none');
+        host.fire('pointermove', { clientX: 400, clientY: 554 });
+        host.fire('pointerleave');
+        expect(cluster(host).style.display).toBe('none');
+    });
+
+    it('destroy() unhooks the host listeners and removes the cluster', () => {
+        const host = makeHost();
+        const controls = new CellControls(host as never, makeDeps());
+        controls.destroy();
+        expect(host.children).toHaveLength(0);
+        expect(host.listeners.get('pointermove') ?? []).toHaveLength(0);
+        expect(host.listeners.get('pointerleave') ?? []).toHaveLength(0);
+    });
+});
+
+describe('CellControls — actions', () => {
+    it('routes maximize and reset to the deps', () => {
+        const host = makeHost();
+        const reset = vi.fn();
+        const toggleMaximize = vi.fn();
+        new CellControls(host as never, makeDeps({ reset, toggleMaximize }));
+        cluster(host).children[2]!.fire('click');
+        expect(toggleMaximize).toHaveBeenCalledTimes(1);
+        cluster(host).children[3]!.fire('click');
+        expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('zoom in glides THIS cell toward a right-anchored narrower range', () => {
+        // Synchronous rAF: the glide converges geometrically, so driving the frames
+        // inline terminates on the snap step (see followStep).
+        vi.stubGlobal('requestAnimationFrame', (cb: () => void): number => {
+            cb();
+            return 1;
+        });
+        vi.stubGlobal('cancelAnimationFrame', () => {});
+        const host = makeHost();
+        const applied: Array<{ from: number; to: number }> = [];
+        const chart = {
+            getVisibleRange: () => ({ from: 0, to: 1_000_000 }),
+            setVisibleRange: (r: { from: number; to: number }) => applied.push(r),
+        } as unknown as Vela;
+        new CellControls(host as never, makeDeps({ chart: () => chart }));
+        cluster(host).children[1]!.fire('click'); // zoom in
+        const last = applied[applied.length - 1]!;
+        expect(last.to).toBe(1_000_000); // right edge anchored
+        expect(last.from).toBeCloseTo(200_000, -3); // span × 0.8
+    });
+});

--- a/test/cell-controls.test.ts
+++ b/test/cell-controls.test.ts
@@ -70,9 +70,10 @@ function makeEl(doc: unknown, tagName: string): StubEl {
             el.parent = null;
         },
         fire(t, event = {}) {
-            for (const fn of el.listeners.get(t) ?? []) fn({ stopPropagation: () => {}, ...event });
+            for (const fn of [...(el.listeners.get(t) ?? [])]) fn({ stopPropagation: () => {}, preventDefault: () => {}, ...event });
         },
     };
+    (el as unknown as { setPointerCapture(id: number): void }).setPointerCapture = () => {};
     return el;
 }
 
@@ -85,9 +86,12 @@ function makeDeps(over: Partial<CellControlsDeps> = {}): CellControlsDeps {
     return {
         chart: () => null,
         reset: () => {},
-        canMaximize: () => true,
+        multiCell: () => true,
         isMaximized: () => false,
         toggleMaximize: () => {},
+        dragTargetAt: () => null,
+        previewDrop: () => {},
+        dropOn: () => {},
         ...over,
     };
 }
@@ -121,25 +125,26 @@ describe('nearBottomCenter (pure)', () => {
 });
 
 describe('CellControls — button set and gating', () => {
-    it('builds zoom out / zoom in / maximize / reset when maximize applies', () => {
+    it('builds drag / zoom out / zoom in / maximize / reset on a multi-cell grid', () => {
         const host = makeHost();
         new CellControls(host as never, makeDeps());
-        expect(titles(host)).toEqual(['Zoom out', 'Zoom in', 'Maximize chart', 'Reset chart']);
+        expect(titles(host)).toEqual(['Drag to move chart', 'Zoom out', 'Zoom in', 'Maximize chart', 'Reset chart']);
     });
 
-    it('drops the maximize button on single-cell grids (no space to trade)', () => {
+    it('drops the drag handle and maximize on single-cell grids (nowhere to go)', () => {
         const host = makeHost();
-        new CellControls(host as never, makeDeps({ canMaximize: () => false }));
+        new CellControls(host as never, makeDeps({ multiCell: () => false }));
         expect(titles(host)).toEqual(['Zoom out', 'Zoom in', 'Reset chart']);
     });
 
-    it('refresh() flips maximize to restore for the maximized cell', () => {
+    it('refresh() flips maximize to restore for the maximized cell and hides its drag handle', () => {
         const host = makeHost();
         let maximized = false;
         const controls = new CellControls(host as never, makeDeps({ isMaximized: () => maximized }));
-        expect(cluster(host).children[2]!.className).toBe('vela-cc-btn'); // resting state — no chip
+        expect(cluster(host).children[3]!.className).toBe('vela-cc-btn'); // resting state — no chip
         maximized = true;
         controls.refresh();
+        // No drag handle while this chart covers the grid — there is nowhere to move it.
         expect(titles(host)).toEqual(['Zoom out', 'Zoom in', 'Restore layout', 'Reset chart']);
         // The maximized state reads as the inverse "selected" chip (the collapsed-pane idiom).
         expect(cluster(host).children[2]!.className).toBe('vela-cc-btn vela-cc-on');
@@ -160,6 +165,20 @@ describe('CellControls — proximity reveal', () => {
         expect(cluster(host).style.display).toBe('none');
     });
 
+    it('setSuspended(true) hides the cluster and blocks reveals (mobile mode)', () => {
+        const host = makeHost();
+        const controls = new CellControls(host as never, makeDeps());
+        host.fire('pointermove', { clientX: 400, clientY: 554 });
+        expect(cluster(host).style.display).toBe('flex');
+        controls.setSuspended(true); // mode flip hides a revealed cluster immediately
+        expect(cluster(host).style.display).toBe('none');
+        host.fire('pointermove', { clientX: 400, clientY: 554 });
+        expect(cluster(host).style.display).toBe('none'); // no reveal while suspended
+        controls.setSuspended(false);
+        host.fire('pointermove', { clientX: 400, clientY: 554 });
+        expect(cluster(host).style.display).toBe('flex'); // back to desktop behavior
+    });
+
     it('destroy() unhooks the host listeners and removes the cluster', () => {
         const host = makeHost();
         const controls = new CellControls(host as never, makeDeps());
@@ -176,10 +195,43 @@ describe('CellControls — actions', () => {
         const reset = vi.fn();
         const toggleMaximize = vi.fn();
         new CellControls(host as never, makeDeps({ reset, toggleMaximize }));
-        cluster(host).children[2]!.fire('click');
-        expect(toggleMaximize).toHaveBeenCalledTimes(1);
         cluster(host).children[3]!.fire('click');
+        expect(toggleMaximize).toHaveBeenCalledTimes(1);
+        cluster(host).children[4]!.fire('click');
         expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('the drag handle previews the hovered cell and commits the drop on release', () => {
+        const host = makeHost();
+        let over: string | null = null;
+        const previewDrop = vi.fn();
+        const dropOn = vi.fn();
+        new CellControls(host as never, makeDeps({ dragTargetAt: () => over, previewDrop, dropOn }));
+        const grip = cluster(host).children[0]!;
+        expect(grip.title).toBe('Drag to move chart');
+        grip.fire('pointerdown', { button: 0, pointerType: 'mouse', pointerId: 1 });
+        over = 'eth';
+        grip.fire('pointermove', { clientX: 500, clientY: 100 });
+        expect(previewDrop).toHaveBeenLastCalledWith('eth');
+        grip.fire('pointerup');
+        expect(previewDrop).toHaveBeenLastCalledWith(null); // highlight cleared before the commit
+        expect(dropOn).toHaveBeenCalledWith('eth');
+        expect(dropOn).toHaveBeenCalledTimes(1);
+    });
+
+    it('releasing over nothing (or a cancel) commits no move', () => {
+        const host = makeHost();
+        const dropOn = vi.fn();
+        const previewDrop = vi.fn();
+        new CellControls(host as never, makeDeps({ dragTargetAt: () => null, previewDrop, dropOn }));
+        const grip = cluster(host).children[0]!;
+        grip.fire('pointerdown', { button: 0, pointerType: 'mouse', pointerId: 1 });
+        grip.fire('pointermove', { clientX: 10, clientY: 10 });
+        grip.fire('pointerup');
+        grip.fire('pointerdown', { button: 0, pointerType: 'mouse', pointerId: 2 });
+        grip.fire('pointercancel');
+        expect(dropOn).not.toHaveBeenCalled();
+        expect(previewDrop).toHaveBeenLastCalledWith(null);
     });
 
     it('zoom in glides THIS cell toward a right-anchored narrower range', () => {
@@ -197,7 +249,7 @@ describe('CellControls — actions', () => {
             setVisibleRange: (r: { from: number; to: number }) => applied.push(r),
         } as unknown as Vela;
         new CellControls(host as never, makeDeps({ chart: () => chart }));
-        cluster(host).children[1]!.fire('click'); // zoom in
+        cluster(host).children[2]!.fire('click'); // zoom in
         const last = applied[applied.length - 1]!;
         expect(last.to).toBe(1_000_000); // right edge anchored
         expect(last.from).toBeCloseTo(200_000, -3); // span × 0.8

--- a/test/watermark-price-pane.test.ts
+++ b/test/watermark-price-pane.test.ts
@@ -75,3 +75,38 @@ describe('price-pane overlay insets (symbol watermark clip)', () => {
         expect(DATA_H + TIME_AXIS_H - top - bottom).toBe(0);
     });
 });
+
+// COLLAPSED_PANE_H in NativeRenderer — the strip a collapsed pane keeps (legend + expand chip).
+const COLLAPSED_PANE_H = 26;
+
+describe('bottom-gutter inset (host overlays above the bottom chrome)', () => {
+    it('with every pane open, the gutter is just the time axis', () => {
+        const { host } = primed((scene) => {
+            scene.ensurePane('rsi', 'study', 1, 1);
+        });
+        expect(host.style.getPropertyValue('--vela-bottom-gutter')).toBe(`${TIME_AXIS_H}px`);
+    });
+
+    it('a collapsed bottom pane pushes the gutter up by its strip', () => {
+        // The regression case: the ONLY study pane collapses — an overlay anchored to
+        // the gutter (the workspace attribution mark) must climb above the strip
+        // instead of overlapping its legend row.
+        const { r, host } = primed((scene) => {
+            scene.ensurePane('rsi', 'study', 1, 1);
+        });
+        r.scene.panes.get('rsi')!.collapsed = true;
+        r.layoutPanes();
+        expect(host.style.getPropertyValue('--vela-bottom-gutter')).toBe(`${TIME_AXIS_H + COLLAPSED_PANE_H}px`);
+    });
+
+    it('a maximized pane fills the plot — the gutter drops back to the time axis', () => {
+        const { r, host } = primed((scene) => {
+            scene.ensurePane('rsi', 'study', 1, 1);
+        });
+        r.scene.panes.get('rsi')!.collapsed = true;
+        r.layoutPanes();
+        r.maximizedPaneId = 'price';
+        r.layoutPanes();
+        expect(host.style.getPropertyValue('--vela-bottom-gutter')).toBe(`${TIME_AXIS_H}px`);
+    });
+});


### PR DESCRIPTION
## Summary

- **Per-chart view cluster.** Resting the cursor near the bottom-center of any workspace chart reveals a small cluster (same proximity reveal as the jump-to-latest button): a **drag handle** (hold and sweep onto another chart — a dashed ring previews the target — release to trade slots), **zoom out / zoom in** (eased, right-edge anchored), **maximize/restore** (that one chart covers the whole grid; the hidden charts keep everything and return instantly), and **reset** (auto price scale + full history, the context menu action).
- **Mobile.** The hover clusters (cell + per-pane) stay away on mobile — the bottom bar gains a **maximize stop** instead, which isolates the active chart and lights up as an inverse chip whenever that chart covers the grid *or* one of its panes is maximized (double-tap state, previously invisible); pressing while lit restores.
- **State-lit chips on desktop.** The maximized cell''s restore button and a maximized pane''s top-right restore button both render as the inverse selected chip (white on dark, dark on light), and the pane chip stays visible without hover — the collapsed-pane idiom.
- **Public API.** `ws.maximizeCell(id | null)`, `ws.maximizedCell`, `ws.swapCells(a, b)`, and a `cell:maximized` event; the renderer additionally publishes `--vela-bottom-gutter` beside its existing gutter variables.
- **Fixes.** The workspace''s shared attribution mark now rides that bottom gutter inside the bottom-left cell, so collapsing a lone indicator pane no longer leaves the mark on top of the collapsed strip''s legend. The `reset` icon lost the stray square in its center. Cluster pills darkened to `rgba(0,0,0,0.65)` so volume columns don''t bleed through the icons.

Docs (`docs/user/workspace.md`) and the changelog (`[Unreleased]`) are updated in the same change.

## Test plan

- [x] Gate: `typecheck` / `lint` / `test` (1388, incl. 15 targeted `cell-controls` + 3 bottom-gutter cases) / `build`
- [x] Oracle suite `oracle-tests/vela`: 22/22
- [x] Browser (workspace playground, live data): cluster reveal/hide by proximity; drag with mid-drag highlight, swap, and cancel; maximize/restore round-trips incl. layout-switch restore; zoom ratios exactly 0.8/1.25; reset re-enabling auto scale; mobile (narrow container) cluster suppression, maximize stop toggle + lit chip for both chart and pane isolation; attribution mark climbing above a collapsed pane strip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace grid layout, pointer/drag gestures, and shared attribution positioning across cells; presentation-only maximize state but easy to regress mobile/desktop chrome sync.
> 
> **Overview**
> Adds **per-chart view controls** in multi-cell workspaces: a bottom-center hover cluster (same proximity reveal as jump-to-latest) with drag-to-swap slots, zoom in/out, maximize/restore, and reset view. **Hosts** get `maximizeCell(id | null)`, `maximizedCell`, `swapCells(a, b)`, and `cell:maximized`; maximize is transient and clears on layout or state restore.
> 
> **Mobile** hides hover clusters (cells and pane controls) and adds a **maximize stop** on the bottom bar that isolates the active chart or restores when a chart or pane is already maximized (inverse chip).
> 
> **UX polish:** maximized pane restore buttons stay visible as lit inverse chips (like collapsed expand); cluster scrim darkened; new plus/minus icons and updated reset icon.
> 
> **Fix:** shared workspace attribution re-mounts in the bottom-left cell and uses new `--vela-bottom-gutter` (with existing toolbar gutter) so it sits above collapsed pane strips and follows the maximized cell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d8a2ce9b760c98e1a6e21b6b4b7f1d0c231e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->