### PR TITLE
Side panels: overlay placement with a pin to dock, and restore dock state at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,25 @@ All notable changes to Vela, newest first.
 
 ## [Unreleased]
 
+### Added
+
+- **Side panels can float over the chart.** A contributed side panel may now
+  declare `overlay: true` (`registerSidePanel`) to open over the chart's right
+  edge instead of docking beside it — the chart keeps its width and layout, and
+  the panel covers whatever sits under it. Meant for panels wide enough that a
+  docked column would crush the plot, such as a code editor. A floating panel
+  shows a pin in its header: press it to dock the panel as a column beside the
+  chart, press again to let it float — your choice is remembered with the rest
+  of the layout. Resizing, the double-click reset and width persistence behave
+  the same in both placements; docking stays the default.
+
 ### Fixed
 
+- **Side panels come back the way you left them.** With the default
+  (localStorage) persistence, the open side panel and the widths you had dragged
+  were saved but not restored on the next load — the column always started
+  closed. They are restored at start-up now, along with the new pinned
+  placements.
 - **Overnight extended sessions now shade as one session, and the status
   badge says so.** Markets whose extended session runs through midnight —
   the trading day opens in the evening and closes the next afternoon — were
@@ -22,6 +39,17 @@ All notable changes to Vela, newest first.
   through a candle.
 ### Changed
 
