### PR TITLE
Keep the native color chooser open while picking a custom color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **The custom color chooser stays open while you pick.** Pressing `+` in a color
+  picker opens the browser's own color chooser; clicking or dragging on its
+  gradient used to slam it shut after the first change, so you could only ever
+  land one step away from where you started. The chooser now stays open until
+  you dismiss it, the chart previews every color you hover through, and only the
+  color you settle on is added to the recents row. Picking a swatch also updates
+  the chooser's starting color, so `+` opens on what is currently selected.
+
 ## [v0.6.15]
 
 ### Added

--- a/src/ui/components/color-picker/view.ts
+++ b/src/ui/components/color-picker/view.ts
@@ -68,8 +68,24 @@ export function buildColorPicker(color: string, theme: VelaTheme, onChange: (v: 
 
     const recentRow = document.createElement('div');
     recentRow.style.cssText = 'display:flex;align-items:center;gap:5px;flex-wrap:wrap;border-top:1px solid var(--vela-border);padding-top:9px;';
+    // Swatches get their own wrapper so re-rendering them never detaches the native
+    // color input — the browser closes its chooser the moment its input leaves the DOM.
+    const recentSwatches = document.createElement('div');
+    recentSwatches.style.cssText = 'display:contents;';
+    const add = document.createElement('label');
+    add.style.cssText = `width:17px;height:17px;border-radius:var(--vela-radius-sm);border:1px dashed var(--vela-border-strong);cursor:pointer;display:flex;align-items:center;justify-content:center;color:${theme.textColor};font:14px ${theme.fontFamily};position:relative;`;
+    add.textContent = '+';
+    const customInput = document.createElement('input');
+    customInput.type = 'color';
+    customInput.value = curHex;
+    customInput.style.cssText = 'position:absolute;inset:0;opacity:0;cursor:pointer;';
+    // `input` streams while the chooser is open (preview); `change` is the committed pick.
+    customInput.addEventListener('input', () => previewHex(customInput.value));
+    customInput.addEventListener('change', () => pickHex(customInput.value, true));
+    add.appendChild(customInput);
+    recentRow.append(recentSwatches, add);
     const renderRecents = (): void => {
-        recentRow.replaceChildren();
+        recentSwatches.replaceChildren();
         for (const c of recents) {
             const sw = document.createElement('button');
             sw.type = 'button';
@@ -78,18 +94,8 @@ export function buildColorPicker(color: string, theme: VelaTheme, onChange: (v: 
                 e.stopPropagation();
                 pickHex(c);
             });
-            recentRow.appendChild(sw);
+            recentSwatches.appendChild(sw);
         }
-        const add = document.createElement('label');
-        add.style.cssText = `width:17px;height:17px;border-radius:var(--vela-radius-sm);border:1px dashed var(--vela-border-strong);cursor:pointer;display:flex;align-items:center;justify-content:center;color:${theme.textColor};font:14px ${theme.fontFamily};position:relative;`;
-        add.textContent = '+';
-        const input = document.createElement('input');
-        input.type = 'color';
-        input.value = curHex;
-        input.style.cssText = 'position:absolute;inset:0;opacity:0;cursor:pointer;';
-        input.addEventListener('input', () => pickHex(input.value, true));
-        add.appendChild(input);
-        recentRow.appendChild(add);
     };
 
     const opLabel = document.createElement('div');
@@ -131,13 +137,17 @@ export function buildColorPicker(color: string, theme: VelaTheme, onChange: (v: 
     function emit(): void {
         onChange(combineColor(curHex, curAlpha));
     }
-    function pickHex(hex: string, custom = false): void {
+    function previewHex(hex: string): void {
         curHex = splitColor(hex).hex6;
-        addRecent(curHex);
         paintSelection();
         paintOpacity();
-        if (custom) renderRecents();
         emit();
+    }
+    function pickHex(hex: string, custom = false): void {
+        previewHex(hex);
+        addRecent(curHex);
+        customInput.value = curHex;
+        if (custom) renderRecents();
     }
 
     renderRecents();

--- a/test/color-picker.test.ts
+++ b/test/color-picker.test.ts
@@ -1,5 +1,114 @@
-import { describe, it, expect } from 'vitest';
-import { splitColor, combineColor } from '../src/ui/components/color-picker';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { VelaTheme } from '../src/core/options';
+import { splitColor, combineColor, buildColorPicker } from '../src/ui/components/color-picker';
+
+// A minimal element stub (this suite runs in the node env — no jsdom). It models just
+// enough of the tree for `buildColorPicker`: parent links so `isConnected` can be
+// answered, child mutation, and per-element listeners.
+interface FakeEl {
+    tag: string;
+    type: string;
+    value: string;
+    textContent: string;
+    style: { cssText: string } & Record<string, string>;
+    dataset: Record<string, string>;
+    children: FakeEl[];
+    parentNode: FakeEl | null;
+    attached: boolean;
+    readonly isConnected: boolean;
+    addEventListener: (t: string, fn: (e: unknown) => void) => void;
+    dispatchEvent: (e: { type: string; stopPropagation?: () => void }) => boolean;
+    appendChild: (c: FakeEl) => FakeEl;
+    append: (...cs: FakeEl[]) => void;
+    replaceChildren: (...cs: FakeEl[]) => void;
+}
+
+function fakeEl(tag: string): FakeEl {
+    const listeners = new Map<string, Array<(e: unknown) => void>>();
+    const el: FakeEl = {
+        tag,
+        type: '',
+        value: '',
+        textContent: '',
+        style: { cssText: '' },
+        dataset: {},
+        children: [],
+        parentNode: null,
+        attached: false,
+        get isConnected(): boolean {
+            let n: FakeEl | null = el;
+            while (n.parentNode) n = n.parentNode;
+            return n.attached;
+        },
+        addEventListener: (t, fn) => { const a = listeners.get(t) ?? []; a.push(fn); listeners.set(t, a); },
+        dispatchEvent: (e) => { for (const fn of listeners.get(e.type) ?? []) fn(e); return true; },
+        appendChild: (c) => { c.parentNode?.children.splice(c.parentNode.children.indexOf(c), 1); c.parentNode = el; el.children.push(c); return c; },
+        append: (...cs) => { for (const c of cs) el.appendChild(c); },
+        replaceChildren: (...cs) => { for (const c of el.children) c.parentNode = null; el.children = []; el.append(...cs); },
+    };
+    return el;
+}
+
+describe('color picker custom "+" input', () => {
+    const theme = { textColor: '#fff', fontFamily: 'sans-serif' } as unknown as VelaTheme;
+    let savedDocument: unknown;
+
+    beforeEach(() => {
+        savedDocument = (globalThis as { document?: unknown }).document;
+        (globalThis as { document: unknown }).document = { createElement: (tag: string) => fakeEl(tag) };
+    });
+    afterEach(() => {
+        (globalThis as { document?: unknown }).document = savedDocument;
+    });
+
+    function mount(): { input: FakeEl; recentSwatches: FakeEl; picked: string[] } {
+        const picked: string[] = [];
+        const body = fakeEl('body');
+        body.attached = true;
+        const root = buildColorPicker('#089981', theme, (v) => picked.push(v)) as unknown as FakeEl;
+        body.appendChild(root);
+        // root → [grid, recentRow, …]; recentRow → [swatches wrapper, "+" label → [input]].
+        const recentRow = root.children[1]!;
+        const recentSwatches = recentRow.children[0]!;
+        const input = recentRow.children[1]!.children[0]!;
+        expect(input.type).toBe('color');
+        return { input, recentSwatches, picked };
+    }
+
+    it('keeps the same native color input in the DOM while the chooser streams values', () => {
+        const { input, recentSwatches, picked } = mount();
+        const recentsBefore = recentSwatches.children.length;
+        for (const v of ['#aa0000', '#bb1111', '#cc2222']) {
+            input.value = v;
+            input.dispatchEvent(new Event('input'));
+            // The browser closes its chooser if the owning input is detached — it must stay put.
+            expect(input.isConnected).toBe(true);
+        }
+        expect(picked).toEqual(['#aa0000', '#bb1111', '#cc2222']);
+        expect(recentSwatches.children.length).toBe(recentsBefore);
+    });
+
+    it('adds the committed color to the recents only on change, keeping the input attached', () => {
+        const { input, recentSwatches } = mount();
+        const recentsBefore = recentSwatches.children.length;
+        input.value = '#cc2222';
+        input.dispatchEvent(new Event('input'));
+        input.dispatchEvent(new Event('change'));
+        expect(input.isConnected).toBe(true);
+        expect(recentSwatches.children.length).toBe(recentsBefore + 1);
+        expect(recentSwatches.children[0]!.style.cssText).toContain('background:#cc2222');
+    });
+
+    it('syncs the native input to a swatch pick so the chooser opens on the current color', () => {
+        const { input, recentSwatches } = mount();
+        // Second recent: not the color the picker was opened with.
+        const swatch = recentSwatches.children[1]!;
+        const expected = /background:(#[0-9a-f]{6})/.exec(swatch.style.cssText)![1]!;
+        expect(input.value).not.toBe(expected);
+        swatch.dispatchEvent({ type: 'click', stopPropagation: () => {} });
+        expect(input.value).toBe(expected);
+    });
+});
 
 describe('color picker color math', () => {
     it('splitColor parses #RRGGBB, #RRGGBBAA, #RGB and rgba()', () => {


### PR DESCRIPTION
## Problem

Pressing `+` in a color picker opens the browser's native color chooser. Clicking or dragging on its gradient closed it immediately after the first change, so a custom color could only ever be picked one step at a time.

## Root cause

The chooser's `input` handler called `pickHex(value, true)`, which re-ran `renderRecents()`. That did `recentRow.replaceChildren()`, destroying the `<input type="color">` that owns the native chooser — and the browser closes its chooser the moment the owning input leaves the DOM. Confirmed in the playground: after one `input` event the original input reported `isConnected === false` and a fresh element had replaced it.

## Fix

- The `+` label and its native input are created once and never rebuilt. The recent swatches live in their own `display:contents` wrapper so re-rendering them can't touch the input.
- `input` (streamed while the chooser is open) previews the color live via a small `previewHex` helper; `change` (the committed pick) goes through the existing `pickHex(hex, true)` path and is what enters the recents row.
- Picking any swatch also syncs the native input's value, so `+` opens on the currently selected color.

## Tests

Three regression tests in `test/color-picker.test.ts` using a minimal element stub (node env, same pattern as `native-pane-resize.test.ts`). They fail on the previous code (input detached after the first `input`) and pass with the fix.

## Verification

- Playground, chart settings → color field: after three streamed `input` events and a `change`, the same input is still connected, the popover stays open, recents grow only on `change`, the row layout is intact, and the field swatch previews live.
- Gate: `typecheck` · `lint` · `test` (123 files / 1504 tests) · `build` all green.
- Not automatable: clicking the OS-native chooser itself — a quick manual drag on the `+` gradient is the final confirmation.

## Changelog

Entry added under `[Unreleased] → Fixed` (v0.6.15 is already tagged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to color-picker DOM/event handling and new unit tests; no auth, data, or chart rendering pipeline changes.
> 
> **Overview**
> Fixes the color picker's **+** custom color flow so the browser's native chooser stays open while you drag on the gradient instead of closing after the first `input` event.
> 
> **`buildColorPicker`** now builds the **+** label and its `input[type=color]` once outside the recents refresh path. Recent swatches live in a separate wrapper so `renderRecents()` only replaces swatch buttons and never detaches the native input (which was what forced the chooser shut). Streaming **`input`** events call a new **`previewHex`** path for live chart preview; **`change`** commits via **`pickHex`** and is when a color joins recents. Picking a swatch updates **`customInput.value`** so **+** opens on the current selection.
> 
> Regression coverage in **`test/color-picker.test.ts`** uses a minimal DOM stub (node env) for attachment, preview-without-recents, commit-on-change, and input sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b2093a1c9dd5ef38480fc53cfe3309e97a0de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->