### PR TITLE
Fix multi-chart screenshots and the mobile symbol search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to Vela, newest first.
   active chart. They now download every visible chart in its grid slot, with
   the seams between them. A maximized cell still exports that one chart, and
   a single-chart workspace is unchanged.
+- **Opening the symbol search on a phone no longer zooms the page.** iOS
+  Safari enlarges the view when a focused field is under 16px and often
+  leaves it there after you pick a symbol. Mobile text fields are now 16px,
+  so the tap does not zoom. The search bar and market tabs also stay pinned
+  while you scroll the results.
 
 ## [v0.6.14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **A multi-chart screenshot now captures the whole layout.** The camera
+  button, its keyboard chord, and the mobile drawer used to export only the
+  active chart. They now download every visible chart in its grid slot, with
+  the seams between them. A maximized cell still exports that one chart, and
+  a single-chart workspace is unchanged.
+
 ## [v0.6.14]
 
 ### Changed

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -381,7 +381,8 @@ The shell is keyboard-first (bindings act on the **active cell**):
 - Type a **letter** anywhere on a chart → the symbol search opens, seeded with it.
 - Type a **digit** → the timeframe entry opens (`15`, `4h`, `D`, `3M`, … — a bare
   number is minutes, a bare letter means one unit).
-- `alt+S` → download a PNG screenshot. `?` → the shortcuts panel.
+- `alt+S` → download a PNG of the visible layout (every chart, or the
+  maximized one). `?` → the shortcuts panel.
 - `mod+↑/↓` glide-zoom, `mod+←/→` glide-pan with the exact feel and limits of a drag
   (toward now it rests on the newest candle plus the usual empty space). `alt+T` arms
   the trend line tool; `alt+H` / `alt+V` drop a horizontal / vertical line at the

--- a/src/core/RendererControl.ts
+++ b/src/core/RendererControl.ts
@@ -102,6 +102,16 @@ export class RendererControl {
     }
 
     /**
+     * Raster of the current chart onto a canvas (same pixels as {@link screenshot}),
+     * or null if the renderer has no canvas export. Silent — a host compositing
+     * several charts skips a renderer that cannot contribute.
+     */
+    screenshotCanvas(): HTMLCanvasElement | null {
+        if (typeof this.renderer.screenshotCanvas === 'function') return this.renderer.screenshotCanvas();
+        return null;
+    }
+
+    /**
      * The active renderer's full cosmetic config as a serializable, versioned JSON
      * document — persist it (templates, saved settings) and feed it back to
      * `applyConfig`. Returns null if the renderer has no rich config (warns).

--- a/src/core/ports/IChartRenderer.ts
+++ b/src/core/ports/IChartRenderer.ts
@@ -414,6 +414,11 @@ export interface IChartRenderer {
      * rasterize its surface omits it). DOM overlays may not be included.
      */
     screenshot?(): string | null;
+    /**
+     * Raster of the current chart onto a canvas (optional). Same pixels as
+     * {@link screenshot}, for hosts that composite several charts into one image.
+     */
+    screenshotCanvas?(): HTMLCanvasElement | null;
 
     /**
      * Snapshot the renderer's full cosmetic configuration as a serializable,

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1117,9 +1117,10 @@ export class NativeRenderer implements IChartRenderer {
      * opts in with a `data-vela-screenshot` attribute on the mount container's
      * subtree (the widget marks its status line, and its symbol watermark with
      * `"under"` — drawn beneath the canvases, where it sits on screen). Only the
-     * crosshair (L2) is intentionally excluded.
+     * crosshair (L2) is intentionally excluded. {@link screenshot} is this canvas
+     * as a PNG data URL.
      */
