### PR TITLE
Screenshot export includes the attribution mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Chart screenshots now include the corner attribution mark.** The mark in
+  the bottom-left corner of the plot — Vela's own or the custom one a host
+  supplies — appeared on screen but was missing from the PNG the screenshot
+  export produced. Exports now show it exactly where the chart does; charts
+  with the mark disabled export unchanged.
+
 ## [v0.6.14]
 
 ### Changed

--- a/src/renderers/native/chrome/AttributionMark.ts
+++ b/src/renderers/native/chrome/AttributionMark.ts
@@ -122,6 +122,9 @@ export function createCustomMark(doc: Document, html: string, background: string
     });
     el.style.color = attributionMarkColor(background);
     el.innerHTML = html;
+    // A mark visible on screen belongs in the PNG export too — the renderer rasterizes
+    // every `data-vela-screenshot` overlay (a hidden mark is skipped by the rasterizer).
+    el.dataset.velaScreenshot = '1';
     return el;
 }
 
@@ -142,6 +145,9 @@ export function createAttributionMark(doc: Document, background: string): HTMLAn
         cursor: 'pointer',
     });
     applyAttributionMarkTheme(a, background);
+    // Same screenshot opt-in as the custom mark: the attribution the NOTICE file asks
+    // hosts to keep visible must survive into exported PNGs as well.
+    a.dataset.velaScreenshot = '1';
     const symbol = doc.createElement('span');
     symbol.className = 'vela-attr-symbol';
     symbol.setAttribute('aria-hidden', 'true');

--- a/test/attribution-mark.test.ts
+++ b/test/attribution-mark.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from 'vitest';
-import { attributionMarkColor } from '../src/renderers/native/chrome/AttributionMark';
+import { attributionMarkColor, createAttributionMark, createCustomMark } from '../src/renderers/native/chrome/AttributionMark';
 import { LUXALGO_SYMBOL_SVG, LUXALGO_WORDMARK_SVG } from '../src/renderers/native/chrome/luxalgo-logos';
+
+/** The DOM subset the mark builders touch — tests run in a plain node environment. */
+function stubDocument(): Document {
+    const makeEl = (): Record<string, unknown> => ({
+        className: '',
+        id: '',
+        textContent: '',
+        innerHTML: '',
+        style: { setProperty: () => undefined },
+        dataset: {},
+        setAttribute: () => undefined,
+        append: () => undefined,
+        appendChild: () => undefined,
+    });
+    return {
+        getElementById: () => null,
+        createElement: () => makeEl(),
+        head: { appendChild: () => undefined },
+    } as unknown as Document;
+}
 
 describe('attributionMarkColor', () => {
     it('is white on dark chart backgrounds', () => {
@@ -25,6 +45,20 @@ describe('attributionMarkColor', () => {
         // one crossover only — never white → gray → black
         const flips = inks.filter((ink, i) => i > 0 && ink !== inks[i - 1]).length;
         expect(flips).toBe(1);
+    });
+});
+
+describe('attribution mark screenshot opt-in', () => {
+    // The PNG export rasterizes only overlays tagged `data-vela-screenshot`; a mark
+    // that loses the tag silently vanishes from every exported chart.
+    it('the built-in mark opts into the PNG export', () => {
+        const mark = createAttributionMark(stubDocument(), '#151619');
+        expect(mark.dataset.velaScreenshot).toBe('1');
+    });
+
+    it('a host-supplied custom mark opts in the same way', () => {
+        const mark = createCustomMark(stubDocument(), 'ACME', '#151619');
+        expect(mark.dataset.velaScreenshot).toBe('1');
     });
 });
 


### PR DESCRIPTION
## Summary

The corner attribution mark (Vela's own logomark, or the custom mark a host supplies through `attribution: '<html>'`) rendered on screen but was missing from the PNG the screenshot export produces. The renderer's export rasterizes only DOM overlays tagged `data-vela-screenshot`, and the mark builders never set that tag.

- `createAttributionMark` and `createCustomMark` now tag the element they build, so every mounting context — the renderer's per-chart mark, the workspace's shared grid mark, a custom host mark — opts into the export from one place.
- A mark that is hidden (attribution disabled, or a workspace cell's suppressed per-chart mark) is skipped by the rasterizer as before, so charts with the mark disabled export unchanged.
- Targeted tests pin the opt-in for both builders; changelog entry under `[Unreleased]`.

## Verification

- Four-way gate green: typecheck, lint, 1470 tests (2 new), build.
- Browser-verified in the playground (served from `src`): the export PNG now shows the mark for both the workspace's shared mark and the renderer's own per-chart mark, and shows none when attribution is disabled (negative control).
- Workspace oracle suite: 23/23 deterministic checks pass.

Note: on `fix/layout-screenshot-and-mobile-search` (#110) the workspace tags its grid mark manually — after this lands, that line becomes redundant (it re-sets the same value) but stays harmless; the two branches do not conflict.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow export-layer change with tests; no data, auth, or trading-path impact.
> 
> **Overview**
> **Chart PNG exports now include the bottom-left attribution mark** when it is visible on screen. Screenshot rasterization only composites DOM overlays tagged with `data-vela-screenshot`; the built-in LuxAlgo mark and host **custom** marks from `createCustomMark` / `createAttributionMark` did not set that flag, so exports dropped the corner branding even though the live chart showed it.
> 
> Both mark builders now set `dataset.velaScreenshot = '1'` at creation, so every mounting path (per-chart renderer, workspace grid mark, custom HTML) opts in from one place. Marks that are hidden when attribution is off are still omitted by the rasterizer, so disabled attribution behavior is unchanged.
> 
> Tests assert the opt-in on both builders; the changelog records the fix under **[Unreleased] → Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ae309f76353e6b4d3bbb587c3d2a5a876054db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->