### PR TITLE
Release version 0.6.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Vela, newest first.
 
-## [v0.6.16]
+## [Unreleased]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Vela, newest first.
 
-## [Unreleased]
+## [v0.6.16]
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.15",
+      "version": "0.6.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",


### PR DESCRIPTION
## Summary

Cuts **v0.6.16**: `package.json` / lockfile bumped from 0.6.15, and the `[Unreleased]` changelog section renamed to `[v0.6.16]`. Nothing else changes.

What ships in 0.6.16 (already described in `CHANGELOG.md`):

- **Added** — the built-in catalog of 74 classic indicators (#119).
- **Fixed** — the custom color chooser stays open while picking (#118, already on `dev`).

## Stacked on #119

This PR is opened against `feat/classic-indicator-catalog` on purpose: the release must carry the catalog, and #119 has not landed on `dev` yet. Once #119 merges, GitHub retargets this PR to `dev` automatically and its diff shrinks to the three release files. Merge order: **#119 → this PR → then the usual `dev` → `main` "Release: version 0.6.16" PR** (which creates the `v0.6.16` tag and publishes).

If more work is meant to ride 0.6.16 (there is in-flight multi-instance work on the classics on the same branch), merge it into #119 first and this PR picks it up — only a new `[Unreleased]` changelog heading would need folding into the `[v0.6.16]` section.

Version choice: **patch** bump, matching the 0.6.12 → 0.6.15 convention (each of those shipped `Added` entries as patches). Strict semver would call a 74-study catalog a minor (0.7.0) — say so and I will retarget the number.

## Test plan

- [x] Same tree as #119's head plus the version strings: `npm run typecheck` · `npm run lint` · `npm run test` (1528) · `npm run build` green there.
- [ ] After merge to `dev`: open the `dev` → `main` release PR, tag `v0.6.16`, then bump `@luxalgo/vela-pro` (`^0.6.16`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only package version strings change; no runtime, API, or build logic is modified in this diff.
> 
> **Overview**
> **Release prep for v0.6.16** — bumps `@luxalgo/vela` from `0.6.15` to `0.6.16` in `package.json` and `package-lock.json` so the next publish/tag matches the intended patch release.
> 
> This diff is version metadata only; feature work for 0.6.16 (e.g. the classic indicator catalog and related fixes) lives on the stacked base branch described in the PR, not in these two files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0dbb44995fad40afe432250b544bd7827977a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->