+- **Panel resize handles highlight in the theme's own ink.** Hovering or dragging
+  a side panel's edge now shows the same neutral line the workspace grid
+  splitters and pane separators use (light on a dark theme, dark on a light one)
+  instead of the accent blue.
+- **The crosshair's time label spells out the date.** Hovering a bar now
+  labels the time axis with the weekday, day, month, and year — for example
+  `Sun 30 Aug '26 19:00` — instead of a bare month-day and clock, so a stamp
+  reads unambiguously however far back you scroll. On daily and longer
+  timeframes the clock is omitted and only the date shows. The time and
+  price chips also sit on a brighter, warmer gray so they stand off the
+  axis more clearly.
 - **Symbol search shows letters in uppercase.** Typed queries and ticker names
   in the results list display in uppercase — the same case a letter typed on
   the chart already seeds the dialog with. Descriptions, tabs, and the

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -578,6 +578,7 @@ registerSidePanel({
     resizable: true,             // drag the inner edge; double-click returns to `width`
     minWidth: 240,
     maxWidth: 560,
+    overlay: false,              // true floats the panel OVER the chart (with a pin to dock it)
     mount: (ctx, body, header) => {
         const list = document.createElement('div');
         body.appendChild(list);                       // `body` is the panel's scrolling area
@@ -601,6 +602,14 @@ registerSidePanel({
 - **Width is a per-panel choice.** Omit `resizable` for a fixed column; with it, the drag is
   clamped to `[minWidth, maxWidth]` (defaults 200/640) and the width the user settles on is
   saved with the shell's state document, under the panel id.
+- **Placement is a per-panel choice too.** A panel docks by default — a column beside the
+  chart, which shrinks to make room. With `overlay: true` the panel floats over the chart's
+  right edge instead: the chart keeps its width and layout, and the panel covers whatever
+  sits under it. Pick it for panels wide enough that a column would crush the plot (a code
+  editor). A floating panel's header carries a **pin**: pressed, the panel docks as a column
+  after all (the chart makes room), released, it floats again — the user's choice, saved with
+  the shell's state next to the widths. Resizing and width persistence work the same way in
+  both placements.
 - **The dock is exclusive.** Opening a panel closes the one showing — the chart keeps its
   width, and only one column is ever docked. `onOpen` is where a lazy panel renders.
 - **`onChart` is the rebind hook**, not a one-shot: the widget hands over a new chart instance

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -447,7 +447,10 @@ they work from the very first keystroke, before any click.
   ([`registerSidePanel`](../contributing/plugin-sdk.md#side-panels--registersidepanel)): every
   panel gets a toggle in the topbar's panel group, one panel shows at a time, and a panel that
   declares itself resizable has a drag handle on its inner edge (double-click returns it to its
-  declared width). Which panel is open and the widths you dragged are part of the saved state.
+  declared width). A panel may also declare itself an overlay: it then floats over the chart's
+  right edge instead of shrinking the chart, and a pin in its header docks it as a column
+  whenever you prefer that. Which panel is open, the widths you dragged and the panels you
+  pinned are part of the saved state.
 - **Bottom bar** — range chips, a live clock, and the timezone picker. Each chip switches
   the active chart's timeframe, **fetches the depth its window needs**, and frames it:
   `1D`→1m, `7D`→5m, `1M`→30m, `3M`→1h, `6M`→4h, `YTD`/`1Y`→1D, `5Y`/`ALL`→1W. Changing

--- a/src/core/icons.ts
+++ b/src/core/icons.ts
@@ -135,6 +135,9 @@ registerIcon('chevrons-right', S('<path d="m4 3.5 4.5 4.5L4 12.5"/><path d="m8.5
 registerIcon('chevrons-left', S('<path d="M12 3.5 7.5 8l4.5 4.5"/><path d="M7.5 3.5 3 8l4.5 4.5"/>'));
 registerIcon('check', S('<path d="m2.8 8.4 3.4 3.4 7-7.6"/>'));
 registerIcon('close', S('<path d="m3.8 3.8 8.4 8.4M12.2 3.8l-8.4 8.4"/>'));
+// A pushpin — outline while something floats (press to pin it), filled once pinned.
+registerIcon('pin', S('<path d="M5.6 2.5h4.8M6.4 2.5v3.6L4.4 8.4v.9h7.2v-.9L9.6 6.1V2.5M8 9.3v4.2"/>'));
+registerIcon('pin-filled', S('<path d="M5.6 2.5h4.8M6.4 2.5v3.6L4.4 8.4v.9h7.2v-.9L9.6 6.1V2.5M8 9.3v4.2"/><path d="M6.4 2.5h3.2v3.6l2 2.3v.9H4.4v-.9l2-2.3z" fill="currentColor" stroke="none"/>'));
 registerIcon('eye', S('<path d="M1.5 8s2.5-5.4 6.5-5.4S14.5 8 14.5 8 12 13.4 8 13.4 1.5 8 1.5 8z"/><circle cx="8" cy="8" r="1.8"/>'));
 registerIcon('eye-off', S('<path d="M1.5 8s2.5-5.4 6.5-5.4S14.5 8 14.5 8 12 13.4 8 13.4 1.5 8 1.5 8z" opacity="0.45"/><path d="m3 13 10-10"/>'));
 registerIcon('lock', S('<rect x="3.2" y="7" width="9.6" height="6.6" rx="1.2"/><path d="M5.6 7V5.2a2.4 2.4 0 0 1 4.8 0V7"/>'));

--- a/src/core/palette.ts
+++ b/src/core/palette.ts
@@ -52,11 +52,15 @@ export const SERIES_LINE = '#3b82f6';
 /** Crosshair ink: a cool gray that stays legible over both candles and empty surface. */
 export const CROSSHAIR = '#9aa0ad';
 
-/** Fixed slate plates for canvas chrome that floats over chart content of any color
- *  (crosshair value chips, info badges) — they cannot follow the theme surface and stay
- *  readable. `SLATE_DEEP` is the plate, `SLATE` its border. */
+/** Fixed slate plates for canvas badges that float over chart content of any color (info
+ *  badges on drawings) — they cannot follow the theme surface and stay readable.
+ *  `SLATE_DEEP` is the plate, `SLATE` its border. */
 export const SLATE_DEEP = '#1e293b';
 export const SLATE = '#475569';
+
+/** The crosshair's axis chips: the dark chart surface itself, so the chip reads as a cut-out
+ *  of the axis with only its white ink standing out rather than as a floating plate. */
+export const CHIP_PLATE = '#595959';
 
 /** Strategy trade markers — entry arrows per position side, and the exits' shared violet.
  *  The entry pair deliberately reuses the accent blue / bearish red (the reference palette

--- a/src/renderers/native/chrome/CrosshairRenderer.ts
+++ b/src/renderers/native/chrome/CrosshairRenderer.ts
@@ -2,10 +2,9 @@ import type { VelaTheme } from '../../../core/options';
 import type { LineStyle } from '../../../core/model/series';
 import type { CoordinateSystem } from '../core/CoordinateSystem';
 import type { SceneGraph, PaneNode } from '../core/SceneGraph';
-import { formatAxisValue } from './ticks';
+import { formatAxisValue, formatTimeStamp } from './ticks';
 import { readableText } from '../backend/gl/color';
 import { percentScaleFor } from './ChromeRenderer';
-import { zonedDate } from './tz';
 
 /**
  * Renderer-owned crosshair layer (chrome). Lives on its OWN transparent canvas
@@ -89,7 +88,7 @@ export class CrosshairRenderer {
             this.chip(ctx, dataW + 1, ch.y, formatAxisValue(pane.scale, pane.bounds.height, price, percentScaleFor(scene, pane), scene.priceMintick, pane.axisFormat), chipBg, 'left', false, theme.background);
         }
         // time chip on the bottom axis
-        this.chip(ctx, x, dataH + 1, formatStamp(coords.logicalToTime(logical), scene.timezone), chipBg, 'center', true, theme.background);
+        this.chip(ctx, x, dataH + 1, formatTimeStamp(coords.logicalToTime(logical), scene.timezone, coords.barInterval), chipBg, 'center', true, theme.background);
     }
 
     destroy(): void {
@@ -141,7 +140,7 @@ export class CrosshairRenderer {
                 this.chip(ctx, dataW + 1, ext.y, formatAxisValue(pane.scale, pane.bounds.height, ext.price, percentScaleFor(scene, pane), scene.priceMintick, pane.axisFormat), chipBg, 'left', false, theme.background);
             }
         }
-        this.chip(ctx, x, dataH + 1, formatStamp(ext.time, scene.timezone), chipBg, 'center', true, theme.background);
+        this.chip(ctx, x, dataH + 1, formatTimeStamp(ext.time, scene.timezone, coords.barInterval), chipBg, 'center', true, theme.background);
         ctx.globalAlpha = 1;
     }
 
@@ -176,10 +175,4 @@ function setDash(ctx: CanvasRenderingContext2D, style: LineStyle): void {
     if (style === 'dashed') ctx.setLineDash([6, 4]);
     else if (style === 'dotted') ctx.setLineDash([2, 3]);
     else ctx.setLineDash([]);
-}
-
-function formatStamp(ms: number, timeZone: string): string {
-    const d = zonedDate(ms, timeZone);
-    const pad = (n: number): string => (n < 10 ? `0${n}` : String(n));
-    return `${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
 }

--- a/src/renderers/native/chrome/ticks.ts
+++ b/src/renderers/native/chrome/ticks.ts
@@ -5,6 +5,7 @@
  *    DST/session-aware ticks are a later refinement — see the plan's risk list).
  */
 import type { PctScale } from '../core/SceneGraph';
+import { zonedDate } from './tz';
 
 export function priceTicks(min: number, max: number, target = 6): number[] {
     if (!(max > min) || !Number.isFinite(min) || !Number.isFinite(max)) return [];
@@ -226,7 +227,21 @@ const STEP_LADDER = [
 ];
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const pad2 = (n: number): string => (n < 10 ? `0${n}` : String(n));
+
+/**
+ * The crosshair's time-axis chip: `Sun 30 Aug '26 19:00`. Always the full calendar date
+ * (weekday, day, month, two-digit year) so the stamp is unambiguous however far the view
+ * is scrolled; the wall-clock time is appended only when bars are intraday — on a daily
+ * or coarser bar the hh:mm would just echo the bar's open and add noise.
+ */
+export function formatTimeStamp(ms: number, timeZone: string, barIntervalMs: number): string {
+    const d = zonedDate(ms, timeZone);
+    const date = `${WEEKDAYS[d.getUTCDay()]} ${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]} '${pad2(d.getUTCFullYear() % 100)}`;
+    if (barIntervalMs >= DAY) return date;
+    return `${date} ${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}`;
+}
 
 function pickStep(targetMs: number): number {
     for (const step of STEP_LADDER) if (step >= targetMs) return step;

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -1,7 +1,7 @@
 import type { LineStyle } from '../../../core/model/series';
 import { chartTypes, settingsRowValueKeys, type SettingsRowDescriptor } from '../../../chart-types/registry';
 import { withAlpha } from '../../../core/color';
-import { ACCENT, BEARISH, BULLISH, CROSSHAIR, SERIES_LINE, SLATE, WARNING } from '../../../core/palette';
+import { ACCENT, BEARISH, BULLISH, CHIP_PLATE, CROSSHAIR, SERIES_LINE, WARNING } from '../../../core/palette';
 import type { PriceStyle } from '../../../core/options';
 import type { ScaleMode } from './SceneGraph';
 
@@ -166,7 +166,7 @@ export function defaultChartStyle(): ChartStyle {
         gridHorz: { visible: true, color: null },
         borderColor: null,
         separatorColor: null,
-        crosshair: { color: CROSSHAIR, width: 1, style: 'dashed', opacity: 0.4, labelBackground: SLATE },
+        crosshair: { color: CROSSHAIR, width: 1, style: 'dashed', opacity: 0.4, labelBackground: CHIP_PLATE },
         candle: {
             bodyVisible: true,
             borderVisible: false,

--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -50,11 +50,13 @@ export interface TrackSizes {
  * The docked side panels — a SHELL-level pref (one dock serves every cell of a workspace).
  * `open` is the single panel showing (the dock is exclusive); `widths` holds only the columns
  * the user actually resized, by panel id, so a panel's declared width stays in charge until
- * then. Absent altogether in documents written before the dock existed.
+ * then; `pinned` lists the floating (overlay) panels the user pinned as columns. Absent
+ * altogether in documents written before the dock existed.
  */
 export interface PanelsState {
     open?: string;
     widths?: Record<string, number>;
+    pinned?: string[];
 }
 
 /** Per-chart (per-cell) state: the market, the display prefs, the content documents,
@@ -281,7 +283,11 @@ function sanitizePanels(raw: unknown): PanelsState | null {
         }
         if (Object.keys(widths).length > 0) out.widths = widths;
     }
-    return out.open || out.widths ? out : null;
+    if (Array.isArray(p.pinned)) {
+        const pinned = p.pinned.filter((id): id is string => typeof id === 'string' && id !== '');
+        if (pinned.length > 0) out.pinned = [...new Set(pinned)];
+    }
+    return out.open || out.widths || out.pinned ? out : null;
 }
 
 function sanitizeTrackSizes(raw: unknown): Record<string, TrackSizes> | null {

--- a/src/widget/contributions.ts
+++ b/src/widget/contributions.ts
@@ -161,6 +161,11 @@ export interface SidePanelDescriptor {
     resizable?: boolean;
     minWidth?: number;
     maxWidth?: number;
+    /** Float over the chart's right edge instead of docking beside it: the chart keeps its
+     *  width and layout, and the panel covers its right-hand part (default false — a docked
+     *  column that shrinks the chart). For panels wide enough that a column would crush
+     *  the plot. The dock stays exclusive either way. */
+    overlay?: boolean;
     mount(ctx: WidgetContext, body: HTMLElement, header: SidePanelHeader): SidePanelHandle | void;
 }
 

--- a/src/widget/panel-dock.ts
+++ b/src/widget/panel-dock.ts
@@ -54,6 +54,8 @@ export class PanelDock {
     private readonly entries: Entry[] = [];
     /** Widths the USER settled, by panel id — the only ones worth persisting. */
     private readonly widths = new Map<string, number>();
+    /** Floating panels the USER pinned as columns, by id — remembered for late registrations too. */
+    private pinned = new Set<string>();
     /** A restored `open` naming a panel that has not registered yet: honored when it docks. */
     private pendingOpen: string | null = null;
     private chart: Vela | null = null;
@@ -85,6 +87,7 @@ export class PanelDock {
                 resizable: desc.resizable,
                 minWidth: desc.minWidth,
                 maxWidth: desc.maxWidth,
+                overlay: desc.overlay,
             });
             const entry: Entry = {
                 id: desc.id,
@@ -139,7 +142,8 @@ export class PanelDock {
         const open = this.openId;
         if (open) out.open = open;
         if (this.widths.size > 0) out.widths = Object.fromEntries(this.widths);
-        return out.open || out.widths ? out : null;
+        if (this.pinned.size > 0) out.pinned = [...this.pinned];
+        return out.open || out.widths || out.pinned ? out : null;
     }
 
     /**
@@ -148,7 +152,8 @@ export class PanelDock {
      * a document that predates the dock has no `panels` field at all, so the shell never calls
      * this and the default (everything closed) stands. An `open` naming a panel that has not
      * registered yet is held until it docks (a plugin loaded after the restore), unless the user
-     * opens something in the meantime.
+     * opens something in the meantime. `pinned` is the whole list of floating panels the user
+     * docked — its absence means none is, so every floatable panel floats again.
      */
     applyState(state: PanelsState | undefined): void {
         if (!state) return;
@@ -158,6 +163,8 @@ export class PanelDock {
                 this.entries.find((e) => e.id === id)?.panel.setWidth(px);
             }
         }
+        this.pinned = new Set(state.pinned ?? []);
+        for (const entry of this.entries) entry.panel.setOverlay(!this.pinned.has(entry.id));
         for (const entry of this.entries) entry.panel.toggle(entry.id === state.open);
         this.pendingOpen = state.open && !this.entries.some((e) => e.id === state.open) ? state.open : null;
     }
@@ -173,6 +180,7 @@ export class PanelDock {
         this.entries.sort((a, b) => a.order - b.order);
         const stored = this.widths.get(entry.id);
         if (stored !== undefined) entry.panel.setWidth(stored);
+        if (this.pinned.has(entry.id)) entry.panel.setOverlay(false);
         entry.panel.onOpenChange = (open) => {
             if (open) {
                 for (const other of this.entries) if (other !== entry) other.panel.toggle(false);
@@ -184,6 +192,11 @@ export class PanelDock {
         };
         entry.panel.onWidthChange = (px) => {
             this.widths.set(entry.id, px);
+            this.deps.changed?.();
+        };
+        entry.panel.onPlacementChange = (overlay) => {
+            if (overlay) this.pinned.delete(entry.id);
+            else this.pinned.add(entry.id);
             this.deps.changed?.();
         };
         if (this.pendingOpen === entry.id) entry.panel.toggle(true);

--- a/src/widget/side-panel.ts
+++ b/src/widget/side-panel.ts
@@ -6,6 +6,11 @@
 //
 // Width is a per-panel choice: fixed by default, or `resizable` — a drag handle on the panel's
 // inner edge, clamped to [minWidth, maxWidth], double-click back to the declared width.
+// Placement is too: docked (the default, a column beside the chart) or `overlay` — the panel
+// floats over the chart's right edge and the chart keeps its width, for panels wide enough
+// that a docked column would crush the plot (an editor). A floating panel carries a PIN in
+// its header: pinned, it docks as a column after all; the choice is the user's and persists
+// with the dock state.
 import { injectStyles } from '../ui/styles';
 import { iconEl } from '../ui/icons';
 
@@ -60,6 +65,22 @@ const CSS = `
 }
 .vela-panel-close .vela-icon { width: 16px; height: 16px; }
 .vela-panel-close:hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
+/* The pin: same footprint as the close button it sits beside; filled + bright once pinned. */
+.vela-panel-pin {
+    all: unset;
+    cursor: pointer;
+    width: 26px;
+    height: 26px;
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    color: var(--vela-fg-muted);
+}
+.vela-panel-pin .vela-icon { width: 15px; height: 15px; }
+.vela-panel-pin:hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
+.vela-panel-pin[data-on='1'] { color: var(--vela-fg-bright); }
 .vela-panel-body { flex: 1; overflow: auto; padding: 8px; }
 .vela-panel-body::-webkit-scrollbar { width: 8px; }
 .vela-panel-body::-webkit-scrollbar-thumb { background: var(--vela-scroll); border-radius: 4px; border: 2px solid transparent; background-clip: padding-box; }
@@ -84,8 +105,23 @@ const CSS = `
     width: 1px;
     background: transparent;
 }
+/* The same hover ink as the workspace grid splitters and the canvas pane separators, so
+   every draggable seam in the shell reads as one family. */
 .vela-panel-resizer:hover::after,
-.vela-panel-resizer[data-dragging]::after { background: var(--vela-accent); }
+.vela-panel-resizer[data-dragging]::after { background: var(--vela-separator-hover-line); }
+/* An OVERLAY panel floats over the chart's right edge instead of taking a column: the
+   chart keeps its width and layout (the dock host is position:relative — the anchoring the
+   mobile rule below relies on too). Same z-order as that mobile overlay, above the chart's
+   own DOM overlays; the shadow separates it from the plot it covers. */
+.vela-panel[data-overlay] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    max-width: 100%;
+    z-index: 25;
+    box-shadow: var(--vela-shadow);
+}
 /* Mobile: a 280px column would crush a phone-width chart — the panel overlays the
    chart area instead (its flex parent is position:relative), full-bleed, closed by
    the same header ✕. Width dragging is a pointer affordance; off on mobile. */
@@ -107,6 +143,10 @@ export interface SidePanelOptions {
     resizable?: boolean;
     minWidth?: number;
     maxWidth?: number;
+    /** Float over the chart's right edge instead of docking beside it — the chart keeps
+     *  its width. Docked when false/omitted. A floating panel gets a header pin the user
+     *  can dock it with (see {@link SidePanel.onPlacementChange}). */
+    overlay?: boolean;
 }
 
 /**
@@ -134,6 +174,9 @@ export class SidePanel {
     /** Notified when the USER settles a new width (drag release, or double-click reset) — never on
      *  a programmatic {@link setWidth}, so restoring a persisted width raises no change. */
     onWidthChange: ((px: number) => void) | null = null;
+    /** Notified when the USER pins or unpins a floating panel (`overlay` is the NEW placement) —
+     *  never on a programmatic {@link setOverlay}, for the same reason as widths. */
+    onPlacementChange: ((overlay: boolean) => void) | null = null;
     protected readonly body: HTMLElement;
     private readonly heading: HTMLElement;
     private readonly slot: HTMLElement;
@@ -141,6 +184,10 @@ export class SidePanel {
     private readonly minWidth: number;
     private readonly maxWidth: number;
     private widthPx: number;
+    /** Declared `overlay` — the panel CAN float; {@link overlay} says whether it does right now. */
+    private readonly floatable: boolean;
+    private overlayOn: boolean;
+    private readonly pin: HTMLButtonElement | null = null;
 
     /** `modifier` is the panel's own class, carrying its content styles (e.g. `vela-ot`). */
     constructor(host: HTMLElement, title: string, modifier: string, opts: SidePanelOptions = {}) {
@@ -155,6 +202,9 @@ export class SidePanel {
         this.el = doc.createElement('div');
         this.el.className = `vela-panel ${modifier}`;
         this.el.hidden = true;
+        this.floatable = opts.overlay === true;
+        this.overlayOn = this.floatable;
+        if (this.overlayOn) this.el.dataset.overlay = '1';
         this.el.style.setProperty('--vela-panel-w', `${this.widthPx}px`);
         const header = doc.createElement('div');
         header.className = 'vela-panel-header';
@@ -171,7 +221,18 @@ export class SidePanel {
         close.appendChild(iconEl('close', doc));
         close.title = 'Close';
         close.addEventListener('click', () => this.toggle(false));
-        header.append(this.heading, this.slot, close);
+        // The pin exists only on a panel that can float: pressed, it docks the panel as a
+        // column (the chart makes room); released, the panel floats again.
+        if (this.floatable) {
+            this.pin = doc.createElement('button');
+            this.pin.className = 'vela-panel-pin';
+            this.pin.addEventListener('click', () => {
+                this.setOverlay(!this.overlayOn);
+                this.onPlacementChange?.(this.overlayOn);
+            });
+            this.refreshPin();
+        }
+        header.append(this.heading, this.slot, ...(this.pin ? [this.pin] : []), close);
         this.body = doc.createElement('div');
         this.body.className = 'vela-panel-body';
         this.el.append(header, this.body);
@@ -219,6 +280,32 @@ export class SidePanel {
         if (next === this.widthPx) return;
         this.widthPx = next;
         this.el.style.setProperty('--vela-panel-w', `${next}px`);
+    }
+
+    /** Whether the panel floats over the chart right now (false for every docked panel). */
+    get overlay(): boolean {
+        return this.overlayOn;
+    }
+
+    /** Float or dock the panel. Only a panel declared `overlay` can float — on any other this is
+     *  a no-op. Silent — {@link onPlacementChange} reports the user's pin clicks only. */
+    setOverlay(overlay: boolean): void {
+        if (!this.floatable || overlay === this.overlayOn) return;
+        this.overlayOn = overlay;
+        if (overlay) this.el.dataset.overlay = '1';
+        else delete this.el.dataset.overlay;
+        this.refreshPin();
+    }
+
+    private refreshPin(): void {
+        if (!this.pin) return;
+        const pinned = !this.overlayOn;
+        const doc = this.pin.ownerDocument;
+        this.pin.replaceChildren(iconEl(pinned ? 'pin-filled' : 'pin', doc));
+        this.pin.dataset.on = pinned ? '1' : '0';
+        this.pin.title = pinned ? 'Unpin — float over the chart' : 'Pin beside the chart';
+        this.pin.setAttribute('aria-label', this.pin.title);
+        this.pin.setAttribute('aria-pressed', pinned ? 'true' : 'false');
     }
 
     destroy(): void {

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -525,6 +525,10 @@ export class VelaWorkspace {
         this.dock.addBuiltIn({ id: 'dataWindow', title: 'Data window', icon: 'datawindow', order: 10, panel: this.dataWindow, onChart: (c) => this.dataWindow.onChart(c) });
         this.dock.addBuiltIn({ id: 'objects', title: 'Object tree', icon: 'objects', order: 20, panel: this.objectTree, onChart: (c) => this.objectTree.onChart(c) });
         this.dock.refresh();
+        // The dock's own slice of the boot document (open panel, dragged widths, pinned
+        // placements) — the sync-storage twin of what `applyState` does for a late document.
+        // Panels that are not registered yet keep their entry until they dock.
+        if (boot?.panels) this.dock.applyState(boot.panels);
         this.root.appendChild(main);
         this.toastHost = new Toast(this.gridEl);
 

--- a/test/native-chart-config.test.ts
+++ b/test/native-chart-config.test.ts
@@ -109,7 +109,7 @@ describe('defaultChartStyle', () => {
         // resolves light chrome lines instead of the dark constants.
         expect(s.borderColor).toBeNull();
         expect(s.separatorColor).toBeNull();
-        expect(s.crosshair).toEqual({ color: '#9aa0ad', width: 1, style: 'dashed', opacity: 0.4, labelBackground: '#475569' });
+        expect(s.crosshair).toEqual({ color: '#9aa0ad', width: 1, style: 'dashed', opacity: 0.4, labelBackground: '#151619' });
         expect(s.candle.borderVisible).toBe(false);
         expect(s.candle.wickVisible).toBe(true);
     });
@@ -122,7 +122,7 @@ describe('NativeRenderer.getConfig — defaults resolve to concrete values', () 
         expect(cfg.layout).toEqual({ background: '#151619', textColor: '#b2b5be', fontFamily: 'sans-serif', fontSize: 11 });
         expect(cfg.grid.vertLines).toEqual({ visible: true, color: '#20222c' });
         expect(cfg.grid.horzLines).toEqual({ visible: true, color: '#20222c' });
-        expect(cfg.crosshair).toEqual({ color: '#9aa0ad', width: 1, style: 'dashed', opacity: 0.4, labelBackground: '#475569' });
+        expect(cfg.crosshair).toEqual({ color: '#9aa0ad', width: 1, style: 'dashed', opacity: 0.4, labelBackground: '#151619' });
         expect(cfg.priceScale).toEqual({ mode: 'price', log: false, invert: false, borderColor: '#2a2b30', labelsVisible: true, currentPriceLine: true, priceLabel: true, countdown: true });
         expect(cfg.panes).toEqual({ separatorColor: '#2a2b30' }); // inherits the theme border
         expect(cfg.timeScale).toEqual({ timezone: 'UTC' });

--- a/test/native-ticks.test.ts
+++ b/test/native-ticks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { logPriceTicks, valueDecimals, priceTicks, tickDecimals, axisDecimals, formatPriceLabel, formatAxisValue } from '../src/renderers/native/chrome/ticks';
+import { logPriceTicks, valueDecimals, priceTicks, tickDecimals, axisDecimals, formatPriceLabel, formatAxisValue, formatTimeStamp } from '../src/renderers/native/chrome/ticks';
 
 describe('native ticks · logPriceTicks', () => {
     it('places 1/2/5 per decade over a wide (multi-decade) range', () => {
@@ -88,5 +88,32 @@ describe('native ticks · formatPriceLabel / formatAxisValue', () => {
 
     it('indexed mode ignores the tick size (plain number to 2 decimals)', () => {
         expect(formatAxisValue({ min: 100, max: 110 }, 600, 105, { baseline: 100, indexed: true }, 0.01)).toBe('105.00');
+    });
+});
+
+describe('native ticks · formatTimeStamp (crosshair time chip)', () => {
+    const HOUR = 3_600_000;
+    const DAY = 24 * HOUR;
+    const sun30Aug26_19h = Date.UTC(2026, 7, 30, 19, 0); // a Sunday
+
+    it('reads weekday, day, short month, two-digit year and hh:mm on intraday bars', () => {
+        expect(formatTimeStamp(sun30Aug26_19h, 'UTC', HOUR)).toBe("Sun 30 Aug '26 19:00");
+        expect(formatTimeStamp(Date.UTC(2031, 0, 3, 9, 5), 'UTC', 60_000)).toBe("Fri 3 Jan '31 09:05");
+    });
+
+    it('drops hh:mm on daily and coarser bars', () => {
+        expect(formatTimeStamp(sun30Aug26_19h, 'UTC', DAY)).toBe("Sun 30 Aug '26");
+        expect(formatTimeStamp(sun30Aug26_19h, 'UTC', 7 * DAY)).toBe("Sun 30 Aug '26");
+        expect(formatTimeStamp(sun30Aug26_19h, 'UTC', 12 * HOUR)).toBe("Sun 30 Aug '26 19:00");
+    });
+
+    it('zero-pads the year and renders the wall clock in the chosen time zone', () => {
+        expect(formatTimeStamp(Date.UTC(2005, 11, 31, 23, 30), 'UTC', HOUR)).toBe("Sat 31 Dec '05 23:30");
+        // 23:30 UTC on Dec 31 is already Jan 1 in Tokyo (UTC+9) — date, weekday and year roll.
+        expect(formatTimeStamp(Date.UTC(2005, 11, 31, 23, 30), 'Asia/Tokyo', HOUR)).toBe("Sun 1 Jan '06 08:30");
+    });
+
+    it('treats an unknown bar interval (no bars yet) as intraday', () => {
+        expect(formatTimeStamp(sun30Aug26_19h, 'UTC', 0)).toBe("Sun 30 Aug '26 19:00");
     });
 });

--- a/test/side-panel-dock.test.ts
+++ b/test/side-panel-dock.test.ts
@@ -19,6 +19,7 @@ interface StubEl {
     listeners: Map<string, Array<(e: unknown) => void>>;
     append(...nodes: StubEl[]): void;
     appendChild(node: StubEl): StubEl;
+    replaceChildren(...nodes: StubEl[]): void;
     setAttribute(name: string, value: string): void;
     addEventListener(type: string, fn: (e: unknown) => void): void;
     setPointerCapture(id: number): void;
@@ -48,6 +49,7 @@ function stubDoc(): { doc: unknown; root: StubEl } {
                 listeners: new Map(),
                 append: (...nodes) => void el.children.push(...nodes),
                 appendChild: (node) => (el.children.push(node), node),
+                replaceChildren: (...nodes) => void el.children.splice(0, el.children.length, ...nodes),
                 setAttribute: () => {},
                 addEventListener: (type, fn) => void el.listeners.set(type, [...(el.listeners.get(type) ?? []), fn]),
                 setPointerCapture: () => {},
@@ -134,6 +136,52 @@ describe('SidePanel width', () => {
     });
 });
 
+describe('SidePanel placement', () => {
+    it('docks by default; `overlay` marks the element so the shell floats it over the chart', () => {
+        const { root } = stubDoc();
+        const docked = new SidePanel(root as never, 'Docked', 'x-docked', { resizable: true });
+        expect((docked.el as unknown as StubEl).dataset.overlay).toBeUndefined();
+        expect(docked.overlay).toBe(false);
+        expect(find(docked.el as never, 'vela-panel-pin')).toBeUndefined(); // nothing to pin
+        const floating = new SidePanel(root as never, 'Floating', 'x-floating', { width: 800, resizable: true, overlay: true });
+        expect((floating.el as unknown as StubEl).dataset.overlay).toBe('1');
+        expect(floating.overlay).toBe(true);
+        // Width policy is independent of placement — an overlay still resizes and clamps.
+        expect(floating.width).toBe(640);
+        expect(find(floating.el as never, 'vela-panel-resizer')).toBeDefined();
+    });
+
+    it('the pin docks a floating panel and reports the user’s choice; setOverlay is silent', () => {
+        const { root } = stubDoc();
+        const panel = new SidePanel(root as never, 'Floating', 'x-floating', { overlay: true });
+        const seen: boolean[] = [];
+        panel.onPlacementChange = (overlay) => seen.push(overlay);
+        const pin = find(panel.el as never, 'vela-panel-pin')!;
+        expect(pin).toBeDefined();
+        expect(pin.dataset.on).toBe('0');
+
+        pin.fire('click'); // pin → docked column
+        expect(panel.overlay).toBe(false);
+        expect((panel.el as unknown as StubEl).dataset.overlay).toBeUndefined();
+        expect(pin.dataset.on).toBe('1');
+        pin.fire('click'); // unpin → floats again
+        expect(panel.overlay).toBe(true);
+        expect(seen).toEqual([false, true]);
+
+        panel.setOverlay(false); // a restore: applied, not reported
+        expect(panel.overlay).toBe(false);
+        expect(seen).toEqual([false, true]);
+    });
+
+    it('a docked panel cannot be floated from code — only a declared overlay can', () => {
+        const { root } = stubDoc();
+        const docked = new SidePanel(root as never, 'Docked', 'x-docked');
+        docked.setOverlay(true);
+        expect(docked.overlay).toBe(false);
+        expect((docked.el as unknown as StubEl).dataset.overlay).toBeUndefined();
+    });
+});
+
 describe('registerSidePanel', () => {
     it('sorts by order, replaces by id, and unregisters through the disposer', () => {
         const mount = (): void => {};
@@ -162,6 +210,7 @@ describe('PanelDock', () => {
         buttons: () => SidePanelButton[];
         active: Map<string, boolean>;
         changed: () => number;
+        root: StubEl;
     } {
         const { root } = stubDoc();
         let buttons: SidePanelButton[] = [];
@@ -179,7 +228,7 @@ describe('PanelDock', () => {
         const b = new SidePanel(root as never, 'B', 'x-b', { resizable: true });
         d.addBuiltIn({ id: 'a', title: 'A', icon: 'ia', order: 10, panel: a });
         d.addBuiltIn({ id: 'b', title: 'B', icon: 'ib', order: 20, panel: b });
-        return { dock: d, panels: { a, b }, buttons: () => buttons, active, changed: () => changes };
+        return { dock: d, panels: { a, b }, buttons: () => buttons, active, changed: () => changes, root };
     }
 
     it('projects one button per panel, in dock order', () => {
@@ -222,6 +271,35 @@ describe('PanelDock', () => {
         expect(changed()).toBeGreaterThan(0);
     });
 
+    it('persists the floating panels the user pinned, applies them on restore, and remembers them for late panels', () => {
+        const { dock: d, root, changed } = dock();
+        const off = registerSidePanel({ id: 'x', title: 'X', icon: 'ix', overlay: true, mount: () => {} });
+        d.refresh();
+        const pin = find(root, 'vela-panel-x')!.children.find((c) => c.className === 'vela-panel-header')!.children.find((c) => c.className === 'vela-panel-pin')!;
+        const before = changed();
+        pin.fire('click');
+        expect(d.getState()).toEqual({ pinned: ['x'] });
+        expect(changed()).toBe(before + 1);
+        pin.fire('click');
+        expect(d.getState()).toBeNull();
+
+        // A restore applies the list wholesale — and its absence unpins.
+        d.applyState({ pinned: ['x'] });
+        expect(find(root, 'vela-panel-x')!.dataset.overlay).toBeUndefined();
+        d.applyState({ open: 'a' });
+        expect(find(root, 'vela-panel-x')!.dataset.overlay).toBe('1');
+
+        // A pinned id naming a panel that registers later applies when it docks.
+        off();
+        d.refresh();
+        d.applyState({ pinned: ['late'] });
+        registerSidePanel({ id: 'late', title: 'Late', icon: 'il', overlay: true, mount: () => {} });
+        d.refresh();
+        expect(find(root, 'vela-panel-late')!.dataset.overlay).toBeUndefined();
+        unregisterSidePanel('late');
+        d.refresh();
+    });
+
     it('restores a document: widths apply, the named panel opens, the others close', () => {
         const { dock: d, panels } = dock();
         d.toggle('a');
@@ -256,16 +334,18 @@ describe('PanelDock', () => {
     });
 
     it('mounts contributed panels with their body, rebinds them, and keeps them open across a refresh', () => {
-        const { dock: d, buttons } = dock();
+        const { dock: d, buttons, root } = dock();
         const onChart = vi.fn();
         const mount = vi.fn((_ctx: WidgetContext, body: HTMLElement) => {
             body.appendChild(body.ownerDocument.createElement('div'));
             return { onChart };
         });
-        const off = registerSidePanel({ id: 'x', title: 'X', icon: 'ix', width: 320, resizable: true, mount });
+        const off = registerSidePanel({ id: 'x', title: 'X', icon: 'ix', width: 320, resizable: true, overlay: true, mount });
         d.refresh();
         expect(buttons().map((b) => b.id)).toEqual(['a', 'b', 'x']); // default order lands last
         expect(mount).toHaveBeenCalledTimes(1);
+        // The descriptor's placement reaches the panel the dock builds.
+        expect(find(root, 'vela-panel-x')!.dataset.overlay).toBe('1');
 
         const chart = {} as never;
         d.onChart(chart);
@@ -331,12 +411,14 @@ describe('sanitizeState — panels', () => {
     const base = { version: 1, layout: '1', charts: [] };
 
     it('keeps a usable dock state', () => {
-        const st = sanitizeState({ ...base, panels: { open: 'objects', widths: { objects: 320 } } });
-        expect(st?.panels).toEqual({ open: 'objects', widths: { objects: 320 } });
+        const st = sanitizeState({ ...base, panels: { open: 'objects', widths: { objects: 320 }, pinned: ['editor'] } });
+        expect(st?.panels).toEqual({ open: 'objects', widths: { objects: 320 }, pinned: ['editor'] });
     });
 
     it('drops malformed fields rather than throwing', () => {
         expect(sanitizeState({ ...base, panels: { open: 42, widths: { a: 'wide', b: -5, c: 0, d: 260 } } })?.panels).toEqual({ widths: { d: 260 } });
+        expect(sanitizeState({ ...base, panels: { pinned: ['x', 7, '', 'x', null] } })?.panels).toEqual({ pinned: ['x'] });
+        expect(sanitizeState({ ...base, panels: { pinned: 'x' } })?.panels).toBeUndefined();
         expect(sanitizeState({ ...base, panels: 'nope' })?.panels).toBeUndefined();
         expect(sanitizeState({ ...base, panels: { open: '', widths: {} } })?.panels).toBeUndefined();
     });

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -16,6 +16,7 @@ const fullDoc: WorkspaceState = {
     timeframeFavorites: ['15', '60', 'D'],
     sync: { viewport: true, symbol: { c1: 'a', c2: 'a' }, crosshair: true, drawings: true, style: true },
     trackSizes: { '4': { cols: [1.4, 0.6], rows: [1, 1] } },
+    panels: { open: 'objects', widths: { objects: 320 }, pinned: ['vendor.editor'] },
     charts: [
         {
             id: 'c1',


### PR DESCRIPTION
## Summary

- **Side panels can float over the chart.** `registerSidePanel({ overlay: true })` places a contributed panel over the chart's right edge instead of docking it as a column; the chart keeps its width and layout. Docking stays the default. Motivated by the Pine editor in Vela-pro (a 800 px column crushes the plot), shaped as a neutral placement seam any plugin can use.
- **Pin to dock.** A floating panel's header carries a pin (new `pin` / `pin-filled` icons): pressed, the panel docks as a column (the chart makes room); released, it floats again. The user's choice persists in the dock state (`PanelsState.pinned`) next to `open` and `widths`, and is remembered for panels that register later.
- **Resize handle ink.** The panel resizer's hover/drag line now uses `--vela-separator-hover-line` (the workspace splitters' and pane separators' token) instead of the accent.
- **Fix: dock state was never restored with sync storage.** The boot path applied `timezone`, `favorites`, `layout`, `trackSizes`… but not `boot.panels`, so with the default localStorage adapter the open panel and dragged widths were saved and then ignored on the next load. `dock.applyState(boot.panels)` now runs at construction.
- Also on this branch (committed together): crosshair time label spells out the full date; ticks/palette/chart-config follow-ups.

Docs: `docs/contributing/plugin-sdk.md`, `docs/user/workspace.md`; `CHANGELOG.md` under `[Unreleased]` (Added / Changed / Fixed). Semver: additive (minor).

Downstream consumer: **LuxAlgo/Vela-pro#71** (https://github.com/LuxAlgo/Vela-pro/pull/71) sets `overlay: true` on the Pine editor and needs a release carrying this seam.

## Test plan

- [x] `npm run typecheck` · `npm run lint` · `npm run test` (1501) · `npm run build`
- [x] New tests: `overlay` marks the element, pin toggles and reports, `setOverlay` silent, dock persists/applies `pinned` (incl. late registration), codec sanitises `pinned`, full-document round-trip
- [x] Browser (Vela-pro playground over a local link): chart canvas width unchanged when the overlay opens (1757.6 → 1757.6); pin click docks it (→ 862.4) and writes `pinned`; reload restores open + pinned; unpin + reload restores floating
- [ ] Reviewer: open the object tree / data window — docked panels are unaffected (no pin, same layout)
