### PR TITLE
Extended boxes no longer squeeze the price scale from off-screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Extended boxes no longer squeeze the price scale from off-screen.** A box
+  drawn with a one-sided extension (`extend.right` or `extend.left`) contributes
+  its prices to the automatic price scale only while some painted part of it —
+  the anchor span or the side its extension actually covers — crosses the
+  visible bars. Previously any extended box counted everywhere on the time
+  axis, so an indicator keeping a box near the latest bars (a common
+  order-block idiom) flattened the candles in every earlier window the moment
+  you scrolled back in history. Boxes extended toward the window, and
+  `extend.both` boxes, still scale into view as before.
+
 ## [v0.6.11]
 
 ### Fixed

--- a/src/renderers/shared/DrawingSceneRenderer.ts
+++ b/src/renderers/shared/DrawingSceneRenderer.ts
@@ -161,8 +161,13 @@ export class DrawingSceneRenderer {
     priceRange(from: number, to: number): DrawingPriceRange | null {
         const lo = Math.min(from, to);
         const hi = Math.max(from, to);
+        // Painted-part coverage: the anchor span plus the side(s) `extend` projects
+        // toward. A one-sided extension paints nothing on its other side, so a window
+        // entirely there must not inherit the drawing's prices.
         const visible = (a: number, b: number, extend: DrawingExtend): boolean => {
-            if (extend !== 'none') return true;
+            if (extend === 'both') return true;
+            if (extend === 'left') return Math.max(a, b) >= lo;
+            if (extend === 'right') return Math.min(a, b) <= hi;
             return Math.max(a, b) >= lo && Math.min(a, b) <= hi;
         };
         let min = Infinity;

--- a/test/drawing-extend-autoscale.test.ts
+++ b/test/drawing-extend-autoscale.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DrawingSceneRenderer, EMPTY_DRAWING_SET, type DrawingSet } from '../src/renderers/shared/DrawingSceneRenderer';
-import type { DrawingLine } from '../src/core/model/drawings';
+import type { DrawingBox, DrawingLine } from '../src/core/model/drawings';
 import type { VelaTheme } from '../src/core/options';
 
 /**
@@ -88,5 +88,78 @@ describe('extended lines and autoscale (priceRange)', () => {
             expect(rangeOf(point, 500, 600)).toBeNull();
             expect(rangeOf(point, 0, 50)).toBeNull();
         }
+    });
+});
+
+function box(over: Partial<DrawingBox>): DrawingBox {
+    return {
+        id: 'bx',
+        paneId: 'price',
+        xloc: 'bar_index',
+        extend: 'none',
+        left: 100,
+        top: 6,
+        right: 110,
+        bottom: 5,
+        bgColor: '#0f04',
+        borderColor: '#0f0',
+        borderWidth: 1,
+        borderStyle: 'solid',
+        textSize: 'auto',
+        hAlign: 'center',
+        vAlign: 'center',
+        wrap: false,
+        fontFamily: 'default',
+        bold: false,
+        italic: false,
+        ...over,
+    };
+}
+
+function boxRangeOf(bx: DrawingBox, from: number, to: number) {
+    const set: DrawingSet = { ...EMPTY_DRAWING_SET, boxes: [bx] };
+    const r = new DrawingSceneRenderer({ timeToLogical: () => 0, barAt: () => null, theme });
+    r.setSet(set);
+    return r.priceRange(from, to);
+}
+
+/**
+ * Boxes and autoscale: a box folds its top/bottom while some painted part of it —
+ * anchor span plus its `extend` projection — crosses the visible bar window. An
+ * `extend.right` box paints nothing LEFT of its anchors, so a window entirely
+ * before it must not inherit its prices (the box would otherwise squeeze every
+ * earlier window's pane toward wherever it sits).
+ */
+describe('extended boxes and autoscale (priceRange)', () => {
+    it('folds top/bottom while the anchor span is in view — extended or not', () => {
+        for (const extend of ['none', 'left', 'right', 'both'] as const) {
+            const r = boxRangeOf(box({ extend }), 90, 120);
+            expect(r).not.toBeNull();
+            expect(r!.min).toBe(5);
+            expect(r!.max).toBe(6);
+        }
+    });
+
+    it('extend.both keeps folding with OFF-SCREEN anchors — the projection crosses every window', () => {
+        for (const window of [[500, 600], [0, 50]] as const) {
+            const r = boxRangeOf(box({ extend: 'both' }), window[0], window[1]);
+            expect(r).not.toBeNull();
+            expect(r!.min).toBe(5);
+            expect(r!.max).toBe(6);
+        }
+    });
+
+    it('extend.left / extend.right fold only on the side the projection covers', () => {
+        // Anchors at bars 100..110; extend.right paints over [100, ∞).
+        expect(boxRangeOf(box({ extend: 'right' }), 500, 600)).not.toBeNull();
+        expect(boxRangeOf(box({ extend: 'right' }), 0, 50)).toBeNull();
+        // extend.left paints over (-∞, 110].
+        expect(boxRangeOf(box({ extend: 'left' }), 0, 50)).not.toBeNull();
+        expect(boxRangeOf(box({ extend: 'left' }), 500, 600)).toBeNull();
+    });
+
+    it('unextended off-screen boxes stay excluded (regression baseline)', () => {
+        expect(boxRangeOf(box({}), 500, 600)).toBeNull();
+        expect(boxRangeOf(box({}), 0, 50)).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

- `DrawingSceneRenderer.priceRange` treated any box with `extend != 'none'` as visible everywhere on the time axis, so a box with a one-sided extension folded its `top`/`bottom` into the autoscale of windows its painted part never reaches. An indicator keeping an `extend.right` box near the latest bars (a common order-block idiom) flattened the candles in every earlier window the moment the user scrolled back through history.
- The visibility helper is now direction-aware, mirroring the line semantics shipped in v0.6.11 (`lineCoversWindow`): `extend.right` covers `[left, +inf)`, `extend.left` covers `(-inf, right]`, `extend.both` still covers every window, and unextended boxes keep the plain overlap test. Polylines and labels (always `'none'`) and linefills (mapped to `'both'`/`'none'`) are unaffected.
- New "extended boxes and autoscale" cases in `test/drawing-extend-autoscale.test.ts` pin the coverage rules per extend direction (written failing first), and the changelog carries the fix under `[Unreleased]`.

## Verification

- Gate: typecheck, lint, full test suite (1438 tests), build — all green.
- Workspace oracle suites: vela 23/23, vela-pro 11/11.
- Real-runtime proof: reproduced with a Pine order-block indicator on BTCUSDT 1m over 50,000 bars (boxes anchored at the newest bars, `extend.right`); scrolling into earlier history squashed the candles before the fix and autoscales tightly after it, while windows the boxes genuinely cover still fold them into the scale.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to drawing autoscale geometry with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Extended Pine boxes** now follow the same direction-aware autoscale rules as extended lines (v0.6.11): `DrawingSceneRenderer.priceRange` no longer treats any `extend != 'none'` box as visible on the entire time axis.
> 
> One-sided extensions only fold `top`/`bottom` into the price scale when the visible bar window overlaps where the box is actually painted — anchor span plus `extend.right` toward `[left, ∞)` or `extend.left` toward `(-∞, right]`. `extend.both` still affects every window. Scrolling into history no longer flattens candles when an `extend.right` order-block box sits on the latest bars.
> 
> Tests in `drawing-extend-autoscale.test.ts` lock in the per-direction coverage; the changelog documents the fix under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d69bd232e30f4d76ebeb196ecb643db4a0d575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->