### PR TITLE
Center multi-chart view controls on the candle plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to Vela, newest first.
   bar scrolls out of view it stops pulling its price into the scale — previously
   a far-away anchor price kept flattening the candles from off-screen. Extended
   lines that do cross the window still scale into view by their anchor prices.
+- **Multi-chart view controls sit on the candles.** The hover cluster that
+  zooms, resets, and moves a chart now centers on the price plot — the area
+  where the candles live — instead of the full cell, so the price scale on
+  the right no longer pulls it off-center.
+
 ### Added
 
 - **Indicator input and prop edits survive a reload — as deltas.** Changing an

--- a/src/widget/cell-controls.ts
+++ b/src/widget/cell-controls.ts
@@ -1,8 +1,9 @@
-// Per-cell view controls — a hover cluster pinned to the bottom-center of a workspace
-// cell: a drag handle to move the chart within the grid, zoom out / zoom in,
-// maximize-or-restore, and reset view. Revealed by cursor proximity, the same
-// affordance as the renderer's scroll-to-realtime button, and styled like the pane
-// clusters (a neutral scrim pill over chart content).
+// Per-cell view controls — a hover cluster pinned to the bottom-center of a
+// workspace cell's PRICE PLOT (the candles, not the price-scale gutter): a drag
+// handle to move the chart within the grid, zoom out / zoom in, maximize-or-
+// restore, and reset view. Revealed by cursor proximity, the same affordance as
+// the renderer's scroll-to-realtime button, and styled like the pane clusters
+// (a neutral scrim pill over chart content).
 import { icon } from '../core/icons';
 import { injectStyles } from '../ui/styles';
 import { Glider, ZOOM_IN, ZOOM_OUT } from './glide';
@@ -23,6 +24,14 @@ const CLUSTER_H = 24;
  *  rather than a themed surface (same value as the pane clusters). */
 const CLUSTER_PILL = 'rgba(0,0,0,0.65)';
 
