### PR TITLE
restore the first-paint hold at 20 bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 All notable changes to Vela, newest first.
 
-## [v0.6.13]
+## [v0.6.14]
 
 ### Changed
 
-- **Charts paint from the very first bars of a progressive load.** The minimum
-  bar-count hold before the first paint is removed (it was 100, briefly 20): as
-  soon as the first snapshot carries any bars at all they are drawn, and deeper
-  snapshots repaint with the viewport preserved. Monthly charts of short-lived
-  contracts — whose whole history holds fewer bars than any threshold — used to
-  sit blank until the data source's polling budget ran out (up to ~90 s) before
-  showing anything. The final answer still paints whatever depth exists,
-  exactly as before.
+- **The first paint of a progressive load now waits for 20 bars instead
+  of 100.** The first paint is the frame the view is sized against, so a
+  2-3 bar head would draw a few giant candles; but the old 100-bar hold kept
+  monthly charts of short-lived contracts — whose whole history holds fewer
+  bars — blank until the data source's polling budget ran out (up to ~90 s).
+  Twenty bars frame a readable view on every timeframe, deeper snapshots
+  repaint with the viewport preserved, and the final answer still paints
+  whatever depth exists.
 
 ## [v0.6.12]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.13",
+      "version": "0.6.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -77,6 +77,17 @@ const SINGLE_LOAD_BARS = 5_000;
  */
 const CHUNK_BARS = 10_000;
 /**
+ * A progressive source's FIRST paint waits for at least this many bars (or the full ask,
+ * whichever is smaller): the first paint is the frame the renderer sizes the view against,
+ * and framing onto a 2-3 bar head draws a few giant candles that later view-preserved
+ * repaints never fix. The FINAL answer always paints whatever exists — a genesis-era
+ * symbol may simply have fewer bars than this. The number's history: 100 starved short
+ * monthly contracts for the provider's whole poll budget (~90 s measured); briefly 1
+ * (no hold), which framed unusable slivers; 20 frames a readable view on every timeframe
+ * now that the server converges small monthlies in seconds.
+ */
+const FIRST_PAINT_BARS = 20;
+/**
  * A live bar more than this many intervals ahead of the last one signals MISSED bars (a throttled
  * background tab, a socket reconnect, system sleep) → backfill. 1.5 tolerates timestamp drift and
  * variable-length periods (a 31-day month on the ~30-day 'M' interval) without false positives.
@@ -429,12 +440,8 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             let painted = false;
             const paint = (bars: OHLCV[], final: boolean): void => {
                 if (this.generation !== gen || (!final && bars.length === 0)) return;
-                // Paint from the FIRST bars — no minimum hold: any confirmed head beats a
-                // blank chart. The old hold (100, then 20) kept monthly charts of short-
-                // lived contracts — whose whole history is smaller than any threshold —
-                // blank for the provider's entire poll budget (~90 s measured). Empty
-                // non-final batches are already skipped above; the FINAL answer paints
-                // whatever depth exists.
+                if (!painted && !final && bars.length < Math.min(requested, FIRST_PAINT_BARS)) return; // hold the framing paint until it can carry the view
+
                 this.setBarSeries(bars, painted ? { preserveView: true } : undefined);
                 if (!painted && bars.length > 0) {
                     painted = true;

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -840,15 +840,17 @@ describe('EngineOrchestrator', () => {
         const renderer = new FakeRenderer();
         const chart = new Vela({} as unknown as HTMLElement, { bars: 120 }, { renderer, engines: [new MockEngine()], dataFeed: feed });
         await Promise.resolve(); // let loadMarketInner reach the progressive await
-        emit!(all.slice(-10)); // the very FIRST bars paint — no minimum hold, any head beats a blank chart
+        emit!(all.slice(-10)); // below the 20-bar first-paint hold — held, the frame it would set is unusable
+        expect(renderer.setBarsCalls).toEqual([]);
+        emit!(all.slice(-40)); // deep enough to carry the framing — paints, load resolves
         await chart.ready();
-        expect(renderer.setBarsCalls).toEqual([{ n: 10, preserveView: false }]);
+        expect(renderer.setBarsCalls).toEqual([{ n: 40, preserveView: false }]);
         emit!(all.slice(-110)); // deeper snapshot — repaints, viewport preserved
-        expect(renderer.setBarsCalls).toEqual([{ n: 10, preserveView: false }, { n: 110, preserveView: true }]);
+        expect(renderer.setBarsCalls).toEqual([{ n: 40, preserveView: false }, { n: 110, preserveView: true }]);
         finish!(all); // convergence — final paint + completion
         await chart.historyComplete();
         expect(renderer.setBarsCalls).toEqual([
-            { n: 10, preserveView: false },
+            { n: 40, preserveView: false },
             { n: 110, preserveView: true },
             { n: 120, preserveView: true },
         ]);
@@ -866,25 +868,22 @@ describe('EngineOrchestrator', () => {
         expect(fallback.setBarsCalls).toEqual([{ n: 30, preserveView: false }]);
     });
 
-    it('a tiny progressive stream paints its first bars AND its final depth — a genesis symbol has no more', async () => {
-        // No minimum hold: the first snapshot paints immediately, and the resolution
-        // repaints (view preserved) whatever depth actually exists.
+    it('a progressive FINAL answer below the first-paint hold still paints — a genesis symbol has no more', async () => {
+        // Every snapshot stays under the hold: nothing paints until the source
+        // resolves — and the resolution paints whatever depth actually exists.
         const renderer = new FakeRenderer();
         const feed: MarketDataFeed = {
             load: () => Promise.resolve([]),
             subscribe: () => () => {},
             loadProgressive: (_cfg, onBatch) => {
-                onBatch(makeBars(10)); // paints immediately — the first bars are the frame
+                onBatch(makeBars(10)); // held — a frame set from this would be unusable
                 return Promise.resolve(makeBars(15)); // all the history there is
             },
         };
         const chart = new Vela({} as unknown as HTMLElement, { bars: 500 }, { renderer, engines: [new MockEngine()], dataFeed: feed });
         await chart.ready();
         await chart.historyComplete();
-        expect(renderer.setBarsCalls).toEqual([
-            { n: 10, preserveView: false },
-            { n: 15, preserveView: true },
-        ]);
+        expect(renderer.setBarsCalls).toEqual([{ n: 15, preserveView: false }]);
     });
 
     it('switching markets ABORTS the in-flight progressive stream — the source stops polling', async () => {


### PR DESCRIPTION
100 starved short monthly contracts for the provider's whole poll budget; no hold framed unusable 2-3 bar slivers. Twenty frames a readable view on every timeframe now that the server converges small monthlies in seconds — and the final answer still paints whatever depth exists. Tests re-pinned,