### PR TITLE
An empty first run no longer strands an indicator off its prepared pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **An indicator added before its chart has bars no longer strands in a wrong,
+  empty sub pane.** When the initial bar load resolves empty (a slow feed, an
+  authentication race, an unresolved symbol) and a script indicator is added in
+  that window — typically by a host restoring a saved layout — its first run
+  produces nothing. That empty first result used to be taken as the script's
+  real output: the indicator was moved off its declared pane into a new sub
+  pane with a generic "Indicator" legend title, and it stayed there with no
+  plots even after the data arrived. While the chart itself is still without
+  bars, such a result now keeps the indicator loading on the pane its
+  declaration asked for, and the first run over real data places, titles, and
+  announces it exactly as if the data had been there from the start. Loading
+  still ends with the run, not with output: a script that runs over real bars
+  and simply draws nothing (alerts only, for example) finishes loading as
+  before.
+
 ## [v0.6.11]
 
 ### Fixed

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1505,8 +1505,10 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
                     // consumed cause must not leak into the next model.
                     const first = !record.announced;
                     const cause = record.pendingCause ?? 'history';
+                    // A deferred (output-free while loading) model counts as no run at all:
+                    // the pending cause stays for the real run, and no events fire.
+                    if (!this.applyModel(id, model)) return;
                     record.pendingCause = undefined;
-                    this.applyModel(id, model);
                     this.emitContextChanged(id); // throttled — streamed ticks collapse to ~1/s
                     this.emitScriptRun(id, cause, first);
                 },
@@ -1843,10 +1845,30 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
      * Apply an emitted model. First emission mounts (and routes the pane); a pending
      * structural change (after an input edit) remounts idempotently; everything else
      * (live tick / viewport re-run) value-patches.
+     *
+     * Returns false when the model was DEFERRED — an output-free model arriving while
+     * the record is still loading and the chart has no bars (see below); every other
+     * outcome, including the hidden drop, returns true so the caller's event semantics
+     * stay unchanged.
      */
-    private applyModel(id: string, model: IndicatorModel): void {
+    private applyModel(id: string, model: IndicatorModel): boolean {
         const record = this.registry.get(id);
-        if (!record || record.hidden) return; // a model arriving for a just-hidden indicator is dropped
+        if (!record || record.hidden) return true; // a model arriving for a just-hidden indicator is dropped
+
+        // While the CHART ITSELF has no bars, an output-free model is the signature of a
+        // run over zero bars (empty initial load: auth race, unresolved symbol, transient
+        // feed failure) — an engine may then fabricate default metadata (generic title,
+        // overlay: false) because the script body never executed. Letting it through
+        // while loading would finalize pane routing off fabricated flags and clear the
+        // spinner, stranding the indicator on the wrong pane with a value patch (no
+        // title, no pane, unmounted series ids) as its only future. Keep the prepared
+        // placeholder up and the one-shot pane re-route unconsumed; the session re-runs
+        // when bars arrive and the first REAL model still routes. The bars check keeps
+        // the guard narrow on purpose: loading ends when the run completes, not when it
+        // produces output — a script that ran over real bars and legitimately emitted
+        // nothing visual (e.g. alerts only) still clears its spinner and announces.
+        if (record.loading && this.bars.length === 0 && !EngineOrchestrator.modelHasOutput(model)) return false;
+
         const handle = this.handles.get(id);
 
         if (!record.renderHandle) {
@@ -1857,7 +1879,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             record.renderHandle = this.renderer.mountIndicator(model);
             record.pendingStructural = false;
             this.announce(record, handle);
-            return;
+            return true;
         }
 
         let paneId = record.model?.paneId ?? 'price';
@@ -1892,6 +1914,25 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         }
         if (record.loading) this.setLoading(record, false);
         this.announce(record, handle);
+        return true;
+    }
+
+    /** True when the model carries ANY executed output — series, drawings, bar colors, or trades. */
+    private static modelHasOutput(model: IndicatorModel): boolean {
+        return (
+            model.series.length > 0 ||
+            model.fills.length > 0 ||
+            model.backgrounds.length > 0 ||
+            model.priceLines.length > 0 ||
+            (model.lines?.length ?? 0) > 0 ||
+            (model.boxes?.length ?? 0) > 0 ||
+            (model.labels?.length ?? 0) > 0 ||
+            (model.polylines?.length ?? 0) > 0 ||
+            (model.linefills?.length ?? 0) > 0 ||
+            (model.tables?.length ?? 0) > 0 ||
+            (model.barColors?.length ?? 0) > 0 ||
+            (model.trades?.length ?? 0) > 0
+        );
     }
 
     private routePane(id: string, model: IndicatorModel, options: AddIndicatorOptions): string {

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1340,6 +1340,202 @@ describe('EngineOrchestrator — loading placeholder + legend status', () => {
     });
 });
 