+/**
+ * CSS `left` that centers the cluster on the plot (candles), not the full cell.
+ * `--vela-toolbar-gutter` / `--vela-scale-gutter` are published on the mount
+ * container (the cell host) by the renderer.
+ */
+export const CLUSTER_LEFT_CSS =
+    'calc((100% + var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px)) / 2)';
+
 const STYLE_ID = 'vela-cell-controls';
 const CSS = `
 .vela-cc-btn{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;padding:0;border:none;border-radius:var(--vela-radius-sm);background:transparent;line-height:0;font-size:12px;color:var(--vela-fg-muted);cursor:pointer;}
@@ -33,12 +42,27 @@ const CSS = `
 .vela-cc-grip:active{cursor:grabbing;}
 `;
 
+/** Horizontal center of the plot (candles) in cell-local x — the scale gutter
+ *  is the price axis, the toolbar gutter is the drawings dock. PURE. */
+export function plotCenterX(width: number, toolbarGutter = 0, scaleGutter = 0): number {
+    return (width + toolbarGutter - scaleGutter) / 2;
+}
+
 /**
- * Is the pointer near the cluster's resting spot (bottom-center of the cell)? PURE —
- * `x`/`y` are cell-local coordinates, `width`/`height` the cell's size.
+ * Is the pointer near the cluster's resting spot (bottom-center of the plot)?
+ * PURE — `x`/`y` are cell-local coordinates, `width`/`height` the cell's size.
+ * Pass the renderer gutters so the hotspot tracks the visual center when a
+ * price axis (or drawings toolbar) is reserved.
  */
-export function nearBottomCenter(x: number, y: number, width: number, height: number, proximityPx = CELL_CONTROLS_PROXIMITY_PX): boolean {
-    const cx = width / 2;
+export function nearBottomCenter(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    proximityPx = CELL_CONTROLS_PROXIMITY_PX,
+    gutters: { toolbar?: number; scale?: number } = {},
+): boolean {
+    const cx = plotCenterX(width, gutters.toolbar ?? 0, gutters.scale ?? 0);
     const cy = height - CONTROLS_BOTTOM_PX - CLUSTER_H / 2;
     return Math.hypot(x - cx, y - cy) <= proximityPx;
 }
@@ -90,7 +114,7 @@ export class CellControls {
         this.root = host.ownerDocument.createElement('div');
         Object.assign(this.root.style, {
             position: 'absolute',
-            left: '50%',
+            left: CLUSTER_LEFT_CSS,
             bottom: `${CONTROLS_BOTTOM_PX}px`,
             transform: 'translateX(-50%)',
             zIndex: '6',
@@ -200,11 +224,22 @@ export class CellControls {
         if (on) this.setNear(false);
     }
 
+    /** Live renderer gutters on the cell host (0 when unpublished — a test stub). */
+    private hostGutters(): { toolbar: number; scale: number } {
+        const view = this.host.ownerDocument.defaultView;
+        if (!view) return { toolbar: 0, scale: 0 };
+        const cs = view.getComputedStyle(this.host);
+        return {
+            toolbar: Number.parseFloat(cs.getPropertyValue('--vela-toolbar-gutter')) || 0,
+            scale: Number.parseFloat(cs.getPropertyValue('--vela-scale-gutter')) || 0,
+        };
+    }
+
     private readonly onHostMove = (e: PointerEvent): void => {
         if (this.suspended) return;
         if (this.dragging) return; // captured drag moves sweep the grid — keep the cluster up
         const rect = this.host.getBoundingClientRect();
-        this.setNear(nearBottomCenter(e.clientX - rect.left, e.clientY - rect.top, rect.width, rect.height));
+        this.setNear(nearBottomCenter(e.clientX - rect.left, e.clientY - rect.top, rect.width, rect.height, CELL_CONTROLS_PROXIMITY_PX, this.hostGutters()));
     };
 
     private readonly onHostLeave = (): void => {

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -223,7 +223,7 @@ export class ChartCell {
     /** Keeps the pre/post-market shading on the symbol's real calendar (see {@link SessionShadingTracker}). */
     private readonly sessionShading = new SessionShadingTracker((zones) => this.inner?.renderer.set('sessionZones', zones));
     private readonly watermark: Watermark | null;
-    /** Bottom-center hover cluster: drag handle, zoom in/out, maximize/restore, reset view. */
+    /** Bottom-center hover cluster, pinned to the price plot: drag handle, zoom in/out, maximize/restore, reset view. */
     private readonly cellControls: CellControls;
     private readonly contextMenu: ChartContextMenu;
     private readonly offMarket: () => void;

--- a/test/cell-controls.test.ts
+++ b/test/cell-controls.test.ts
@@ -3,7 +3,7 @@
 // is a MINIMAL stub (element tree, listeners, inline style); real rendering and the
 // workspace's maximize presentation are proven in the browser.
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { CellControls, nearBottomCenter, CELL_CONTROLS_PROXIMITY_PX, type CellControlsDeps } from '../src/widget/cell-controls';
+import { CellControls, nearBottomCenter, plotCenterX, CELL_CONTROLS_PROXIMITY_PX, CLUSTER_LEFT_CSS, type CellControlsDeps } from '../src/widget/cell-controls';
 import type { Vela } from '../src/Vela';
 
 interface StubEl {
@@ -105,7 +105,7 @@ afterEach(() => {
 
 describe('nearBottomCenter (pure)', () => {
     it('is true at the cluster spot and within the proximity radius', () => {
-        // 800×600 cell: the cluster centers at (400, 600 − 34 − 12) = (400, 554).
+        // 800×600 cell, no gutters: the cluster centers at (400, 600 − 34 − 12) = (400, 554).
         expect(nearBottomCenter(400, 554, 800, 600)).toBe(true);
         expect(nearBottomCenter(400 + CELL_CONTROLS_PROXIMITY_PX, 554, 800, 600)).toBe(true); // radius inclusive
         expect(nearBottomCenter(400, 554 - CELL_CONTROLS_PROXIMITY_PX, 800, 600)).toBe(true);
@@ -122,9 +122,33 @@ describe('nearBottomCenter (pure)', () => {
         expect(nearBottomCenter(200, 254, 400, 300)).toBe(true); // half-size cell, its own bottom-center
         expect(nearBottomCenter(400, 554, 400, 300)).toBe(false); // the big cell's spot is outside a small cell
     });
+
+    it('centers on the plot, not the full cell, when a scale gutter is reserved', () => {
+        // 800px cell, 64px price axis: plot center at (800 − 64) / 2 = 368.
+        const scale = 64;
+        const cx = plotCenterX(800, 0, scale);
+        expect(cx).toBe(368);
+        expect(nearBottomCenter(cx, 554, 800, 600, CELL_CONTROLS_PROXIMITY_PX, { scale })).toBe(true);
+        expect(nearBottomCenter(cx + CELL_CONTROLS_PROXIMITY_PX, 554, 800, 600, CELL_CONTROLS_PROXIMITY_PX, { scale })).toBe(true);
+        // The old full-cell right edge (400 + 120 = 520) is now outside the radius.
+        expect(nearBottomCenter(520, 554, 800, 600, CELL_CONTROLS_PROXIMITY_PX, { scale })).toBe(false);
+        expect(nearBottomCenter(520, 554, 800, 600)).toBe(true); // without a gutter, the old spot still holds
+    });
+
+    it('shifts right by half the toolbar gutter (drawings dock on the left)', () => {
+        expect(plotCenterX(800, 44, 64)).toBe(390); // (800 + 44 − 64) / 2
+    });
 });
 
 describe('CellControls — button set and gating', () => {
+    it('pins left to the plot center (scale gutter), not the full cell', () => {
+        const host = makeHost();
+        new CellControls(host as never, makeDeps());
+        expect(cluster(host).style.left).toBe(CLUSTER_LEFT_CSS);
+        expect(cluster(host).style.left).toContain('--vela-scale-gutter');
+        expect(cluster(host).style.transform).toBe('translateX(-50%)');
+    });
+
     it('builds drag / zoom out / zoom in / maximize / reset on a multi-cell grid', () => {
         const host = makeHost();
         new CellControls(host as never, makeDeps());


### PR DESCRIPTION
## Summary

- The per-chart hover cluster (drag, zoom, maximize, reset) was centered on the **full cell**, including the price axis on the right, so it sat ~32px to the right of the candles.
- It now uses the renderer-published `--vela-toolbar-gutter` / `--vela-scale-gutter` CSS variables (the same ones the watermark already follows) so it sits at the center of the price plot. The hover hotspot tracks the same point.
- Changelog entry under `[Unreleased]` / Fixed.

## Test plan

- [x] `test/cell-controls.test.ts` — plot-center math with a 64px scale gutter, toolbar-gutter shift, and the cluster `left` calc pinning `--vela-scale-gutter`.
- [x] Full gate: typecheck, lint, test (1418 passed), build.
- [x] Playground probe on `http://localhost:5190/workspace.html`: cluster center equals plot center (offset 0px); full-cell center is 32px to the right (half of the 64px scale gutter).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only positioning in workspace cell controls with pure helpers and unit tests; no auth, data, or chart rendering logic changes.
> 
> **Overview**
> **Multi-chart hover controls** (drag, zoom, maximize, reset) no longer anchor to the full cell center. They use the renderer’s `--vela-toolbar-gutter` and `--vela-scale-gutter` on the cell host so the pill and its proximity hotspot sit over the **candle plot**, not offset by the right-hand price scale (or left drawings dock).
> 
> `cell-controls` adds `plotCenterX`, `CLUSTER_LEFT_CSS`, and gutter-aware `nearBottomCenter`; `CellControls` positions with the calc-based `left` and reads gutters at pointer-move time. Tests cover plot-center math and the CSS pin; **CHANGELOG** documents the fix under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795479e33e963d2074ab2ae77dc860935d0a4c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->