### PR TITLE
Make the live-bar glide configurable and off by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Changed
+
+- **The live candle now snaps to each tick by default, and its glide is yours to tune.**
+  On a streaming chart the forming candle used to slide toward every new price over a
+  short, fixed ease. That slide is now a setting — `animations: { liveBar }` at
+  construction, or `chart.renderer.set('animLiveBar', …)` live — and it is **off by
+  default**, so the painted candle, the current-price line and its axis label always
+  show the real latest values. Set `liveBar: true` to bring the slide back, or give it
+  a duration in milliseconds to make it as quick or as gentle as your feed calls for
+  (a slow feed reads well with a longer glide; a busy one with a short one). The chart
+  settings dialog gets a matching **Animate price changes** switch in a new *Animation*
+  group of the *Symbol* tab (with a hint explaining it), saved with the rest of the chart's settings and templates; switching it back
+  on reuses the duration you configured. A new bar always opens without a glide, and
+  the crosshair, legend and data window show the real values at all times.
+  `animations: false` keeps disabling every animation at once.
+  _(Breaking: charts that relied on the previous always-on slide now snap; pass
+  `animations: { liveBar: true }` to restore it.)_
+
 ## [v0.6.16]
 
 ### Added

--- a/docs/user/options.md
+++ b/docs/user/options.md
@@ -60,7 +60,7 @@ chart.data.registerProvider('binance', new BinanceProvider());
 | `currentPriceLine` | boolean | `true` | Dashed line + axis label at the latest price. |
 | `logScale` | boolean | `false` | Logarithmic price scale. |
 | `nativeBackend` | `'auto' \| 'canvas2d' \| 'webgl2'` | `auto` | Native geometry backend. `auto` = WebGL2 if available, else canvas2d. Only applies to the native renderer. |
-| `animations` | boolean or `{ zoom?, pan? }` | **on** | `true`/`false` toggles all; an object configures each. Defaults: eased zoom on, inertial pan on (short snappy glide). `{ pan: false }` = instant pan. |
+| `animations` | boolean or `{ zoom?, pan?, liveBar? }` | **on** | `true`/`false` toggles all; an object configures each. Defaults: eased zoom on, inertial pan on (short snappy glide), live-bar glide **off**. `{ pan: false }` = instant pan. `liveBar` makes the forming candle (and the current-price line and label) slide toward each live tick instead of snapping: `true` = a 90 ms ease, a number = the ease duration in ms (settles in about three times that; capped at 1000), `false`/`0` = snap. A new bar always snaps. The settings dialog exposes an on/off switch for it (*Symbol → Animation → Animate price changes*; `priceScale.animateLastPrice` in the rich config); switching it back on reuses the duration set here. |
 | `glow` | number | `0` | Neon glow/bloom for line series (~0.6 = strong). **WebGL2 only** — ignored on canvas2d. |
 | `upColor` | string | `#089981` (green) | Bullish candle color (native renderer). |
 | `downColor` | string | `#f23645` (red) | Bearish candle color (native renderer). |
