### PR TITLE
Progressive market loads: paint as confirmed history lands

### DIFF
--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -58,7 +58,8 @@ const PREVIEW_BARS = 300;
  * itself only in time-to-first-candle, and nothing downstream can use those first candles
  * anyway — an indicator's first run is held until the whole depth has landed (Pine is
  * causal, so running it per chunk would repaint a different curve each time). Below this
- * line, one request wins outright.
+ * line, one request wins outright. (Feeds with `loadProgressive` never reach this split:
+ * their SOURCE decides what is paintable, snapshot by snapshot.)
  */
 const SINGLE_LOAD_BARS = 5_000;
 /**
@@ -146,6 +147,10 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
     /** Invalidates detached async work (backfill loops, in-flight loads, gap heals):
      *  bumped by init(), setMarket() and destroy(). */
     private generation = 0;
+    /** Aborts the in-flight PROGRESSIVE load's source polling on supersession — an
+     *  abandoned stream left polling to its own budget starves the browser's per-host
+     *  connection pool, and the NEXT symbol's very first fetch with it (measured). */
+    private progressiveAbort: AbortController | null = null;
     /** Awaiters racing a superseded load (setMarket callers) — released on every bump so they never hang. */
     private readonly supersedeWaiters: Array<() => void> = [];
     /** `history:complete` fired for the CURRENT load. Each market load re-arms the cycle
@@ -334,6 +339,8 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
      *  superseded setMarket awaiters so their promises resolve instead of hanging. */
     private bumpGeneration(): number {
         const gen = ++this.generation;
+        this.progressiveAbort?.abort(); // the superseded load's source stops polling promptly
+        this.progressiveAbort = null;
         for (const w of this.supersedeWaiters.splice(0)) w();
         return gen;
     }
@@ -396,7 +403,62 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         // Only a DEEP request is worth splitting, and only when a requested initial window
         // does not pin the frame (a chunked load would paint the wrong range, then jump).
         const deep = !market.data?.length && initialRange == null && requested > SINGLE_LOAD_BARS;
