### PR TITLE
Extended lines: fold anchor prices only while the line crosses the view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Extended lines no longer squeeze the price scale when nothing of them is in
+  view.** A line contributes its anchor prices (`y1`/`y2`) to the automatic price
+  scale only while some painted part of it — the anchor segment or its `extend`
+  projection — actually crosses the visible bars, and the projection itself never
+  contributes values of its own. In particular a vertical line (both points on
+  the same bar, the common `extend.both` idiom) extends along itself, so once its
+  bar scrolls out of view it stops pulling its price into the scale — previously
+  a far-away anchor price kept flattening the candles from off-screen. Extended
+  lines that do cross the window still scale into view by their anchor prices.
+
 ## [v0.6.10]
 
 ### Added

--- a/src/renderers/shared/DrawingSceneRenderer.ts
+++ b/src/renderers/shared/DrawingSceneRenderer.ts
@@ -80,6 +80,21 @@ function fontSizePx(size: BoxTextSize): number {
 }
 
 /**
+ * Whether any painted part of a line — anchor segment plus its `extend`
+ * projection — crosses the visible bar window `[lo, hi]` (logical x). A vertical
+ * line (x1 == x2) extends along itself, so extend adds no horizontal coverage.
+ */
+function lineCoversWindow(a: number, b: number, extend: DrawingExtend, lo: number, hi: number): boolean {
+    const minX = Math.min(a, b);
+    const maxX = Math.max(a, b);
+    if (a === b) return a >= lo && a <= hi;
+    if (extend === 'both') return true;
+    if (extend === 'left') return maxX >= lo;
+    if (extend === 'right') return minX <= hi;
+    return maxX >= lo && minX <= hi;
+}
+
+/**
  * Backend-agnostic renderer for all Pine drawing objects (line/box/label/
  * polyline/linefill) — shared verbatim by the lightweight-charts `DrawingLayer`
  * primitive and the native renderer. The caller supplies a canvas2d context plus
@@ -159,7 +174,12 @@ export class DrawingSceneRenderer {
 
         for (const ln of this.set.lines) {
             if (ln.invisible) continue;
-            if (!visible(this.logicalOf(ln.xloc, ln.x1), this.logicalOf(ln.xloc, ln.x2), ln.extend)) continue;
+            // A line folds its ANCHOR prices (y1/y2) while some painted part of it
+            // crosses the window: the extension widens WHERE the line is, but its
+            // projected values never define the scale. A vertical line (x1 == x2)
+            // extends along itself — no horizontal coverage beyond its own bar — so
+            // one anchored off-screen contributes nothing (it paints nothing here).
+            if (!lineCoversWindow(this.logicalOf(ln.xloc, ln.x1), this.logicalOf(ln.xloc, ln.x2), ln.extend, lo, hi)) continue;
             fold(ln.y1);
             fold(ln.y2);
         }

--- a/test/drawing-extend-autoscale.test.ts
+++ b/test/drawing-extend-autoscale.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { DrawingSceneRenderer, EMPTY_DRAWING_SET, type DrawingSet } from '../src/renderers/shared/DrawingSceneRenderer';
+import type { DrawingLine } from '../src/core/model/drawings';
+import type { VelaTheme } from '../src/core/options';
+
+/**
+ * Lines and autoscale: a line folds its ANCHOR prices (y1/y2) while some painted
+ * part of it — anchor segment plus its `extend` projection — crosses the visible
+ * bar window. The extension widens WHERE the line is, but its projected y-values
+ * never define the scale, and a vertical line (x1 == x2) extends along itself,
+ * so one anchored off-screen paints nothing in the window and contributes
+ * nothing — its far-away anchor prices must not squeeze the pane.
+ */
+
+const theme = { textColor: '#fff' } as VelaTheme;
+
+function line(over: Partial<DrawingLine>): DrawingLine {
+    return {
+        id: 'ln',
+        paneId: 'price',
+        xloc: 'bar_index',
+        extend: 'none',
+        x1: 100,
+        y1: 5,
+        x2: 110,
+        y2: 6,
+        color: '#0f0',
+        width: 1,
+        style: 'solid',
+        invisible: false,
+        arrowLeft: false,
+        arrowRight: false,
+        ...over,
+    };
+}
+
+function rangeOf(ln: DrawingLine, from: number, to: number) {
+    const set: DrawingSet = { ...EMPTY_DRAWING_SET, lines: [ln] };
+    const r = new DrawingSceneRenderer({ timeToLogical: () => 0, barAt: () => null, theme });
+    r.setSet(set);
+    return r.priceRange(from, to);
+}
+
+describe('extended lines and autoscale (priceRange)', () => {
+    it('folds y1/y2 while the anchor segment is in view — extended or not', () => {
+        for (const extend of ['none', 'left', 'right', 'both'] as const) {
+            const r = rangeOf(line({ extend }), 90, 120);
+            expect(r).not.toBeNull();
+            expect(r!.min).toBe(5);
+            expect(r!.max).toBe(6);
+        }
+    });
+
+    it('extend.both keeps folding y1/y2 with OFF-SCREEN anchors — the projection crosses every window', () => {
+        for (const window of [[500, 600], [0, 50]] as const) {
+            const r = rangeOf(line({ extend: 'both' }), window[0], window[1]);
+            expect(r).not.toBeNull();
+            expect(r!.min).toBe(5);
+            expect(r!.max).toBe(6);
+        }
+    });
+
+    it('extend.left / extend.right fold only on the side the projection covers', () => {
+        // Segment at bars 100..110; extend.right covers [100, ∞).
+        expect(rangeOf(line({ extend: 'right' }), 500, 600)).not.toBeNull();
+        expect(rangeOf(line({ extend: 'right' }), 0, 50)).toBeNull();
+        // extend.left covers (-∞, 110].
+        expect(rangeOf(line({ extend: 'left' }), 0, 50)).not.toBeNull();
+        expect(rangeOf(line({ extend: 'left' }), 500, 600)).toBeNull();
+    });
+
+    it('unextended off-screen lines stay excluded (regression baseline)', () => {
+        expect(rangeOf(line({}), 500, 600)).toBeNull();
+        expect(rangeOf(line({}), 0, 50)).toBeNull();
+    });
+
+    it('a vertical/point line (x1 == x2) + extend — the vertical-line idiom — folds only while its bar is in view', () => {
+        for (const extend of ['left', 'right', 'both'] as const) {
+            const point = line({ x1: 100, x2: 100, y1: 7, y2: 7, extend });
+            // Anchor bar visible: only the anchor price folds (the full-height
+            // vertical extension is paint-time and contributes nothing).
+            const r = rangeOf(point, 90, 120);
+            expect(r).not.toBeNull();
+            expect(r!.min).toBe(7);
+            expect(r!.max).toBe(7);
+            // Anchor bar off-screen: the vertical extension adds no horizontal
+            // coverage — nothing paints in the window, nothing folds.
+            expect(rangeOf(point, 500, 600)).toBeNull();
+            expect(rangeOf(point, 0, 50)).toBeNull();
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes a price-scale squeeze caused by extended Pine lines: a `line.new` with `extend` folded its anchor prices (`y1`/`y2`) into the automatic price scale unconditionally, so a line whose anchors sat off-screen kept flattening the candles from far away. The reported case is the vertical-line idiom — both points on one bar (`line.new(bar_index[n], y, bar_index[n], y, extend = extend.both)`) — which kept pulling a historical price into the scale long after its bar scrolled out of view.
- New rule in `DrawingSceneRenderer.priceRange`: a line folds `y1`/`y2` only while some painted part of it — the anchor segment or its `extend` projection — crosses the visible bars. `extend.both` still scales into view by its anchor prices; `extend.left`/`extend.right` fold only while the window is on the covered side; a vertical line extends along itself (no horizontal coverage), so it contributes nothing once its bar is off-screen. The projection's own y-values never contribute.
- Adds a targeted unit suite (`test/drawing-extend-autoscale.test.ts`) pinning every branch, and a changelog entry under `[Unreleased]`.

## Test plan

- [x] `test/drawing-extend-autoscale.test.ts` — 5 tests covering: visible anchors fold for every extend; `extend.both` folds with off-screen anchors; `left`/`right` fold only on their covered side; unextended off-screen lines stay excluded; the vertical/point idiom folds only while its bar is in view.
- [x] Full gate: typecheck, lint, test (1413 passed), build.
- [x] Workspace oracle suites re-run against the rebuilt bundles: vela 22/22, vela-pro 11/11.
- [x] Verified live in the Vela-pro playground (linked build): a horizontal `extend.both` level with off-screen anchors scales into view by its anchor price, and an off-screen vertical point line no longer squeezes the pane.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized autoscale geometry in shared drawing renderer with regression tests; no API or persistence changes.
> 
> **Overview**
> Fixes **automatic price-scale squeezing** from Pine extended lines: anchor prices (`y1`/`y2`) are folded into autoscale only while some **painted** part of the line — the anchor segment or its `extend` projection — crosses the visible bar window. The projection widens horizontal coverage but never adds its own y-values to the scale.
> 
> In **`DrawingSceneRenderer.priceRange`**, line handling replaces the old rule (any `extend` other than `none` always counted) with **`lineCoversWindow`**: `extend.both` still affects every window; `left`/`right` only when the window sits on the covered side; unextended off-screen segments stay excluded. **Vertical / point lines** (`x1 === x2`) get no extra horizontal coverage from extend, so once their bar scrolls off-screen they no longer pull a distant anchor price into the scale (the common `extend.both` vertical-line idiom).
> 
> Adds **`test/drawing-extend-autoscale.test.ts`** and a **CHANGELOG** `[Unreleased]` fixed entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a75faafaa8b4c9477b47eb67bcbc9feb7543c4e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->