-    screenshot(): string | null {
+    screenshotCanvas(): HTMLCanvasElement | null {
         if (!this.dataCanvas) return null;
         this.computeScales();
         this.paintData();
@@ -1148,7 +1149,11 @@ export class NativeRenderer implements IChartRenderer {
                 if (el.getAttribute('data-vela-screenshot') !== 'under') rasterizeOverlay(ctx, el, frame);
             }
         }
-        return out.toDataURL('image/png');
+        return out;
+    }
+
+    screenshot(): string | null {
+        return this.screenshotCanvas()?.toDataURL('image/png') ?? null;
     }
 
     /**

--- a/src/ui/tokens.ts
+++ b/src/ui/tokens.ts
@@ -27,6 +27,12 @@ ${STATIC_DECLS}
 .vela-ui *, .vela-ui-layer * { box-sizing: border-box; }
 /* Text ENTRY is the one exception: selection is part of editing. */
 .vela-ui :is(input, textarea), .vela-ui-layer :is(input, textarea) { user-select: text; -webkit-user-select: text; }
+/* iOS Safari zooms the page when a focused field is under 16px, and often
+   keeps that zoom after the field blurs or a dialog closes. The shell's
+   mobile size class is the honest gate — not a media query — so an embedded
+   chart on a wide desktop still gets the rule when it is in the phone layout.
+   Scoped to the kit root so a host page's own [data-layout] is never touched. */
+.vela-ui[data-layout='mobile'] :is(input, textarea, select) { font-size: 16px; }
 .vela-icon { display: inline-flex; align-items: center; flex: none; }
 .vela-icon svg { display: block; }
 `;

--- a/src/widget/symbol-picker.ts
+++ b/src/widget/symbol-picker.ts
@@ -121,6 +121,17 @@ export function filterSymbols(list: readonly SymbolDescriptor[], query: string, 
 
 const STYLE_ID = 'vela-widget-symbolpicker';
 const CSS = `
