### PR TITLE
Ask contributors to sign the org CLA from within their pull requests

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,37 @@
+# Asks external contributors to sign the LuxAlgo CLA from within their pull
+# request (a PR comment signs it) and blocks the PR status until they do.
+# Signatures are stored org-wide in LuxAlgo/cla-signatures, shared with the
+# other LuxAlgo repositories — a contributor signs once for all of them.
+#
+# CLA_PAT is a repository secret: a token able to write to
+# LuxAlgo/cla-signatures, required because signatures live in that remote repo.
+name: 'CLA Assistant'
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'CLA Assistant'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/LuxAlgo/cla-signatures/blob/main/CLA.md'
+          branch: 'main' # Branch of the signatures repo
+          remote-organization-name: 'LuxAlgo'
+          remote-repository-name: 'cla-signatures'
+          allowlist: bot*,dependabot[bot],greenkeeper[bot]


### PR DESCRIPTION
## Summary

- Adds a `CLA Assistant` workflow (contributor-assistant/github-action v2.6.1) that asks external contributors to sign the LuxAlgo CLA by posting a PR comment, and fails the PR status check until they do.
- Signatures are stored org-wide in [LuxAlgo/cla-signatures](https://github.com/LuxAlgo/cla-signatures) (`signatures/cla.json`), the same store PineTS already uses — existing signers are covered on Vela automatically, and a contributor signs once for all LuxAlgo repos.
- Requires the `CLA_PAT` repository secret (already configured): a fine-grained token with Contents read/write on `cla-signatures`.

## Test plan

- [ ] Merge, then open a PR from an account that has not signed: the bot should comment asking for the signature and mark the check failed.
- [ ] Post "I have read the CLA Document and I hereby sign the CLA" on that PR: the check should turn green and the signature should appear in `cla-signatures/signatures/cla.json`.
- [ ] Optionally mark the `CLAAssistant` check as required in branch protection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses `pull_request_target` with write permissions and a PAT to a shared signatures repo—standard for CLA bots but worth keeping the action pin and secret scope tight.
> 
> **Overview**
> Adds a **CLA Assistant** GitHub Actions workflow so external contributors must sign the LuxAlgo CLA before their PR can pass checks.
> 
> The workflow runs on `pull_request_target` (open/sync/close) and on PR comments (`recheck` or the standard sign phrase). It uses `contributor-assistant/github-action@v2.6.1` to post instructions, set a failing status until signing, and record signatures in the org-wide **`LuxAlgo/cla-signatures`** repo (`signatures/cla.json` on `main`). Bots matching `bot*`, Dependabot, and Greenkeeper are allowlisted. It needs the existing **`CLA_PAT`** secret (plus `GITHUB_TOKEN`) and grants the job `actions`, `contents`, `pull-requests`, and `statuses` write access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5891579bef0f5682a6847759361a9bec8bc7738f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->