+/**
+ * An engine the test drives by hand: `prepare` declares the configured meta, `execute`
+ * only captures the handlers — the test emits each model via {@link emit}. Static-only
+ * (streaming: false), so the session shape is identical on live and non-live charts.
+ */
+class HandDrivenEngine implements ScriptingEngine {
+    readonly language = 'pine';
+    readonly capabilities: EngineCapabilities = { streaming: false, visibleRange: false, inputs: true };
+    prepareMeta = { title: 'My Overlay', overlay: true };
+    private sinks: Record<string, ExecutionHandlers> = {};
+    prepare(_source: string, instanceId: string): Promise<PreparedScript> {
+        return Promise.resolve({ language: 'pine', inputs: [], meta: { ...this.prepareMeta }, reactsToViewport: false, token: { instanceId } });
+    }
+    execute(req: ExecutionRequest, handlers: ExecutionHandlers): ExecutionSession {
+        this.sinks[(req.prepared.token as { instanceId: string }).instanceId] = handlers;
+        return { stop: () => {}, update: () => {}, setVisibleRange: () => {}, notifyBars: () => {} };
+    }
+    emit(id: string, model: IndicatorModel): void {
+        this.sinks[id]?.onModel(model);
+    }
+}
+
+/** The fabricated shape an engine run over ZERO bars produces: the script body never
+ *  executed, so the metadata is defaults (generic title, overlay: false) and there is
+ *  no output of any kind. */
+function emptyRunModel(id: string): IndicatorModel {
+    return { id, title: 'Indicator', overlay: false, paneHint: 'new', series: [], fills: [], backgrounds: [], priceLines: [], inputs: [], inputValues: {} };
+}
+
+/** A feed whose INITIAL load resolves empty (auth race / transient failure); the test
+ *  pushes live bars by hand afterwards. */
+class EmptyThenLiveFeed implements MarketDataFeed {
+    push: ((bar: OHLCV) => void) | null = null;
+    load(): Promise<OHLCV[]> { return Promise.resolve([]); }
+    subscribe(_cfg: unknown, onBar: (bar: OHLCV) => void): Unsubscribe {
+        this.push = onBar;
+        return () => { this.push = null; };
+    }
+}
+
+function realOverlayModel(id: string, overlay: boolean, title = 'My Overlay'): IndicatorModel {
+    return {
+        id, title, overlay, paneHint: overlay ? 'price' : 'new',
+        series: [{ id: `${id}:line:out#0`, title: 'Out', paneId: 'unrouted', kind: 'line', points: [{ time: 1_700_000_000_000, value: 1 }], style: { color: '#fff', width: 1, lineStyle: 'solid' } }],
+        fills: [], backgrounds: [], priceLines: [], inputs: [], inputValues: {},
+    };
+}
+
+describe('EngineOrchestrator — a no-output first model never finalizes routing', () => {
+    it('keeps the prepared pane + loading state when the first run produced no output on a bar-less chart; the later real model lands normally', async () => {
+        const renderer = new FakeRenderer();
+        const engine = new HandDrivenEngine();
+        // The chart's own initial load resolved EMPTY — the only window where a run can
+        // produce nothing because the script never executed.
+        const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [engine], dataFeed: new EmptyThenLiveFeed() });
+        const added: string[] = [];
+        chart.on('indicator:added', (e) => added.push(e.id));
+
+        const ind = chart.addIndicator('//@version=5\nindicator("My Overlay", overlay=true)\nplot(close)');
+        await chart.ready();
+        await flush();
+
+        // The prepared placeholder sits on the price pane with the declared title.
+        const mountsFor = (): IndicatorModel[] => renderer.mountedModels.filter((m) => m.id === ind.id);
+        expect(mountsFor()[0]?.paneId).toBe('price');
+        expect(mountsFor()[0]?.title).toBe('My Overlay');
+
+        // The first run resolved over zero bars: fabricated metadata, no output.
+        engine.emit(ind.id, emptyRunModel(ind.id));
+        await flush();
+
+        // Nothing moved, nothing announced: still the placeholder on price, no study
+        // pane exists, the spinner stays, and inspect() still excludes the record.
+        expect(mountsFor()).toHaveLength(1);
+        expect(mountsFor()[0]?.paneId).toBe('price');
+        expect(mountsFor()[0]?.title).toBe('My Overlay');
+        expect(renderer.panes.every((p) => p.id === 'price')).toBe(true);
+        expect(chart.panes.list().map((p) => p.id)).toEqual(['price']);
+        expect(renderer.statuses[renderer.statuses.length - 1]).toEqual({ id: ind.id, status: 'loading' });
+        expect(added).toHaveLength(0);
+        expect(chart.inspect().indicators).toHaveLength(0);
+
+        // Bars arrived and the session re-ran for real: the model mounts on price with
+        // its series, announced exactly once.
+        engine.emit(ind.id, realOverlayModel(ind.id, true));
+        await flush();
+        const last = mountsFor()[mountsFor().length - 1];
+        expect(last?.paneId).toBe('price');
+        expect(last?.title).toBe('My Overlay');
+        expect(last?.series).toHaveLength(1);
+        expect(renderer.statuses[renderer.statuses.length - 1]).toEqual({ id: ind.id, status: 'idle' });
+        expect(added).toEqual([ind.id]);
+        expect(chart.inspect().indicators).toHaveLength(1);
+        expect(chart.inspect().totals.series).toBe(1);
+    });
+
+    it('the one-shot self-heal still moves a REAL first model that disagrees with the prepare-time guess', async () => {
+        const renderer = new FakeRenderer();
+        const engine = new HandDrivenEngine(); // prepare says overlay:true — the wrong static guess
+        const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [engine], dataFeed: new MockDataFeed() });
+        const added: string[] = [];
+        chart.on('indicator:added', (e) => added.push(e.id));
+
+        const ind = chart.addIndicator('//@version=5\nindicator("My Overlay", overlay=true)\nplot(close)');
+        await chart.ready();
+        await flush();
+        expect(renderer.mountedModels.find((m) => m.id === ind.id)?.paneId).toBe('price');
+
+        // The first REAL model (it has output) says non-overlay: the re-route must fire.
+        engine.emit(ind.id, realOverlayModel(ind.id, false));
+        await flush();
+        const last = renderer.mountedModels[renderer.mountedModels.length - 1];
+        expect(last?.id).toBe(ind.id);
+        expect(last?.paneId).toBe(`pane-${ind.id}`);
+        expect(renderer.statuses[renderer.statuses.length - 1]).toEqual({ id: ind.id, status: 'idle' });
+        expect(added).toEqual([ind.id]);
+        // The indicator lives on its study pane only — no price-pane residue.
+        expect(chart.panes.list().find((p) => p.id === 'price')?.indicators).toHaveLength(0);
+        expect(chart.panes.list().find((p) => p.id === `pane-${ind.id}`)?.indicators.map((i) => i.id)).toEqual([ind.id]);
+    });
+
+    it('an output-free run over REAL bars still completes the load: spinner stops, indicator announced', async () => {
+        const renderer = new FakeRenderer();
+        const engine = new HandDrivenEngine();
+        const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [engine], dataFeed: new MockDataFeed() });
+        const added: string[] = [];
+        chart.on('indicator:added', (e) => added.push(e.id));
+
+        const ind = chart.addIndicator('//@version=5\nindicator("My Overlay", overlay=true)\nalertcondition(close > open)');
+        await chart.ready();
+        await flush();
+        expect(renderer.statuses[renderer.statuses.length - 1]).toEqual({ id: ind.id, status: 'loading' });
+
+        // The script RAN (the chart has bars) — it just plots nothing (e.g. alerts only).
+        // Loading ends with the run, not with output.
+        engine.emit(ind.id, { ...emptyRunModel(ind.id), title: 'My Overlay', overlay: true, paneHint: 'price' });
+        await flush();
+        expect(renderer.statuses[renderer.statuses.length - 1]).toEqual({ id: ind.id, status: 'idle' });
+        expect(added).toEqual([ind.id]);
+        expect(chart.inspect().indicators).toHaveLength(1);
+        expect(chart.inspect().totals.series).toBe(0);
+        const last = renderer.mountedModels[renderer.mountedModels.length - 1];
+        expect(last?.id).toBe(ind.id);
+        expect(last?.paneId).toBe('price'); // stays on its declared pane
+    });
+
+    it('late bars end-to-end: an empty initial load, then bars — the indicator ends on price with its plots', async () => {
+        // The feed resolves the INITIAL load empty (auth race / transient failure) and
+        // only later pushes live bars — the workspace-restore window users actually hit.
+        // A pinets-shaped engine: every run derives its model from the CURRENT bars —
+        // over zero bars the fabricated empty shape, over real bars the declared one.
+        class ZeroBarEngine extends HandDrivenEngine {
+            override execute(req: ExecutionRequest, handlers: ExecutionHandlers): ExecutionSession {
+                const id = (req.prepared.token as { instanceId: string }).instanceId;
+                const run = (): void => {
+                    const bars = req.getBars?.() ?? req.bars;
+                    handlers.onModel(bars.length === 0 ? emptyRunModel(id) : realOverlayModel(id, true));
+                    handlers.onDone?.();
+                };
+                run();
+                return { stop: () => {}, update: run, setVisibleRange: run, notifyBars: run };
+            }
+        }
+        const renderer = new FakeRenderer();
+        const engine = new ZeroBarEngine();
+        const feed = new EmptyThenLiveFeed();
+        const chart = new Vela({} as unknown as HTMLElement, { live: true, volume: false }, { renderer, engines: [engine], dataFeed: feed });
+        const added: string[] = [];
+        chart.on('indicator:added', (e) => added.push(e.id));
+
+        const ind = chart.addIndicator('//@version=5\nindicator("My Overlay", overlay=true)\nplot(close)');
+        await chart.ready();
+        await flush();
+
+        // The empty first run left the placeholder untouched: price pane, still loading.
+        const mountsFor = (): IndicatorModel[] => renderer.mountedModels.filter((m) => m.id === ind.id);
+        expect(mountsFor()).toHaveLength(1);
+        expect(mountsFor()[0]?.paneId).toBe('price');
+        expect(added).toHaveLength(0);
+        expect(renderer.statuses[renderer.statuses.length - 1]).toEqual({ id: ind.id, status: 'loading' });
+
+        // Bars arrive; the session re-runs over them.
+        for (const b of makeBars(3)) feed.push!(b);
+        await flush();
+
+        const last = mountsFor()[mountsFor().length - 1];
+        expect(last?.paneId).toBe('price');
+        expect(last?.title).toBe('My Overlay');
+        expect(last?.series).toHaveLength(1);
+        expect(added).toEqual([ind.id]);
+        expect(renderer.statuses[renderer.statuses.length - 1]).toEqual({ id: ind.id, status: 'idle' });
+        expect(chart.inspect().totals.series).toBe(1);
+        expect(chart.panes.list().map((p) => p.id)).toEqual(['price']);
+    });
+});
+
 /** MockEngine that additionally captures every ExecutionRequest (market metadata / fetchSeries). */
 class RequestCaptureEngine extends MockEngine {
     requests: ExecutionRequest[] = [];


### PR DESCRIPTION
## Summary

- **Bug:** an indicator added while the chart''s initial bar load resolved **empty** (auth race, unresolved symbol, transient feed failure — typically a host restoring a saved workspace) had its first, output-free model treated as real output: `applyModel` consumed the one-shot pane re-route off fabricated metadata (`overlay: false`, generic Indicator title), cleared `loading`, and the indicator stayed stranded in an empty sub pane even after bars arrived (the later real model only value-patched — no title, no pane, unmounted series ids).
- **Fix:** while `record.loading` **and the chart itself has zero bars**, a model carrying no output of any kind (series, drawings, bar colors, trades) is deferred — placeholder, pane, spinner, and the pending run-cause all stay untouched; the first real model still routes through the existing self-heal. The bars condition keeps the guard narrow: **loading ends when a run completes, not when it produces output** — a script that runs over real bars and plots nothing (alerts only) clears its spinner and announces exactly as before.

## Companion PR

Root cause lives in the engine: **LuxAlgo/Vela-pinets#30** stops the PineTS engines from fabricating a model for a run that never executed the script body. This orchestrator guard is the second, engine-agnostic layer — any `ScriptingEngine` emitting an empty model over a bar-less chart is handled, and either PR alone fixes the user-visible symptom for Pine.

## Tests

Four new orchestrator tests (stub engines, no PineTS dependency): the stranding scenario (placeholder kept, nothing announced, real model lands normally), the self-heal regression (a real first model that disagrees with the prepare-time guess still re-routes), spinner semantics (an output-free run over real bars completes the load), and the late-bars end-to-end (feed loads 0 bars, live push re-runs the session, final state is price pane / declared title / plots). The stranding, spinner, and end-to-end tests fail without the fix. Full gate green: typecheck / lint / 1442 tests / build; workspace oracle suites re-run green (vela 23/23, vela-pro 11/11).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes indicator mount and event timing on a core orchestrator path, but the guard is narrowly scoped (loading + zero bars + no output) and covered by new regression tests.
> 
> **Overview**
> Fixes indicators that were added while the chart’s **initial bar load was still empty** (saved layout restore, auth race, slow feed). An output-free first model used to be treated as real script output, which **re-routed the pane** off prepare-time metadata, cleared loading, and left a generic empty sub pane even after data arrived.
> 
> **`EngineOrchestrator.applyModel`** now returns a boolean and **defers** models that have no series, drawings, bar colors, trades, etc. when the indicator is still loading **and** `this.bars.length === 0`. The placeholder pane, spinner, and `pendingCause` stay put; **`onModel`** skips `indicator:added` / script-run events until a real apply. The first model with real output still uses the existing one-shot pane self-heal. **Loading still ends when a run completes over real bars**, not when output exists (alerts-only scripts unchanged).
> 
> Changelog updated; **four orchestrator tests** cover stranding, self-heal regression, alerts-only completion, and empty-then-live feed end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d2a8aefde9518ed2900ff673703cada6d21640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->