+/* Search + market tabs stay pinned while the result list scrolls underneath
+   (mobile fullscreen: the dialog body is the scroller). Negative margin eats
+   the body's padding so scrolled rows cannot peek around the island. */
+.vela-sp-sticky {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--vela-surface);
+    margin: calc(-1 * var(--vela-space-4)) calc(-1 * var(--vela-space-4)) 0;
+    padding: var(--vela-space-4) var(--vela-space-4) 0;
+}
 .vela-sp-searchrow {
     display: flex;
     align-items: center;
@@ -141,7 +152,7 @@ const CSS = `
     font-size: 14px;
     outline: none;
 }
-.vela-sp-tabs { display: flex; gap: 14px; margin: 12px 2px 6px; border-bottom: 1px solid var(--vela-border); padding-bottom: 8px; }
+.vela-sp-tabs { display: flex; gap: 14px; margin: 12px 2px 0; border-bottom: 1px solid var(--vela-border); padding-bottom: 8px; }
 /* Mobile (fullscreen dialog): the asset-class strip scrolls sideways instead of
    overflowing the body, and the result list stops capping itself — the body owns
    the scrolling in the fullscreen presentation. */
@@ -274,6 +285,8 @@ export class SymbolPicker {
         searchRow.append(iconEl('search', doc), this.input);
         this.tabs = doc.createElement('div');
         this.tabs.className = 'vela-sp-tabs';
+        const sticky = doc.createElement('div');
+        sticky.className = 'vela-sp-sticky';
         for (const t of ['All', 'Stocks', 'ETFs', 'Crypto', 'Futures', 'Forex', 'Commodities']) {
             const b = doc.createElement('button');
             b.className = 'vela-sp-tab';
@@ -287,6 +300,7 @@ export class SymbolPicker {
             });
             this.tabs.appendChild(b);
         }
+        sticky.append(searchRow, this.tabs);
         this.list = doc.createElement('div');
         this.list.className = 'vela-sp-list';
         // Infinite scroll: nearing the bottom grows the page and APPENDS the new rows —
@@ -304,7 +318,7 @@ export class SymbolPicker {
             title: 'Symbol Search',
             host: opts.host,
             closeOnInteractOutside: true,
-            content: (body) => body.append(searchRow, this.tabs, this.list),
+            content: (body) => body.append(sticky, this.list),
             onOpenChange: (open) => {
                 if (open) {
                     this.input.value = this.seed;
@@ -315,6 +329,10 @@ export class SymbolPicker {
                         this.input.focus();
                         this.input.setSelectionRange(this.input.value.length, this.input.value.length);
                     }, 0);
+                } else {
+                    // Every close path (pick, Escape, X, outside tap) — a field still
+                    // focused when it leaves the screen keeps iOS's focus-zoom alive.
+                    this.input.blur();
                 }
                 opts.onOpenChange?.(open);
             },
@@ -354,7 +372,7 @@ export class SymbolPicker {
     }
 
     close(): void {
-        this.dialog.hide();
+        this.dialog.hide(); // onOpenChange(false) blurs the field (iOS focus-zoom)
     }
 
     destroy(): void {

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -913,6 +913,11 @@ export class ChartCell {
         this.inner?.renderer.focus();
     }
 
+    /** Raster of this cell's chart (same pixels as the PNG download), or null. */
+    screenshotCanvas(): HTMLCanvasElement | null {
+        return this.inner?.renderer.screenshotCanvas() ?? null;
+    }
+
     /** Download this cell's chart as a PNG (named after its market). */
     downloadScreenshot(): void {
         const url = this.inner?.renderer.screenshot();

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -71,6 +71,7 @@ import {
     type TrackSizes,
 } from './layouts';
 import { SplitterLayer, evenTracks } from './splitters';
+import { compositeLayoutScreenshot, tilesFromCellRects, triggerPngDownload, type LayoutShotTile } from './screenshot';
 
 /**
  * The workspace options: the widget's chart vocabulary + the shared shell surface + the
@@ -456,7 +457,7 @@ export class VelaWorkspace {
             ...(picker ? { onIndicatorsClick: () => picker.open() } : {}),
             onUndoClick: () => this.active.history.undo(),
             onRedoClick: () => this.active.history.redo(),
-            onScreenshotClick: () => this.active.downloadScreenshot(),
+            onScreenshotClick: () => this.downloadScreenshot(),
             onAlertsClick: (anchor) => this.openAlertsMenu(anchor),
             timeframe: '60',
             timeframes: opts.timeframes ?? DEFAULT_TIMEFRAMES,
@@ -550,6 +551,7 @@ export class VelaWorkspace {
                 bottom: `calc(var(--vela-bottom-gutter, ${TIME_AXIS_H}px) + 10px)`,
                 zIndex: '11',
             });
+            mark.dataset.velaScreenshot = '1';
             this.gridEl.appendChild(mark); // pre-cells fallback host; re-parented by mountAttributionMark
             this.attributionMark = mark; // kept so a live theme swap re-inks it
         }
@@ -726,6 +728,60 @@ export class VelaWorkspace {
      *  the point of use; the durable identity to hold is the cell (or its id). */
     get chart(): Vela {
         return this.active.chart;
+    }
+
+    /**
+     * PNG data URL of the visible layout: every live cell in its grid slot, or the
+     * maximized cell alone. Same pixels the screenshot button downloads. A single
+     * visible cell returns that cell's own chart export (the one-chart case).
+     */
+    screenshot(): string | null {
+        const cells = this.shotCells();
+        if (cells.length === 0) return null;
+        if (cells.length === 1) return cells[0]!.chart.renderer.screenshot();
+        return this.compositeLayoutShot(cells);
+    }
+
+    /** Download {@link screenshot} as a PNG. A multi-cell layout is named
+     *  `vela-layout.png`; one visible cell keeps `${symbol}-${timeframe}.png`. */
+    downloadScreenshot(): void {
+        const cells = this.shotCells();
+        if (cells.length <= 1) {
+            (cells[0] ?? this.active).downloadScreenshot();
+            return;
+        }
+        const url = this.compositeLayoutShot(cells);
+        if (!url) return;
+        triggerPngDownload(this.root.ownerDocument, url, 'vela-layout.png');
+    }
+
+    /** Live cells the screenshot should include — maximized siblings are `hidden`. */
+    private shotCells(): ChartCell[] {
+        return this.cells().filter((c) => c.host.style.visibility !== 'hidden');
+    }
+
+    /** Place every cell's raster onto one canvas the size of the grid. */
+    private compositeLayoutShot(cells: ChartCell[]): string | null {
+        const gridEl = this.gridEl;
+        const grid = gridEl.getBoundingClientRect();
+        const win = gridEl.ownerDocument.defaultView;
+        const dpr = win?.devicePixelRatio ?? 1;
+        const gapColor = win ? win.getComputedStyle(gridEl).backgroundColor : '';
+        const tiles: LayoutShotTile[] = [];
+        for (const cell of cells) {
+            const source = cell.screenshotCanvas();
+            if (!source) continue;
+            const r = cell.host.getBoundingClientRect();
+            const place = tilesFromCellRects(grid, [{ left: r.left, top: r.top, width: r.width, height: r.height }])[0];
+            if (!place) continue;
+            tiles.push({ source, ...place });
+        }
+        return compositeLayoutScreenshot(gridEl.ownerDocument, {
+            width: grid.width,
+            height: grid.height,
+            dpr,
+            gapColor: gapColor || '#000000',
+        }, tiles);
     }
 
     setActiveCell(id: string | null): void {
@@ -1952,7 +2008,7 @@ export class VelaWorkspace {
             host: this.root,
             ...(has('undo-redo') ? { onUndo: () => this.active.history.undo(), onRedo: () => this.active.history.redo() } : {}),
             ...(has('screenshot')
-                ? { onScreenshot: this.screenshotOverride ? () => this.runOverride(this.screenshotOverride!) : () => this.active.downloadScreenshot() }
+                ? { onScreenshot: this.screenshotOverride ? () => this.runOverride(this.screenshotOverride!) : () => this.downloadScreenshot() }
                 : {}),
             canUndo: () => this.active.history.canUndo,
             canRedo: () => this.active.history.canRedo,
@@ -2072,9 +2128,9 @@ export class VelaWorkspace {
             this.keymap.register({
                 id: 'chart.screenshot',
                 keys: 'mod+alt+s',
-                label: ov ? ov.label : 'Download a chart screenshot',
+                label: ov ? ov.label : 'Download a screenshot of the layout',
                 category: 'Chart',
-                run: ov ? () => this.runOverride(ov) : () => this.active.downloadScreenshot(),
+                run: ov ? () => this.runOverride(ov) : () => this.downloadScreenshot(),
             });
         }
         this.keymap.register({ id: 'chart.reset-view', keys: 'alt+r', label: 'Reset view (all history)', category: 'Chart', run: () => this.active.chart.setVisibleRangePreset('ALL') });

--- a/src/workspace/screenshot.ts
+++ b/src/workspace/screenshot.ts
@@ -1,0 +1,91 @@
+// Layout screenshot compositing — PURE geometry + a thin canvas blit.
+//
+// Each cell already knows how to rasterize itself (`renderer.screenshotCanvas()`).
+// The workspace chrome's job is to place those rasters onto one PNG in the same
+// positions the grid shows, with the seam color in the gaps. Hidden cells
+// (maximized siblings) are dropped before they get here.
+
+/** A cell's box in CSS pixels, origin at the grid's top-left. */
+export interface LayoutShotTile {
+    source: CanvasImageSource;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/** The grid's CSS box + the device-pixel scale of the export. */
+export interface LayoutShotFrame {
+    width: number;
+    height: number;
+    dpr: number;
+    /** Computed background of the grid — paints the visible seams. */
+    gapColor: string;
+}
+
+/** Pixel dest of a CSS tile, rounded so adjacent cells share an edge (no 1px gap). */
+export function destRect(
+    tile: Pick<LayoutShotTile, 'x' | 'y' | 'width' | 'height'>,
+    dpr: number,
+): { dx: number; dy: number; dw: number; dh: number } {
+    const dx = Math.round(tile.x * dpr);
+    const dy = Math.round(tile.y * dpr);
+    return {
+        dx,
+        dy,
+        dw: Math.round((tile.x + tile.width) * dpr) - dx,
+        dh: Math.round((tile.y + tile.height) * dpr) - dy,
+    };
+}
+
+/** CSS tiles for every cell that is on screen (not hidden, non-zero box). */
+export function tilesFromCellRects(
+    grid: { left: number; top: number; width: number; height: number },
+    cells: ReadonlyArray<{ hidden?: boolean; left: number; top: number; width: number; height: number }>,
+): Array<Pick<LayoutShotTile, 'x' | 'y' | 'width' | 'height'>> {
+    if (grid.width <= 0 || grid.height <= 0) return [];
+    const tiles: Array<Pick<LayoutShotTile, 'x' | 'y' | 'width' | 'height'>> = [];
+    for (const c of cells) {
+        if (c.hidden || c.width <= 0 || c.height <= 0) continue;
+        tiles.push({ x: c.left - grid.left, y: c.top - grid.top, width: c.width, height: c.height });
+    }
+    return tiles;
+}
+
+/**
+ * Composite `tiles` onto a canvas the size of the grid and return a PNG data URL.
+ * Empty / zero-size frames, or a tile list that painted nothing, return null.
+ */
+export function compositeLayoutScreenshot(
+    doc: Document,
+    frame: LayoutShotFrame,
+    tiles: readonly LayoutShotTile[],
+): string | null {
+    if (frame.width <= 0 || frame.height <= 0 || tiles.length === 0) return null;
+    const dpr = frame.dpr > 0 ? frame.dpr : 1;
+    const out = doc.createElement('canvas');
+    out.width = Math.max(1, Math.round(frame.width * dpr));
+    out.height = Math.max(1, Math.round(frame.height * dpr));
+    const ctx = out.getContext('2d');
+    if (!ctx) return null;
+    ctx.fillStyle = frame.gapColor;
+    ctx.fillRect(0, 0, out.width, out.height);
+    let painted = 0;
+    for (const tile of tiles) {
+        if (tile.width <= 0 || tile.height <= 0) continue;
+        const { dx, dy, dw, dh } = destRect(tile, dpr);
+        if (dw <= 0 || dh <= 0) continue;
+        ctx.drawImage(tile.source, dx, dy, dw, dh);
+        painted += 1;
+    }
+    if (painted === 0) return null;
+    return out.toDataURL('image/png');
+}
+
+/** Fire a PNG download in `doc` (the same `<a download>` the cell screenshot uses). */
+export function triggerPngDownload(doc: Document, url: string, filename: string): void {
+    const a = doc.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+}

--- a/test/workspace-screenshot.test.ts
+++ b/test/workspace-screenshot.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+    compositeLayoutScreenshot,
+    destRect,
+    tilesFromCellRects,
+    type LayoutShotTile,
+} from '../src/workspace/screenshot';
+
+/**
+ * The workspace screenshot button composites every visible cell onto one PNG.
+ * These tests guard the geometry: hidden cells drop out, adjacent tiles share an
+ * edge after DPR rounding, and every contributed raster is blitted in place.
+ *
+ * The vitest env is `node` (no DOM/canvas), so `document.createElement('canvas')`
+ * is stubbed with a recording canvas — same technique as native-screenshot.test.ts.
+ */
+
+interface FakeSource { __id: string }
+const src = (id: string): CanvasImageSource => ({ __id: id }) as unknown as CanvasImageSource;
+
+const originalDocument = (globalThis as { document?: unknown }).document;
+afterEach(() => { (globalThis as { document?: unknown }).document = originalDocument; });
+
+function setupComposite(): { drawn: Array<{ id: string; dx: number; dy: number; dw: number; dh: number }>; filled: { color: string; w: number; h: number } | null } {
+    const drawn: Array<{ id: string; dx: number; dy: number; dw: number; dh: number }> = [];
+    let filled: { color: string; w: number; h: number } | null = null;
+    const ctx = {
+        fillStyle: '',
+        fillRect(_x: number, _y: number, w: number, h: number) {
+            filled = { color: this.fillStyle as string, w, h };
+        },
+        drawImage(source: FakeSource, dx: number, dy: number, dw: number, dh: number) {
+            drawn.push({ id: source.__id, dx, dy, dw, dh });
+        },
+    };
+    const out = { width: 0, height: 0, getContext: () => ctx, toDataURL: () => 'data:image/png;base64,LAYOUT' };
+    (globalThis as { document?: unknown }).document = { createElement: () => out };
+    return { drawn, get filled() { return filled; } } as { drawn: typeof drawn; filled: { color: string; w: number; h: number } | null };
+}
+
+describe('tilesFromCellRects', () => {
+    const grid = { left: 10, top: 20, width: 200, height: 100 };
+
+    it('maps each cell into grid-local CSS pixels', () => {
+        expect(tilesFromCellRects(grid, [
+            { left: 10, top: 20, width: 99, height: 100 },
+            { left: 111, top: 20, width: 99, height: 100 },
+        ])).toEqual([
+            { x: 0, y: 0, width: 99, height: 100 },
+            { x: 101, y: 0, width: 99, height: 100 },
+        ]);
+    });
+
+    it('drops hidden cells and zero-size boxes (maximized siblings, collapsed slots)', () => {
+        expect(tilesFromCellRects(grid, [
+            { hidden: true, left: 10, top: 20, width: 99, height: 100 },
+            { left: 111, top: 20, width: 99, height: 100 },
+            { left: 10, top: 20, width: 0, height: 100 },
+        ])).toEqual([{ x: 101, y: 0, width: 99, height: 100 }]);
+    });
+
+    it('returns nothing for a zero-size grid', () => {
+        expect(tilesFromCellRects({ left: 0, top: 0, width: 0, height: 100 }, [
+            { left: 0, top: 0, width: 50, height: 100 },
+        ])).toEqual([]);
+    });
+});
+
+describe('destRect rounding', () => {
+    it('makes adjacent tiles share an edge so DPR rounding cannot open a 1px gap', () => {
+        const dpr = 1.5;
+        const a = destRect({ x: 0, y: 0, width: 99, height: 100 }, dpr);
+        const b = destRect({ x: 101, y: 0, width: 99, height: 100 }, dpr);
+        // 2px CSS seam at x=99..101 → the tiles must not overlap and must not
+        // leave a hole besides that seam.
+        expect(a.dx + a.dw).toBe(Math.round(99 * dpr));
+        expect(b.dx).toBe(Math.round(101 * dpr));
+        expect(a.dx + a.dw).toBeLessThanOrEqual(b.dx);
+    });
+});
+
+describe('compositeLayoutScreenshot', () => {
+    it('fills the seam color first, then blits every tile at its dest rect', () => {
+        const rec = setupComposite();
+        const tiles: LayoutShotTile[] = [
+            { source: src('a'), x: 0, y: 0, width: 99, height: 100 },
+            { source: src('b'), x: 101, y: 0, width: 99, height: 100 },
+        ];
+        const url = compositeLayoutScreenshot(document as Document, { width: 200, height: 100, dpr: 2, gapColor: 'rgb(40, 40, 40)' }, tiles);
+
+        expect(url).toBe('data:image/png;base64,LAYOUT');
+        expect(rec.filled).toEqual({ color: 'rgb(40, 40, 40)', w: 400, h: 200 });
+        expect(rec.drawn.map((d) => d.id)).toEqual(['a', 'b']);
+        expect(rec.drawn[0]).toMatchObject(destRect(tiles[0]!, 2));
+        expect(rec.drawn[1]).toMatchObject(destRect(tiles[1]!, 2));
+    });
+
+    it('returns null when the frame is empty or no tile paints', () => {
+        setupComposite();
+        expect(compositeLayoutScreenshot(document as Document, { width: 0, height: 100, dpr: 1, gapColor: '#000' }, [
+            { source: src('a'), x: 0, y: 0, width: 10, height: 10 },
+        ])).toBeNull();
+        expect(compositeLayoutScreenshot(document as Document, { width: 200, height: 100, dpr: 1, gapColor: '#000' }, [])).toBeNull();
+        expect(compositeLayoutScreenshot(document as Document, { width: 200, height: 100, dpr: 1, gapColor: '#000' }, [
+            { source: src('a'), x: 0, y: 0, width: 0, height: 10 },
+        ])).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

- **Multi-chart screenshots capture the whole layout.** The camera button, the `mod+alt+S` chord, and the mobile drawer used to export only the active chart. They now composite every visible cell onto one PNG the size of the grid (seam color in the gaps), downloaded as `vela-layout.png`. A maximized cell still exports that one chart, and a single-chart workspace is unchanged. Adds an optional `screenshotCanvas()` seam to the renderer port (non-breaking) and a public `ws.screenshot()` / `ws.downloadScreenshot()` on the workspace. The grid-wide attribution mark is now included in exports.
- **The symbol search no longer triggers iOS focus-zoom.** iOS Safari zooms the page when a focused field is under 16px and often leaves it zoomed after picking a symbol. Text fields inside the shell's mobile layout are now 16px (scoped to the kit root, so host-page inputs are untouched), and the field blurs on every close path. The search bar + market tabs also sit in a sticky island, pinned while the result list scrolls.

## Test plan

- [x] Gate: `typecheck` · `lint` · `test` (1474, incl. new compositor unit tests) · `build`
- [x] Playground, 4-cell layout: camera button downloads a PNG matching the grid size (679×777 vs the active cell's 338×387), all four charts visible in it
- [x] Playground, maximized cell: export falls back to the single-chart PNG (`BTCUSDT-60.png`)
- [x] Mobile layout: search input computes to 16px, island stays pinned after scrolling the results, Escape-close blurs the field
- [ ] Real-device iOS check that the tap no longer zooms (only verifiable on hardware)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Screenshot export touches the renderer port, native raster path, and workspace compositing with layout geometry—user-visible output and a new public `ws.screenshot()` API, but behavior is gated and single-chart paths are preserved.
> 
> **Overview**
> **Multi-chart screenshots now capture the whole grid.** The camera button, `mod+alt+S`, and the mobile drawer route through `VelaWorkspace.downloadScreenshot()` / `screenshot()` instead of only the active cell. Visible cells are rasterized via a new optional `screenshotCanvas()` on the renderer port (native renderer splits raster from PNG encoding), positioned with grid geometry in `screenshot.ts`, and composited into one PNG named `vela-layout.png`. A single visible chart or a maximized cell still exports one chart as before. The workspace attribution mark is tagged for screenshot inclusion.
> 
> **Mobile symbol search avoids iOS focus-zoom and scroll UX.** Shell mobile layout forces **16px** on text fields (scoped under `.vela-ui[data-layout='mobile']`). The picker wraps the search row and market tabs in a **sticky** header, and **blurs** the input on every dialog close path so Safari does not stay zoomed after picking a symbol.
> 
> Changelog and workspace keyboard docs describe layout-wide PNG export. Unit tests cover compositor tile math and DPR rounding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc0f60cee318cf5baf2b69882ab628b0f25e8aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->