-        if (deep && this.feed.loadRange) {
+        // PROGRESSIVE-CAPABLE source first: paint every snapshot it emits while it heals —
+        // first candles in seconds on a cold symbol, depth growing behind them — and
+        // complete when the final answer resolves. The pipeline returns at the FIRST paint
+        // (exactly the deep head + backfill shape below); the remainder streams in,
+        // generation-checked. Snapshots are cumulative and confirmed-from-the-newest-bar
+        // by the port contract, so each paint replaces the series with a superset,
+        // viewport preserved. A NULL resolution means the resolved provider lacks the
+        // capability — no snapshot was emitted, and the classic paths below run untouched.
+        let progressiveServed = false;
+        if (!market.data?.length && initialRange == null && this.feed.loadProgressive) {
+            let painted = false;
+            const paint = (bars: OHLCV[], final: boolean): void => {
+                if (this.generation !== gen || (!final && bars.length === 0)) return;
+                this.setBarSeries(bars, painted ? { preserveView: true } : undefined);
+                if (!painted && bars.length > 0) {
+                    painted = true;
+                    if (opts.firstLoad) this.activateBarLayers();
+                    if (!final) this.historyState = 'backfill';
+                }
+            };
+            const abort = new AbortController();
+            this.progressiveAbort = abort;
+            progressiveServed = await new Promise<boolean>((firstPaint) => {
+                let signaled = false;
+                const signal = (served: boolean): void => {
+                    if (!signaled) {
+                        signaled = true;
+                        firstPaint(served);
+                    }
+                };
+                // Supersession must release THIS wait immediately (the newer switch owns the
+                // chart) — the provider's own resolution can lag its abort by one poll.
+                abort.signal.addEventListener('abort', () => signal(true), { once: true });
+                this.feed
+                    .loadProgressive!(market, (bars) => {
+                        paint(bars, false);
+                        if (painted) signal(true);
+                    }, { signal: abort.signal })
+                    .then((full) => {
+                        if (this.progressiveAbort === abort) this.progressiveAbort = null;
+                        if (full == null) return signal(false); // incapable — classic paths take over
+                        if (this.generation !== gen) return signal(true);
+                        paint(full, true);
+                        this.completeHistory(full.length >= requested ? 'depth' : 'genesis');
+                        signal(true);
+                    })
+                    .catch(() => {
+                        if (this.progressiveAbort === abort) this.progressiveAbort = null;
+                        if (this.generation === gen) this.completeHistory('aborted');
+                        signal(true);
+                    });
+            });
+        }
+        if (progressiveServed) {
+            /* painted above; the final snapshot and completion stream in behind */
+        } else if (deep && this.feed.loadRange) {
             // Paint the newest chunk, stream the rest in behind it. The first chunk is a full
             // CHUNK_BARS, not a token head: at this depth the round trips are what cost, so
             // each one carries as much as the source answers well.

--- a/src/core/ports/DataProvider.ts
+++ b/src/core/ports/DataProvider.ts
@@ -68,6 +68,23 @@ export interface DataProvider {
      */
     getBars(ticker: string, timeframe: string, range: BarRange): Promise<OHLCV[]>;
 
+    /**
+     * Progressive variant of {@link getBars}, for sources that HEAL a cold symbol while
+     * answering: instead of holding the load until the whole depth converged, the
+     * provider emits growing snapshots as history lands and the chart paints each one.
+     * Every `onBatch` list (and the resolved final list) is the WHOLE answer so far —
+     * ascending, and CONFIRMED from its newest bar backward: a snapshot is cut at the
+     * newest stretch the SOURCE still owes (its own accounting of unanswered work,
+     * oldest-last), NEVER inferred from bar-time gaps — markets hold real empty
+     * stretches (holidays, quiet sessions) that must flow through immediately. Bars
+     * never move or vanish between snapshots; each extends the previous one. The
+     * resolved value is the final answer. `opts.signal` aborts the stream — the chart
+     * switched away: stop polling PROMPTLY and resolve with whatever is confirmed
+     * (an abandoned load left polling starves the browser's per-host connection pool
+     * and the next symbol with it). Absent ≡ single-answer `getBars` semantics.
+     */
+    getBarsProgressive?(ticker: string, timeframe: string, range: BarRange, onBatch: (bars: OHLCV[]) => void, opts?: { signal?: AbortSignal }): Promise<OHLCV[]>;
+
     /** Provider metadata. Absent ⇒ the registry synthesizes a record from the methods present. */
     info?(): ProviderInfo;
 

--- a/src/core/ports/MarketDataFeed.ts
+++ b/src/core/ports/MarketDataFeed.ts
@@ -40,6 +40,14 @@ export interface BarRange {
 export interface MarketDataFeed {
     /** Load the initial history (from a provider or the offline `data` array). */
     load(cfg: MarketConfig): Promise<OHLCV[]>;
+    /**
+     * Progressive load: emit growing snapshots while the source heals a cold symbol,
+     * resolve with the final answer — `DataProvider.getBarsProgressive` semantics
+     * (cumulative, confirmed-from-the-newest-bar snapshots; each extends the last).
+     * Resolves NULL when the resolved source lacks the capability — the caller then
+     * runs its non-progressive paths (single load, deep head + backfill) untouched.
+     */
+    loadProgressive?(cfg: MarketConfig, onBatch: (bars: OHLCV[]) => void, opts?: { signal?: AbortSignal }): Promise<OHLCV[] | null>;
     /** Subscribe to live forming-candle ticks. Returns an unsubscribe fn. */
     subscribe(cfg: MarketConfig, onBar: (bar: OHLCV) => void): Unsubscribe;
     /** Optional symbol metadata for engines that need it; absent/undefined ≡ engine synthesizes. */

--- a/src/data/CachingDataFeed.ts
+++ b/src/data/CachingDataFeed.ts
@@ -68,6 +68,29 @@ export class CachingDataFeed implements MarketDataFeed {
     }
 
     /**
+     * Progressive twin of {@link load}: a COLD load streams through the inner feed's
+     * progressive path — batches forwarded verbatim, the FINAL answer cached exactly as
+     * `load` caches — while a cache-covered load answers once through `load` itself (a
+     * warm chart has nothing to stream). Falls back to `load` wholesale when the inner
+     * feed lacks the capability, so callers may prefer this method unconditionally.
+     */
+    async loadProgressive(cfg: MarketConfig, onBatch: (bars: OHLCV[]) => void, opts?: { signal?: AbortSignal }): Promise<OHLCV[] | null> {
+        if (cfg.data && cfg.data.length > 0) return this.inner.load(cfg);
+        if (!this.inner.loadProgressive) return null;
+        const symbol = cfg.symbol ?? 'TEST';
+        const key = cacheKey(symbol, cfg.timeframe ?? '60', cfg.session);
+        const cached = this.store.get(key);
+        const n = cfg.bars ?? 500;
+        const lastCached = cached?.[cached.length - 1];
+        if (cached && lastCached && cached.length >= n - 1 && this.inner.loadRange) return this.load(cfg); // warm: the tail-merge path
+        this.store.retainSymbol(symbol);
+        const bars = await this.inner.loadProgressive(cfg, onBatch, opts);
+        if (bars == null) return null; // the resolved provider turned out incapable
+        this.store.merge(key, dropForming(bars));
+        return bars;
+    }
+
+    /**
      * Cache-backed ranged fetch — the gateway engines use for secondary series
      * (`request.security` HTF/LTF/cross-symbol) and the orchestrator's backward
      * history chunks. Caches per `(provider, symbol, timeframe)` in the shared

--- a/src/data/MultiProviderFeed.ts
+++ b/src/data/MultiProviderFeed.ts
@@ -156,6 +156,18 @@ export class MultiProviderFeed implements MarketDataFeed {
         return this.cache.load(canonical(cfg, resolved));
     }
 
+    /** Progressive twin of {@link load} — same resolution, the cache streams the batches. */
+    async loadProgressive(cfg: MarketConfig, onBatch: (bars: OHLCV[]) => void, opts?: { signal?: AbortSignal }): Promise<OHLCV[] | null> {
+        if (cfg.data && cfg.data.length > 0) {
+            this.liveBars = cfg.data.map((b) => ({ ...b }));
+            return cfg.data;
+        }
+        const resolved = await this.registry.whenResolvable(rawSymbol(cfg), { default: this.primaryProvider });
+        this.primaryProvider = resolved.provider;
+        this.prefetchSymbolInfo(resolved);
+        return this.cache.loadProgressive(canonical(cfg, resolved), onBatch, opts);
+    }
+
     /**
      * Synchronous per-symbol metadata for engines (Pine `syminfo.*`), served from the cache
      * warmed by load(). Undefined until the prefetch lands (the engine then synthesizes a
@@ -272,6 +284,21 @@ class RegistryFetchFeed implements MarketDataFeed {
         const provider = this.registry.get(name ?? '');
         if (!provider) return Promise.resolve([]);
         return safeBars(provider, ticker, cfg.timeframe ?? '60', { limit: cfg.bars ?? 500, session: cfg.session });
+    }
+
+    async loadProgressive(cfg: MarketConfig, onBatch: (bars: OHLCV[]) => void, opts?: { signal?: AbortSignal }): Promise<OHLCV[] | null> {
+        const { provider: name, ticker } = parseSymbol(cfg.symbol ?? '');
+        const provider = this.registry.get(name ?? '');
+        if (!provider) return [];
+        if (!provider.getBarsProgressive) return null; // incapable — the caller keeps its own paths
+        try {
+            return await provider.getBarsProgressive(ticker, cfg.timeframe ?? '60', { limit: cfg.bars ?? 500, session: cfg.session }, onBatch, opts);
+        } catch (e) {
+            // Same fault posture as `safeBars`: a throwing provider empties the chart,
+            // never rejects the load — batches already painted stay painted.
+            console.warn(`[vela] progressive fetch failed for ${ticker} ${cfg.timeframe ?? '60'} — ${e instanceof Error ? e.message : String(e)}`);
+            return [];
+        }
     }
 
     loadRange(cfg: MarketConfig, range: BarRange): Promise<OHLCV[]> {

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -824,6 +824,78 @@ describe('EngineOrchestrator', () => {
         expect(renderer.setBarsCalls).toEqual([{ n: 2000, preserveView: false }]);
     });
 
+    it('a progressive-capable feed paints every snapshot, completes on resolve — and null falls back', async () => {
+        // The streaming source: two growing snapshots, then the final answer resolves.
+        const all = makeBars(120);
+        let emit: ((bars: OHLCV[]) => void) | null = null;
+        let finish: ((bars: OHLCV[]) => void) | null = null;
+        const feed: MarketDataFeed = {
+            load: () => Promise.resolve([]),
+            subscribe: () => () => {},
+            loadProgressive: (_cfg, onBatch) => {
+                emit = onBatch;
+                return new Promise((res) => { finish = res; });
+            },
+        };
+        const renderer = new FakeRenderer();
+        const chart = new Vela({} as unknown as HTMLElement, { bars: 120 }, { renderer, engines: [new MockEngine()], dataFeed: feed });
+        await Promise.resolve(); // let loadMarketInner reach the progressive await
+        emit!(all.slice(-40)); // first confirmed snapshot — paints, load resolves
+        await chart.ready();
+        expect(renderer.setBarsCalls).toEqual([{ n: 40, preserveView: false }]);
+        emit!(all.slice(-90)); // deeper snapshot — repaints, viewport preserved
+        expect(renderer.setBarsCalls).toEqual([{ n: 40, preserveView: false }, { n: 90, preserveView: true }]);
+        finish!(all); // convergence — final paint + completion
+        await chart.historyComplete();
+        expect(renderer.setBarsCalls).toEqual([
+            { n: 40, preserveView: false },
+            { n: 90, preserveView: true },
+            { n: 120, preserveView: true },
+        ]);
+
+        // NULL = the resolved provider lacks the capability: the classic single load runs.
+        const fallback = new FakeRenderer();
+        const legacy: MarketDataFeed = {
+            load: () => Promise.resolve(makeBars(30)),
+            subscribe: () => () => {},
+            loadProgressive: () => Promise.resolve(null),
+        };
+        const b = new Vela({} as unknown as HTMLElement, { bars: 30 }, { renderer: fallback, engines: [new MockEngine()], dataFeed: legacy });
+        await b.ready();
+        await b.historyComplete();
+        expect(fallback.setBarsCalls).toEqual([{ n: 30, preserveView: false }]);
+    });
+
+    it('switching markets ABORTS the in-flight progressive stream — the source stops polling', async () => {
+        // An abandoned stream left polling its budget out starves the browser's per-host
+        // connection pool — and the NEXT symbol's very first fetch with it (measured on a
+        // live gateway switch). The bump must reach the source as an abort, promptly.
+        const signals: AbortSignal[] = [];
+        let emit: ((bars: OHLCV[]) => void) | null = null;
+        const feed: MarketDataFeed = {
+            load: () => Promise.resolve(makeBars(20)),
+            subscribe: () => () => {},
+            loadProgressive: (_cfg, onBatch, opts) => {
+                signals.push(opts!.signal!);
+                emit = onBatch;
+                return new Promise(() => {}); // a slow source that never resolves on its own
+            },
+        };
+        const chart = new Vela({} as unknown as HTMLElement, { bars: 100 }, { renderer: new FakeRenderer(), engines: [new MockEngine()], dataFeed: feed });
+        await Promise.resolve();
+        emit!(makeBars(15)); // first paint releases the load pipeline
+        await chart.ready();
+        expect(signals).toHaveLength(1);
+        expect(signals[0]!.aborted).toBe(false);
+        const switching = chart.setMarket({ symbol: 'OTHER' }); // supersede mid-stream
+        await Promise.resolve(); // let the switch reach its own progressive await
+        expect(signals[0]!.aborted).toBe(true); // the old stream was told to stop, promptly
+        expect(signals).toHaveLength(2); // the new market got its own stream + fresh signal
+        expect(signals[1]!.aborted).toBe(false);
+        emit!(makeBars(10)); // the new stream paints — the switch resolves
+        await switching;
+    });
+
     it('the single-request depth boundary: 5000 in one pass, and 5001 still one (a chunk covers it)', async () => {
         const atLimit = new FakeRenderer();
         const a = new Vela({} as unknown as HTMLElement, { bars: 5000 }, { renderer: atLimit, engines: [new MockEngine()], dataFeed: new SizedDataFeed() });


### PR DESCRIPTION
New optional port capability: DataProvider.getBarsProgressive / MarketDataFeed.loadProgressive stream growing snapshots while a source heals a cold symbol — cumulative, confirmed from the newest bar back to the newest stretch the source still owes, never cut on bar-time gaps (holidays are data). The orchestrator paints every snapshot, returns at the first paint, and completes when the final answer resolves; a NULL resolution means the source lacks the capability and the classic single/deep paths run untouched.

Supersession aborts the in-flight stream (AbortSignal through every feed layer): an abandoned loop left polling its budget out starved the browser's per-host connection pool — and the next symbol's very first fetch with it (measured on a live switch; the old symbol now goes silent within one poll).