@@ -154,6 +154,8 @@ new VelaWorkspace('#chart', {
       'symbol.style.baseline.fill-bottom',   //     Fill bottom area
       'symbol.style.baseline.base-level',    //     Base level %
       'symbol.style.baseline.width',         //     Width
+      'symbol.animation',                    //   Animation group
+      'symbol.animation.price-changes',      //     Animate price changes (the live-bar glide)
       'symbol.timezone',                     //   Time zone group
 
       // ══ Scales and lines tab ══════════════════════════════════════

--- a/docs/user/renderer-features.md
+++ b/docs/user/renderer-features.md
@@ -56,6 +56,7 @@ Available on every renderer:
 |---|---|---|---|
 | `animZoom` | boolean | `true` | Eased wheel-zoom; takes effect on the next interaction. |
 | `animPan` | boolean | `true` | Inertial pan glide; takes effect on the next interaction. |
+| `animLiveBar` | number (ms) \| boolean | `0` | Glide of the forming bar on live ticks: the displayed high/low/close (and the current-price line and label) ease toward each new value instead of snapping. `0`/`false` = snap; `true` = the 90 ms default; a number = the ease duration in ms (visually settled in about three times that; capped at 1000). Reads back as a number. A new bar always snaps; the crosshair, legend and data window always show the real values. Takes effect on the next tick. The rich config carries only the on/off state (`priceScale.animateLastPrice`, the *Animate price changes* row of the settings dialog's Symbol → Animation group); turning it on there reuses the last non-zero duration set here. |
 | `intro` | `'settle' \| 'grow' \| false` | `'settle'` | Reveal animation on first paint. Setting it replays the intro (handy for comparing styles from the console). |
 | `zoomAnchor` | `'right' \| 'cursor'` | `'right'` | Wheel-zoom anchor: pin the right edge / latest bar, or the bar under the cursor. Affects the next wheel-zoom. Holding `Shift` (or a horizontal/trackpad swipe) makes the wheel **pan through history** instead of zooming. |
 | `axisDrag` | boolean | `true` | Drag the right price-axis strip to rescale vertically and the bottom time-axis strip to zoom horizontally; scrolling the wheel over the price-axis strip rescales the same way, gently (scroll up compresses the span, down expands it); double-clicking an axis strip resets it. |
@@ -155,7 +156,7 @@ chart.renderer.applyConfig({ candles: { upColor: '#26a69a' } }); // partial patc
 
 The covered cosmetics include layout (background, text, font), grid colors/visibility,
 crosshair (color/width/style/opacity/label), price scale (mode, log, border, labels,
-current-price line), time-scale timezone, candle border/wick, and per-style colors for
+current-price line, last-price animation on/off), time-scale timezone, candle border/wick, and per-style colors for
 bars / line / area / baseline.
 
 ## Custom renderers

--- a/playground/widget.ts
+++ b/playground/widget.ts
@@ -54,7 +54,7 @@ const ws = new VelaWorkspace('#chart', {
     // upColor: '#089981',             // bullish candles (default: the palette's bullish green)
     // downColor: '#f23645',           // bearish candles (default: the palette's bearish red)
     // glow: 0,                        // neon glow on line series, 0..~0.6 — WebGL2 backend only
-    // animations: { zoom: true, pan: true }, // eased zoom + inertial pan; false disables both
+    // animations: { zoom: true, pan: true, liveBar: false }, // eased zoom + inertial pan + forming-bar glide (true = 90 ms, or a duration in ms); false disables all
     // nativeBackend: 'auto',          // 'auto' = WebGL2 when available, else canvas2d; or force either
     // renderer: NativeRenderer,       // a custom IChartRenderer class (default: the native renderer)
     // drawings: true,                 // user drawings — default: toolbar VISIBLE; false removes the whole

--- a/playground/workspace.ts
+++ b/playground/workspace.ts
@@ -50,7 +50,7 @@ const ws = new VelaWorkspace("#workspace", {
   // upColor: '#089981',             // bullish candles (default: the palette's bullish green)
   // downColor: '#f23645',           // bearish candles (default: the palette's bearish red)
   // glow: 0,                        // neon glow on line series, 0..~0.6 — WebGL2 cells only
-  // animations: { zoom: true, pan: true }, // eased zoom + inertial pan; false disables both
+  // animations: { zoom: true, pan: true, liveBar: false }, // eased zoom + inertial pan + forming-bar glide (true = 90 ms, or a duration in ms); false disables all
   // nativeBackend: 'auto',          // explicit 'canvas2d'/'webgl2' wins over the maxWebglCells policy
   // renderer: NativeRenderer,       // a custom IChartRenderer class for every cell
   // drawings: true,                 // per-cell tools config — its `toolbar` key is ignored: the grid's

--- a/src/Vela.ts
+++ b/src/Vela.ts
@@ -3,6 +3,7 @@ import type { ScriptingEngine } from './core/ports/ScriptingEngine';
 import type { MarketDataFeed } from './core/ports/MarketDataFeed';
 import type { VisibleRangePreset } from './core/visible-range';
 import type { VelaOptions, VelaTheme, ThemeName, MarketSwitch, MarketSnapshot, AddIndicatorOptions } from './core/options';
+import { resolveAnimations } from './core/options';
 import type { InputValue } from './core/model/inputs';
 import type { IndicatorHandle } from './core/IndicatorHandle';
 import type { EngineContextSnapshot } from './core/ports/ScriptingEngine';
@@ -68,22 +69,11 @@ export class Vela {
         registerClassicIndicators();
         const element = resolveElement(container);
         const theme = resolveTheme(options.theme);
-        // Resolve animations: boolean toggles all; object configures each; default = zoom on, pan on.
-        let animZoom = true;
-        let animPan = true;
-        if (typeof options.animations === 'boolean') {
-            animZoom = options.animations;
-            animPan = options.animations;
-        } else if (options.animations) {
-            animZoom = options.animations.zoom ?? true;
-            animPan = options.animations.pan ?? true;
-        }
         const display = {
             currentPriceLine: options.currentPriceLine ?? true,
             logScale: options.logScale ?? false,
             nativeBackend: options.nativeBackend ?? 'auto',
-            animZoom,
-            animPan,
+            ...resolveAnimations(options.animations),
             glow: options.glow ?? 0,
             upColor: options.upColor ?? BULLISH,
             downColor: options.downColor ?? BEARISH,

--- a/src/core/icons.ts
+++ b/src/core/icons.ts
@@ -165,6 +165,9 @@ registerIcon('star-filled', S('<path d="M8 2.2l1.75 3.55 3.9.55-2.8 2.75.65 3.9L
 registerIcon('grip', S('<circle cx="6" cy="3.5" r="1"/><circle cx="10" cy="3.5" r="1"/><circle cx="6" cy="8" r="1"/><circle cx="10" cy="8" r="1"/><circle cx="6" cy="12.5" r="1"/><circle cx="10" cy="12.5" r="1"/>', 'fill="currentColor" stroke="none"'));
 registerIcon('kebab', S('<circle cx="8" cy="3.2" r="1.2"/><circle cx="8" cy="8" r="1.2"/><circle cx="8" cy="12.8" r="1.2"/>', 'fill="currentColor" stroke="none"'));
 registerIcon('burger', S('<path d="M2.5 4.5h11M2.5 8h11M2.5 11.5h11"/>'));
+// The ⓘ hint glyph: an "i" drawn as geometry (dot + stem) so it centers exactly in its
+// badge — a text "i" would sit at the font's mercy. The badge draws the circle.
+registerIcon('info', S('<path d="M8 7.4v4.4"/><circle cx="8" cy="4.6" r="0.9" fill="currentColor" stroke="none"/>'));
 registerIcon('reset', S('<path d="M2 8a6 6 0 1 0 6-6 6.5 6.5 0 0 0-4.5 1.83L2 5.33"/><path d="M2 2v3.33h3.33"/>'));
 
 // ── pane chrome (stack order, collapse, maximize) ──

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -117,7 +117,9 @@ export interface VelaOptions extends MarketConfig {
     nativeBackend?: NativeBackend;
     /** Native-renderer animations. `true`/`false` toggles all; an object configures
      *  each independently. Default: eased **zoom on**, inertial **pan on but snappy**
-     *  (short glide). Set `{ pan: false }` for an instant pan with no momentum. */
+     *  (short glide), live-bar glide **off**. Set `{ pan: false }` for an instant pan
+     *  with no momentum, `{ liveBar: true }` (or a duration in ms) to make the forming
+     *  candle slide toward each live tick instead of snapping. */
     animations?: boolean | AnimationConfig;
     /** Neon glow/bloom intensity for line series (0 = off, ~0.6 = strong). WebGL2 only
      *  — the canvas2d backend ignores it. Default 0. */
@@ -160,6 +162,37 @@ export interface AnimationConfig {
     zoom?: boolean;
     /** Inertial/kinetic pan — a short snappy glide after a drag-release. Default true. */
     pan?: boolean;
+    /** Glide of the forming bar: on a live tick the displayed high/low/close ease toward
+     *  the new values instead of snapping (the price line and axis label follow). `true`
+     *  uses the default duration ({@link LIVE_BAR_EASE_DEFAULT_MS}); a number is the ease
+     *  time-constant in ms (visually settled after ~3×; clamped to
+     *  {@link LIVE_BAR_EASE_MAX_MS}); `false`/`0` snaps. A new bar always snaps. Default
+     *  `false` — the painted candle is then never behind the real data. */
+    liveBar?: boolean | number;
+}
+
+/** Time-constant (ms) of the live-bar glide when `animations.liveBar` is `true`. */
+export const LIVE_BAR_EASE_DEFAULT_MS = 90;
+/** Upper bound (ms) for `animations.liveBar` — past this the candle visibly lags the feed. */
+export const LIVE_BAR_EASE_MAX_MS = 1000;
+
+/** Normalize an `animations.liveBar` value to an ease time-constant in ms (0 = snap). */
+export function resolveLiveBarEaseMs(value: unknown): number {
+    if (value === true) return LIVE_BAR_EASE_DEFAULT_MS;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 0;
+    return Math.min(value, LIVE_BAR_EASE_MAX_MS);
+}
+
+/** Resolve `VelaOptions.animations` to the renderer's per-feature values.
+ *  A boolean toggles zoom + pan and leaves the live-bar glide at its default (off) for
+ *  `true`; `false` disables everything. An object configures each independently. */
+export function resolveAnimations(animations: boolean | AnimationConfig | undefined): Pick<RendererDisplayOptions, 'animZoom' | 'animPan' | 'animLiveBar'> {
+    if (typeof animations === 'boolean') return { animZoom: animations, animPan: animations, animLiveBar: 0 };
+    return {
+        animZoom: animations?.zoom ?? true,
+        animPan: animations?.pan ?? true,
+        animLiveBar: resolveLiveBarEaseMs(animations?.liveBar),
+    };
 }
 
 /** Native geometry-layer backend selection. */
@@ -182,6 +215,7 @@ export interface RendererDisplayOptions {
     nativeBackend: NativeBackend;
     animZoom: boolean;
     animPan: boolean;
+    animLiveBar: number;
     glow: number;
     upColor: string;
     downColor: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export type {
     ProviderName,
     RendererConstructor,
     RendererDisplayOptions,
+    AnimationConfig,
     AddIndicatorOptions,
     SettingsVisibilityPolicy,
 } from './core/options';

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -26,6 +26,7 @@ import type { IndicatorModel, PaneAxisBand } from '../../core/model/indicator';
 import type { ScenePatch } from '../../core/model/patch';
 import type { InputValue, SymbolPickerFn } from '../../core/model/inputs';
 import type { RendererDisplayOptions, NativeBackend, PriceStyle, MoveTarget, ThemeName } from '../../core/options';
+import { resolveLiveBarEaseMs, LIVE_BAR_EASE_DEFAULT_MS } from '../../core/options';
 import type { Unsubscribe } from '../../core/util/types';
 import { isLineLikeSeries } from '../../core/model/series';
 import { InputsUI, type LegendPlotValue } from '../shared/InputsUI';
@@ -102,7 +103,7 @@ const ZOOM_OUT_MARGIN_BARS = 6; // breathing room at max zoom-out: all bars + th
 const ZOOM_TAU_MS = 70; // wheel-zoom glide
 const SCALE_TAU_MS = 80; // autoscale glide during zoom/fling
 const FLING_TAU_MS = 110; // inertial-pan velocity decay — short/snappy glide (≈ v0·tau drift), not a long drift
-const LIVE_BAR_TAU_MS = 90; // forming-bar OHLC glide — a fast ease so the live candle slides to each tick instead of snapping
+// (The forming-bar glide's time-constant is user-configurable — `animLiveBar`, off by default.)
 const SCROLL_TO_TAU_MS = 130; // scroll-to-latest glide — eases rightOffset back to the latest bars
 // Fling ends when on-screen motion drops below this (PIXELS/ms). Kept in pixel units
 // so the stop point is zoom-invariant + agrees with InputController's FLING_MIN_SPEED.
@@ -204,9 +205,11 @@ export class NativeRenderer implements IChartRenderer {
     private historyChordsEnabled = true;
     private liveRegion: HTMLDivElement | null = null;
 
-    // ── animation state (eased zoom + inertial pan) ──
+    // ── animation state (eased zoom + inertial pan + live-bar glide) ──
     private animZoom = true;
     private animPan = true;
+    private animLiveBarMs = 0; // forming-bar OHLC glide time-constant; 0 = each tick snaps
+    private animLiveBarOnMs = LIVE_BAR_EASE_DEFAULT_MS; // the duration the settings-dialog on/off toggle restores (last non-zero value configured)
     // Brand default candles.
     private candleUp = BULLISH;
     private candleDown = BEARISH;
@@ -320,6 +323,7 @@ export class NativeRenderer implements IChartRenderer {
             this.backendMode = opts.nativeBackend;
             this.animZoom = opts.animZoom;
             this.animPan = opts.animPan;
+            this.setLiveBarEase(resolveLiveBarEaseMs(opts.animLiveBar));
             this.glowAmount = opts.glow;
             this.candleUp = opts.upColor;
             this.candleDown = opts.downColor;
@@ -333,7 +337,7 @@ export class NativeRenderer implements IChartRenderer {
     }
 
     readonly name = 'native';
-    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'sessionZones', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles', 'indicatorValues'];
+    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'animLiveBar', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'sessionZones', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles', 'indicatorValues'];
 
     /** Apply a render feature live — mutate the field + invalidate, no engine re-run. */
     applyFeature(key: string, value: unknown): void {
@@ -375,6 +379,9 @@ export class NativeRenderer implements IChartRenderer {
             case 'animPan':
                 this.animPan = Boolean(value);
                 return;
+            case 'animLiveBar':
+                this.setLiveBarEase(resolveLiveBarEaseMs(value));
+                return; // affects the next tick only; a glide in flight finishes at the new rate (or snaps at 0)
             case 'intro': {
                 const s = value === false || value === 'none' || value === 'off' || value == null ? '' : String(value);
                 this.introStyle = s;
@@ -514,6 +521,7 @@ export class NativeRenderer implements IChartRenderer {
             case 'glow': return this.glowAmount;
             case 'animZoom': return this.animZoom;
             case 'animPan': return this.animPan;
+            case 'animLiveBar': return this.animLiveBarMs;
             case 'intro': return this.introStyle;
             case 'zoomAnchor': return this.zoomAnchorMode;
             case 'axisDrag': return this.input ? this.input.axisDrag : this.axisDragEnabled;
@@ -672,6 +680,7 @@ export class NativeRenderer implements IChartRenderer {
                 currentPriceLine: this.scene.showPriceLine,
                 priceLabel: this.scene.showPriceLabel,
                 countdown: this.scene.showCountdown,
+                animateLastPrice: this.animLiveBarMs > 0,
             },
             panes: { separatorColor: s.separatorColor ?? t.borderColor },
             trades: {
@@ -802,6 +811,7 @@ export class NativeRenderer implements IChartRenderer {
         this.scene.showPriceLabel = next.priceScale.priceLabel;
         this.scene.showCountdown = next.priceScale.countdown;
         this.syncCountdownTimer();
+        this.animLiveBarMs = next.priceScale.animateLastPrice ? this.animLiveBarOnMs : 0; // on/off only — the duration is the host's
         // panes
         s.separatorColor = keepInherit(s.separatorColor, next.panes.separatorColor, prevTheme.borderColor);
         // trade markers
@@ -1785,8 +1795,11 @@ export class NativeRenderer implements IChartRenderer {
         const last = this.bars[n - 1];
         if (last && bar.time === last.time) {
             this.bars[n - 1] = bar; // actual forming bar — the ease target
-            if (this.liveEaseTime !== bar.time) this.syncLiveEase(bar); // first tick of this bar (snap), then ease
-            this.animator.start(); // glide the displayed high/low/close toward this tick
+            if (this.animLiveBarMs <= 0 || this.liveEaseTime !== bar.time) {
+                this.syncLiveEase(bar); // glide off, or the first tick of this bar: snap
+            } else {
+                this.animator.start(); // glide the displayed high/low/close toward this tick
+            }
         } else if (!last || bar.time > last.time) {
             this.bars.push(bar);
             this.syncLiveEase(bar); // a fresh bar — snap (never ease across bars)
@@ -1799,6 +1812,13 @@ export class NativeRenderer implements IChartRenderer {
         }
         this.scene.bars = this.bars;
         this.scheduler.invalidate(InvalidateLevel.Full);
+    }
+
+    /** Set the live-bar glide duration (0 = off). A non-zero value is also remembered as
+     *  what the config's on/off toggle (`priceScale.animateLastPrice`) switches back on to. */
+    private setLiveBarEase(ms: number): void {
+        this.animLiveBarMs = ms;
+        if (ms > 0) this.animLiveBarOnMs = ms;
     }
 
     /** Snap the eased forming-bar state to `bar` — no glide (a fresh bar or the first tick of one). */
@@ -1814,9 +1834,10 @@ export class NativeRenderer implements IChartRenderer {
         const target = this.bars[this.bars.length - 1];
         if (!target || this.liveEaseTime !== target.time) return false;
         const eps = Math.max(1e-9, Math.abs(target.close) * 1e-6);
-        const nh = easeToward(this.liveEaseHigh, target.high, dtMs, LIVE_BAR_TAU_MS);
-        const nl = easeToward(this.liveEaseLow, target.low, dtMs, LIVE_BAR_TAU_MS);
-        const nc = easeToward(this.liveEaseClose, target.close, dtMs, LIVE_BAR_TAU_MS);
+        const tau = this.animLiveBarMs; // 0 ⇒ easeToward returns the target (a mid-glide switch-off snaps)
+        const nh = easeToward(this.liveEaseHigh, target.high, dtMs, tau);
+        const nl = easeToward(this.liveEaseLow, target.low, dtMs, tau);
+        const nc = easeToward(this.liveEaseClose, target.close, dtMs, tau);
         const active = Math.abs(nh - target.high) > eps || Math.abs(nl - target.low) > eps || Math.abs(nc - target.close) > eps;
         this.liveEaseHigh = active ? nh : target.high;
         this.liveEaseLow = active ? nl : target.low;

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -28,6 +28,7 @@ import {
     buildFieldControl,
 } from '../../../ui/components/field';
 import { priceStyleIds, hasOwnCandlePaint } from '../core/chartConfig';
+import { chromeHint } from '../../shared/chrome-tooltip';
 import {
     filterHiddenHostRows,
     filterHiddenRows,
@@ -173,8 +174,7 @@ ${overlayScrollbarCss('.vela-sd-pane')}
 .vela-sd-mobile .vela-select-trigger,.vela-sd-mobile .vela-num input,.vela-sd-mobile .vela-width-field{height:34px;}
 .vela-sd-mobile .vela-sd-close{width:40px;height:40px;}
 .vela-sd-mobile .vela-sd-btn{height:38px;}
-.vela-sd-mobile .vela-sd-row span,.vela-sd-mobile .vela-sd-bool span,.vela-sd-mobile .vela-field-label{white-space:normal !important;}
-`;
+.vela-sd-mobile .vela-sd-row span,.vela-sd-mobile .vela-sd-bool span,.vela-sd-mobile .vela-field-label{white-space:normal !important;}`;
     if (!existing) document.head.appendChild(st);
 }
 
@@ -193,6 +193,7 @@ export class SettingsDialog {
     private themeControl: { current: ThemeName; onSelect: (name: ThemeName) => void } | null = null;
     /** The built tabs, by title — how `showSection` reaches a pane while the dialog is open. */
     private tabs: Array<{ title: string; show: () => void }> = [];
+    private hintTips: Array<() => void> = []; // ⓘ tooltip disposers of the open build (see hint)
     /** Active instance-strip tab per chart type — remembered across dialog rebuilds. */
     private readonly typeActiveInstance = new Map<string, number>();
     /** Active TOC group per structured pane (`<typeId>/<pane>` → group label). */
@@ -335,7 +336,6 @@ export class SettingsDialog {
                 this.syncTypeTabs?.(v);
             }), 'symbol.type'),
         );
-
         // Candles — the reference compact rows: one toggle + an up/down swatch pair each.
         const candles = sid(this.group(), 'symbol.style.candles');
         candles.append(this.sectionTitle('Candles'));
@@ -425,6 +425,15 @@ export class SettingsDialog {
         }
         showActive(config.series.style);
 
+        // Style-independent (the glide applies to every price style), so it gets its own group.
+        body.append(sid(this.sectionTitle('Animation'), 'symbol.animation'));
+        body.append(sid(this.boolRow(
+            'Animate price changes',
+            config.priceScale.animateLastPrice,
+            (v) => this.emit({ priceScale: { animateLastPrice: v } }),
+            this.hint('Glide the live bar to each new price instead of snapping.'),
+        ), 'symbol.animation.price-changes'));
+
         body.append(sid(this.sectionTitle('Time zone'), 'symbol.timezone'));
         body.append(sid(this.selectRowLabeled('Time zone', normalizeTimezone(config.timeScale.timezone), timezoneOptions(config.timeScale.timezone), (v) => this.emit({ timeScale: { timezone: v } })), 'symbol.timezone'));
 
@@ -488,8 +497,7 @@ export class SettingsDialog {
         body.append(sid(this.separator(), 'scales.price-scale'));
         body.append(sid(this.boolRow('Last Price Line', config.priceScale.currentPriceLine, (v) => this.emit({ priceScale: { currentPriceLine: v } })), 'scales.price-scale.last-price-line'));
         body.append(sid(this.boolRow('Last price label', config.priceScale.priceLabel, (v) => this.emit({ priceScale: { priceLabel: v } })), 'scales.price-scale.last-price-label'));
-        body.append(sid(this.boolRow('Countdown to bar close', config.priceScale.countdown, (v) => this.emit({ priceScale: { countdown: v } })), 'scales.price-scale.countdown'));
-        body.append(sid(this.boolRow('Axis labels', config.priceScale.labelsVisible, (v) => this.emit({ priceScale: { labelsVisible: v } })), 'scales.price-scale.axis-labels'));
+        body.append(sid(this.boolRow('Countdown to bar close', config.priceScale.countdown, (v) => this.emit({ priceScale: { countdown: v } })), 'scales.price-scale.countdown'));        body.append(sid(this.boolRow('Axis labels', config.priceScale.labelsVisible, (v) => this.emit({ priceScale: { labelsVisible: v } })), 'scales.price-scale.axis-labels'));
         body.append(sid(this.colorRow('Scale border color', config.priceScale.borderColor, (v) => this.emit({ priceScale: { borderColor: v } })), 'scales.price-scale.border-color'));
         body.append(sid(this.sectionTitle('Crosshair'), 'scales.crosshair'));
         body.append(sid(this.colorRow('Color', config.crosshair.color, (v) => this.emit({ crosshair: { color: v } })), 'scales.crosshair.color'));
@@ -685,6 +693,8 @@ export class SettingsDialog {
         this.ui = null;
         this.root = null;
         this.tabs = [];
+        for (const dispose of this.hintTips) dispose(); // a tip open at close time must not outlive its row
+        this.hintTips = [];
         ui?.destroy();
     }
 
@@ -1171,23 +1181,32 @@ export class SettingsDialog {
         });
     }
 
-    /** A toggle row: the checkbox sits to the LEFT of its label (never in the control area). */
-    private boolRow(label: string, value: boolean, onChange: (v: boolean) => void): HTMLElement {
-        return this.toggleRow(label, value, onChange, []);
+    /** A toggle row: the checkbox sits to the LEFT of its label (never in the control area).
+     *  `info` (see {@link hint}) rides after the label. */
+    private boolRow(label: string, value: boolean, onChange: (v: boolean) => void, info?: HTMLElement): HTMLElement {
+        return this.toggleRow(label, value, onChange, [], undefined, info);
     }
 
     /** An enable row: checkbox + label in the label column, dependent controls in the
      *  shared control column; the control group dims and ignores input while the toggle
      *  is off. With `get`, the row re-reads its state on a 'vela-sync' event. */
-    private toggleRow(label: string, value: boolean, onToggle: (v: boolean) => void, controls: HTMLElement[], get?: () => boolean): HTMLElement {
+    private toggleRow(label: string, value: boolean, onToggle: (v: boolean) => void, controls: HTMLElement[], get?: () => boolean, info?: HTMLElement): HTMLElement {
         return fieldRow({
             label,
             labelSize: 'sm',
             bool: controls.length === 0,
             toggle: { checked: value, onChange: onToggle, get },
             control: controls,
+            info,
             className: controls.length === 0 ? 'vela-sd-bool' : 'vela-sd-row',
         });
+    }
+
+    /** The shared ⓘ hint after a row label (see {@link chromeHint}). Disposed with the dialog. */
+    private hint(text: string): HTMLElement {
+        const { el, dispose } = chromeHint(text, { host: this.container, theme: () => this.theme });
+        this.hintTips.push(dispose);
+        return el;
     }
 
     private numberRow(label: string, value: number, min: number, max: number, step: number, onChange: (v: number) => void): HTMLElement {

--- a/src/renderers/native/chrome/settings-visibility.ts
+++ b/src/renderers/native/chrome/settings-visibility.ts
@@ -172,6 +172,8 @@ export const BUILTIN_SETTINGS_IDS: readonly string[] = [
     'symbol.style.baseline.fill-bottom',
     'symbol.style.baseline.base-level',
     'symbol.style.baseline.width',
+    'symbol.animation',
+    'symbol.animation.price-changes',
     'symbol.timezone',
     'scales',
     'scales.price-scale',

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -223,6 +223,10 @@ export interface ChartConfig {
         currentPriceLine: boolean;
         priceLabel: boolean;
         countdown: boolean;
+        /** Glide the forming bar (and the last-price line/label) toward each live tick
+         *  instead of snapping. The duration comes from `animations.liveBar` / the
+         *  `animLiveBar` feature; this is only the on/off switch the settings dialog shows. */
+        animateLastPrice: boolean;
     };
     /** Stacked-pane chrome — the draggable line between an indicator's pane and the one above it. */
     panes: {
@@ -571,6 +575,7 @@ export function mergeConfig(base: ChartConfig, patch: unknown): ChartConfig {
             currentPriceLine: isBool(ps.currentPriceLine) ? ps.currentPriceLine : base.priceScale.currentPriceLine,
             priceLabel: isBool(ps.priceLabel) ? ps.priceLabel : base.priceScale.priceLabel,
             countdown: isBool(ps.countdown) ? ps.countdown : base.priceScale.countdown,
+            animateLastPrice: isBool(ps.animateLastPrice) ? ps.animateLastPrice : base.priceScale.animateLastPrice,
         },
         panes: {
             separatorColor: isColor(panes.separatorColor) ? panes.separatorColor : base.panes.separatorColor,

--- a/src/renderers/shared/IndicatorInputsDialog.ts
+++ b/src/renderers/shared/IndicatorInputsDialog.ts
@@ -3,7 +3,7 @@ import type { VelaTheme } from '../../core/options';
 import { isDarkColor } from '../../core/color';
 import { iconAt } from '../../core/icons';
 import { applyChromeTokens } from './theme-tokens';
-import { attachChromeTooltip } from './chrome-tooltip';
+import { attachChromeTooltip, chromeHint } from './chrome-tooltip';
 import { toggleSelectList, type SelectOption } from '../../ui/components/select';
 import { Popover, closeOpenPopovers, eventDismissedPopover, isPopoverOpen, openPopoverTrigger } from '../../ui/components/popover';
 import { Dialog } from '../../ui/components/dialog';
@@ -459,14 +459,11 @@ export class IndicatorInputsDialog {
         return buildFieldControl({ kind: 'text', id, value: current, onChange: emit }).el;
     }
 
-    /** A hoverable ⓘ affordance carrying an input's `tooltip` (themed chrome tip; wraps). */
+    /** The shared ⓘ hint carrying an input's `tooltip` (see {@link chromeHint}). */
     private infoButton(tooltip: string): HTMLElement {
-        const b = document.createElement('span');
-        b.textContent = 'i';
-        this.dialogTips.push(attachChromeTooltip(b, { host: this.host.container, theme: () => this.host.theme(), text: () => tooltip, wrap: true, delayMs: 250 }));
-        b.className = 'vela-ind-hint';
-        b.style.cssText = 'flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:50%;font-weight:600;font-size:11px;font-family:inherit;line-height:1;cursor:help;user-select:none;';
-        return b;
+        const { el, dispose } = chromeHint(tooltip, { host: this.host.container, theme: () => this.host.theme(), size: 18 });
+        this.dialogTips.push(dispose);
+        return el;
     }
 
     /** A dropdown over plain string options (value === label) — a thin case of {@link selectPairs}. */
@@ -946,8 +943,6 @@ export function ensureDialogStyles(): void {
 ${overlayScrollbarCss('.vela-dialog.vela-ind-dialog *', 9)}
 .vela-ind-tab{font-weight:600;font-size:13px;line-height:20px;transition:color var(--vela-dur-fast) ease,border-color var(--vela-dur-fast) ease;}
 .vela-ind-tab:not(.vela-ind-tab-active):hover{color:var(--vela-fg-bright);}
-.vela-ind-hint{background:var(--vela-hover);color:var(--vela-fg-muted);transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
-.vela-ind-hint:hover{background:var(--vela-active);color:var(--vela-fg-bright);}
 .vela-ind-ctl,.vela-ind-close{background-color:transparent;color:inherit;transition:color var(--vela-dur-fast) ease,background-color var(--vela-dur-fast) ease;}
 .vela-ind-ctl svg,.vela-ind-close svg{width:${LEGEND_ICON_PX}px;height:${LEGEND_ICON_PX}px;display:block;flex:none;stroke-width:1;}
 .vela-ind-ctl:hover{background-color:var(--vela-hover-strong);}

--- a/src/renderers/shared/chrome-tooltip.ts
+++ b/src/renderers/shared/chrome-tooltip.ts
@@ -5,6 +5,7 @@
 // chrome. Native `title` tooltips are banned here for the same reason they are banned on
 // the widget chrome: they look foreign and cannot be themed.
 import type { VelaTheme } from '../../core/options';
+import { iconAt } from '../../core/icons';
 import { applyChromeTokens } from './theme-tokens';
 
 export interface ChromeTooltipOptions {
@@ -94,4 +95,41 @@ export function attachChromeTooltip(anchor: HTMLElement, opts: ChromeTooltipOpti
         anchor.removeEventListener('pointerdown', clear);
         clear();
     };
+}
+
+export interface ChromeHintOptions {
+    /** See {@link ChromeTooltipOptions.host}. */
+    host: HTMLElement;
+    /** See {@link ChromeTooltipOptions.theme}. */
+    theme: () => VelaTheme;
+    /** Badge diameter in px. Default 16. */
+    size?: number;
+}
+
+/**
+ * The ⓘ hint badge every in-chart dialog puts after a label: a round chip with the `info`
+ * icon and a wrapped chrome tooltip that opens quickly (a hint is asked for, not stumbled
+ * on). The glyph is an SVG, so it is centered in the badge regardless of the font. Styled
+ * inline (renderer chrome carries no stylesheet); the hover state is the tip's own
+ * pointer listeners. Returns the element and a disposer for the tooltip.
+ */
+export function chromeHint(text: string, opts: ChromeHintOptions): { el: HTMLElement; dispose: () => void } {
+    const px = opts.size ?? 16;
+    const el = document.createElement('span');
+    el.className = 'vela-hint';
+    el.setAttribute('role', 'img');
+    el.setAttribute('aria-label', text);
+    el.innerHTML = iconAt('info', px);
+    el.style.cssText =
+        `flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:${px}px;height:${px}px;` +
+        'border-radius:50%;cursor:help;user-select:none;background:var(--vela-hover);color:var(--vela-fg-muted);' +
+        'transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;';
+    const hover = (on: boolean): void => {
+        el.style.background = on ? 'var(--vela-active)' : 'var(--vela-hover)';
+        el.style.color = on ? 'var(--vela-fg-bright)' : 'var(--vela-fg-muted)';
+    };
+    el.addEventListener('pointerenter', () => hover(true));
+    el.addEventListener('pointerleave', () => hover(false));
+    const dispose = attachChromeTooltip(el, { host: opts.host, theme: opts.theme, text: () => text, wrap: true, delayMs: 250 });
+    return { el, dispose };
 }

--- a/test/native-chart-config.test.ts
+++ b/test/native-chart-config.test.ts
@@ -123,7 +123,7 @@ describe('NativeRenderer.getConfig — defaults resolve to concrete values', () 
         expect(cfg.grid.vertLines).toEqual({ visible: true, color: '#20222c' });
         expect(cfg.grid.horzLines).toEqual({ visible: true, color: '#20222c' });
         expect(cfg.crosshair).toEqual({ color: '#9aa0ad', width: 1, style: 'dashed', opacity: 0.4, labelBackground: '#595959' });
-        expect(cfg.priceScale).toEqual({ mode: 'price', log: false, invert: false, borderColor: '#2a2b30', labelsVisible: true, currentPriceLine: true, priceLabel: true, countdown: true });
+        expect(cfg.priceScale).toEqual({ mode: 'price', log: false, invert: false, borderColor: '#2a2b30', labelsVisible: true, currentPriceLine: true, priceLabel: true, countdown: true, animateLastPrice: false });
         expect(cfg.panes).toEqual({ separatorColor: '#2a2b30' }); // inherits the theme border
         expect(cfg.timeScale).toEqual({ timezone: 'UTC' });
         expect(cfg.candles.upColor).toBe('#089981');

--- a/test/native-live-bar-ease.test.ts
+++ b/test/native-live-bar-ease.test.ts
@@ -1,0 +1,131 @@
+// The forming-bar glide (`animations.liveBar` / renderer feature `animLiveBar`): on a live
+// tick the displayed high/low/close ease toward the new values with a configurable
+// time-constant. Off (0, the default) every tick snaps and the animator never starts; on,
+// the first tick of a bar and every NEW bar still snap — only same-bar ticks glide.
+import { describe, it, expect } from 'vitest';
+import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+import { resolveAnimations, resolveLiveBarEaseMs, LIVE_BAR_EASE_DEFAULT_MS, LIVE_BAR_EASE_MAX_MS } from '../src/core/options';
+import type { OHLCV } from '../src/core/model/ohlcv';
+
+const bar = (time: number, close: number): OHLCV => ({ time, open: 100, high: Math.max(100, close), low: Math.min(100, close), close, volume: 1 });
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- the eased state is private by design; the test reads it */
+function makeRenderer(animLiveBar: number) {
+    const r = new NativeRenderer({
+        currentPriceLine: true, logScale: false, nativeBackend: 'canvas2d', animZoom: true, animPan: true,
+        animLiveBar, glow: 0, upColor: '#0f0', downColor: '#f00', priceStyle: 'candles',
+    });
+    const anyR = r as any;
+    anyR.coords.setSize(800, 200, 1); // unmounted, but sized — the bar/ease math is pure
+    let starts = 0;
+    anyR.scheduler = { invalidate: () => {} }; // mount-owned; stubbed for the unmounted path
+    anyR.animator = { active: false, start: () => { starts += 1; }, stop: () => {} };
+    anyR.introPlayed = true;
+    return { r, anyR, starts: () => starts };
+}
+
+describe('resolveAnimations / resolveLiveBarEaseMs', () => {
+    it('defaults: zoom + pan on, live-bar glide OFF', () => {
+        expect(resolveAnimations(undefined)).toEqual({ animZoom: true, animPan: true, animLiveBar: 0 });
+        expect(resolveAnimations({})).toEqual({ animZoom: true, animPan: true, animLiveBar: 0 });
+    });
+    it('a boolean toggles zoom + pan; `true` keeps the live-bar default (off), `false` turns everything off', () => {
+        expect(resolveAnimations(true)).toEqual({ animZoom: true, animPan: true, animLiveBar: 0 });
+        expect(resolveAnimations(false)).toEqual({ animZoom: false, animPan: false, animLiveBar: 0 });
+    });
+    it('liveBar: true = the default duration, a number = that duration (clamped), false/0/junk = off', () => {
+        expect(resolveAnimations({ liveBar: true }).animLiveBar).toBe(LIVE_BAR_EASE_DEFAULT_MS);
+        expect(resolveAnimations({ liveBar: 250 }).animLiveBar).toBe(250);
+        expect(resolveAnimations({ liveBar: 5000 }).animLiveBar).toBe(LIVE_BAR_EASE_MAX_MS);
+        expect(resolveAnimations({ liveBar: false }).animLiveBar).toBe(0);
+        expect(resolveLiveBarEaseMs(0)).toBe(0);
+        expect(resolveLiveBarEaseMs(-10)).toBe(0);
+        expect(resolveLiveBarEaseMs(NaN)).toBe(0);
+        expect(resolveLiveBarEaseMs('90')).toBe(0);
+    });
+});
+
+describe('NativeRenderer forming-bar glide', () => {
+    it('OFF (default): a same-bar tick snaps the displayed close and never starts the animator', () => {
+        const { r, anyR, starts } = makeRenderer(0);
+        r.setBars([bar(1000, 100), bar(2000, 101)]);
+        r.updateBar(bar(2000, 105)); // first tick of the bar — snaps in either mode
+        r.updateBar(bar(2000, 110)); // a second tick — the one that would glide
+        expect(anyR.liveEaseClose).toBe(110);
+        expect(anyR.liveEaseHigh).toBe(110);
+        expect(anyR.easeLiveBar(16)).toBe(false); // nothing in flight
+        expect(starts()).toBe(0);
+        expect(r.readFeature('animLiveBar')).toBe(0);
+    });
+
+    it('ON: the first tick of a bar snaps; later ticks glide toward the target and settle there', () => {
+        const { r, anyR, starts } = makeRenderer(90);
+        r.setBars([bar(1000, 100), bar(2000, 101)]);
+        r.updateBar(bar(2000, 105));
+        expect(anyR.liveEaseClose).toBe(105); // first tick of this bar: no glide from stale state
+        expect(starts()).toBe(0);
+        r.updateBar(bar(2000, 110));
+        expect(starts()).toBe(1);
+        expect(anyR.liveEaseClose).toBe(105); // still displayed at the previous value…
+        expect(anyR.easeLiveBar(16)).toBe(true); // …and moving toward the new one
+        expect(anyR.liveEaseClose).toBeGreaterThan(105);
+        expect(anyR.liveEaseClose).toBeLessThan(110);
+        let frames = 1;
+        while (anyR.easeLiveBar(16) && frames < 200) frames += 1;
+        expect(frames).toBeLessThan(200); // settles
+        expect(anyR.liveEaseClose).toBe(110);
+        expect(anyR.liveEaseHigh).toBe(110);
+    });
+
+    it('ON: a NEW bar always snaps — the ease never runs across bars', () => {
+        const { r, anyR, starts } = makeRenderer(90);
+        r.setBars([bar(1000, 100), bar(2000, 101)]);
+        r.updateBar(bar(2000, 105));
+        r.updateBar(bar(3000, 130));
+        expect(anyR.liveEaseTime).toBe(3000);
+        expect(anyR.liveEaseClose).toBe(130);
+        expect(starts()).toBe(0);
+    });
+
+    it('a longer time-constant glides slower; switching to 0 mid-glide snaps on the next frame', () => {
+        const fast = makeRenderer(50);
+        const slow = makeRenderer(400);
+        for (const { r } of [fast, slow]) {
+            r.setBars([bar(1000, 100), bar(2000, 101)]);
+            r.updateBar(bar(2000, 105));
+            r.updateBar(bar(2000, 110));
+            (r as any).easeLiveBar(16);
+        }
+        expect(fast.anyR.liveEaseClose).toBeGreaterThan(slow.anyR.liveEaseClose);
+
+        slow.r.applyFeature('animLiveBar', false); // live toggle, mid-glide
+        expect(slow.r.readFeature('animLiveBar')).toBe(0);
+        expect(slow.anyR.easeLiveBar(16)).toBe(false);
+        expect(slow.anyR.liveEaseClose).toBe(110);
+    });
+
+    it('the rich config carries an on/off switch only; toggling it on restores the configured duration', () => {
+        const { r } = makeRenderer(250);
+        expect(r.getConfig().priceScale.animateLastPrice).toBe(true);
+        r.applyConfig({ priceScale: { animateLastPrice: false } }); // the settings-dialog toggle
+        expect(r.readFeature('animLiveBar')).toBe(0);
+        expect(r.getConfig().priceScale.animateLastPrice).toBe(false);
+        r.applyConfig({ priceScale: { animateLastPrice: true } });
+        expect(r.readFeature('animLiveBar')).toBe(250); // the host's duration, not the built-in default
+
+        const off = makeRenderer(0);
+        expect(off.r.getConfig().priceScale.animateLastPrice).toBe(false);
+        off.r.applyConfig({ priceScale: { animateLastPrice: true } });
+        expect(off.r.readFeature('animLiveBar')).toBe(LIVE_BAR_EASE_DEFAULT_MS); // nothing configured → the default
+        off.r.applyConfig({ priceScale: { animateLastPrice: 'yes' as unknown as boolean } }); // junk is dropped, not applied
+        expect(off.r.readFeature('animLiveBar')).toBe(LIVE_BAR_EASE_DEFAULT_MS);
+    });
+
+    it('the renderer feature accepts `true` (default duration) and clamps numbers', () => {
+        const { r } = makeRenderer(0);
+        r.applyFeature('animLiveBar', true);
+        expect(r.readFeature('animLiveBar')).toBe(LIVE_BAR_EASE_DEFAULT_MS);
+        r.applyFeature('animLiveBar', 99_999);
+        expect(r.readFeature('animLiveBar')).toBe(LIVE_BAR_EASE_MAX_MS);
+    });
+});


### PR DESCRIPTION
## Summary

The forming candle used to slide toward every live tick over a fixed 90 ms ease hard-coded in the native renderer. This makes the glide a setting and turns it **off by default**, so the painted candle, the current-price line and its axis label always show the real latest values unless the host opts in.

## What changes

**Public option** — `animations: { liveBar?: boolean | number }`
- `false` / `0` → snap (**default**)
- `true` → the built-in 90 ms ease
- a number → the ease time-constant in ms (settles in ~3×; clamped to 1000)
- `animations: false` still disables every animation; `animations: true` keeps zoom + pan on and leaves the glide at its default (off), so it stays equivalent to the default config.

**Renderer feature** — `chart.renderer.set('animLiveBar', …)` / `get` / `supports`, same value shape; reads back as a number.

**Rich config** — `priceScale.animateLastPrice: boolean` in `getConfig()` / `applyConfig()`, so the state persists and rides templates. It carries on/off only; switching it back on restores the last non-zero duration the host configured (falling back to 90 ms), not blindly the default.

**Settings dialog** — an **Animate price changes** switch in a new *Animation* group of the Symbol tab (ids `symbol.animation`, `symbol.animation.price-changes`), with a hint tooltip: *"Glide the live bar to each new price instead of snapping."*

**Shared hint badge** — the ⓘ badge both in-chart dialogs used is now one `chromeHint()` helper next to `attachChromeTooltip`. It draws a new `info` SVG icon instead of a text `"i"`, so the glyph centers in its badge regardless of font. The indicator inputs dialog's tooltips get the same fix.

Unchanged guarantees: a new bar always opens without a glide; the crosshair, legend, `inspect()` and data window always read the real values.

## Breaking

Streaming charts that relied on the always-on slide now snap. Pass `animations: { liveBar: true }` to restore it. Flagged in the `[Unreleased]` changelog entry.

## Verification

- Gate: typecheck, lint, tests (1539, incl. 9 new in `test/native-live-bar-ease.test.ts`), build — green.
- `oracle-tests/vela`: 23/23.
- Browser (live BTCUSDT playground): default reads `0` and a same-bar tick snaps with the animator idle; at 600 ms the displayed close moved monotonically toward the target across frames while the underlying bar stayed exact; the dialog row renders in the Animation group, the tooltip opens themed above the dialog, clicking the switch sets `animLiveBar` → 90 and the config flag → `true`, and `listSettingsIds()` lists the two new ids.

## Docs

`docs/user/options.md` (option row + settings id catalog), `docs/user/renderer-features.md` (feature row, rich-config summary), JSDoc on the option, playground option comments, `CHANGELOG.md` under `[Unreleased]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior change affects all live charts (snap vs glide); implementation is localized to animation/options and native renderer tick path with dedicated tests.
> 
> **Overview**
> **Breaking:** streaming charts no longer ease the forming candle on every tick unless opted in. The old fixed ~90 ms glide becomes **`animations.liveBar`** (`false`/`0` default, `true` → 90 ms, or a duration in ms up to 1000) and the renderer feature **`animLiveBar`**, with shared resolution via **`resolveAnimations`** / **`resolveLiveBarEaseMs`**.
> 
> The native renderer snaps on each tick when glide is off; same-bar updates still ease when enabled. New bars always snap, and crosshair/legend/data window keep real values. **`priceScale.animateLastPrice`** in rich config is on/off only—turning it back on restores the last configured duration.
> 
> Chart settings gain **Symbol → Animation → Animate price changes** (`symbol.animation.*` ids) with a shared **`chromeHint()`** ⓘ badge (new **`info`** icon); indicator inputs reuse that helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c21bdcca6a5ce638d8b0052010a87b32430ad1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->