### PR TITLE
Keep price gaps open in the zoomed-out candle aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **A price gap stays visible at every zoom level.** When the two candles on
+  either side of a large price jump landed in the same pixel column on a far
+  zoom-out, that column rendered as one solid stick bridging the empty price
+  range between them. The zoomed-out view now keeps the gap open and paints
+  each side separately, each with its own up/down color.
+
 ## [v0.6.14]
 
 ### Changed

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -6,7 +6,7 @@ import type { SeriesSpec, LineLikeSeries, CandleSeries, LineStyle, CandleBarColo
 import { isLineLikeSeries } from '../../../core/model/series';
 import type { CoordinateSystem } from '../core/CoordinateSystem';
 import type { SceneGraph, PaneNode } from '../core/SceneGraph';
-import { candleTier, wickWidth, candleGeometry, snapY } from './candle-lod';
+import { candleTier, wickWidth, candleGeometry, snapY, aggregateCandleColumns } from './candle-lod';
 import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, effectiveCandlePaint } from '../core/chartConfig';
 import type { IRenderBackend } from './IRenderBackend';
 
@@ -508,10 +508,11 @@ export class Canvas2dBackend implements IRenderBackend {
     }
 
     /**
-     * Sub-pixel LOD: bucket every bar sharing a rounded pixel column into ONE
-     * high-low stick, so draw cost is bounded by screen width (not bar count) when
-     * zoomed far out. The bucket's color follows its first-open→last-close
-     * direction (a barcolor() on the head bar still wins).
+     * Sub-pixel LOD: bars sharing a rounded pixel column collapse into high-low
+     * sticks (one per contiguous coverage run — see {@link aggregateCandleColumns}),
+     * so draw cost is bounded by screen width (not bar count) when zoomed far out
+     * and a price gap inside the column stays a void. Each stick's color follows
+     * its first-open→last-close direction (a barcolor() on the head bar still wins).
      */
     private drawCandlesAggregated(
         ctx: CanvasRenderingContext2D,
@@ -524,44 +525,16 @@ export class Canvas2dBackend implements IRenderBackend {
         down: string,
         barColors: ReadonlyMap<number, string>,
     ): void {
-        let px = NaN;
-        let lo = Infinity;
-        let hi = -Infinity;
-        let openV = 0;
-        let closeV = 0;
-        let headTime = 0;
-        let active = false;
-        const flush = (): void => {
-            if (!active) return;
-            const color = barColors.get(headTime) ?? (closeV >= openV ? up : down);
-            const hY = coords.priceToY(hi, pane.scale, pane.bounds);
-            const lY = coords.priceToY(lo, pane.scale, pane.bounds);
-            ctx.strokeStyle = color;
-            ctx.lineWidth = 1;
+        const yOf = (price: number): number => coords.priceToY(price, pane.scale, pane.bounds);
+        ctx.lineWidth = 1;
+        for (const s of aggregateCandleColumns(bars, i0, i1, (i) => coords.logicalToX(i), yOf)) {
+            const x = s.x + 0.5;
+            ctx.strokeStyle = barColors.get(s.headTime) ?? (s.close >= s.open ? up : down);
             ctx.beginPath();
-            ctx.moveTo(px, hY);
-            ctx.lineTo(px, lY);
+            ctx.moveTo(x, yOf(s.hi));
+            ctx.lineTo(x, yOf(s.lo));
             ctx.stroke();
-        };
-        for (let i = i0; i <= i1; i += 1) {
-            const b = bars[i];
-            if (!b || b.high <= b.low) continue;
-            const x = Math.round(coords.logicalToX(i)) + 0.5;
-            if (!active || x !== px) {
-                flush();
-                px = x;
-                lo = b.low;
-                hi = b.high;
-                openV = b.open;
-                headTime = b.time;
-                active = true;
-            } else {
-                if (b.low < lo) lo = b.low;
-                if (b.high > hi) hi = b.high;
-            }
-            closeV = b.close;
         }
-        flush();
     }
 
     private drawSeries(ctx: CanvasRenderingContext2D, spec: SeriesSpec, pane: PaneNode, coords: CoordinateSystem, i0: number, i1: number, theme: VelaTheme, off = 0): void {

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -6,7 +6,7 @@ import type { SeriesSpec, LineLikeSeries, CandleSeries, LineStyle, CandleBarColo
 import { isLineLikeSeries } from '../../../core/model/series';
 import type { CoordinateSystem } from '../core/CoordinateSystem';
 import type { SceneGraph, PaneNode } from '../core/SceneGraph';
-import { candleTier, wickWidth, candleGeometry, snapY } from './candle-lod';
+import { candleTier, wickWidth, candleGeometry, snapY, aggregateCandleColumns } from './candle-lod';
 import { BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha as cssWithAlpha, effectiveCandlePaint } from '../core/chartConfig';
 import type { IRenderBackend } from './IRenderBackend';
 import { Batch, type RGBA } from './gl/Batch';
@@ -928,44 +928,19 @@ export class WebGL2Backend implements IRenderBackend {
     }
 
     /**
-     * Sub-pixel LOD (mirrors Canvas2dBackend.drawCandlesAggregated): bucket bars
-     * sharing a rounded pixel column into one high-low stick → draw cost bounded by
-     * screen width, not bar count. Bucket color follows first-open→last-close.
+     * Sub-pixel LOD (mirrors Canvas2dBackend.drawCandlesAggregated): bars sharing a
+     * rounded pixel column collapse into high-low sticks — one per contiguous
+     * coverage run (see {@link aggregateCandleColumns}), so a price gap inside the
+     * column stays a void. Draw cost stays bounded by screen width, not bar count;
+     * stick color follows its own first-open→last-close.
      */
     private emitCandlesAggregated(b: Batch, bars: OHLCV[], i0: number, i1: number, coords: CoordinateSystem, pane: PaneNode, up: string, down: string, barColors: ReadonlyMap<number, string>): void {
-        let px = NaN;
-        let lo = Infinity;
-        let hi = -Infinity;
-        let openV = 0;
-        let closeV = 0;
-        let headTime = 0;
-        let active = false;
-        const flush = (): void => {
-            if (!active) return;
-            const c = parseColor(barColors.get(headTime) ?? (closeV >= openV ? up : down));
-            const hY = coords.priceToY(hi, pane.scale, pane.bounds);
-            const lY = coords.priceToY(lo, pane.scale, pane.bounds);
-            b.rect(px - 0.5, hY, 1, lY - hY, c);
-        };
-        for (let i = i0; i <= i1; i += 1) {
-            const bar = bars[i];
-            if (!bar || bar.high <= bar.low) continue;
-            const x = Math.round(coords.logicalToX(i));
-            if (!active || x !== px) {
-                flush();
-                px = x;
-                lo = bar.low;
-                hi = bar.high;
-                openV = bar.open;
-                headTime = bar.time;
-                active = true;
-            } else {
-                if (bar.low < lo) lo = bar.low;
-                if (bar.high > hi) hi = bar.high;
-            }
-            closeV = bar.close;
+        const yOf = (price: number): number => coords.priceToY(price, pane.scale, pane.bounds);
+        for (const s of aggregateCandleColumns(bars, i0, i1, (i) => coords.logicalToX(i), yOf)) {
+            const c = parseColor(barColors.get(s.headTime) ?? (s.close >= s.open ? up : down));
+            const hY = yOf(s.hi);
+            b.rect(s.x - 0.5, hY, 1, yOf(s.lo) - hY, c);
         }
-        flush();
     }
 
     private emitSeries(b: Batch, spec: SeriesSpec, pane: PaneNode, coords: CoordinateSystem, i0: number, i1: number, theme: VelaTheme, off = 0): void {

--- a/src/renderers/native/backend/candle-lod.ts
+++ b/src/renderers/native/backend/candle-lod.ts
@@ -9,6 +9,8 @@
  *   high-low stick, so draw cost stays bounded by screen width when zoomed far out
  *   (true LOD) instead of growing with the bar count.
  */
+import type { OHLCV } from '../../../core/model/ohlcv';
+
 export type CandleTier = 'full' | 'wick' | 'aggregate';
 
 /** Below this spacing a candle has no body (wick-only). */
@@ -83,4 +85,109 @@ export function candleGeometry(xCss: number, spacing: number, dpr: number, bodyS
         bodyW: bodyDev / dpr,
         center: (wickLeftDev + wickDev / 2) / dpr,
     };
+}
+
+/** One aggregate-tier stick: a contiguous run of price coverage inside one pixel column. */
+export interface AggregatedStick {
+    /** The rounded CSS-px column shared by the stick's bars (canvas2d strokes at `x + 0.5`). */
+    x: number;
+    hi: number;
+    lo: number;
+    /** The stick's FIRST bar — the barcolor() lookup key and the direction's open. */
+    headTime: number;
+    open: number;
+    /** The stick's LAST bar's close (direction = `close >= open`, as everywhere). */
+    close: number;
+}
+
+/** One in-progress coverage interval of the current column (price space, index-tracked). */
+interface Coverage {
+    lo: number;
+    hi: number;
+    headIdx: number;
+    headTime: number;
+    open: number;
+    lastIdx: number;
+    close: number;
+}
+
+/**
+ * Aggregate-tier bucketing shared by both backends: bars whose centers round to the
+ * same pixel column collapse into high-low sticks. Coverage is kept as the UNION of
+ * the bars' true high-low ranges — one stick per contiguous run — instead of one
+ * min-to-max span, so a PRICE GAP between bars sharing the column (the bars around
+ * an overnight jump, once zoomed far out) stays a visible void instead of being
+ * painted over as a solid connection. Runs whose separation is under one pixel
+ * (`yOf` measures it) merge anyway: an invisible void isn't worth a second stick, and
+ * ordinary contiguous data keeps producing exactly one stick per column. Each stick
+ * carries its own first-open/last-close direction and its head bar's time, so
+ * barcolor() and up/down coloring follow the run that actually holds those bars.
+ */
+export function aggregateCandleColumns(
+    bars: ArrayLike<OHLCV | undefined>,
+    i0: number,
+    i1: number,
+    xOf: (index: number) => number,
+    yOf: (price: number) => number,
+): AggregatedStick[] {
+    const out: AggregatedStick[] = [];
+    let col = NaN;
+    let intervals: Coverage[] = []; // sorted by `lo`; typically length 1
+    const flush = (): void => {
+        if (intervals.length === 0) return;
+        // Coalesce runs whose void is sub-pixel — it cannot render anyway.
+        const merged: Coverage[] = [intervals[0]!];
+        for (let k = 1; k < intervals.length; k += 1) {
+            const prev = merged[merged.length - 1]!;
+            const next = intervals[k]!;
+            if (Math.abs(yOf(prev.hi) - yOf(next.lo)) < 1) {
+                prev.hi = next.hi;
+                if (next.headIdx < prev.headIdx) {
+                    prev.headIdx = next.headIdx;
+                    prev.headTime = next.headTime;
+                    prev.open = next.open;
+                }
+                if (next.lastIdx > prev.lastIdx) {
+                    prev.lastIdx = next.lastIdx;
+                    prev.close = next.close;
+                }
+            } else {
+                merged.push(next);
+            }
+        }
+        for (const iv of merged) out.push({ x: col, hi: iv.hi, lo: iv.lo, headTime: iv.headTime, open: iv.open, close: iv.close });
+        intervals = [];
+    };
+    for (let i = i0; i <= i1; i += 1) {
+        const b = bars[i];
+        if (!b || b.high <= b.low) continue;
+        const x = Math.round(xOf(i));
+        if (x !== col) {
+            flush();
+            col = x;
+        }
+        // Merge the bar's range into every overlapping interval (usually zero or one).
+        let lo = b.low;
+        let hi = b.high;
+        let headIdx = i;
+        let headTime = b.time;
+        let open = b.open;
+        for (let k = intervals.length - 1; k >= 0; k -= 1) {
+            const iv = intervals[k]!;
+            if (iv.lo > hi || iv.hi < lo) continue;
+            if (iv.lo < lo) lo = iv.lo;
+            if (iv.hi > hi) hi = iv.hi;
+            if (iv.headIdx < headIdx) {
+                headIdx = iv.headIdx;
+                headTime = iv.headTime;
+                open = iv.open;
+            }
+            intervals.splice(k, 1);
+        }
+        let insertAt = 0;
+        while (insertAt < intervals.length && intervals[insertAt]!.lo < lo) insertAt += 1;
+        intervals.splice(insertAt, 0, { lo, hi, headIdx, headTime, open, lastIdx: i, close: b.close });
+    }
+    flush();
+    return out;
 }

--- a/test/native-candle-lod.test.ts
+++ b/test/native-candle-lod.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { candleTier, wickWidth, candleGeometry, CANDLE_AGG_MAX_SPACING, CANDLE_BODY_MIN_SPACING, CANDLE_WICK_W } from '../src/renderers/native/backend/candle-lod';
+import { candleTier, wickWidth, candleGeometry, aggregateCandleColumns, CANDLE_AGG_MAX_SPACING, CANDLE_BODY_MIN_SPACING, CANDLE_WICK_W } from '../src/renderers/native/backend/candle-lod';
+import type { OHLCV } from '../src/core/model/ohlcv';
 
 describe('native candle LOD tiers', () => {
     it('draws a full body when bars are wide enough', () => {
@@ -103,5 +104,69 @@ describe('candle geometry (device-pixel snapping)', () => {
                 expect(g.bodyW).toBeGreaterThanOrEqual(g.wickW);
             }
         }
+    });
+});
+
+describe('aggregateCandleColumns (sub-pixel LOD bucketing)', () => {
+    const bar = (time: number, open: number, high: number, low: number, close: number): OHLCV => ({ time, open, high, low, close, volume: 0 });
+    // 10 px per price unit, chart top at price 100 — plenty of resolution for the void checks.
+    const yOf = (price: number): number => (100 - price) * 10;
+    const oneColumn = (): number => 0;
+
+    it('collapses a column of overlapping bars into ONE min-to-max stick', () => {
+        const bars = [bar(1, 10, 12, 9, 11), bar(2, 11, 13, 10, 12), bar(3, 12, 14, 11, 13)];
+        const sticks = aggregateCandleColumns(bars, 0, 2, oneColumn, yOf);
+        expect(sticks).toEqual([{ x: 0, hi: 14, lo: 9, headTime: 1, open: 10, close: 13 }]);
+    });
+
+    it('keeps a PRICE GAP inside a column as a void — two sticks, never one solid span', () => {
+        // The regression: the bars around a large price jump land in the same pixel
+        // column once zoomed far out; a single min-to-max stick would paint the void.
+        const bars = [bar(1, 10, 12, 9, 11), bar(2, 40, 42, 39, 41)];
+        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf);
+        expect(sticks).toEqual([
+            { x: 0, hi: 12, lo: 9, headTime: 1, open: 10, close: 11 },
+            { x: 0, hi: 42, lo: 39, headTime: 2, open: 40, close: 41 },
+        ]);
+    });
+
+    it('coalesces a SUB-PIXEL void — an invisible gap is not worth a second stick', () => {
+        // 0.05 price units = 0.5 px: below one pixel, the runs merge back into one.
+        const bars = [bar(1, 10, 12, 9, 11), bar(2, 12.1, 12.15, 12.05, 12.1)];
+        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf);
+        expect(sticks).toEqual([{ x: 0, hi: 12.15, lo: 9, headTime: 1, open: 10, close: 12.1 }]);
+    });
+
+    it('a later bar bridging two disjoint runs merges them (head stays the earliest bar)', () => {
+        const bars = [bar(1, 10, 12, 9, 11), bar(2, 40, 42, 39, 41), bar(3, 25, 41, 10, 30)];
+        const sticks = aggregateCandleColumns(bars, 0, 2, oneColumn, yOf);
+        expect(sticks).toEqual([{ x: 0, hi: 42, lo: 9, headTime: 1, open: 10, close: 30 }]);
+    });
+
+    it('emits one stick per pixel column and skips holes and zero-range bars', () => {
+        const bars: Array<OHLCV | undefined> = [
+            bar(1, 10, 12, 9, 11),
+            bar(2, 11, 13, 10, 12),
+            undefined,
+            bar(4, 20, 20, 20, 20), // zero-range: skipped
+            bar(5, 30, 32, 29, 31),
+        ];
+        // Two bars in column 0, the last one in column 1.
+        const xOf = (i: number): number => (i < 2 ? 0 : 1);
+        const sticks = aggregateCandleColumns(bars, 0, 4, xOf, yOf);
+        expect(sticks).toEqual([
+            { x: 0, hi: 13, lo: 9, headTime: 1, open: 10, close: 12 },
+            { x: 1, hi: 32, lo: 29, headTime: 5, open: 30, close: 31 },
+        ]);
+    });
+
+    it('sticks carry their OWN run direction (a gap-up column colors each side by its bars)', () => {
+        // Below the gap: a down run (open 12 → close 10). Above: an up run (40 → 42).
+        const bars = [bar(1, 12, 13, 9, 10), bar(2, 40, 43, 39, 42)];
+        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf);
+        const below = sticks.find((s) => s.hi === 13)!;
+        const above = sticks.find((s) => s.hi === 43)!;
+        expect(below.close).toBeLessThan(below.open);
+        expect(above.close).toBeGreaterThan(above.open);
     });
 });


### PR DESCRIPTION
## Summary

- Fixes the zoomed-out rendering artifact around large price gaps: when the two candles bracketing a gap rounded into the same pixel column at sub-pixel bar spacing, the aggregate LOD collapsed them into one min-to-max stick that painted a solid colored column across the empty price range.
- Both backends (canvas2d and WebGL2) now bucket through a shared `aggregateCandleColumns` helper in `candle-lod.ts` that keeps each pixel column's coverage as the union of the bars' true high-low ranges: one stick per contiguous run, so a real gap stays a visible void. Runs separated by less than one pixel coalesce, so ordinary contiguous data still produces exactly one stick per column and draw cost stays bounded by screen width.
- Each stick carries its own first-open/last-close direction and its head bar's time, so up/down coloring and `barcolor()` follow the run that actually holds those bars.

## Verification

- Unit tests for the new helper: gap preservation, sub-pixel void coalescing, run bridging, per-column bucketing, hole/zero-range skipping (`test/native-candle-lod.test.ts`).
- Reproduced the artifact in the playground with synthetic gapped data (10k one-minute bars with a 55-point jump) before the fix: a canvas pixel probe found a full-height colored column inside the void band at 4 of 9 sub-pixel pan phases. After the fix the same probe finds zero ink in the void at all phases, on both backends.
- Full gate green: typecheck, lint, 1474 tests, build. Workspace oracle suite: 23/23 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized rendering/LOD change with shared logic and tests; no data, auth, or API surface changes.
> 
> **Overview**
> Fixes a **zoomed-out candle artifact** where two bars bracketing a large price jump could round into the same pixel column and the aggregate LOD drew one min–max stick, filling the empty range with solid color.
> 
> **`aggregateCandleColumns`** in `candle-lod.ts` now buckets bars by rounded column but emits **one high–low stick per contiguous price coverage run**, leaving real gaps unpainted. Runs separated by less than one screen pixel still merge so normal dense data stays one stick per column and draw cost stays bounded by width. Each stick keeps its own open/close direction and head bar time for up/down and `barcolor()`.
> 
> **Canvas2d** and **WebGL2** drop duplicated flush loops and call the shared helper from `drawCandlesAggregated` / `emitCandlesAggregated`. **Unit tests** cover gap preservation, sub-pixel coalescing, bridging bars, and per-column behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efdca1b999014ee00691cc23f39059dd92294116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->