### PR TITLE
Status line action menu, symbol logo toggle, and hidden-chart eye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Right-click the status line to shape it.** The in-chart status line now opens
+  an action menu on right-click with a toggle for each of its elements — the new
+  symbol logo toggle (also in the settings dialog's Status line tab), the symbol
+  name, the market status badge, the OHLC values, and the bar change — plus a
+  hide/show for the chart's price series itself, the same switch as the object
+  tree's eye. Hiding the symbol name also hides the venue and timeframe beside it,
+  since the three read as one label. The line also behaves like the indicator
+  legend rows around it: hovering outlines it, and while the chart is hidden it
+  dims, drops its OHLC and change readouts, and shows an eye button that brings
+  the chart back — everything returns exactly as configured.
+
 ## [v0.6.11]
 
 ### Fixed

--- a/docs/user/options.md
+++ b/docs/user/options.md
@@ -185,7 +185,8 @@ new VelaWorkspace('#chart', {
 
       // ══ Widget & workspace tabs (shell-contributed) ═══════════════
       'status-line',                         // the whole Status line tab
-      'status-line.parts',                   //   Status line group (the four rows below)
+      'status-line.parts',                   //   Status line group (the five rows below)
+      'status-line.logo',                    //     Symbol logo
       'status-line.name',                    //     Symbol name
       'status-line.market',                  //     Market status
       'status-line.ohlc',                    //     OHLC values

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -414,10 +414,16 @@ they work from the very first keystroke, before any click.
   in the right-hand cluster. The whole bar is composable — see
   [Composing the topbar](#composing-the-topbar).
 - **Status line** — symbol + OHLC and change of the hovered bar (resting on the latest
-  live bar), stacked above the renderer's indicator legend. In multi-cell grids it
-  stays on one row — segments that don't fit the cell hide instead of wrapping (bar
-  change first, then venue/timeframe, then the market badge; the logo + ticker always
-  stay).
+  live bar), stacked above the renderer's indicator legend and dressed like its rows:
+  hovering outlines the chip, and while the chart's price series is hidden the line
+  dims, drops its value readouts, and shows an eye that brings the chart back.
+  Right-clicking it opens an action menu with a
+  toggle per element (logo, name, market status, OHLC, bar change — the same toggles
+  as the settings dialog's Status line tab; hiding the name also hides the
+  venue/timeframe beside it) plus hide/show for the chart's price series. In
+  multi-cell grids it stays on one row — segments that don't fit the cell hide instead
+  of wrapping (bar change first, then venue/timeframe, then the market badge; the logo
+  + ticker always stay).
 - **Object tree** — a docked panel grouping every item under the pane it belongs to. Each pane is
   one column read top to bottom as front to back: its drawings, its indicators and, in the main
   pane, the price series, all in draw order — new indicators and new drawings both start under

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -12,7 +12,7 @@ export {
     type TopbarComposition,
     type ResolvedTopbarComposition,
 } from './topbar-composition';
-export { Statusline } from './statusline';
+export { Statusline, type StatuslineMenuHooks, type StatuslinePart } from './statusline';
 export { Watermark } from './watermark';
 export { Bottombar, RANGE_PRESETS, type BottombarOptions, type RangePreset } from './bottombar';
 export { SymbolPicker, filterSymbols, type SymbolPickerOptions } from './symbol-picker';

--- a/src/widget/statusline-model.ts
+++ b/src/widget/statusline-model.ts
@@ -1,0 +1,32 @@
+// Status line MODEL — the segment visibility the parts config implies, plus the item
+// descriptors for the status line's right-click menu. Pure functions over plain state,
+// so both can be tested without a DOM; `Statusline` projects them onto its elements.
+import type { MenuItemDescriptor } from '../ui/components/menu';
+
+/** The status line's toggleable segments — the settings dialog's Status line tab and
+ *  the status line's own right-click menu drive these. */
+export type StatuslinePart = 'logo' | 'name' | 'market' | 'ohlc' | 'change';
+
+/** Per-segment visibility the parts config implies. The venue/timeframe meta carries no
+ *  part of its own: it reads as an extension of the symbol name ("BTCUSDT · BINANCE ·
+ *  1h" is one identity readout), so it follows 'name'. A hidden chart (the price series
+ *  eye) drops the whole value readout — OHLC and bar change, values of a series that
+ *  isn't painted — without touching the parts themselves, so showing the chart brings
+ *  them straight back; the eye affordance that re-shows the chart is out only then. */
+export function segmentVisibility(parts: Record<StatuslinePart, boolean>, chartHidden = false): { avatar: boolean; symbol: boolean; meta: boolean; market: boolean; ohlc: boolean; change: boolean; eye: boolean } {
+    return { avatar: parts.logo, symbol: parts.name, meta: parts.name, market: parts.market, ohlc: parts.ohlc && !chartHidden, change: parts.change && !chartHidden, eye: chartHidden };
+}
+
+/** Right-click menu rows: one checkable toggle per part (same labels as the settings
+ *  dialog's Status line tab), then the chart itself — the same hide/show of the price
+ *  series the object tree's eye drives. */
+export function statuslineMenuItems(parts: Record<StatuslinePart, boolean>, chartVisible: boolean): MenuItemDescriptor[] {
+    return [
+        { id: 'part:logo', label: 'Symbol logo', checked: parts.logo },
+        { id: 'part:name', label: 'Symbol name', checked: parts.name },
+        { id: 'part:market', label: 'Market status', checked: parts.market },
+        { id: 'part:ohlc', label: 'OHLC values', checked: parts.ohlc },
+        { id: 'part:change', label: 'Bar change values', checked: parts.change },
+        { id: 'chart', label: chartVisible ? 'Hide chart' : 'Show chart', separatorBefore: true },
+    ];
+}

--- a/src/widget/statusline.ts
+++ b/src/widget/statusline.ts
@@ -6,7 +6,10 @@ import type { OHLCV } from '../core/model/ohlcv';
 import { injectStyles } from '../ui/styles';
 import { Tooltip } from '../ui/components/tooltip';
 import { CalloutBubble } from '../ui/components/callout-bubble';
+import { Menu } from '../ui/components/menu';
+import { segmentVisibility, statuslineMenuItems, type StatuslinePart } from './statusline-model';
 import { SESSION_PRE, SESSION_POST, SESSION_OFF } from '../core/palette';
+import { iconAt } from '../core/icons';
 import { fmtPrice, fmtChange, decimalsFor } from './format';
 import { timeframeLabel } from './timeframe';
 import { tickerIconEl } from './symbol-icon';
@@ -41,7 +44,13 @@ const CSS = `
     padding: 2px 7px;
     margin-left: -7px;
 }
-.vela-statusline:hover { background: var(--vela-bg); }
+/* Hovering opens the chip the same way a legend row opens: solid chart background
+ * plus the same inset neutral outline the indicator rows wear (InputsUI's
+ * setRowHighlighted) — the two columns read as one family. */
+.vela-statusline:hover { background: var(--vela-bg); box-shadow: inset 0 0 0 1px var(--vela-border); }
+/* Chart hidden (the price series' eye — renderer 'candleVisible'): the line dims to
+ * the same 0.5 wash a hidden indicator's legend row wears. */
+.vela-statusline.vela-sl-chart-hidden { opacity: 0.5; }
 .vela-statusline .vela-sl-avatar {
     width: 18px;
     height: 18px;
@@ -66,6 +75,24 @@ const CSS = `
  * these are the pre-ink fallbacks only. */
 .vela-statusline .vela-sl-change[data-dir='up'] { color: var(--vela-up); }
 .vela-statusline .vela-sl-change[data-dir='down'] { color: var(--vela-down); }
+/* The show-chart eye — out only while the chart is hidden (syncParts drives display),
+ * replacing the value readout it took away. Same footprint as a legend action button. */
+.vela-statusline .vela-sl-eye {
+    align-self: center;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: none;
+    border-radius: 3px;
+    background: none;
+    color: var(--vela-fg-muted);
+    cursor: pointer;
+    line-height: 0;
+    flex: none;
+}
+.vela-statusline .vela-sl-eye:hover { color: var(--vela-fg); background: color-mix(in srgb, var(--vela-fg) 12%, transparent); }
 /* Stack the TOP pane's legend below the status line (lower study panes stay put).
  * The renderer marks whichever legend sits at the plot's top edge — the price pane
  * normally, or a maximized study pane filling the plot — so the legend never merges
@@ -222,8 +249,17 @@ export function statuslineInkOf(renderer: RendererReads, priceStyle: string): [s
     }
 }
 
-/** The status line's toggleable segments (the settings dialog's Status line tab). */
-export type StatuslinePart = 'name' | 'market' | 'ohlc' | 'change';
+export { segmentVisibility, statuslineMenuItems, type StatuslinePart } from './statusline-model';
+
+/** Host hooks behind the right-click action menu. Part toggles route through the host
+ *  (never straight into {@link Statusline.setPartVisible}) so its persistence and
+ *  style-link mirroring follow; the chart toggle reaches the renderer the host owns. */
+export interface StatuslineMenuHooks {
+    setPart: (part: StatuslinePart, visible: boolean) => void;
+    /** Whether the main price series is currently painted (the renderer's `candleVisible`). */
+    chartVisible: () => boolean;
+    setChartVisible: (visible: boolean) => void;
+}
 
 export class Statusline {
     readonly el: HTMLElement;
@@ -234,9 +270,17 @@ export class Statusline {
     /** The badge itself — a kit callout bubble (the same element as {@link marketEl}). */
     private readonly marketBubble: CalloutBubble;
     private marketTip!: Tooltip;
+    /** The show-chart eye — visible only while the chart is hidden. */
+    private readonly eyeEl: HTMLButtonElement;
+    private eyeTip!: Tooltip;
     private avatarEl: HTMLElement;
     private metaEl!: HTMLElement;
-    private readonly parts = { name: true, market: true, ohlc: true, change: true };
+    private readonly parts: Record<StatuslinePart, boolean> = { logo: true, name: true, market: true, ohlc: true, change: true };
+    /** The right-click action menu — present once a host wires it via {@link attachMenu}. */
+    private menu: Menu | null = null;
+    private menuHooks: StatuslineMenuHooks | null = null;
+    /** Mirror of the renderer's `candleVisible` — see {@link setChartHidden}. */
+    private chartHidden = false;
     private lastBar: BarLike | null = null;
     private hoverBar: BarLike | null = null;
     private unsubs: Array<() => void> = [];
@@ -291,11 +335,25 @@ export class Statusline {
         this.ohlcEl.className = 'vela-sl-ohlc';
         this.changeEl = doc.createElement('span');
         this.changeEl.className = 'vela-sl-change';
-        this.el.append(this.avatarEl, this.symbolEl, this.metaEl, this.marketEl, this.ohlcEl, this.changeEl);
+        // Show-chart eye: takes the value readout's place while the chart is hidden
+        // (same glyph the legend rows wear on a hidden indicator). syncParts drives it.
+        this.eyeEl = doc.createElement('button');
+        this.eyeEl.type = 'button';
+        this.eyeEl.className = 'vela-sl-eye';
+        this.eyeEl.innerHTML = iconAt('eye-off', 14);
+        this.eyeEl.setAttribute('aria-label', 'Show chart');
+        this.eyeEl.style.display = 'none';
+        this.eyeEl.addEventListener('click', (e) => {
+            e.stopPropagation(); // never bubbles into the chip's own handlers
+            this.menuHooks?.setChartVisible(true);
+            this.setChartHidden(false);
+        });
+        this.el.append(this.avatarEl, this.symbolEl, this.metaEl, this.marketEl, this.ohlcEl, this.changeEl, this.eyeEl);
         host.appendChild(this.el);
-        // The tooltip portals to the nearest `.vela-ui` ancestor for theme tokens — resolve
-        // it AFTER the statusline is in the DOM. Content follows setMarketStatus.
+        // The tooltips portal to the nearest `.vela-ui` ancestor for theme tokens — resolve
+        // them AFTER the statusline is in the DOM. The badge's content follows setMarketStatus.
         this.marketTip = new Tooltip(this.marketEl, { content: MARKET_LABELS.open, placement: 'bottom' });
+        this.eyeTip = new Tooltip(this.eyeEl, { content: 'Show chart', placement: 'bottom' });
         this.setMarketStatus('open'); // crypto trades continuously (no session model yet)
         this.render();
     }
@@ -306,6 +364,7 @@ export class Statusline {
         const fresh = tickerIconEl(this.el.ownerDocument, baseOfTicker(ticker), ticker, 'vela-sl-avatar', this.iconFor?.(symbol));
         this.avatarEl.replaceWith(fresh);
         this.avatarEl = fresh;
+        this.syncParts(); // the fresh avatar must inherit a hidden logo part
         this.fit();
     }
 
@@ -335,21 +394,26 @@ export class Statusline {
 
     /** Project the parts config onto the segments (the baseline fit() prunes from). */
     private syncParts(): void {
-        this.symbolEl.style.display = this.parts.name ? '' : 'none';
-        this.marketEl.style.display = this.parts.market ? '' : 'none';
-        this.ohlcEl.style.display = this.parts.ohlc ? '' : 'none';
-        this.changeEl.style.display = this.parts.change ? '' : 'none';
+        const seg = segmentVisibility(this.parts, this.chartHidden);
+        this.avatarEl.style.display = seg.avatar ? '' : 'none';
+        this.symbolEl.style.display = seg.symbol ? '' : 'none';
+        this.metaEl.style.display = seg.meta ? '' : 'none';
+        this.marketEl.style.display = seg.market ? '' : 'none';
+        this.ohlcEl.style.display = seg.ohlc ? '' : 'none';
+        this.changeEl.style.display = seg.change ? '' : 'none';
+        this.eyeEl.style.display = seg.eye ? 'inline-flex' : 'none';
     }
 
     /** Hide overflowing segments until the row fits its max-width (fit mode only). */
     private fit(): void {
         if (!this.fitMode) return;
         this.syncParts(); // start from the full (parts-allowed) row, then prune
+        const seg = segmentVisibility(this.parts, this.chartHidden);
         const order: Array<[HTMLElement, boolean]> = [
-            [this.ohlcEl, this.parts.ohlc],
-            [this.changeEl, this.parts.change],
-            [this.metaEl, true],
-            [this.marketEl, this.parts.market],
+            [this.ohlcEl, seg.ohlc],
+            [this.changeEl, seg.change],
+            [this.metaEl, seg.meta],
+            [this.marketEl, seg.market],
         ];
         for (const [el, shown] of order) {
             if (this.el.scrollWidth <= this.el.clientWidth) break;
@@ -372,7 +436,6 @@ export class Statusline {
         this.render();
     }
 
-    /** Show/hide one part (the settings dialog's Status line tab drives these). */
     /** The "· BINANCE · 1h" segment after the symbol — venue first, then resolution. */
     setMeta(timeframe: string, provider: string): void {
         this.metaEl.textContent = `${provider ? `· ${provider.toUpperCase()} ` : ''}· ${timeframeLabel(timeframe)}`;
@@ -393,6 +456,9 @@ export class Statusline {
         this.marketTip.setContent(MARKET_LABELS[status]);
     }
 
+    /** Show/hide one part — the settings dialog's Status line tab and the right-click
+     *  menu both drive these. 'name' owns the venue/timeframe meta too (see
+     *  {@link segmentVisibility}). */
     setPartVisible(part: StatuslinePart, visible: boolean): void {
         this.parts[part] = visible;
         this.syncParts();
@@ -401,6 +467,61 @@ export class Statusline {
 
     partVisible(part: StatuslinePart): boolean {
         return this.parts[part];
+    }
+
+    /** Mirror the chart's (price series') visibility: dim the whole line like a hidden
+     *  indicator's legend row, drop the value readout (OHLC + bar change — values of a
+     *  series that isn't painted), and put the show-chart eye out in its place. The
+     *  parts config is untouched, so showing the chart restores the readout exactly as
+     *  configured. Idempotent; {@link render} re-syncs it from the live renderer, so
+     *  toggles made elsewhere (the object tree's eye) converge too. */
+    setChartHidden(hidden: boolean): void {
+        if (hidden === this.chartHidden) return;
+        this.chartHidden = hidden;
+        this.el.classList.toggle('vela-sl-chart-hidden', hidden);
+        this.syncParts();
+        this.fit();
+    }
+
+    /** Wire the right-click action menu: one checkable toggle per part plus hide/show
+     *  for the chart itself. The menu is built once; later calls just swap the hooks. */
+    attachMenu(hooks: StatuslineMenuHooks): void {
+        this.menuHooks = hooks;
+        if (this.menu) return;
+        this.menu = new Menu({
+            host: this.host,
+            items: [],
+            placement: 'bottom-start',
+            // Pointer-anchored action menu — checked state reads as a leading ✓ (the
+            // same shape as the chart's own context menu).
+            checkmarks: true,
+            onSelect: (id) => this.runMenuItem(id),
+        });
+        this.el.addEventListener('contextmenu', this.onContextMenu);
+    }
+
+    private readonly onContextMenu = (e: MouseEvent): void => {
+        if (!this.menu || !this.menuHooks) return;
+        // This right-click is the status line's — keep the chart's own context menu closed.
+        e.preventDefault();
+        e.stopPropagation();
+        const chartVisible = this.menuHooks.chartVisible();
+        this.setChartHidden(!chartVisible); // opportunistic re-sync with the live renderer
+        this.menu.setItems(statuslineMenuItems(this.parts, chartVisible));
+        this.menu.openAt(e.clientX, e.clientY);
+    };
+
+    private runMenuItem(id: string): void {
+        const hooks = this.menuHooks;
+        if (!hooks) return;
+        if (id.startsWith('part:')) {
+            const part = id.slice('part:'.length) as StatuslinePart;
+            hooks.setPart(part, !this.parts[part]);
+        } else if (id === 'chart') {
+            const next = !hooks.chartVisible();
+            hooks.setChartVisible(next);
+            this.setChartHidden(!next);
+        }
     }
 
     /** (Re)bind to a chart instance — called after every widget rebuild. */
@@ -425,7 +546,11 @@ export class Statusline {
         this.detach();
         this.fitRO?.disconnect();
         this.fitRO = null;
+        this.el.removeEventListener('contextmenu', this.onContextMenu);
+        this.menu?.destroy();
+        this.menu = null;
         this.marketTip.destroy();
+        this.eyeTip.destroy();
         this.marketBubble.destroy();
         this.host.classList.remove('vela-has-statusline', 'vela-sl-fit-host'); // the legend shift leaves with the line
         this.el.remove();
@@ -437,6 +562,10 @@ export class Statusline {
     }
 
     private render(): void {
+        // Chart visibility has no change event of its own — re-derive it from the live
+        // renderer on every readout refresh (bar ticks, crosshair moves), so a toggle
+        // made anywhere (the object tree's eye) reaches the status line.
+        if (this.menuHooks) this.setChartHidden(!this.menuHooks.chartVisible());
         const bar = this.hoverBar ?? this.lastBar;
         if (!bar) {
             this.ohlcEl.replaceChildren();

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -392,6 +392,13 @@ export class ChartCell {
         this.statusline = deps.statusline ? new Statusline(this.host, symbol ?? '', (sym) => this.inner?.data.symbolIcon(sym)) : null;
         this.statusline?.setMeta(seed.timeframe ?? '60', this.state.provider ?? '');
         this.statusline?.onChart(this.inner);
+        // The status line's right-click menu: part toggles route through the cell so the
+        // style link mirrors them; the chart toggle is the object tree's same eye seam.
+        this.statusline?.attachMenu({
+            setPart: (part, visible) => this.setStatuslinePart(part, visible),
+            chartVisible: () => this.inner?.renderer.get('candleVisible') !== false,
+            setChartVisible: (visible) => this.inner?.renderer.set('candleVisible', visible),
+        });
         this.marketStatus = this.statusline ? new MarketStatusTracker((s) => this.statusline?.setMarketStatus(s)) : null;
         // The venue chip above is provisional (persisted/typed prefix): once the shared
         // feed's indexes settle, re-derive it from the DATA — a cell restored as
@@ -664,6 +671,7 @@ export class ChartCell {
                 id: 'status-line',
                 rows: [
                     { kind: 'heading', label: 'Status line', id: 'parts' },
+                    { kind: 'toggle', label: 'Symbol logo', id: 'logo', get: () => sl.partVisible('logo'), set: (v: boolean) => this.setStatuslinePart('logo', v) },
                     { kind: 'toggle', label: 'Symbol name', id: 'name', get: () => sl.partVisible('name'), set: (v: boolean) => this.setStatuslinePart('name', v) },
                     { kind: 'toggle', label: 'Market status', id: 'market', get: () => sl.partVisible('market'), set: (v: boolean) => this.setStatuslinePart('market', v) },
                     { kind: 'toggle', label: 'OHLC values', id: 'ohlc', get: () => sl.partVisible('ohlc'), set: (v: boolean) => this.setStatuslinePart('ohlc', v) },
@@ -726,7 +734,7 @@ export class ChartCell {
         const sl = this.statusline;
         return {
             parts: sl
-                ? { name: sl.partVisible('name'), market: sl.partVisible('market'), ohlc: sl.partVisible('ohlc'), change: sl.partVisible('change') }
+                ? { logo: sl.partVisible('logo'), name: sl.partVisible('name'), market: sl.partVisible('market'), ohlc: sl.partVisible('ohlc'), change: sl.partVisible('change') }
                 : null,
             indicatorTitles: this.indicatorTitlesOn,
             indicatorValues: this.indicatorValuesOn,

--- a/test/statusline-model.test.ts
+++ b/test/statusline-model.test.ts
@@ -1,0 +1,73 @@
+// The status line's model (src/widget/statusline-model.ts): which segments each part
+// gates — 'logo' owns the avatar, 'name' owns the symbol text AND the venue/timeframe
+// meta — and the right-click menu's rows. Pure functions over plain objects, node env;
+// the real overlay and menu are proven in the browser.
+import { describe, it, expect } from 'vitest';
+import { segmentVisibility, statuslineMenuItems, type StatuslinePart } from '../src/widget/statusline-model';
+
+const allOn: Record<StatuslinePart, boolean> = { logo: true, name: true, market: true, ohlc: true, change: true };
+
+describe('segmentVisibility', () => {
+    it('everything on shows every segment (and keeps the eye stowed)', () => {
+        expect(segmentVisibility(allOn)).toEqual({ avatar: true, symbol: true, meta: true, market: true, ohlc: true, change: true, eye: false });
+    });
+
+    it("'logo' gates only the avatar", () => {
+        const seg = segmentVisibility({ ...allOn, logo: false });
+        expect(seg.avatar).toBe(false);
+        expect(seg.symbol).toBe(true);
+        expect(seg.meta).toBe(true);
+    });
+
+    it("'name' hides the venue/timeframe meta along with the symbol text", () => {
+        const seg = segmentVisibility({ ...allOn, name: false });
+        expect(seg.symbol).toBe(false);
+        expect(seg.meta).toBe(false);
+        expect(seg.avatar).toBe(true); // the logo keeps its own toggle
+    });
+
+    it('the value parts stay independent', () => {
+        const seg = segmentVisibility({ ...allOn, ohlc: false, change: false, market: false });
+        expect(seg.ohlc).toBe(false);
+        expect(seg.change).toBe(false);
+        expect(seg.market).toBe(false);
+        expect(seg.symbol).toBe(true);
+    });
+
+    it('a hidden chart drops the whole value readout and puts the eye out', () => {
+        const seg = segmentVisibility(allOn, true);
+        expect(seg.ohlc).toBe(false);
+        expect(seg.change).toBe(false);
+        expect(seg.eye).toBe(true);
+        expect(seg.avatar).toBe(true);
+        expect(seg.symbol).toBe(true);
+        expect(seg.market).toBe(true);
+    });
+
+    it('showing the chart again restores the value parts as configured, and stows the eye', () => {
+        const seg = segmentVisibility(allOn, false);
+        expect(seg.ohlc).toBe(true);
+        expect(seg.change).toBe(true);
+        expect(seg.eye).toBe(false);
+        expect(segmentVisibility({ ...allOn, ohlc: false }, false).ohlc).toBe(false);
+    });
+});
+
+describe('statuslineMenuItems', () => {
+    it('offers one checkable toggle per part, checked after the current state', () => {
+        const items = statuslineMenuItems({ ...allOn, logo: false, ohlc: false }, true);
+        const byId = new Map(items.map((i) => [i.id, i]));
+        expect(byId.get('part:logo')?.checked).toBe(false);
+        expect(byId.get('part:name')?.checked).toBe(true);
+        expect(byId.get('part:market')?.checked).toBe(true);
+        expect(byId.get('part:ohlc')?.checked).toBe(false);
+        expect(byId.get('part:change')?.checked).toBe(true);
+    });
+
+    it('ends with the chart toggle, worded after the current visibility and set apart', () => {
+        const shownItems = statuslineMenuItems(allOn, true);
+        expect(shownItems[shownItems.length - 1]).toMatchObject({ id: 'chart', label: 'Hide chart', separatorBefore: true });
+        const hiddenItems = statuslineMenuItems(allOn, false);
+        expect(hiddenItems[hiddenItems.length - 1]).toMatchObject({ id: 'chart', label: 'Show chart' });
+    });
+});


### PR DESCRIPTION
## Summary

- **Right-click action menu on the status line** — a checkable toggle per element (Symbol logo, Symbol name, Market status, OHLC values, Bar change values) plus **Hide chart / Show chart**, driving the same `candleVisible` renderer feature as the object tree's eye. The click never opens the chart's own context menu.
- **New Symbol logo toggle** in the settings dialog's Status line tab (`status-line.logo`), mirrored across style-linked cells like the other parts. Hiding **Symbol name** now also hides the venue/timeframe meta beside it ("BTCUSDT · BINANCE · 1h" reads as one label).
- **Legend-row dressing** — hovering the status line outlines it with the same inset border the indicator legend rows wear; while the chart is hidden the line dims to 0.5, drops its OHLC and bar-change readouts, and shows an **eye button** that brings the chart back. Everything returns exactly as configured. External toggles (object tree eye) converge via a re-sync on every readout refresh, since `candleVisible` has no change event.
- Segment visibility and menu descriptors are extracted into a pure `statusline-model.ts` (mirroring `context-menu-model.ts`) with unit tests; CHANGELOG and user docs updated.

## Test plan

- [x] Gate: `typecheck`, `lint`, `test` (1442, incl. 8 new model tests), `build` all green
- [x] Oracle suite: 23/23 scenarios pass
- [x] Playground (live Binance data): menu opens with correct check states; logo/name toggles hide the right segments; Hide chart dims the line, hides OHLC+change, shows the eye; the eye restores the chart; settings dialog shares state with the menu; object-tree eye toggles converge on the status line

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to the status line overlay and prefs shape; chart visibility uses the existing `candleVisible` renderer feature with no auth or data-path changes.
> 
> **Overview**
> The in-chart **status line** gains a **right-click menu** with checkable toggles for each segment (symbol logo, name, market status, OHLC, bar change) plus **Hide chart / Show chart**, wired to the same `candleVisible` path as the object tree. Part changes go through the cell host so **style sync** and persistence stay consistent with the settings dialog.
> 
> A new **`logo`** segment is exposed in chart settings (`status-line.logo`) and in saved status prefs; hiding **symbol name** also hides the venue/timeframe meta beside it.
> 
> **Legend-row behavior** matches indicator rows: hover inset outline, 0.5 opacity when the price series is hidden, OHLC/change suppressed in that state, and an **eye** control to show the chart again. Visibility rules live in pure **`statusline-model.ts`** (`segmentVisibility`, `statuslineMenuItems`) with unit tests; docs and the changelog describe the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb9530766ca164f2e413ed471a5db1ff8023494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->