### PR TITLE
Release version 0.6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Vela, newest first.
 
-## [Unreleased]
+## [v0.6.17]
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",


### PR DESCRIPTION
## Summary

Cuts **v0.6.17**: `package.json` / lockfile bumped from 0.6.16, and the `[Unreleased]` changelog section renamed to `[v0.6.17]`. Nothing else changes.

What ships in 0.6.17 (already described in `CHANGELOG.md`):

- **Changed** — the live candle snaps to each tick by default, and its glide is now a setting (`animations: { liveBar }`, renderer feature `animLiveBar`, an *Animate price changes* switch in the chart settings). _Breaking for charts that relied on the always-on slide: pass `animations: { liveBar: true }` to restore it._ (#128)

## Stacked on #128

Opened against `feat/live-bar-glide-option` on purpose: the release must carry the glide option, and #128 has not landed on `dev` yet. Once #128 merges, GitHub retargets this PR to `dev` automatically and its diff shrinks to the three release files. Merge order: **#128 → this PR → then the usual `dev` → `main` "Release 0.6.17" PR** (which creates the `v0.6.17` tag and publishes).

If more work is meant to ride 0.6.17, merge it into #128 first and this PR picks it up — only a new `[Unreleased]` changelog heading would need folding into the `[v0.6.17]` section.

Version choice: **patch** bump, matching the 0.6.12 → 0.6.16 convention. Strict semver would call the default-behavior change a minor (0.7.0) — say so and I will retarget the number.

## Test plan

- [x] Same tree as #128's head plus the version strings: `npm run typecheck` · `npm run lint` · `npm run test` (1539) · `npm run build` green.
- [ ] After merge to `dev`: open the `dev` → `main` release PR, tag `v0.6.17`, then bump `@luxalgo/vela-pro` (`^0.6.17`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only edits with no runtime or API code touched in this PR.
> 
> **Overview**
> **Release housekeeping for `@luxalgo/vela` 0.6.17** — bumps `version` in `package.json` and `package-lock.json` from **0.6.16** to **0.6.17**, and retitles the changelog section from **`[Unreleased]`** to **`[v0.6.17]`** (the live-bar animation notes already under that section are what this tag documents).
> 
> No library source changes in this diff; it prepares the npm publish / git tag once the stacked feature work lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc0144cb410cdd826ebdf605e6b716fa2c09f09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->