### PR TITLE
Add persistent visibility, named sessions, and interaction controls

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,41 @@
+name: Browser tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: browser-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromium:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps --only-shell chromium
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build
+      - run: npm run test:browser
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: chromium-browser-results
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.log
 .env.local
 .DS_Store
+test-results/
+playwright-report/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Named trading sessions.** Hosts can define ordered trading sessions with their own
+  labels, market-time windows, colors, and provider-facing IDs. Workspaces show a
+  selector when several choices are available, shade the selected intraday session,
+  and restore the selected ID with saved state.
+
+- **Box selection for drawings.** Hold Ctrl/Cmd and drag from empty plot space to select
+  every drawing touched by the box, or add Shift to keep the current selection. The
+  gesture keeps the viewport fixed, supports one-step delete and undo, and leaves
+  locked drawings protected.
+
+### Changed
+
+- **Charts follow the system reduced-motion preference by default.** When `animations`
+  is omitted, reduced motion removes chart easing, presentation animation, workspace
+  glides, and contributed layer animation, and responds to preference changes live.
+  Pass `true` or an animation object to opt into full presentation motion, or `false`
+  to force reduced mode.
+
+### Fixed
+
+- **Hidden price series stay hidden after restore.** Hiding the base price series from
+  the status line or object tree now survives renderer templates, workspace state, and
+  persisted reloads.
+
 ## [v0.6.17]
 
 ### Changed

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -80,14 +80,14 @@ If any condition fails, the core uses the static re-run path: it pokes the engin
 
 ## Switching markets in place
 
-`chart.setMarket({ symbol?, provider?, timeframe?, bars?, data?, visibleRange? })` changes what the chart shows **without destroying it**. The switch is a controlled re-entry into the same load pipeline the chart booted with:
+`chart.setMarket({ symbol?, timeframe?, bars?, session?, data?, visibleRange? })` changes what the chart shows **without destroying it**. The symbol itself carries an optional provider prefix. A session change selects a different bar series, so it follows the same controlled re-entry into the load pipeline as a symbol or timeframe change:
 
 1. **Quiesce** — the live subscription stops, pending gap-heals and viewport pokes are dropped, and history tracking re-arms (the superseded load's `historyComplete()` promise resolves rather than hanging).
-2. **Reload** — the shared load pipeline runs for the new market (preview → chunk → background backfill for deep histories, a single fetch otherwise). Every step is generation-guarded: a newer switch (or destroy) abandons a stale load before it can touch the chart.
+2. **Reload** — the shared load pipeline runs for the new market (preview → chunk → background backfill for deep histories, a single fetch otherwise). The selected, case-sensitive session ID reaches history, range, progressive, subscription, and explicit/custom calendar paths unchanged, and the cache keeps every explicit session ID separate from the omitted provider default. The legacy metadata-derived status badge also requests both conventional calendars to derive its pre/regular/post states. Every step is generation-guarded: a newer switch (or destroy) abandons a stale load before it can touch the chart.
 3. **Restart consumers** — engine sessions are re-executed over the new bars (their next `ExecutionRequest` carries the new market), native indicators restart with a fresh context, the active chart-type data engine is rebuilt, and the live subscription re-targets.
-4. **Announce** — `market:changed` fires with the previous identity, so hosts can re-key per-symbol state (drawing documents, watchlists).
+4. **Announce** — `market:changed` fires with the current and previous session as part of the identity, so hosts can re-key per-market state (drawing documents, watchlists).
 
-What deliberately survives: panes and indicator records (legend rows, inputs, pane placement), user drawings, the renderer's cosmetic config, the zoom (the view keeps its bar spacing and only re-anchors the newest bars at the right edge — the previous pan pointed at another market's time range), and every event subscription. Old sessions are never poked with the new market's bars — bar/viewport notifications are held during the switch, and the re-execution that follows is what computes over the new data.
+What deliberately survives: panes and indicator records (legend rows, inputs, pane placement), user drawings, the renderer's cosmetic config, and every event subscription. A new symbol or timeframe keeps the bar spacing and re-anchors the newest bars at the right edge because the previous market's clock is no longer meaningful. A session-only switch preserves the number of visible bars and the newest visible-bar anchor against the incoming tape, so different session densities do not appear to change the zoom. Old engine sessions are never poked with the new market's bars — bar/viewport notifications are held during the switch, and the re-execution that follows is what computes over the new data.
 
 ## Causal, stateful execution
 

--- a/docs/contributing/adding-a-data-provider.md
+++ b/docs/contributing/adding-a-data-provider.md
@@ -19,15 +19,15 @@ One method is **required**; the rest are **progressive** — present them when y
 
 #### Required
 
-- **`getBars(ticker, timeframe, range)`** — return bars for the requested window. `ticker` is what the user typed minus any `provider:` prefix (any `.ext` suffix is **kept** — you own its meaning). `range` is `{ from?, to?, limit?, session? }` (epoch ms; `to` omitted = now). The newest bar is treated as the forming candle. `session` (`'regular'` | `'extended'`) names the trading session the chart shows on markets that have one — honor it if your source can filter (regular vs extended bars are cached as separate series), ignore it otherwise. The same flag reaches `subscribe` as `opts.session` (4th argument).
+- **`getBars(ticker, timeframe, range)`** — return bars for the requested window. `ticker` is what the user typed minus any `provider:` prefix (any `.ext` suffix is **kept** — you own its meaning). `range` is `{ from?, to?, limit?, session? }` (epoch ms; `to` omitted = now). The newest bar is treated as the forming candle. `session` is the optional, case-sensitive provider-facing ID selected by the host; Vela™ forwards any non-empty ID unchanged after trimming it, even when the host declares no catalog. Metadata-derived workspace choices remain `regular` and `extended`; an explicit catalog adds labels, windows, colors, and ID validation. Honor the ID if your source can filter, and ignore it otherwise. The same selected ID reaches `subscribe` as `opts.session` (4th argument). Explicit and custom-session calendar lookups receive it as `range.session`; the legacy metadata-derived status badge separately requests both `regular` and `extended` calendars.
 
 #### Optional
 
 - **`listSymbols()`** — enumerate the symbols you serve, as `{ ticker, description?, type?, prefix? }[]`. This builds the **eager index** at registration that lets a **bare** symbol (no `provider:` prefix) resolve to you, and powers autocomplete. Without it, your provider is reachable **only** by an explicit `name:SYMBOL` prefix. Declare `prefix` when the symbol's **listing venue** is its identity (`NASDAQ` for AAPL, `NYSE` for IBM — a property of the symbol, not of your provider): it is what `NASDAQ:AAPL` strings resolve against and what every label displays. Leave it out where the provider *is* the identity (crypto, fx). **Grouped listings** (futures roots): emit one **group row** per root — `group` repeated in `ticker` (`{ ticker: 'ES', group: 'ES', … }`) — then its members carrying the same `group` with their own tickers, in deliberate order, one marked `default: true`. The picker folds members under the group row (a chevron unfolds them) and a group pick — clicked, or typed as `ES` / `CME:ES` — loads the `default` member (none or several marked ⇒ the **first listed**). The group row itself is listed, never loadable. Declare `market` when sibling markets of one source differ in session shape (futures product classes): consumers resolving per-market vocabulary key on it.
 - **`getSymbolInfo(ticker)`** — per-symbol metadata an engine may read (Pine `syminfo.*`). Absent ⇒ the engine synthesizes a fallback.
 - **`resolveSymbolIcon(descriptor)`** — the icon URL for one of your symbols; the provider owns the knowledge of where its asset class's icons live (the bundled crypto providers predefine the Ledger crypto-icon CDN). Called lazily per RENDERED row — cheap and synchronous. Return `undefined` for "no icon" (the shells show a colored-initials badge; a URL that 404s degrades the same way). Serve CORS-clean images (`Access-Control-Allow-Origin`) or drawing them taints the canvas and breaks the PNG export.
-- **`getCalendar(ticker, range)`** — the RESOLVED market calendar over `[from, to)`: ascending epoch-ms `[start, end)` pairs of open market time, **holidays and DST already applied by your source**. `range.session` selects the window set (`'regular'` default, `'extended'` = the full tape). This is the single market-time truth: the widget's market-status badge (open / pre / post / closed / holiday) and session-anchored consumers read these windows and never recompute a holiday themselves. Absent ⇒ no calendar (the right answer for continuous markets — crypto, most fx): the badge stays "Market Open" and consumers fall back to their own anchoring.
-- **`subscribe(ticker, timeframe, onBar)`** — open a true live candle stream and return an unsubscribe fn. Absent ⇒ the feed **polls `getBars`** for live ticks instead.
+- **`getCalendar(ticker, range)`** — the RESOLVED market calendar over `[from, to)`: ascending epoch-ms `[start, end)` pairs of open market time, **holidays and DST already applied by your source**. For explicit catalogs and custom IDs, `range.session` is the exact selected ID used by history and live requests. The metadata-derived status badge instead requests the conventional `regular` and `extended` calendars together so it can derive premarket, regular, and postmarket states. An absent ID remains the provider default. This is the single market-time truth: the widget's market-status badge and session-anchored consumers read these windows and never recompute a holiday themselves. Absent method ⇒ no calendar (the right answer for continuous markets — crypto, most fx): the badge stays "Market Open" and consumers fall back to their own anchoring.
+- **`subscribe(ticker, timeframe, onBar, opts?)`** — open a true live candle stream and return an unsubscribe fn. `opts.session` is the same selected ID used for history. Absent ⇒ the feed **polls `getBars`** for live ticks instead.
 - **`info()`** — provider metadata (display name, supported timeframes, capabilities). Absent ⇒ the registry synthesizes one from the methods you implement.
 - **`configure(config)`** — apply runtime config (e.g. API keys).
 
@@ -58,7 +58,7 @@ Registration is what **fires the chart's parked initial load** — until a provi
 
 ```ts
 const myProvider = {
-  // required — read ticker/timeframe per call (never stash them)
+  // required — read ticker, timeframe, and range.session per call (never stash them)
   async getBars(ticker, timeframe, range) {
     const bars = await fetchBars(ticker, timeframe, range); // your API
     return normalize(bars); // sorted + deduped by open-time, time in epoch ms
@@ -82,11 +82,11 @@ If you never add `listSymbols`/`getSymbolInfo`/`subscribe`, nothing breaks — t
 
 ### Caching is automatic
 
-The default feed caches **closed** bars in a shared in-memory store, keyed on the **resolved** `(provider, ticker, timeframe)` — so `BTCUSDT` and `BINANCE:BTCUSDT` share one entry. On a re-run it re-fetches only the uncached **tail** (newly-closed + forming bars) by calling your `getBars` with a bounded `range` whose `from` may **overlap** bars already held. Return the requested window as-is (sorted, de-duplicated); never error on an overlapping `from`. You implement no caching yourself.
+The default feed caches **closed** bars in a shared in-memory store, keyed on the **resolved** `(provider, ticker, timeframe, session)` — so `BTCUSDT` and `BINANCE:BTCUSDT` share one entry only when their session is also the same. Every explicit ID, including `regular`, gets a separate series; only an omitted ID uses the provider-default entry. On a re-run it re-fetches only the uncached **tail** (newly-closed + forming bars) by calling your `getBars` with a bounded `range` whose `from` may **overlap** bars already held. Return the requested window as-is (sorted, de-duplicated); never error on an overlapping `from`. You implement no caching yourself.
 
 ### The source-of-truth pitfall
 
-**Read the ticker and timeframe from the call arguments, never from stashed instance state.** The cache can serve history without ever calling your `getBars` for the primary load, then later call it for just the tail — a captured "current symbol" may be stale or never set.
+**Read the ticker, timeframe, and session from the call arguments, never from stashed instance state.** The cache can serve history without ever calling your `getBars` for the primary load, then later call it for just the tail — a captured "current market" may be stale or never set.
 
 ## Part 2 — A custom `MarketDataFeed` (advanced)
 
@@ -100,11 +100,16 @@ const chart = new Vela(container, options, {
 
 A feed injected this way is used as-is: `chart.data.registerProvider(...)` becomes a no-op + warning (there's no registry to register into), and you own any caching. Use this only when the provider model doesn't fit; for a normal data source, Part 1 is the path.
 
+The chart passes the selected ID as `cfg.session` to a custom feed's load, range, and
+subscription methods. If the feed supports session filtering, treat that value as part
+of the market identity and keep its cached series separate.
+
 ## Checklist
 
-- `getBars` implemented; reads ticker/timeframe from arguments, returns open-time-in-ms bars, sorted + de-duplicated.
+- `getBars` implemented; reads ticker, timeframe, and session from its arguments, returns open-time-in-ms bars, sorted + de-duplicated.
 - Newest bar treated as the forming candle; roll forward by emitting a larger open-time (no separate close event).
 - Ranged `getBars` tolerates an overlapping `from` and honors "`to` omitted = now"; no timeframe aggregation across requests unless your venue needs it internally.
+- History and live subscriptions honor the same exact `session` ID when the source supports filtering. Explicit/custom calendar requests do too; the metadata-derived status badge requests both conventional calendars. Unsupported sources ignore IDs consistently.
 - (Optional) `listSymbols` so bare symbols resolve to you; `getSymbolInfo` for real syminfo; `subscribe` for a true candle stream (else polling is used); `getCalendar` for resolved market-time windows on venues with trading sessions.
 - Registered via `chart.data.registerProvider(name, provider)`.
 

--- a/docs/contributing/adding-a-renderer.md
+++ b/docs/contributing/adding-a-renderer.md
@@ -33,8 +33,17 @@ Mount into a host element with a theme, react to theme changes and resizes, and 
 
 - **Mount** attaches your surface to the container and adopts the supplied theme.
 - **Set theme** re-skins in place.
+- **Apply motion policy** through the optional `applyMotionPolicy(policy)` hook when your
+  renderer has presentation animation. Vela™ may call it before `mount` and again when a
+  system preference changes. Treat `policy.reduced` as a runtime gate, separate from the
+  configured feature values. When it becomes true, finish fixed-target motion immediately,
+  stop targetless motion at its current position, and paint a complete static frame.
 - **Resize** re-measures against the container.
 - **Destroy** must leave **nothing** behind — no DOM nodes, no observers, no event listeners, no floating overlays. A renderer that leaks on destroy will accumulate state across chart re-creation. Treat "destroy is exact" as a hard requirement.
+
+`applyMotionPolicy` is optional for compatibility with existing renderers. If you omit it,
+the host still removes its own DOM transitions, but your renderer remains responsible for
+honoring reduced motion on its surface.
 
 ### 2. Price bars
 
@@ -230,7 +239,11 @@ That alone gives you candles, panes, and basic indicator plots — a usable char
 - **External crosshair** — the optional `setExternalCrosshair(time, price?)` method: draw a dimmed **ghost crosshair** at a data-space position pushed from outside (multi-chart sync). Detected by presence (no capability flag); the one contract rule: a ghost must **never** re-emit `onCrosshairMove` — that one-way flow is what keeps the sync loop-free.
 - **Data-window readout** — the optional `getDataWindowReadout()` method: hand back the bar under the crosshair (the latest bar when the cursor is off the plot) with its values already formatted on the scale of the pane each one belongs to, grouped per indicator. Detected by presence (no capability flag); host panels such as the widget's data window read it through `chart.renderer.dataWindowReadout()` and simply show nothing without it.
 - **Loading affordance** — the optional `setLoading(loading)` method: the core raises it while a market load is in flight with **no bars painted yet** (the first load, and every symbol/timeframe switch — the core blanks the old series first), and drops it with the first series it hands over, or when a load fails or parks. Show something subtle (the native renderer pulses three small dots at the plot center), and hide content that does **not** ride the bar series — corner-anchored tables stay painted through an emptied chart unless you hide them, while bar-mapped content vanishes with the series on its own. Plugins get the same window as the `load:start` / `load:end` chart events. Without the method the chart is simply blank while loading. Detected by presence (no capability flag).
-- **Animations / polish** — transitions and presentation refinements.
+- **Animations / polish** — transitions and presentation refinements. Implement
+  `applyMotionPolicy(policy)` so an omitted `animations` option follows the live system
+  preference. Do not overwrite `animZoom`, `animPan`, `animLiveBar`, or other configured
+  features when reduction is active; the policy is an effective runtime gate, not saved
+  chart configuration.
 
 The key idea: a flag stays **false and renders blank** until its tier is real, and the core simply won't send that content meanwhile.
 

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -92,7 +92,7 @@ registerRendererLayer({
     repaintOnCursor: true,           // opt-in: pointer moves repaint this layer too
     create: () => ({
         mount(canvas) { /* keep the canvas reference */ },
-        render({ bars, data, pending, coords, scale, bounds, theme, priceStyle, nowMs, cursor }) {
+        render({ bars, data, pending, coords, scale, bounds, theme, priceStyle, nowMs, cursor, reducedMotion }) {
             // Always clear + repaint your own canvas. Gate on `priceStyle` if the
             // layer belongs to a chart type. Key mappings:
             //   coords.logicalToX(i) / coords.timeToX(ms)  → x
@@ -100,6 +100,7 @@ registerRendererLayer({
             //   coords.width / coords.dpr                  → sizing
             // `cursor` is the plot-relative pointer ({ x, y } | null) — hover
             // hit-testing input for layers that set `repaintOnCursor`.
+            // When `reducedMotion` is true, paint the complete static/end state.
         },
         animating?: () => false,     // return true while a pulse/fade needs frames
         modulateBase?: (args) => ({ candleBodyScale: 0.07, gridAlpha: 0 }),
@@ -107,6 +108,11 @@ registerRendererLayer({
     }),
 });
 ```
+
+`reducedMotion` is the effective presentation policy for that frame. Do not advance a
+pulse, fade, or reveal while it is true; paint the final state directly. The native
+renderer does not consult `animating()` while motion is reduced, so correctness must not
+depend on animation progress eventually producing a complete frame.
 
 **Ownership — layers backed by a native indicator.** When a mounted native indicator's
 type equals a layer's id, that indicator OWNS the layer, and the layer joins the chart's

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -38,10 +38,43 @@ The browser bundle inlines the worker (see [setup.md](./setup.md#two-artifacts-f
 
 This is the end-to-end tier: **real indicators run all the way through the playground** in a real browser with a real renderer. It is the check that the whole pipeline — feed to engine to neutral model to renderer — actually produces the right picture.
 
-- **Today it is MANUAL.** You run it by hand in the playground (`npm run playground`) and look at the result.
-- The **intended direction is an automated harness** for these runs. Treat manual smoke testing as the current state, not the end state.
+Run the maintained Chromium suite below for its covered scenarios. Use manual playground
+checks for other visual and interactive changes.
 
 The playground serves the **source directly** (vite): `npm run playground`, then exercise the change live — no build step. See [workflow.md](./workflow.md#the-playground).
+
+### Automated Chromium regressions
+
+Install the browser once after `npm install`, then run the maintained suite:
+
+```sh
+npx playwright install --only-shell chromium
+npm run test:browser
+```
+
+Playwright starts and stops its own source playground server on port 5191. Keep that
+port free; the runner refuses to reuse another server so it cannot accidentally test a
+neighboring checkout. Each test gets a fresh browser context and storage. The fixture
+uses deterministic provider data and the playground demo engine, with attribution on.
+It needs no exchange connection, API key, or separate scripting addon.
+
+The suite covers price-series visibility and persistence, native reduced-motion
+emulation, named-session provider calls and shading, and Ctrl/Cmd marquee selection
+with cancellation and locked-drawing delete/undo. Assertions check canvas pixels,
+computed styles, focus, saved state, and real keyboard/pointer interactions. Browser
+errors, leaked subscriptions, and chart DOM left after destroy fail the test. The pointer
+cancellation case injects a browser `pointercancel` event after a real drag because
+Playwright has no OS-level mouse cancellation command.
+
+Run a subset with `npm run test:browser -- motion.spec.ts`. To watch with `--headed`,
+install the full browser first with `npx playwright install chromium`. Failed tests retain screenshots and traces in `test-results/`. Open the HTML report
+with `npx playwright show-report`; its trace viewer includes actions and DOM snapshots.
+For a standalone trace, run `npx playwright show-trace path/to/trace.zip`.
+
+The Browser tests workflow runs the four-way gate and Chromium suite on pull requests
+and pushes to `main`, and uploads reports for seven days. On Linux machines missing
+browser system libraries, install them with
+`npx playwright install --with-deps --only-shell chromium`.
 
 ## Which tier for which change
 

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -20,7 +20,7 @@ The public, imperative chart and the composition root — the one place that wir
 
 - **`container`** — an `HTMLElement` or a CSS selector string. A missing selector throws.
 - **`options`** — display, behavior, and market options. See [options.md](./options.md).
-- **`deps`** — the **swap point** for the three layers (see below).
+- **`deps`** — the **swap point** for backends and browser motion observation (see below).
 
 Constructing a chart renders candles immediately. Scripting engines are opt-in.
 
@@ -36,8 +36,9 @@ Constructing a chart renders candles immediately. Scripting engines are opt-in.
 | `indicators()` | Live `IndicatorHandle[]` of everything on the chart (script + native), in insertion order — the seam for host panels (object trees, indicator lists) that need per-id visibility/removal. |
 | `availableNativeIndicators()` | Returns `Promise<NativeIndicatorInfo[]>` — the catalog of built-in native indicators with their live state on this chart, for building an "add indicator" picker UI (lets a host list them, gate unsupported ones, avoid duplicates). Async because support may need to probe the provider (a type may need data the symbol lacks). |
 | `presentNativeIndicators()` | Returns `string[]` — the native types present on the chart **right now**, one entry per instance (a multi-instance type repeats), synchronously (the presence slice of `availableNativeIndicators()`, which stays async only for support probing). Persistence snapshots read this: an unload-time save must see an add or remove made microseconds earlier. |
-| `setMarket(next)` | Switch the chart's market **in place** — `{ symbol?, timeframe?, bars?, data?, visibleRange? }` — without destroying the chart. The symbol string carries the venue: bare = registered providers in declaration order, `'coinbase:BTC-USD'` pins one. Only the fields given change. Indicators re-execute over the new bars, native indicators restart, and panes, user drawings, renderer config and event subscriptions all **survive**. Resolves once the new market's history is painted (a deep backfill continues behind it — await `historyComplete()`); a call superseded by a newer `setMarket` resolves silently. Emits `market:changed` when the market identity changed (a depth-only `bars` reload is silent). `visibleRange` frames the first paint of the new market. Drawings are kept as-is — per-symbol drawing documents are a host policy (`chart.drawings.toJSON()/fromJSON()` keyed off `market:changed`). |
-| `market` (getter) | The current market identity — the read counterpart of `setMarket`. A **snapshot** `{ symbol?, provider?, timeframe?, bars?, offline }` of the *requested* market (`provider` = the symbol's own `EXCHANGE:` prefix, or undefined when bare — the venue that actually served it is `chart.data.resolve(symbol)`): it reflects an in-flight switch immediately (before the new bars land), which is what persist-on-close flows want. Listen to `market:changed` for *committed* identity changes. Mutating the returned object changes nothing. |
+| `setMarket(next)` | Switch the chart's market **in place** — `{ symbol?, timeframe?, session?, bars?, data?, visibleRange? }` — without destroying the chart. The symbol string carries the venue: bare = registered providers in declaration order, `'coinbase:BTC-USD'` pins one. Only the fields given change. A session switch reloads with the exact case-sensitive provider-facing ID while preserving the visible bar count and newest visible-bar anchor. Indicators re-execute over the new bars, native indicators restart, and panes, user drawings, renderer config and event subscriptions all **survive**. Resolves once the new market's history is painted (a deep backfill continues behind it — await `historyComplete()`); a call superseded by a newer `setMarket` resolves silently. Emits `market:changed` when the market identity changed (a depth-only `bars` reload is silent). `visibleRange` frames the first paint of the new market. Drawings are kept as-is — per-symbol drawing documents are a host policy (`chart.drawings.toJSON()/fromJSON()` keyed off `market:changed`). |
+| `market` (getter) | The current market identity — the read counterpart of `setMarket`. A **snapshot** `{ symbol?, provider?, timeframe?, session?, bars?, offline }` of the *requested* market (`provider` = the symbol's own `EXCHANGE:` prefix, or undefined when bare — the venue that actually served it is `chart.data.resolve(symbol)`): it reflects an in-flight switch immediately (before the new bars land), which is what persist-on-close flows want. Listen to `market:changed` for *committed* identity changes. Mutating the returned object changes nothing. |
+| `reducedMotion` (getter) | The effective runtime motion gate. It follows `prefers-reduced-motion` only when `animations` is omitted; explicit `false` keeps it true, while `true` or an animation object keeps it false. It is not saved state. |
 | `ready()` | Returns a promise that resolves once the chart is painted and interactive. On a ranged feed the first paint is a small recent head (~200 bars) and the rest of the history keeps backfilling **behind** this — await `historyComplete()` for the full depth. |
 | `historyComplete()` | Returns a promise that resolves once the **current load's** full requested history has loaded — immediately for small/offline charts, after the background backfill for deep ones. **Per-load**: each `setMarket` re-arms the cycle (the superseded load's promise resolves rather than hanging), so call it again after a switch for the new market's depth. Never rejects: on destroy or a failed backfill it resolves with whatever depth loaded. |
 | `on(event, handler)` | Subscribe to a chart-level event. Returns an unsubscribe function. |
@@ -233,9 +234,9 @@ Subscribe with `chart.on(event, handler)`; every subscription returns an unsubsc
 | Event | Payload | Fires when |
 |---|---|---|
 | `ready` | — | The chart is painted and interactive (a deep chart's history may still be backfilling). |
-| `market:changed` | `{ symbol, timeframe, prev: { symbol, timeframe } }` | The market switched **in place** via `setMarket` — symbol (venue prefix included), timeframe, or offline data changed (a depth-only reload does not fire). Fires after the new market's history is painted and every consumer restarted. `prev` lets hosts re-key per-symbol state (e.g. swap user-drawing documents between symbols). |
-| `load:start` | `{ symbol, timeframe, firstLoad }` | A bar load began with nothing painted: the first load (fires during construction — later subscribers see only its `load:end`), or an identity switch, which blanks the old series in the same breath. Fires **before** the first fetch — plugins and custom indicators hide or reset their own visuals here. A depth-only reload fires neither event. |
-| `load:end` | `{ symbol, timeframe, bars }` | The load ended: its first bars painted (`bars` > 0 — on deep histories the quick preview), or it ended with none (`bars` = 0 — a failed fetch, an empty market, or a parked symbol). Exactly one per `load:start`; plugins restore or rebuild their visuals here. |
+| `market:changed` | `{ symbol, timeframe, session?, prev: { symbol, timeframe, session? } }` | The market switched **in place** via `setMarket` — symbol (venue prefix included), timeframe, session, or offline data changed (a depth-only reload does not fire). Fires after the new market's history is painted and every consumer restarted. `prev` lets hosts re-key per-market state. |
+| `load:start` | `{ symbol, timeframe, session?, firstLoad }` | A bar load began with nothing painted: the first load (fires during construction — later subscribers see only its `load:end`), or an identity switch, including a session switch, which blanks the old series in the same breath. Fires **before** the first fetch — plugins and custom indicators hide or reset their own visuals here. A depth-only reload fires neither event. |
+| `load:end` | `{ symbol, timeframe, session?, bars }` | The load ended: its first bars painted (`bars` > 0 — on deep histories the quick preview), or it ended with none (`bars` = 0 — a failed fetch, an empty market, or a parked symbol). Exactly one per `load:start`; plugins restore or rebuild their visuals here. |
 | `history:progress` | `{ loaded, target }` | A deep-history backfill chunk landed — `loaded` of `target` bars are on the chart. |
 | `history:complete` | `{ reason, oldestTime, barsLoaded }` | The history load finished. `reason`: `'depth'` (requested count loaded), `'genesis'` (the source has nothing older), or `'aborted'` (a fetch failed — the chart keeps what loaded). Fires exactly once, including for small/offline charts. |
 | `indicator:added` | `{ id }` | An indicator was added. |
@@ -382,8 +383,24 @@ The optional third constructor argument is where you replace a layer's default w
 | `renderer` | The drawing/output layer. Injects an already-constructed renderer *instance*, bypassing the `renderer` option's display-options wiring (a different axis from built-in vs custom — `options.renderer` already accepts any custom class too). | [Adding a renderer](../contributing/adding-a-renderer.md) |
 | `engines` | Scripting engines to register at construction (bulk form of `registerEngine`). | [Scripting engines](./scripting-engines.md) · [Adding an engine](../contributing/adding-an-engine.md) |
 | `dataFeed` | The market-data source. Replaces the default provider registry entirely with your own `MarketDataFeed` (used bare — no registry, no auto-cache). | [Adding a data provider](../contributing/adding-a-data-provider.md) |
+| `motionPreference` | A shared `MotionPreferenceSource`. The workspace injects one observer into all cells; a standalone chart creates its own when this key is absent. The source remains host-owned, and `destroy()` only removes Vela's subscription. | [Options](./options.md#display--behavior-options) |
 
-Each layer is one narrow port — implement it, declare its honest capabilities, and inject it here. The composition root is the only place that imports concrete backends.
+Each backend is one narrow port — implement it, declare its honest capabilities, and inject it here. The composition root is the only place that imports concrete backends.
+
+## Session and motion helpers
+
+The package root exports the same pure validation and policy helpers used by the built-in
+shells:
+
+| Export | Purpose |
+|---|---|
+| `normalizeSession(value)` | Trims an untrusted ID, preserves its case, and returns `undefined` for a non-string or empty value. |
+| `normalizeSessionDefinitions(value)` | Validates and defensively copies a catalog, dropping invalid entries and later duplicate IDs. |
+| `resolveMarketSession(candidate, definitions)` | Returns an exact catalog match, the first definition as fallback, or `undefined` for an empty catalog. |
+| `MarketSessionDefinition` | The `{ id, label, windows, color }` host-catalog type. |
+| `resolveMotionPolicy(animations, systemReduced)` | Resolves configured animation values and the effective reduced-motion gate without reading browser globals. |
+| `ResolvedMotionPolicy` | The resolved zoom, pan, live-bar, intro, and `reduced` values delivered to a renderer. |
+| `MotionPreferenceSource` | The injectable `{ reduced, onChange }` preference-observer contract. |
 
 > The three *adding-a-backend* guides are **Contributing** docs and are still being written. Until they land, no link points at them — see the Contributing section of the [docs index](../index.md).
 

--- a/docs/user/data-providers.md
+++ b/docs/user/data-providers.md
@@ -130,6 +130,14 @@ Because Hyperliquid coins are bare, a bare `BTC` won't collide with Binance's `B
 
 Implement the `DataProvider` interface and register it under any name — see [Adding a data provider](../contributing/adding-a-data-provider.md). The only required method is `getBars`; everything else (`listSymbols`, `getSymbolInfo`, `info`, `subscribe`, `resolveSymbolIcon`) is a progressive enhancement. Symbol icons are the provider's call too: `resolveSymbolIcon(descriptor)` returns the icon URL the shells render in the symbol search, the status line and the object tree (the bundled crypto providers predefine a crypto-icon CDN; no resolver, or no URL, means a colored-initials badge — nothing breaks).
 
+`range.session` and `subscribe(..., opts.session)` receive the exact selected session
+ID. An explicit or custom session also reaches `getCalendar(..., range.session)`
+unchanged. The metadata-derived market-status badge additionally asks for both
+conventional `regular` and `extended` calendars so it can distinguish premarket,
+regular, and postmarket status. Filter each requested calendar consistently. Vela keeps
+cached series separate by session; providers without a session concept may ignore the
+ID.
+
 ## See also
 
 - [Adding a data provider](../contributing/adding-a-data-provider.md) — implement your own.

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -94,6 +94,18 @@ label (a trend line, a box), all four controls stay in that panel with the label
 
 Drag a handle to reshape; drag the body to move the whole drawing.
 
+Hold Ctrl/Cmd and drag from empty plot space to select every visible drawing whose
+clipped bounds touch the box. This replaces the selection; add Shift to union the hits
+with the selection captured when the drag began. Drawing and handle hits, active tools
+and modes, axes, pane separators, and touch gestures keep priority, and the chart does
+not pan. Escape or a pointer cancellation abandons an active box. Moving less than the
+drag threshold remains a normal empty click.
+
+Locked drawings remain selectable, including through the box, but interactive drag,
+nudge, Delete/Backspace, middle-click, and eraser actions leave them unchanged. Explicit
+`chart.drawings` API calls still have authority. Deleting several unlocked drawings from
+a box selection creates one history operation, so one Undo restores the set.
+
 ### Keyboard shortcuts
 
 When a drawing is selected (or hovered), with focus on the chart:
@@ -110,7 +122,8 @@ When a drawing is selected (or hovered), with focus on the chart:
 Shortcuts stand down while a text field (e.g. a label editor) is focused, so typing is never
 hijacked.
 
-Three mouse shortcuts complement these, and need no selection first: **middle-click** a drawing
+Five mouse shortcuts complement these, and need no selection first: **Ctrl/Cmd-drag** empty plot
+space to replace the drawing selection, add **Shift** to union with it, **middle-click** a drawing
 to delete it, **right-click** while a drawing tool, the ruler, or the eraser is active — placing
 or merely armed — to cancel it and return to the pointer (even in stay-in-drawing-mode, and
 without opening the chart's context menu for that click; persistent toggles like the magnet and

--- a/docs/user/options.md
+++ b/docs/user/options.md
@@ -16,7 +16,9 @@ How the chart obtains its candles.
 |---|---|---|
 | `symbol` | string | Symbol to load — the string is the WHOLE market identity. A **bare** ticker (`'BTCUSDT'`) resolves against the registered providers in **declaration order** (first one whose index lists it); an `EXCHANGE:` prefix (`'coinbase:BTC-USD'`, case-insensitive) **pins** the venue — a registered provider name, or a [listing prefix](./data-providers.md#listing-prefixes-nasdaqaapl) a provider's index declares (`'NASDAQ:AAPL'`, strict: a wrong venue resolves to nothing). |
 | `timeframe` | string | Bar interval, e.g. `'1h'`. |
-| `session` | `'regular' \| 'extended'` | Trading session to show, on markets that have one (`regular` = RTH, the default; `extended` = pre/post-market included). The flag rides every data request — providers without a session concept ignore it. Switch at runtime with `chart.setMarket({ session })` or the bottombar's RTH/ETH toggle. |
+| `session` | `MarketSession` (non-empty string) | Case-sensitive trading-session ID to show. Any non-empty provider-facing ID works without a catalog; metadata-derived workspace choices use `regular` / `extended`. History and live paths receive the ID unchanged; the legacy metadata-derived status badge also queries both conventional calendars. Switch it with `chart.setMarket({ session })` or the workspace's session dropdown. |
+| `sessions` | `readonly MarketSessionDefinition[]` | Explicit ordered session catalog. Each entry has `{ id, label, windows, color }`; omit it to derive regular/extended choices from symbol metadata, or pass `[]` to disable session structure. The first valid entry is the fallback. |
+| `sessionTimezone` | IANA zone string | Market timezone for explicit `sessions` windows. Resolution order is this option, symbol metadata, then `Etc/UTC`. An invalid explicit zone paints no bands. |
 | `bars` | number | How many bars of history to load. Depths beyond one ~10k-bar chunk paint the recent window first, then backfill older bars in the background — watch `history:progress` / await `chart.historyComplete()` for the full depth. |
 | `visibleRange` | `VisibleRangePreset \| {from,to}` | — | The window to frame on the **first paint** (`'1D'`, `'YTD'`, an explicit range…). The chart then loads its depth in one pass and paints that window straight away, instead of flashing a recent-bars preview and re-framing a moment later. |
 | `data` | `OHLCV[]` | **Offline bars.** When set, no network fetch happens. |
@@ -26,6 +28,48 @@ How the chart obtains its candles.
 > **The fetch path needs a registered provider.** No provider is bundled — register one with [`chart.data.registerProvider(...)`](./data-providers.md); registering it fires the chart's parked initial load. Each bar is `{ time, open, high, low, close, volume? }` with `time` in epoch milliseconds.
 >
 > With offline `data`, `timeframe` is still honored — it sets bar spacing and axis labels — while `symbol` and `bars` are ignored.
+
+### Named sessions
+
+You can send any non-empty session ID to a provider without declaring a catalog. Add an
+explicit catalog when you also want the workspace to validate IDs and present named,
+colored session choices, or when the symbol has no session metadata:
+
+```ts
+new VelaWorkspace('#chart', {
+  layout: false,
+  symbol: 'MYVENUE:JP225',
+  timeframe: '15',
+  session: 'afternoon',
+  sessionTimezone: 'Asia/Tokyo',
+  sessions: [
+    { id: 'morning', label: 'Morning', windows: ['0900-1130'], color: 'rgba(41, 98, 255, 0.12)' },
+    { id: 'afternoon', label: 'Afternoon', windows: ['1230-1500'], color: 'rgba(156, 39, 176, 0.12)' },
+    { id: 'overnight', label: 'Overnight', windows: ['1700-0500'], color: 'rgba(255, 152, 0, 0.12)' },
+  ],
+});
+```
+
+Windows use `HHMM-HHMM` in market time, recur each civil day, and may wrap midnight.
+Use several windows in one definition for a split session. Invalid definitions are
+dropped as a unit. IDs are trimmed and remain case-sensitive. History, range,
+progressive, subscription, and explicit/custom calendar requests receive them unchanged;
+declaration order is preserved and the first duplicate ID wins. The workspace shows one
+accessible dropdown when at least two valid choices exist and shades the selected session
+on intraday charts. Daily and longer charts do not shade partial-day windows. The
+selected ID is document state; the catalog and timezone remain host options and are not
+persisted.
+
+An explicit catalog takes precedence over symbol metadata. An unknown initial or saved
+ID resolves to the first valid definition; `sessions: []` disables session structure.
+`sessionTimezone` is independent of the display timezone. It falls back to symbol
+metadata and then `Etc/UTC`; an invalid explicit zone paints no bands. A bare `Vela`
+chart forwards an uncataloged provider-facing ID after trimming it, or validates it
+against an explicit catalog. It has no workspace dropdown or host-owned shading
+tracker. For explicit catalogs and custom IDs, the workspace asks `getCalendar` with
+the exact selected ID for holiday-aware market status. The legacy metadata-derived badge
+instead asks for both `regular` and `extended`; declared windows control shading, not
+calendar truth.
 
 A fetching chart pairs these market options with a registered provider — the display flags ride along in the same object, and registering the provider fires the parked initial load.
 
@@ -60,11 +104,11 @@ chart.data.registerProvider('binance', new BinanceProvider());
 | `currentPriceLine` | boolean | `true` | Dashed line + axis label at the latest price. |
 | `logScale` | boolean | `false` | Logarithmic price scale. |
 | `nativeBackend` | `'auto' \| 'canvas2d' \| 'webgl2'` | `auto` | Native geometry backend. `auto` = WebGL2 if available, else canvas2d. Only applies to the native renderer. |
-| `animations` | boolean or `{ zoom?, pan?, liveBar? }` | **on** | `true`/`false` toggles all; an object configures each. Defaults: eased zoom on, inertial pan on (short snappy glide), live-bar glide **off**. `{ pan: false }` = instant pan. `liveBar` makes the forming candle (and the current-price line and label) slide toward each live tick instead of snapping: `true` = a 90 ms ease, a number = the ease duration in ms (settles in about three times that; capped at 1000), `false`/`0` = snap. A new bar always snaps. The settings dialog exposes an on/off switch for it (*Symbol → Animation → Animate price changes*; `priceScale.animateLastPrice` in the rich config); switching it back on reuses the duration set here. |
+| `animations` | boolean or `{ zoom?, pan?, liveBar? }` | system-aware | Omit it to follow `prefers-reduced-motion`. `false` forces reduced motion; `true` and any object (including `{}`) explicitly keep full-motion behavior. Full-motion defaults: eased zoom on, inertial pan on (short snappy glide), live-bar glide **off**. `{ pan: false }` = instant pan. `liveBar` makes the forming candle and latest-price chrome slide toward a live tick: `true` = 90 ms, a number = milliseconds (capped at 1000), `false`/`0` = snap. Reduced mode also removes intro, shell-glide, loading/status, layer, and nonessential UI motion without rewriting configured values. |
 | `glow` | number | `0` | Neon glow/bloom for line series (~0.6 = strong). **WebGL2 only** — ignored on canvas2d. |
 | `upColor` | string | `#089981` (green) | Bullish candle color (native renderer). |
 | `downColor` | string | `#f23645` (red) | Bearish candle color (native renderer). |
-| `priceStyle` | `'candles' \| 'bars' \| 'line' \| 'area' \| 'baseline'` | `'candles'` | How the base price series is drawn (native renderer). |
+| `priceStyle` | `PriceStyle` | `'candles'` | How the base price series is drawn: `candles`, `bars`, `line`, `area`, `baseline`, `heikinashi`, or a registered chart-type ID. |
 | `drawings` | `boolean \| { toolbar?, tools?, groups? }` | **toolbar shown** | Interactive [drawing tools](./drawing-tools.md). `true`/omitted ⇒ toolbar visible; `false` ⇒ toolbar hidden (the `chart.drawings` API still works headlessly); object customizes it (see below). Capability-gated (native renderer only). |
 | `settings` | `{ hidden?: string[] }` | **all visible** | Chart-settings dialog visibility policy: setting ids to hide — a whole tab, a group, or a single row (see below). |
 
@@ -198,7 +242,7 @@ new VelaWorkspace('#chart', {
       'status-line.indicator-values',        //     Values
       'advanced',                            // the whole Advanced tab
       'advanced.bars',                       //   Bars to fetch
-      'trading-session',                     // the RTH/ETH group in the Symbol tab
+      'trading-session',                     // the trading-session group in the Symbol tab
       'trading-session.session',             //   Session select
       'trading-session.premarket-color',     //   Pre-market shading color (day-split markets)
       'trading-session.postmarket-color',    //   Post-market shading color (day-split markets)
@@ -222,8 +266,9 @@ new VelaWorkspace('#chart', {
 });
 ```
 
-Conditional entries hide-and-stay-hidden: `trading-session` only appears on symbols
-that have sessions, `status-line` only when the shell's status line is on,
+Conditional entries hide-and-stay-hidden: `trading-session` appears when symbol
+metadata supplies the legacy session controls or an explicit catalog supplies at least
+two choices, `status-line` only when the shell's status line is on,
 `canvas.theme` only when the host wires the theme switch — hiding them is safe either
 way. Host sections contributed through `setSettingsSections` need nothing from the
 contributor: the `id` fields are optional stability aids, label slugs are the
@@ -231,7 +276,8 @@ fallback.
 
 ### Non-obvious defaults, called out
 
-- **Animations are on** by default (eased zoom, snappy inertial pan).
+- **Animations follow the system preference** by default. Omitted `animations` uses
+  full motion unless `prefers-reduced-motion` requests a static presentation.
 - **The current-price line is on** by default.
 - **The price scale is linear** by default (`logScale: false`).
 
@@ -270,7 +316,7 @@ A native-renderer styling combo: draw price as a glowing line on the GPU backend
 ```js
 new Vela('#chart', {
   data: bars,
-  priceStyle: 'line',                 // candles | bars | line | area | baseline
+  priceStyle: 'line',                 // built-ins include candles, bars, line, area, baseline, heikinashi
   nativeBackend: 'webgl2',            // force the GPU backend
   glow: 0.6,                          // neon bloom on line series (WebGL2 only)
   animations: { zoom: true, pan: false }, // eased zoom, no pan momentum

--- a/docs/user/renderer-features.md
+++ b/docs/user/renderer-features.md
@@ -16,9 +16,10 @@ A key the active renderer **doesn't support emits a console warning and is ignor
 chart is never touched. Use `supports()` to check first (e.g. to hide a UI control on a
 renderer that lacks the feature).
 
-These are the **same keys** you can pass at construction (as [options](./options.md));
-setting them through `chart.renderer.set` applies them **live** instead of rebuilding the
-chart — so toggling them never re-executes your indicators.
+Construction [options](./options.md) cover the common startup settings. Renderer-only
+features such as `candleVisible` are available through `chart.renderer`. Setting any
+supported feature there applies it **live** instead of rebuilding the chart, so toggling
+it never re-executes your indicators.
 
 ## Common features
 
@@ -41,13 +42,14 @@ Available on every renderer:
 | Feature | Type | Default | Notes |
 |---|---|---|---|
 | `glow` | number (0 – ~0.7) | `0` | Neon glow/bloom on line series. **WebGL2 only** — the canvas2d backend stores the value but draws no glow. |
-| `priceStyle` | `'candles' \| 'bars' \| 'line' \| 'area' \| 'baseline'` | `'candles'` | How the base price series is drawn. (Heikin Ashi is not yet available.) |
+| `priceStyle` | `'candles' \| 'bars' \| 'line' \| 'area' \| 'baseline' \| 'heikinashi'` | `'candles'` | How the base price series is drawn. Registered chart-type IDs are also accepted. |
 | `priceBaseline` | number \| `null` | `null` | Reference price for `priceStyle: 'baseline'`. `null` derives it from the config's `baseline.baselineLevel` (a percent of the visible pane range). |
 | `baselinePrice` | number (read-only) | — | The RESOLVED baseline reference price the paint splits on: `priceBaseline` when set, else the level% of the price pane's current range. For host chrome that colors by baseline position (e.g. a status line's value ink). Writes are ignored. |
+| `candleVisible` | boolean | `true` | Show or hide the whole base price series, regardless of whether its active style is candles, bars, line, area, or a plugin type. Stored as `series.visible` in the rich config, so shell state and templates restore it. Drawings, indicators, axes, and attribution remain visible. |
 | `candleZOrder` | number | `0` | Draw-order key of the price candles relative to overlay indicators. Indicators default to z ≥ 1, so candles sit behind all overlays by default. |
 | `seriesOrder` | `{ id, to: 'front' \| 'back' }` or `{ id, z }` | — | Reorder one indicator's series layer — move it to front/back, or set an explicit z key. |
 | `highlights` | `HighlightArea[]` | `[]` | Shaded vertical time bands (session highlighting, e.g. weekends or pre/regular/post), drawn behind grid + data. Malformed entries are dropped; bands are sorted by start time. |
-| `sessionZones` | `{ pre, post, extended }` \| `null` | `null` | Session time bands (`[start, end)` epoch-ms pairs per phase), shaded behind grid + data with the config's `sessions.premarketColor` / `sessions.postmarketColor` / `sessions.extendedColor`. Markets with a same-day pre/post split populate `pre`/`post`; markets whose extended session wraps midnight (an evening open rolling into the next day) populate the single `extended` phase instead. A host derives them from its market calendar (the widget does this automatically on markets with sessions); `null` means the market has no session structure. |
+| `sessionZones` | `{ pre, post, extended, bands? }` \| `null` | `null` | Session time bands behind grid + data. The three legacy arrays contain `[start, end)` epoch-ms pairs and use the config's pre/post/extended colors. `bands` contains `{ from, to, color }` entries for named sessions. The workspace derives both forms; `null` means no session structure. |
 | `tradeMarkers` | `{ visible?, labels?, qty?, colors? }` | everything on | Strategy trade markers (the order-fill arrows a strategy indicator emits via `IndicatorModel.trades`). Partial merge: `visible` hides the units, `labels` the order-id line, `qty` the signed-quantity line; `colors` overrides `{ long, short, exit }` (defaults `#2962ff` / `#f23645` / `#d500f9`). Malformed fields are dropped. |
 
 ### Interaction
@@ -63,6 +65,14 @@ Available on every renderer:
 | `paneResize` | boolean | `true` | Drag the separator between panes to resize them; double-clicking a separator restores the two adjacent panes to an even split. |
 | `keyboard` | boolean | `true` | Keyboard navigation/accessibility: focusable chart with arrow-key crosshair stepping (`Shift`+Arrow pans), `Alt`+`Shift`+`→` scrolls back to the latest bars at the current zoom, `+`/`-` zoom, Home/End jump, `0` **reset (fit content)**, Escape clear, plus ARIA labels and a live region. `Ctrl`/`Cmd` chords are left untouched for the host's own shortcuts (the widget's pan/zoom glides, the browser's `Ctrl`+`0`, …). When the latest bar is scrolled off-screen, a proximity-revealed `»` button in the bottom-right corner does the same. |
 | `historyChords` | boolean | `true` | The drawings layer answers `Ctrl`/`Cmd`+`Z` / `Y` itself (drawing undo/redo). A host that owns a **unified** history — drawings plus its own app actions in one timeline, like the widget — sets it to `false` so the chords bubble up to the host's keymap instead of being consumed in-chart. Copy/paste/duplicate/delete/nudge keys are unaffected. |
+
+When the `animations` option is omitted, Vela follows the live
+`prefers-reduced-motion` browser preference. Reduced mode snaps zoom, pan, live-bar,
+intro, shell-glide, status, and layer motion to a static result. The configured feature
+values above do not change, are not persisted differently, and take effect again on
+future interactions if the preference returns to full motion. Pass `animations: true`
+or an animation object to override the browser preference; pass `false` to force the
+reduced mode. Read the effective result from `chart.reducedMotion`.
 
 > **Double-click behavior changed.** Double-clicking the **chart data area** no longer fits the
 > content to the view. Instead it maximizes the double-clicked pane so it fills the chart and every
@@ -157,7 +167,7 @@ chart.renderer.applyConfig({ candles: { upColor: '#26a69a' } }); // partial patc
 The covered cosmetics include layout (background, text, font), grid colors/visibility,
 crosshair (color/width/style/opacity/label), price scale (mode, log, border, labels,
 current-price line, last-price animation on/off), time-scale timezone, candle border/wick, and per-style colors for
-bars / line / area / baseline.
+bars / line / area / baseline, plus whole-price-series visibility (`series.visible`).
 
 ## Custom renderers
 

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -21,8 +21,14 @@ const ws = new VelaWorkspace('#app', {
     // is its durable identity, DECLARATION ORDER fills the layout's slots:
     symbol: 'BTCUSDT',
     timeframe: '60',
+    session: 'regular',
+    sessions: [
+        { id: 'regular', label: 'Regular', windows: ['0930-1600'], color: 'rgba(41, 98, 255, 0.12)' },
+        { id: 'extended', label: 'Extended', windows: ['0400-2000'], color: 'rgba(156, 39, 176, 0.12)' },
+    ],
+    sessionTimezone: 'America/New_York',
     cells: {
-        btc: { symbol: 'BTCUSDT', timeframe: '60' }, // 1st declared → 1st slot
+        btc: { symbol: 'BTCUSDT', timeframe: '60', session: 'extended' }, // 1st declared → 1st slot
         eth: { symbol: 'ETHUSDT', timeframe: '15' }, // slots 3–4: no entry → pure defaults
     },
     providers: { binance: () => new BinanceProvider() }, // registered ONCE, shared by every cell
@@ -40,9 +46,15 @@ const ws = new VelaWorkspace('#app', {
 `persist`/`storage`) + the grid's own options (`layout`, `cells`, `sync`,
 `drawingToolbar`, `maxWebglCells`, `alertCap`). A chart option means the same thing
 everywhere: on the widget it configures *the* chart, here it is the *default* of each
-cell — `upColor`, `glow`, `logScale`, `animations`, `defaultLanguage`, even `renderer`
-all apply to every cell. An explicit `nativeBackend` (other than `'auto'`) wins over
-the `maxWebglCells` budget policy.
+cell — `upColor`, `glow`, `logScale`, `animations`, `session`, `sessions`,
+`sessionTimezone`, `defaultLanguage`, even `renderer` all apply to every cell. An
+explicit `nativeBackend` (other than `'auto'`) wins over the `maxWebglCells` budget
+policy.
+
+You can use any non-empty provider-facing `session` ID without a `sessions` catalog.
+Add a catalog when the workspace should validate the ID and show named session choices
+with host-defined windows and colors. Omitting it keeps metadata-derived choices while
+preserving a custom selected ID across cell state and layout pooling.
 
 The `drawings` option applies here too, mapped onto the SHARED drawing surface:
 `false` removes it entirely — no toolbar, no mobile drawings entry, no tool pill (the
@@ -228,10 +240,13 @@ const state = ws.getState();
 // → { version: 1, layout, trackSizes?, activeCellId?, sync?, timezone?, favorites?,
 //     timeframeFavorites?, charts: […], ext? }
 // One ORDERED `charts` entry per cell, live AND dormant — array position i restores
-// into slot i, `id` is the cell's durable name: { id: 'btc', symbol, provider?, timeframe,
+// into slot i, `id` is the cell's durable name:
+//   { id: 'btc', symbol, provider?, timeframe, session?,
 //   priceStyle, bars?, watermark?, indicatorTitles?, rendererConfig (renderer.getConfig() document),
 //   drawings (drawings.toJSON() document), indicators: { manifest: string[], natives: string[] },
 //   ext? (third-party per-chart state, by namespaced key) }
+// Only the selected session ID is state. Session catalogs and their market timezone
+// remain host options and are never serialized.
 // `ext` bags (document root and per chart) carry PLUGIN state — written and restored by
 // handlers plugins register (registerStatePersistence, see the plugin SDK); entries pass
 // through opaquely, so a document never loses them when the plugin isn't loaded.
@@ -311,11 +326,13 @@ are self-describing and always resolve.
 **Chart options** (every key of [the chart's options](./options.md) except `height`) sit
 at the top level and are each cell's **default** — `symbol` (bare = first declared
 provider; an `EXCHANGE:` prefix pins a venue), `timeframe`, `bars`, `priceStyle`,
-`data`, `visibleRange`, `theme`, `live`, `volume`, `upColor`, `downColor`, `glow`,
+`session`, `sessions`, `sessionTimezone`, `data`, `visibleRange`, `theme`, `live`,
+`volume`, `upColor`, `downColor`, `glow`,
 `animations`, `logScale`, `currentPriceLine`, `drawings` (toolbar excepted),
 `defaultLanguage`, `renderer`, `nativeBackend` (explicit value wins over the
 `maxWebglCells` policy). `cells` overrides the market/view seeds per cell:
-`{ symbol, timeframe, bars, priceStyle, data, visibleRange }`.
+`{ symbol, timeframe, bars, priceStyle, session, sessions, sessionTimezone, data,
+visibleRange }`.
 
 **Cell names are identities, not positions.** A `cells` key is free-form (`btc`, `main`,
 …): it names the cell durably — persistence, `sync` groups and `ws.cell(name)` all speak
@@ -386,9 +403,12 @@ The shell is keyboard-first (bindings act on the **active cell**):
 - `mod+↑/↓` glide-zoom, `mod+←/→` glide-pan with the exact feel and limits of a drag
   (toward now it rests on the newest candle plus the usual empty space). `alt+T` arms
   the trend line tool; `alt+H` / `alt+V` drop a horizontal / vertical line at the
-  cursor — the drawing toolbar's menus show these chords beside the tools.
+  cursor — the drawing toolbar's menus show these chords beside the tools. When
+  reduced motion is active, the glide shortcuts land at their final viewport immediately.
 - Mouse: `Shift`+scroll pans through history instead of zooming, `Shift`+click starts
   the measure ruler at the cursor, and middle-click deletes the drawing under it.
+  Ctrl/Cmd-drag from empty plot space replaces the drawing selection with every
+  drawing the box touches; add Shift to union them with the current selection.
 - Drawing keys (undo/redo, copy/paste, delete, nudge) come from the core — see
   [Drawing tools](./drawing-tools.md).
 
@@ -421,7 +441,8 @@ they work from the very first keystroke, before any click.
   Right-clicking it opens an action menu with a
   toggle per element (logo, name, market status, OHLC, bar change — the same toggles
   as the settings dialog's Status line tab; hiding the name also hides the
-  venue/timeframe beside it) plus hide/show for the chart's price series. In
+  venue/timeframe beside it) plus hide/show for the chart's price series. The
+  price-series eye state survives workspace state and persisted reloads. In
   multi-cell grids it stays on one row — segments that don't fit the cell hide instead
   of wrapping (bar change first, then venue/timeframe, then the market badge; the logo
   + ticker always stay).
@@ -451,7 +472,10 @@ they work from the very first keystroke, before any click.
   right edge instead of shrinking the chart, and a pin in its header docks it as a column
   whenever you prefer that. Which panel is open, the widths you dragged and the panels you
   pinned are part of the saved state.
-- **Bottom bar** — range chips, a live clock, and the timezone picker. Each chip switches
+- **Bottom bar** — range chips, a live clock, and the timezone picker. An ordered
+  trading-session selector appears when the active cell has at least two choices;
+  selecting one reloads that chart with the exact provider-facing ID and persists the
+  selected ID. Each range chip switches
   the active chart's timeframe, **fetches the depth its window needs**, and frames it:
   `1D`→1m, `7D`→5m, `1M`→30m, `3M`→1h, `6M`→4h, `YTD`/`1Y`→1D, `5Y`/`ALL`→1W. Changing
   the timeframe by hand leaves range mode (the chip clears and the fetch depth returns

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@zag-js/vanilla": "^1.42.0"
       },
       "devDependencies": {
+        "@playwright/test": "1.63.0",
         "eslint": "^9.0.0",
         "tsup": "^8.0.0",
         "typescript": "~5.9.3",
@@ -828,6 +829,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3442,6 +3459,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -73,9 +73,11 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint .",
-    "playground": "vite"
+    "playground": "vite",
+    "test:browser": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "1.63.0",
     "eslint": "^9.0.0",
     "tsup": "^8.0.0",
     "typescript": "~5.9.3",

--- a/playground/browser-fixture.html
+++ b/playground/browser-fixture.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="data:,">
+    <title>Vela browser regression fixture</title>
+    <style>
+        html, body { margin: 0; width: 100%; height: 100%; }
+        #chart { position: absolute; inset: 0; }
+    </style>
+</head>
+<body>
+    <div id="chart"></div>
+    <script type="module" src="./browser-fixture.ts"></script>
+</body>
+</html>

--- a/playground/browser-fixture.ts
+++ b/playground/browser-fixture.ts
@@ -1,0 +1,129 @@
+import { NativeRenderer, type OHLCV } from '../src';
+import { VelaWorkspace } from '../src/workspace';
+import type { DataProvider } from '../src/plugin';
+import { DemoEngine } from './demo-engine';
+import { countColor } from '../test/browser/pixels';
+
+const hour = 3_600_000;
+const first = Date.UTC(2026, 0, 5);
+const bars: OHLCV[] = Array.from({ length: 120 }, (_, index) => {
+    const open = 100 + index * 0.08 + Math.sin(index / 5) * 3;
+    const close = open + (index % 2 ? 1 : -1);
+    return { time: first + index * hour, open, close, high: Math.max(open, close) + 1, low: Math.min(open, close) - 1, volume: 1000 + index };
+});
+const calls: { method: string; session?: string }[] = [];
+let subscribers = 0;
+const provider: DataProvider = {
+    async getBars(_ticker, _timeframe, range) {
+        calls.push({ method: 'history', session: range.session });
+        const result = bars.filter(bar => (range.from === undefined || bar.time >= range.from) && (range.to === undefined || bar.time <= range.to));
+        return (range.limit === undefined ? result : result.slice(-range.limit)).map(bar => ({ ...bar }));
+    },
+    async listSymbols() { return [{ ticker: 'TEST', description: 'Browser fixture' }]; },
+    async getSymbolInfo(ticker) { return { ticker, timezone: 'Etc/UTC' }; },
+    async getCalendar(_ticker, range) {
+        calls.push({ method: 'calendar', session: range.session });
+        return [[first, first + 365 * 24 * hour]];
+    },
+    subscribe(_ticker, _timeframe, _onBar, options) {
+        calls.push({ method: 'subscribe', session: options?.session });
+        subscribers++;
+        return () => { subscribers--; };
+    },
+};
+
+let renderer: NativeRenderer;
+class FixtureRenderer extends NativeRenderer {
+    constructor(...args: ConstructorParameters<typeof NativeRenderer>) {
+        super(...args);
+        renderer = this;
+    }
+}
+
+const options = new URLSearchParams(location.search);
+const ws = new VelaWorkspace('#chart', {
+    layout: false,
+    symbol: 'fixture:TEST',
+    timeframe: '60',
+    bars: bars.length,
+    visibleRange: 'ALL',
+    live: true,
+    nativeBackend: 'canvas2d',
+    renderer: FixtureRenderer,
+    volume: false,
+    watermark: false,
+    drawingToolbar: false,
+    drawings: { toolbar: false },
+    persist: 'vela-browser-fixture',
+    providers: { fixture: () => provider },
+    engines: { demo: () => new DemoEngine() },
+    indicators: [{ name: 'Golden average', enabled: true, language: 'demo', script: 'title Golden average\noverlay true\ninput length = 3\nplot sma(close, length) "Average" #f7c948 width=2' }],
+    sessions: [
+        { id: 'Morning-A', label: 'Morning', windows: ['0000-1200'], color: 'rgba(230,80,20,0.2)' },
+        { id: 'Afternoon-B', label: 'Afternoon', windows: ['1200-2400'], color: 'rgba(20,180,90,0.2)' },
+        { id: 'Night-X', label: 'Night', windows: ['2200-0200'], color: 'rgba(40,120,255,0.2)' },
+    ],
+    session: 'Morning-A',
+    sessionTimezone: 'Etc/UTC',
+    ...(options.get('animations') === 'true' ? { animations: true } : {}),
+});
+
+// Read-only probes of native surfaces complement public state assertions. No layout or
+// input implementation is patched: Chromium exercises the renderer exactly as mounted.
+function surface() {
+    return renderer as unknown as {
+        dataCanvas: HTMLCanvasElement;
+        drawingsCanvas: HTMLCanvasElement;
+        chromeCanvas: HTMLCanvasElement;
+        backdropCanvas: HTMLCanvasElement;
+        userDrawings: { selectedIds: Set<string>; interaction: { marqueeRect(): { x: number; y: number; w: number; h: number } | null } };
+    };
+}
+function pixels(canvas: HTMLCanvasElement) {
+    return canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height).data;
+}
+function ink(canvas: HTMLCanvasElement) {
+    return pixels(canvas).filter((value, index) => index % 4 === 3 && value > 0).length;
+}
+const fixture = {
+    ws,
+    calls,
+    ready: false,
+    get subscribers() { return subscribers; },
+    get selected() { return [...surface().userDrawings.selectedIds]; },
+    get marquee() { return surface().userDrawings.interaction.marqueeRect(); },
+    viewport() { return renderer.getVisibleRange(); },
+    marqueeInk() {
+        const rect = surface().userDrawings.interaction.marqueeRect();
+        if (!rect) return 0;
+        const canvas = surface().drawingsCanvas;
+        const dpr = canvas.width / canvas.getBoundingClientRect().width;
+        const image = canvas.getContext('2d')!.getImageData((rect.x + 4) * dpr, (rect.y + 4) * dpr, Math.min(rect.w - 8, 120) * dpr, 4 * dpr).data;
+        return image.filter((value, index) => index % 4 === 3 && value > 0).length;
+    },
+    plot() { return surface().dataCanvas.getBoundingClientRect().toJSON() as { x: number; y: number; width: number; height: number }; },
+    paint() {
+        const data = pixels(surface().dataCanvas);
+        return {
+            bullish: countColor(data, [8, 153, 129]),
+            bearish: countColor(data, [242, 54, 69]),
+            indicator: countColor(data, [247, 201, 72]),
+            drawings: countColor(pixels(surface().drawingsCanvas), [255, 122, 0]),
+            chrome: ink(surface().chromeCanvas),
+            session: countColor(pixels(surface().backdropCanvas), [40, 120, 255]),
+        };
+    },
+    addDrawing() {
+        return ws.chart.drawings.add('box', {
+            anchors: [{ time: bars[70]!.time, price: 108 }, { time: bars[90]!.time, price: 103 }],
+            zIndex: 10,
+            style: { lineColor: '#ff7a00', lineWidth: 4, fillColor: 'rgba(255,122,0,0.55)' },
+        })!.id;
+    },
+    destroy() { ws.destroy(); },
+};
+
+declare global { interface Window { fixture: typeof fixture } }
+window.fixture = fixture;
+await ws.chart.ready();
+fixture.ready = true;

--- a/playground/demo-engine.ts
+++ b/playground/demo-engine.ts
@@ -398,7 +398,6 @@ export class DemoEngine implements ScriptingEngine {
                     meta: { title: program.title, overlay: program.overlay },
                     plots: Object.fromEntries(series.map((s) => [s.title, s.points.map((p) => ({ time: p.time, value: p.value }))])),
                     variables: { ...values },
-                    result: null,
                     warnings: [],
                 };
                 handlers.onModel(model);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './test/browser',
+    testMatch: '**/*.spec.ts',
+    fullyParallel: true,
+    workers: 1,
+    forbidOnly: true,
+    retries: 0,
+    timeout: 30_000,
+    expect: { timeout: 8_000 },
+    reporter: [['list'], ['html', { open: 'never' }]],
+    use: {
+        browserName: 'chromium',
+        baseURL: 'http://127.0.0.1:5191',
+        viewport: { width: 1280, height: 800 },
+        reducedMotion: 'reduce',
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+    },
+    webServer: {
+        command: 'npm run playground -- --host 127.0.0.1 --port 5191',
+        url: 'http://127.0.0.1:5191/browser-fixture.html',
+        reuseExistingServer: false,
+    },
+});

--- a/src/Vela.ts
+++ b/src/Vela.ts
@@ -2,8 +2,8 @@ import type { IChartRenderer, VisibleRange } from './core/ports/IChartRenderer';
 import type { ScriptingEngine } from './core/ports/ScriptingEngine';
 import type { MarketDataFeed } from './core/ports/MarketDataFeed';
 import type { VisibleRangePreset } from './core/visible-range';
-import type { VelaOptions, VelaTheme, ThemeName, MarketSwitch, MarketSnapshot, AddIndicatorOptions } from './core/options';
-import { resolveAnimations } from './core/options';
+import type { VelaOptions, VelaTheme, ThemeName, MarketSwitch, MarketSnapshot, AddIndicatorOptions, MarketSessionDefinition } from './core/options';
+import { normalizeSession, normalizeSessionDefinitions, resolveAnimations, resolveMarketSession, resolveMotionPolicy } from './core/options';
 import type { InputValue } from './core/model/inputs';
 import type { IndicatorHandle } from './core/IndicatorHandle';
 import type { EngineContextSnapshot } from './core/ports/ScriptingEngine';
@@ -25,6 +25,7 @@ import { registerBuiltinChartTypes } from './chart-types/builtins';
 import { registerVolume } from './core/native-indicators/volume';
 import { registerVpvr } from './core/native-indicators/vpvr';
 import { registerClassicIndicators } from './core/native-indicators/classics';
+import { MotionPreferenceController, type MotionPreferenceSource } from './renderers/shared/motion';
 
 /** Outcome of {@link Vela.runIndicator}: success carries the live handle, failure the error. */
 export interface RunIndicatorResult {
@@ -37,7 +38,7 @@ export interface RunIndicatorResult {
     context: EngineContextSnapshot | null;
 }
 
-/** Optional dependency overrides — inject a different renderer, engines, or data feed (tests, swaps). */
+/** Optional dependency overrides for renderer, engines, data, and motion preference. */
 export interface VelaDeps {
     renderer?: IChartRenderer;
     /** Scripting engines to register at construction (bulk form of `registerEngine`); default none. */
@@ -45,15 +46,19 @@ export interface VelaDeps {
     /** Market-data source; default `new MultiProviderFeed()` (a provider registry; offline `data` needs no provider).
      *  A custom feed injected here is used bare — `chart.data` registration is then a no-op. */
     dataFeed?: MarketDataFeed;
+    /** Shared browser preference observer. The workspace supplies one so every cell
+     * follows the same media query without installing one listener per chart. Vela
+     * unsubscribes on destroy but leaves an injected source under its owner's control. */
+    motionPreference?: MotionPreferenceSource;
 }
 
 /**
  * The public, imperative chart. Composition root: wires the built-in native
- * renderer (the default) + provider data feed and delegates orchestration.
- * Optional renderers (e.g. lightweight-charts) are passed in as a class via
- * `options.renderer` and instantiated here, so this module imports only the
- * built-in native renderer. Scripting engines are opt-in — register one with
- * `registerEngine` (no engine ⇒ candles only).
+ * renderer (the default) + provider data feed and delegates orchestration. Pass a
+ * custom renderer as a class through `options.renderer`, or as a constructed instance
+ * through `deps.renderer`; this module imports only the built-in implementation.
+ * Scripting engines are opt-in — register one with `registerEngine` (no engine ⇒
+ * candles only).
  */
 export class Vela {
     private readonly orchestrator: EngineOrchestrator;
@@ -61,6 +66,14 @@ export class Vela {
     private readonly panesControl: PanesControl;
     private readonly dataControl: DataControl;
     private readonly drawingsControl: DrawingsControl;
+    private readonly motionHost: HTMLElement;
+    private readonly ownedMotionPreference: MotionPreferenceController | null;
+    private readonly motionPreference: MotionPreferenceSource;
+    private readonly rendererForMotion: IChartRenderer;
+    /** Normalized host catalog; `undefined` keeps the open provider-facing legacy API. */
+    private readonly sessionDefinitions: readonly MarketSessionDefinition[] | undefined;
+    private motionUnsub: (() => void) | null = null;
+    private motionReducedState = false;
 
     constructor(container: HTMLElement | string, options: VelaOptions = {}, deps: VelaDeps = {}) {
         registerBuiltinChartTypes(); // built-in chart types through the public SDK registry (idempotent)
@@ -69,6 +82,7 @@ export class Vela {
         registerClassicIndicators();
         const element = resolveElement(container);
         const theme = resolveTheme(options.theme);
+        this.motionHost = element;
         const display = {
             currentPriceLine: options.currentPriceLine ?? true,
             logScale: options.logScale ?? false,
@@ -87,18 +101,27 @@ export class Vela {
             );
         }
         const renderer = deps.renderer ?? new RendererClass(display);
+        this.ownedMotionPreference = deps.motionPreference ? null : new MotionPreferenceController(element, options.animations === undefined);
+        this.motionPreference = deps.motionPreference ?? this.ownedMotionPreference!;
+        this.rendererForMotion = renderer;
+        this.applyMotionPolicy(options.animations, this.motionPreference.reduced);
+        if (options.animations === undefined) {
+            this.motionUnsub = this.motionPreference.onChange((reduced) => this.applyMotionPolicy(options.animations, reduced));
+        }
         const engines = deps.engines ?? [];
         // Default: a multi-provider registry feed (caches closed bars internally). No
         // provider is bundled — register one with `chart.data.registerProvider(...)`;
         // until then a symbol-backed chart parks its initial load. Inject
         // `deps.dataFeed` to source candles from your own feed (used bare, no registry).
         const feed = deps.dataFeed ?? new MultiProviderFeed();
+        this.sessionDefinitions = options.sessions === undefined ? undefined : normalizeSessionDefinitions(options.sessions);
+        const session = this.sessionDefinitions === undefined ? normalizeSession(options.session) : resolveMarketSession(options.session, this.sessionDefinitions);
         const config: ResolvedConfig = {
             market: {
                 symbol: options.symbol,
                 timeframe: options.timeframe,
                 bars: options.bars,
-                session: options.session,
+                session,
                 visibleRange: options.visibleRange,
                 data: options.data,
             },
@@ -275,16 +298,21 @@ export class Vela {
     }
 
     /**
-     * Switch the chart's market IN PLACE — symbol, provider, timeframe, depth, or offline
-     * data — WITHOUT destroying the chart: indicators re-execute over the new bars, native
-     * indicators restart, and panes, user drawings, renderer config and event
+     * Switch the chart's market IN PLACE — symbol, timeframe, session, depth, or offline
+     * data — WITHOUT destroying the chart: indicators re-execute over the new bars,
+     * native indicators restart, and panes, user drawings, renderer config and event
      * subscriptions all survive. Resolves once the new market's history is painted (a
      * deep backfill continues behind it — await {@link historyComplete}); a call
      * superseded by a newer `setMarket` resolves silently. Emits `market:changed`
-     * (with the previous identity) when the market identity changed.
+     * (with the previous identity, including its session) when the identity changed.
      */
     setMarket(next: MarketSwitch): Promise<void> {
-        return this.orchestrator.setMarket(next);
+        if (next.session === undefined) return this.orchestrator.setMarket(next);
+        const { session: candidate, ...rest } = next;
+        const session = this.sessionDefinitions === undefined
+            ? normalizeSession(candidate)
+            : resolveMarketSession(candidate, this.sessionDefinitions);
+        return this.orchestrator.setMarket(session === undefined ? rest : { ...rest, session });
     }
 
     /** The current market identity — the read counterpart of {@link setMarket}. A snapshot
@@ -329,6 +357,12 @@ export class Vela {
      */
     get renderer(): RendererControl {
         return this.rendererControl;
+    }
+
+    /** Whether the chart currently resolves presentation motion to its reduced mode.
+     * Runtime environment state is intentionally absent from serialized chart state. */
+    get reducedMotion(): boolean {
+        return this.motionReducedState;
     }
 
     /**
@@ -421,7 +455,18 @@ export class Vela {
     }
 
     destroy(): void {
+        this.motionUnsub?.();
+        this.motionUnsub = null;
+        this.ownedMotionPreference?.destroy();
         this.orchestrator.destroy();
+        this.motionHost.removeAttribute?.('data-vela-motion');
+    }
+
+    private applyMotionPolicy(animations: VelaOptions['animations'], systemReduced: boolean): void {
+        const policy = resolveMotionPolicy(animations, systemReduced);
+        this.motionReducedState = policy.reduced;
+        if (this.motionHost.dataset) this.motionHost.dataset.velaMotion = policy.reduced ? 'reduced' : 'full';
+        this.rendererForMotion.applyMotionPolicy?.(policy);
     }
 }
 

--- a/src/chart-types/registry.ts
+++ b/src/chart-types/registry.ts
@@ -20,9 +20,9 @@ export interface SeriesDataEngineHost {
     timeframe: string;
     /** Whether the chart runs live (streaming forming bar) or static history. */
     live: boolean;
-    /** The chart's trading session (`'regular'` | `'extended'`); undefined = regular /
-     *  no session model. A session switch reloads the market and REBUILDS the engine,
-     *  so this never changes within one host's lifetime. */
+    /** The chart's case-sensitive, provider-facing trading-session ID; undefined means
+     *  the provider default or no session model. A session switch reloads the market and
+     *  REBUILDS the engine, so this never changes within one host's lifetime. */
     session?: string;
     /** The chart's CURRENT view bars (post-transform) — read fresh, never cache. */
     bars: () => readonly OHLCV[];

--- a/src/core/RendererControl.ts
+++ b/src/core/RendererControl.ts
@@ -12,7 +12,7 @@ import type { SymbolPickerFn } from './model/inputs';
 export class RendererControl {
     constructor(private readonly renderer: IChartRenderer) {}
 
-    /** The active renderer's identity, e.g. `'native'` or `'lwc'`. */
+    /** The active renderer's identity, e.g. `'native'` or `'my-renderer'`. */
     get name(): string {
         return this.renderer.name;
     }

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -380,7 +380,12 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         this.loadingUp = true;
         this.renderer.setLoading?.(true);
         const m = this.config.market;
-        this.events.emit('load:start', { symbol: m.symbol ?? 'TEST', timeframe: m.timeframe ?? '60', firstLoad });
+        this.events.emit('load:start', {
+            symbol: m.symbol ?? 'TEST',
+            timeframe: m.timeframe ?? '60',
+            ...(m.session !== undefined ? { session: m.session } : {}),
+            firstLoad,
+        });
     }
 
     /** Leave the loading state (first bars painted, or a load that ended with none) —
@@ -390,7 +395,12 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         this.loadingUp = false;
         this.renderer.setLoading?.(false);
         const m = this.config.market;
-        this.events.emit('load:end', { symbol: m.symbol ?? 'TEST', timeframe: m.timeframe ?? '60', bars: this.bars.length });
+        this.events.emit('load:end', {
+            symbol: m.symbol ?? 'TEST',
+            timeframe: m.timeframe ?? '60',
+            ...(m.session !== undefined ? { session: m.session } : {}),
+            bars: this.bars.length,
+        });
     }
 
     /**
@@ -629,7 +639,11 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             else if (next.visibleRange) this.renderer.setVisibleRange(next.visibleRange);
             return;
         }
-        const prev = { symbol: m.symbol ?? 'TEST', timeframe: m.timeframe ?? '60' };
+        const prev = {
+            symbol: m.symbol ?? 'TEST',
+            timeframe: m.timeframe ?? '60',
+            ...(m.session !== undefined ? { session: m.session } : {}),
+        };
         // A SESSION-ONLY flip (RTH↔ETH) changes WHICH bars exist but not the time axis:
         // the user's zoom/position carries over to the reload — captured here, before the
         // quiesce below discards it — unless the caller framed a window of its own. Any
@@ -748,7 +762,12 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         }
         this.startLive(); // stopped above on every path, depth-only included
         if (identityChanged) {
-            this.events.emit('market:changed', { symbol: m.symbol ?? 'TEST', timeframe: m.timeframe ?? '60', prev });
+            this.events.emit('market:changed', {
+                symbol: m.symbol ?? 'TEST',
+                timeframe: m.timeframe ?? '60',
+                ...(m.session !== undefined ? { session: m.session } : {}),
+                prev,
+            });
         }
     }
 

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -2,7 +2,7 @@ import type { EngineAlert, EngineWarning } from "../ports/ScriptingEngine";
 import type { ScriptRun } from "../script-run";
 import type { OHLCV } from "../model/ohlcv";
 import type { DrawingTypeKey, SerializedDrawing } from "../drawings/Drawing";
-import type { VelaTheme } from "../options";
+import type { MarketSession, VelaTheme } from "../options";
 import type { SnapMode } from "../drawings/geometry";
 import type { DrawingMode } from "../drawings/port";
 
@@ -11,7 +11,7 @@ export interface VelaEventMap extends Record<string, unknown> {
   ready: undefined;
   /**
    * The chart's market switched IN PLACE via `setMarket` — symbol, provider, timeframe,
-   * or offline data changed (a depth-only reload does not fire). Fires after the new
+   * session, or offline data changed (a depth-only reload does not fire). Fires after the new
    * market's history is painted and every consumer restarted. `prev` carries the
    * previous identity so hosts can re-key per-symbol state (e.g. swap user-drawing
    * documents between symbols).
@@ -19,24 +19,25 @@ export interface VelaEventMap extends Record<string, unknown> {
   "market:changed": {
     symbol: string;
     timeframe: string;
-    prev: { symbol: string; timeframe: string };
+    session?: MarketSession;
+    prev: { symbol: string; timeframe: string; session?: MarketSession };
   };
   /**
    * A bar load began with nothing painted: the FIRST load (fires during construction —
    * subscribers attached later see only its `load:end`), or an identity switch
-   * (symbol/provider/timeframe), which blanks the old series in the same breath. Fires
+   * (symbol/provider/timeframe/session), which blanks the old series in the same breath. Fires
    * before the first fetch — plugins, extensions and custom indicators hide or reset
    * their own visuals here. Exactly one `load:end` follows. A depth-only reload
    * (`bars`) keeps the chart painted and fires neither.
    */
-  "load:start": { symbol: string; timeframe: string; firstLoad: boolean };
+  "load:start": { symbol: string; timeframe: string; session?: MarketSession; firstLoad: boolean };
   /**
    * The load ended: its first bars painted (`bars` > 0 — on deep histories the quick
    * preview, before the full depth), or it ended with none (`bars` = 0 — a failed
    * fetch, an empty market, or a parked symbol nothing serves). Counterpart of
    * `load:start`; plugins restore or rebuild their visuals here.
    */
-  "load:end": { symbol: string; timeframe: string; bars: number };
+  "load:end": { symbol: string; timeframe: string; session?: MarketSession; bars: number };
   "indicator:added": { id: string };
   "indicator:removed": { id: string };
   /** An indicator's stored input/prop VALUES changed (settings dialog, `setInputs`) — what state persistence listens to. */

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -39,9 +39,9 @@ export interface NativeIndicatorContext {
     readonly symbol: string;
     readonly timeframe: string;
     readonly live: boolean;
-    /** The chart's trading session (`'regular'` | `'extended'`); undefined = regular /
-     *  no session model. A session switch reloads the market and RESTARTS the
-     *  indicator, so this never changes within one context's lifetime. */
+    /** The chart's case-sensitive, provider-facing trading-session ID; undefined means
+     *  the provider default or no session model. A session switch reloads the market and
+     *  RESTARTS the indicator, so this never changes within one context's lifetime. */
     readonly session?: string;
     /** The canonical bar array (a live accessor — always current). */
     bars(): readonly OHLCV[];

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -9,15 +9,78 @@ import type { DrawingsOption } from './drawings/toolbar';
 export type ProviderName = string;
 
 /**
- * Which trading session the chart shows, on markets that have one: `regular` = RTH
- * (09:30–16:00 for US equities), `extended` = ETH (pre/post-market included). The
- * provider owns the actual filtering — the flag rides every data request. Meaningless
- * (and ignored end-to-end) on continuous markets like crypto.
+ * Which trading session the chart shows. The two built-in metadata-derived IDs remain
+ * literal union members for editor completion, while providers may accept any non-empty
+ * ID without a catalog. An explicit catalog adds validation and presentation metadata.
+ * The provider owns the actual bar filtering. History and live paths receive the ID
+ * unchanged; a metadata-derived market-status badge may additionally request the
+ * conventional `regular` and `extended` calendars.
  */
-export type MarketSession = 'regular' | 'extended';
+export type MarketSession = 'regular' | 'extended' | (string & Record<never, never>);
 
-/** Narrow an untrusted string (persisted document, URL param) to a {@link MarketSession}. */
-export const normalizeSession = (v: unknown): MarketSession | undefined => (v === 'regular' || v === 'extended' ? v : undefined);
+/** One host-declared market session. Windows use `HHMM-HHMM`, recur each civil day in
+ * market time, and may wrap midnight; several windows represent split sessions such as
+ * a lunch break. */
+export interface MarketSessionDefinition {
+    id: MarketSession;
+    label: string;
+    windows: readonly string[];
+    /** Any non-empty canvas-compatible CSS color literal. Use alpha for translucent shading. */
+    color: string;
+}
+
+/** Normalize an untrusted provider/persisted session ID without changing its case. */
+export const normalizeSession = (v: unknown): MarketSession | undefined => {
+    if (typeof v !== 'string') return undefined;
+    const id = v.trim();
+    return id.length > 0 ? (id as MarketSession) : undefined;
+};
+
+/** Whether a string is one valid `HHMM-HHMM` session window. `2400` is accepted only
+ * as the end boundary; equal edges are empty and therefore invalid. */
+function validSessionWindow(v: unknown): v is string {
+    if (typeof v !== 'string') return false;
+    const m = /^(\d{2})(\d{2})-(\d{2})(\d{2})$/.exec(v);
+    if (!m) return false;
+    const sh = Number(m[1]);
+    const sm = Number(m[2]);
+    const eh = Number(m[3]);
+    const em = Number(m[4]);
+    if (sh > 23 || sm > 59 || eh > 24 || em > 59 || (eh === 24 && em !== 0)) return false;
+    return sh !== eh || sm !== em;
+}
+
+/**
+ * Validate and defensively copy a host session catalog. Invalid definitions are
+ * dropped whole, declaration/window order is preserved, and the first valid duplicate
+ * ID wins. This function deliberately validates colors as non-empty strings, matching
+ * renderer config: syntax is consumed by the renderer in its browser context.
+ */
+export function normalizeSessionDefinitions(value: unknown): readonly MarketSessionDefinition[] {
+    if (!Array.isArray(value)) return [];
+    const seen = new Set<string>();
+    const out: MarketSessionDefinition[] = [];
+    for (const raw of value) {
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+        const r = raw as { id?: unknown; label?: unknown; windows?: unknown; color?: unknown };
+        const id = normalizeSession(r.id);
+        const label = typeof r.label === 'string' ? r.label.trim() : '';
+        const color = typeof r.color === 'string' ? r.color.trim() : '';
+        if (!id || !label || !color || !Array.isArray(r.windows) || r.windows.length === 0 || !r.windows.every(validSessionWindow)) continue;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        out.push({ id, label, windows: [...r.windows], color });
+    }
+    return out;
+}
+
+/** Resolve a candidate against an explicit catalog; an absent/unknown ID falls back to
+ * the first valid definition. An empty catalog deliberately resolves to no session. */
+export function resolveMarketSession(candidate: unknown, definitions: readonly MarketSessionDefinition[]): MarketSession | undefined {
+    const id = normalizeSession(candidate);
+    if (id && definitions.some((definition) => definition.id === id)) return id;
+    return definitions[0]?.id;
+}
 
 /** How the chart obtains its candles. */
 export interface MarketConfig {
@@ -27,8 +90,8 @@ export interface MarketConfig {
     symbol?: string;
     timeframe?: string;
     bars?: number;
-    /** Trading session to show ({@link MarketSession}). Absent = the provider's default
-     *  (`regular` on session markets); continuous markets ignore it entirely. */
+    /** Trading session to show ({@link MarketSession}). Absent asks the provider for its
+     * default (`regular` on legacy session markets); continuous markets ignore it. */
     session?: MarketSession;
     /**
      * The window to frame on the FIRST paint — a preset name (`'1D'`, `'YTD'`, …) or an
@@ -45,8 +108,8 @@ export interface MarketConfig {
 /**
  * One in-place market switch — the argument of `chart.setMarket(next)`. Only the fields
  * given change; the rest of the market keeps its current value. `data` switches to
- * offline bars (and giving `symbol`/`provider` WITHOUT `data` drops a previous offline
- * dataset — back to the provider path). `visibleRange` frames the FIRST paint of the
+ * offline bars (and giving `symbol` WITHOUT `data` drops a previous offline dataset —
+ * back to the provider path). `visibleRange` frames the FIRST paint of the
  * new market (a range chip switching timeframe + depth + window in one call).
  */
 export interface MarketSwitch {
@@ -54,7 +117,7 @@ export interface MarketSwitch {
     symbol?: string;
     timeframe?: string;
     bars?: number;
-    /** Switch the shown trading session (reloads like a timeframe change). */
+    /** Switch to an exact provider-facing trading-session ID (reloads like a timeframe change). */
     session?: MarketSession;
     data?: OHLCV[];
     visibleRange?: VisibleRangePreset | VisibleRange;
@@ -74,7 +137,7 @@ export interface MarketSnapshot {
     provider?: ProviderName;
     timeframe?: string;
     bars?: number;
-    /** The shown trading session — undefined = the provider's default (regular). */
+    /** The shown trading session — undefined = the provider default or no session. */
     session?: MarketSession;
     offline: boolean;
 }
@@ -91,19 +154,26 @@ export interface VelaTheme {
 
 export type ThemeName = 'dark' | 'light';
 
-/** A renderer **class** — Vela instantiates it with the resolved display options.
- *  Built-in default: `NativeRenderer`.
- *  from `'vela/renderers/lwc'` and pass it as `options.renderer`. */
+/** A renderer class — Vela instantiates it with the resolved display options.
+ * Built-in default: `NativeRenderer`; hosts may pass any conforming implementation. */
 export type RendererConstructor = new (opts?: RendererDisplayOptions) => IChartRenderer;
 
 export interface VelaOptions extends MarketConfig {
+    /** Explicit session catalog. A bare chart uses the IDs to validate and resolve the
+     * provider-facing session; a shell also projects labels, windows, and colors into its
+     * UI. `undefined` lets a shell derive legacy regular/extended choices from symbol
+     * metadata; `[]` disables session UI. Host configuration, never chart state. */
+    sessions?: readonly MarketSessionDefinition[];
+    /** IANA market timezone a shell uses to expand explicit session windows. Falls back
+     * to symbol metadata, then `Etc/UTC`; independent from its display timezone. An
+     * invalid explicit zone produces no shading. */
+    sessionTimezone?: string;
     /** false = static history; true = history + live forming candle. */
     live?: boolean;
     theme?: ThemeName | VelaTheme;
     height?: number | string;
-    /** Rendering backend as a renderer **class** that Vela instantiates (with the
-     *  resolved display options). Omit for the built-in native renderer (default); for
-     **/
+    /** Rendering backend as a renderer class that Vela instantiates with the resolved
+     * display options. Omit it for the built-in native renderer. */
     renderer?: RendererConstructor;
     /** Scripting language used when `addIndicator` doesn't specify one. Default `'pine'`
      *  (or the first injected engine's language). */
@@ -115,11 +185,13 @@ export interface VelaOptions extends MarketConfig {
     /** Native geometry backend: `'auto'` (WebGL2 if available, else canvas2d),
      *  or force `'canvas2d'` / `'webgl2'`. Native renderer only. */
     nativeBackend?: NativeBackend;
-    /** Native-renderer animations. `true`/`false` toggles all; an object configures
-     *  each independently. Default: eased **zoom on**, inertial **pan on but snappy**
-     *  (short glide), live-bar glide **off**. Set `{ pan: false }` for an instant pan
-     *  with no momentum, `{ liveBar: true }` (or a duration in ms) to make the forming
-     *  candle slide toward each live tick instead of snapping. */
+    /** Native-renderer animations. When omitted, Vela follows
+     *  `prefers-reduced-motion`; `false` always reduces motion, while `true` and any
+     *  object are explicit full-motion host policies. An object configures each path
+     *  independently. Full-motion defaults: eased **zoom on**, inertial **pan on but
+     *  snappy** (short glide), live-bar glide **off**. Set `{ pan: false }` for an
+     *  instant pan with no momentum, `{ liveBar: true }` (or a duration in ms) to make
+     *  the forming candle slide toward each live tick instead of snapping. */
     animations?: boolean | AnimationConfig;
     /** Neon glow/bloom intensity for line series (0 = off, ~0.6 = strong). WebGL2 only
      *  — the canvas2d backend ignores it. Default 0. */
@@ -171,6 +243,17 @@ export interface AnimationConfig {
     liveBar?: boolean | number;
 }
 
+/** Effective presentation-motion policy after combining host configuration with the
+ * browser preference. `animations` values remain the configured source of truth; this
+ * runtime result is never persisted. */
+export interface ResolvedMotionPolicy {
+    reduced: boolean;
+    animZoom: boolean;
+    animPan: boolean;
+    animLiveBar: number;
+    intro: boolean;
+}
+
 /** Time-constant (ms) of the live-bar glide when `animations.liveBar` is `true`. */
 export const LIVE_BAR_EASE_DEFAULT_MS = 90;
 /** Upper bound (ms) for `animations.liveBar` — past this the candle visibly lags the feed. */
@@ -192,6 +275,20 @@ export function resolveAnimations(animations: boolean | AnimationConfig | undefi
         animZoom: animations?.zoom ?? true,
         animPan: animations?.pan ?? true,
         animLiveBar: resolveLiveBarEaseMs(animations?.liveBar),
+    };
+}
+
+/** Resolve the whole motion surface. Omission follows the system; every supplied value
+ * is an explicit host override. `true` retains the historical live-bar default (off). */
+export function resolveMotionPolicy(animations: boolean | AnimationConfig | undefined, systemReduced: boolean): ResolvedMotionPolicy {
+    const configured = resolveAnimations(animations);
+    const reduced = animations === false || (animations === undefined && systemReduced);
+    return {
+        reduced,
+        animZoom: reduced ? false : configured.animZoom,
+        animPan: reduced ? false : configured.animPan,
+        animLiveBar: reduced ? 0 : configured.animLiveBar,
+        intro: !reduced,
     };
 }
 

--- a/src/core/ports/DataProvider.ts
+++ b/src/core/ports/DataProvider.ts
@@ -132,9 +132,10 @@ export interface DataProvider {
     /**
      * Open a true live stream for `ticker`/`timeframe`. Each call to `onBar` delivers
      * the forming candle (or a freshly-closed one). Returns an unsubscribe fn. Absent
-     * ⇒ the feed polls `getBars` for ticks instead. `opts.session` names the trading
-     * session the chart is showing (see {@link BarRange.session}) — a provider whose
-     * live source cannot filter by session may fall back to polling internally.
+     * ⇒ the feed polls `getBars` for ticks instead. `opts.session` is the exact,
+     * case-sensitive provider-facing ID selected by the host (see
+     * {@link BarRange.session}) — a provider whose live source cannot filter by session
+     * may fall back to polling internally.
      */
     subscribe?(ticker: string, timeframe: string, onBar: (bar: OHLCV) => void, opts?: { session?: string }): Unsubscribe;
 
@@ -143,9 +144,11 @@ export interface DataProvider {
      * `[start, end)` pairs of OPEN market time, holidays and DST already applied by the
      * source — the single market-time truth for session-anchored consumers (market-status
      * badges, session profiles), which must never recompute a holiday themselves.
-     * `range.session` selects the window set (`'regular'` default; `'extended'` = the
-     * full tape). Absent ⇒ the venue offers no calendar (continuous markets) and
-     * consumers fall back to their own anchoring (e.g. UTC days).
+     * Explicit catalogs and custom IDs request the exact provider-facing window set used
+     * for history and live bars. The metadata-derived status badge instead requests both
+     * conventional `regular` and `extended` calendars so it can derive market phases.
+     * An absent session means the provider default. Absent method ⇒ the venue offers no
+     * calendar (continuous markets), so consumers use their fallback.
      */
     getCalendar?(ticker: string, range: { from: number; to: number; session?: string }): Promise<ReadonlyArray<readonly [number, number]>>;
 

--- a/src/core/ports/IChartRenderer.ts
+++ b/src/core/ports/IChartRenderer.ts
@@ -4,7 +4,7 @@ import type { IndicatorModel } from '../model/indicator';
 import type { ScenePatch } from '../model/patch';
 import type { InputValue, SymbolPickerFn } from '../model/inputs';
 import type { Millis } from '../model/time';
-import type { VelaTheme, ThemeName, MoveTarget, PriceStyle } from '../options';
+import type { VelaTheme, ThemeName, MoveTarget, PriceStyle, ResolvedMotionPolicy } from '../options';
 import type { Unsubscribe } from '../util/types';
 import type { IDrawingsRendererPort } from '../drawings/port';
 
@@ -204,14 +204,14 @@ export type PaneAction =
     | { type: 'maximize'; paneId: string; maximized: boolean };
 
 /**
- * The rendering backend abstraction. No backend (e.g. lightweight-charts) types
- * cross this boundary — that is what makes the renderer swappable. The only MVP
- * implementation is `src/renderers/lightweight-charts/LwcRenderer.ts`.
+ * The rendering-backend abstraction. No implementation-specific types cross this
+ * boundary, which is what makes the renderer swappable. The bundled implementation is
+ * the native renderer; a host may supply any conforming backend.
  */
 export interface IChartRenderer {
     readonly capabilities: RendererCapabilities;
 
-    /** Stable identity of this renderer (e.g. `'native'`, `'lwc'`) — the warn label and `chart.renderer.name`. */
+    /** Stable identity of this renderer (e.g. `'native'`, `'my-renderer'`) — the warn label and `chart.renderer.name`. */
     readonly name: string;
     /** Feature keys this renderer can get/set at runtime via `chart.renderer.set` / `.get`. */
     readonly features: readonly string[];
@@ -219,6 +219,12 @@ export interface IChartRenderer {
     applyFeature(key: string, value: unknown): void;
     /** Read a feature's current value (`undefined` if unsupported). */
     readFeature(key: string): unknown;
+
+    /** Apply the effective presentation-motion policy atomically, possibly before
+     * mount. Renderers with presentation animation should settle active motion when
+     * reduction begins; configured feature values remain distinct from this runtime
+     * gate. Optional for compatibility with renderers that manage no motion. */
+    applyMotionPolicy?(policy: ResolvedMotionPolicy): void;
 
     mount(container: HTMLElement, theme: VelaTheme): void;
     setTheme(theme: VelaTheme): void;

--- a/src/core/ports/MarketDataFeed.ts
+++ b/src/core/ports/MarketDataFeed.ts
@@ -30,9 +30,9 @@ export interface BarRange {
     /** Max bars. */
     limit?: number;
     /**
-     * Trading session to serve (`'regular'` | `'extended'`) — rides every request on
-     * markets that have sessions; absent = the provider's default. A provider without
-     * a session concept ignores it.
+     * Trading-session id to serve — rides every request unchanged on markets that have
+     * sessions; absent = the provider's default. A provider without a session concept
+     * ignores it.
      */
     session?: string;
 }

--- a/src/data/BarStore.ts
+++ b/src/data/BarStore.ts
@@ -1,11 +1,10 @@
 import type { OHLCV } from '../core/model/ohlcv';
 
-/** Cache key for one series. Symbols/timeframes never contain `|`. The session is a
- *  KEY dimension when non-default: regular and extended bars of one symbol genuinely
- *  differ (extended has more bars, and session dailies differ in OHLC), so they must
- *  never share a series. Absent/`regular` stays keyless — existing keys don't move. */
+/** Cache key for one series. Symbols/timeframes never contain `|`. Every explicit,
+ * case-sensitive session ID is a key dimension; an omitted session alone uses the
+ * provider-default series. */
 export function seriesKey(provider: string, symbol: string, timeframe: string, session?: string): string {
-    return `${provider}|${symbol}|${timeframe}${session && session !== 'regular' ? `|${session}` : ''}`;
+    return `${provider}|${symbol}|${timeframe}${session ? `|${session}` : ''}`;
 }
 
 function symbolOf(key: string): string {

--- a/src/data/CachingDataFeed.ts
+++ b/src/data/CachingDataFeed.ts
@@ -8,8 +8,9 @@ import { timeframeToMs } from './timeframe';
 
 /** Series cache key — the symbol's own grammar carries the venue: a `provider:` prefix
  *  keys per venue (the multi-provider feed hands canonical prefixed symbols down); a
- *  bare symbol keys venue-less, whatever serves it (single-feed setups). A non-default
- *  session keys its own series (regular and extended bars genuinely differ). */
+ *  bare symbol keys venue-less, whatever serves it (single-feed setups). Every explicit
+ *  provider-facing session ID keys its own series; only an omitted ID uses the
+ *  provider-default series. */
 function cacheKey(symbol: string, timeframe: string, session?: string): string {
     const { provider, ticker } = parseSymbol(symbol);
     return seriesKey(provider ?? '', ticker, timeframe, session);

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,8 @@ export type {
 export type * from './core/model';
 export type {
     VelaOptions,
+    MarketSession,
+    MarketSessionDefinition,
     MarketConfig,
     MarketSwitch,
     MarketSnapshot,
@@ -66,9 +68,12 @@ export type {
     RendererConstructor,
     RendererDisplayOptions,
     AnimationConfig,
+    ResolvedMotionPolicy,
     AddIndicatorOptions,
     SettingsVisibilityPolicy,
 } from './core/options';
+export { normalizeSession, normalizeSessionDefinitions, resolveMarketSession, resolveMotionPolicy } from './core/options';
+export type { MotionPreferenceSource } from './renderers/shared/motion';
 export type { IndicatorHandle, IndicatorEventMap } from './core/IndicatorHandle';
 export type { VelaEventMap } from './core/events/types';
 // The script-run surface: the `script:run` payload and what `chart.runScript()` resolves.

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -25,7 +25,7 @@ import type { Pane } from '../../core/model/scene';
 import type { IndicatorModel, PaneAxisBand } from '../../core/model/indicator';
 import type { ScenePatch } from '../../core/model/patch';
 import type { InputValue, SymbolPickerFn } from '../../core/model/inputs';
-import type { RendererDisplayOptions, NativeBackend, PriceStyle, MoveTarget, ThemeName } from '../../core/options';
+import type { RendererDisplayOptions, NativeBackend, PriceStyle, MoveTarget, ThemeName, ResolvedMotionPolicy } from '../../core/options';
 import { resolveLiveBarEaseMs, LIVE_BAR_EASE_DEFAULT_MS } from '../../core/options';
 import type { Unsubscribe } from '../../core/util/types';
 import { isLineLikeSeries } from '../../core/model/series';
@@ -210,6 +210,9 @@ export class NativeRenderer implements IChartRenderer {
     private animPan = true;
     private animLiveBarMs = 0; // forming-bar OHLC glide time-constant; 0 = each tick snaps
     private animLiveBarOnMs = LIVE_BAR_EASE_DEFAULT_MS; // the duration the settings-dialog on/off toggle restores (last non-zero value configured)
+    /** Runtime gate from host options + system preference. Configured animation values
+     * stay intact while this is true, so a preference change never rewrites state. */
+    private motionReduced = false;
     // Brand default candles.
     private candleUp = BULLISH;
     private candleDown = BEARISH;
@@ -339,6 +342,47 @@ export class NativeRenderer implements IChartRenderer {
     readonly name = 'native';
     readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'animLiveBar', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'sessionZones', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles', 'indicatorValues'];
 
+    applyMotionPolicy(policy: ResolvedMotionPolicy): void {
+        const changed = policy.reduced !== this.motionReduced;
+        this.motionReduced = policy.reduced;
+        if (this.mountContainer) this.mountContainer.dataset.velaMotion = policy.reduced ? 'reduced' : 'full';
+        if (this.wrapper) this.wrapper.dataset.velaMotion = policy.reduced ? 'reduced' : 'full';
+        if (this.inputsUI) this.inputsUI.setReducedMotion(policy.reduced);
+        this.settingsDialog?.setReducedMotion(policy.reduced);
+        if (!changed || !policy.reduced) return;
+        this.settlePresentationMotion();
+    }
+
+    /** Finish fixed-target motion and stop targetless motion in one repaint. */
+    private settlePresentationMotion(): void {
+        if (this.introRaf != null) cancelAnimationFrame(this.introRaf);
+        this.introRaf = null;
+        this.scene.bars = this.bars;
+        this.modelAlpha = 1;
+        const last = this.bars[this.bars.length - 1];
+        if (last) this.syncLiveEase(last);
+        for (const animation of this.wrapper?.getAnimations?.({ subtree: true }) ?? []) animation.cancel();
+        if (!this.animator || !this.scheduler) return; // policy may arrive before mount
+
+        const before = this.coords.getViewport();
+        let barSpacing = before.barSpacing;
+        let rightOffset = before.rightOffset;
+        if (this.targetBarSpacing > 0 && Math.abs(barSpacing - this.targetBarSpacing) > this.targetBarSpacing * 1e-3) {
+            barSpacing = this.targetBarSpacing;
+            rightOffset = this.anchoredRightOffset(barSpacing);
+        }
+        if (this.scrollTargetRO != null) rightOffset = this.scrollTargetRO;
+        const settled = this.clampViewport(barSpacing, rightOffset);
+        this.animator.stop();
+        this.panVelocity = 0; // inertia has no fixed target: stop at the current position
+        this.scrollTargetRO = null;
+        this.coords.setViewport(settled);
+        this.targetBarSpacing = settled.barSpacing;
+        this.computeScales(); // animator is idle, so scale targets snap in the same turn
+        this.scheduler.flushNow(InvalidateLevel.Full);
+        if (settled.barSpacing !== before.barSpacing || settled.rightOffset !== before.rightOffset) this.emitViewportChange();
+    }
+
     /** Apply a render feature live — mutate the field + invalidate, no engine re-run. */
     applyFeature(key: string, value: unknown): void {
         switch (key) {
@@ -385,7 +429,7 @@ export class NativeRenderer implements IChartRenderer {
             case 'intro': {
                 const s = value === false || value === 'none' || value === 'off' || value == null ? '' : String(value);
                 this.introStyle = s;
-                if (s) this.playIntro(s); // setting it replays — used to compare styles from the console
+                if (s && !this.motionReduced) this.playIntro(s); // setting it replays — used to compare styles from the console
                 return;
             }
             case 'zoomAnchor':
@@ -403,9 +447,14 @@ export class NativeRenderer implements IChartRenderer {
             case 'candleZOrder':
                 this.scene.candleZ = Number(value) || 0;
                 break;
-            case 'candleVisible':
-                this.scene.candlesHidden = value === false;
-                break;
+            case 'candleVisible': {
+                const hidden = value === false;
+                if (hidden === this.scene.candlesHidden) return;
+                this.scene.candlesHidden = hidden;
+                this.scheduler?.invalidate(InvalidateLevel.Full);
+                for (const cb of this.configChangedCbs) cb();
+                return;
+            }
             case 'seriesOrder':
                 this.applySeriesOrder(value);
                 break;
@@ -623,7 +672,9 @@ export class NativeRenderer implements IChartRenderer {
             const dot = doc.createElement('span');
             Object.assign(dot.style, { width: '7px', height: '7px', borderRadius: '50%', background: this.chromeTheme().textColor, opacity: '0.15' });
             // Staggered phases via negative delays — every dot animates from the first frame.
-            dot.animate([{ opacity: 0.12 }, { opacity: 0.55 }], { duration: 800, iterations: Infinity, direction: 'alternate', easing: 'ease-in-out', delay: -i * 260 });
+            if (!this.motionReduced) {
+                dot.animate([{ opacity: 0.12 }, { opacity: 0.55 }], { duration: 800, iterations: Infinity, direction: 'alternate', easing: 'ease-in-out', delay: -i * 260 });
+            }
             el.appendChild(dot);
         }
         this.wrapper.appendChild(el); // appended last ⇒ above the canvases, still under dialogs
@@ -738,7 +789,12 @@ export class NativeRenderer implements IChartRenderer {
                     baselineLevel: s.baseline.baselineLevel,
                 };
             })(),
-            series: { style: this.scene.priceStyle, baseline: this.scene.baselineValue, spacing: this.coords.spacingScale },
+            series: {
+                visible: !this.scene.candlesHidden,
+                style: this.scene.priceStyle,
+                baseline: this.scene.baselineValue,
+                spacing: this.coords.spacingScale,
+            },
             sessions: { premarketColor: s.sessions.premarketColor, postmarketColor: s.sessions.postmarketColor, extendedColor: s.sessions.extendedColor },
         };
     }
@@ -857,6 +913,7 @@ export class NativeRenderer implements IChartRenderer {
         // session shading
         s.sessions = { premarketColor: next.sessions.premarketColor, postmarketColor: next.sessions.postmarketColor, extendedColor: next.sessions.extendedColor };
         // series
+        this.scene.candlesHidden = !next.series.visible;
         this.setPriceStyle(next.series.style);
         // Re-read the active style's candle override: setPriceStyle no-ops when the style
         // did not change, but the per-type bag (candle* keys) may have — this is the live
@@ -914,7 +971,7 @@ export class NativeRenderer implements IChartRenderer {
                 this.plot.appendChild(this.settingsButton);
             }
             if (this.settingsButton) this.settingsButton.style.display = 'flex';
-            if (this.plot && !this.settingsDialog) this.settingsDialog = new SettingsDialog(this.dialogHost ?? this.plot, this.theme);
+            if (this.plot && !this.settingsDialog) this.settingsDialog = new SettingsDialog(this.dialogHost ?? this.plot, this.theme, this.motionReduced);
         } else {
             this.settingsButton?.style.setProperty('display', 'none');
             this.settingsDialog?.close();
@@ -957,7 +1014,7 @@ export class NativeRenderer implements IChartRenderer {
      *  in-chart gear — created on demand, independent of the gear feature being enabled. */
     openSettingsDialog(section?: string): void {
         if (!this.settingsDialog && this.plot) {
-            this.settingsDialog = new SettingsDialog(this.dialogHost ?? this.plot, this.theme);
+            this.settingsDialog = new SettingsDialog(this.dialogHost ?? this.plot, this.theme, this.motionReduced);
             this.settingsDialog.setLayoutMode(this.layoutMode);
         }
         this.toggleSettingsDialog(section);
@@ -1104,7 +1161,7 @@ export class NativeRenderer implements IChartRenderer {
      *  instant when pan animation is off. Shared by scroll-to-latest and panBy. */
     private glideRightOffset(target: number): void {
         const vp = this.coords.getViewport();
-        if (!this.animPan) {
+        if (this.motionReduced || !this.animPan) {
             this.applyViewport({ barSpacing: vp.barSpacing, rightOffset: target });
             return;
         }
@@ -1267,6 +1324,7 @@ export class NativeRenderer implements IChartRenderer {
     // ── lifecycle ──
     mount(container: HTMLElement, theme: VelaTheme): void {
         this.mountContainer = container;
+        container.dataset.velaMotion = this.motionReduced ? 'reduced' : 'full';
         this.publishGutters();
         this.theme = this.deriveTheme(theme);
         // provisional chrome surface (refined by the first applyConfig)
@@ -1274,6 +1332,7 @@ export class NativeRenderer implements IChartRenderer {
         this.surfaceTextColor = theme.textColor;
 
         this.wrapper = document.createElement('div');
+        this.wrapper.dataset.velaMotion = this.motionReduced ? 'reduced' : 'full';
         // user-select none: in-chart chrome text (legend, dialogs, axis buttons) is UI,
         // never selectable — the kit's text-entry controls opt back in in their own CSS.
         Object.assign(this.wrapper.style, { position: 'relative', width: '100%', height: '100%', overflow: 'hidden', cursor: 'crosshair', userSelect: 'none', webkitUserSelect: 'none' });
@@ -1380,6 +1439,11 @@ export class NativeRenderer implements IChartRenderer {
             // User drawings claim a gesture before pan when armed / over a drawing.
             drawingsClaim: (x, y) => this.userDrawings?.claim(x, y) ?? false,
             drawingsMeasureStart: (x, y, snap) => this.userDrawings?.beginMeasureAt(x, y, snap) ?? false,
+            drawingsMarqueeStart: (x, y, additive) => this.userDrawings?.beginMarquee(x, y, additive) ?? false,
+            drawingsMarqueeMove: (x, y) => this.userDrawings?.moveMarquee(x, y),
+            drawingsMarqueeEnd: (x, y) => this.userDrawings?.endMarquee(x, y),
+            drawingsMarqueeCancel: () => this.userDrawings?.cancelMarquee(),
+            drawingsMarqueeClick: () => this.userDrawings?.marqueeClick(),
             drawingsDeleteAt: (x, y) => this.userDrawings?.deleteAt(x, y) ?? false,
             drawingsCancelPlacement: () => this.userDrawings?.cancelPlacement() ?? false,
             drawingsSnapMode: () => this.snapMode,
@@ -1469,6 +1533,7 @@ export class NativeRenderer implements IChartRenderer {
         this.setKeyboardEnabled(this.keyboardEnabled); // accessible by default; wires focus + ARIA
 
         this.inputsUI = new InputsUI(this.plot, theme, (paneId) => this.paneBoundsFor(paneId));
+        this.inputsUI.setReducedMotion(this.motionReduced);
         this.inputsUI.setLayoutMode(this.layoutMode);
         this.inputsUI.setTitlesVisible(this.indicatorTitlesOn); // a remount keeps the toggle state
         this.inputsUI.setValuesVisible(this.indicatorValuesOn);
@@ -1719,6 +1784,7 @@ export class NativeRenderer implements IChartRenderer {
         this.mountContainer?.style.removeProperty('--vela-bottom-gutter');
         this.mountContainer?.style.removeProperty('--vela-price-pane-top');
         this.mountContainer?.style.removeProperty('--vela-price-pane-bottom');
+        this.mountContainer?.removeAttribute('data-vela-motion');
         this.mountContainer = null;
         this.wrapper?.remove();
     }
@@ -1782,7 +1848,7 @@ export class NativeRenderer implements IChartRenderer {
         }
         if (!this.introPlayed && this.bars.length > 0) {
             this.introPlayed = true; // play the reveal once, when candles first appear
-            if (this.introStyle) {
+            if (this.introStyle && !this.motionReduced) {
                 this.playIntro(this.introStyle); // the reveal owns the paint — no full-frame flash first
                 return;
             }
@@ -1795,7 +1861,7 @@ export class NativeRenderer implements IChartRenderer {
         const last = this.bars[n - 1];
         if (last && bar.time === last.time) {
             this.bars[n - 1] = bar; // actual forming bar — the ease target
-            if (this.animLiveBarMs <= 0 || this.liveEaseTime !== bar.time) {
+            if (this.motionReduced || this.animLiveBarMs <= 0 || this.liveEaseTime !== bar.time) {
                 this.syncLiveEase(bar); // glide off, or the first tick of this bar: snap
             } else {
                 this.animator.start(); // glide the displayed high/low/close toward this tick
@@ -2269,7 +2335,7 @@ export class NativeRenderer implements IChartRenderer {
         this.zoomAnchorX = anchorX;
         this.panVelocity = 0;
         this.scrollTargetRO = null;
-        if (!this.animZoom) {
+        if (this.motionReduced || !this.animZoom) {
             const v = this.clampViewport(barSpacing, this.anchoredRightOffset(barSpacing));
             this.coords.setViewport(v);
             this.targetBarSpacing = v.barSpacing;
@@ -2283,7 +2349,7 @@ export class NativeRenderer implements IChartRenderer {
 
     /** Inertial pan: continue with a rightOffset velocity (logical units / ms) that decays. */
     private fling(velocity: number): void {
-        if (!this.animPan) return; // pan animation off → drag-release stops dead
+        if (this.motionReduced || !this.animPan) return; // pan animation off → drag-release stops dead
         this.scrollTargetRO = null; // a fresh flick cancels an in-flight scroll-to-latest glide
         this.panVelocity = velocity;
         this.animator.start();
@@ -2964,10 +3030,11 @@ export class NativeRenderer implements IChartRenderer {
         const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
         for (const l of this.extLayers) {
             if (!l.def.repaintOnCursor) continue;
+            if (this.baseSeriesHidesLayer(l.def.id)) continue;
             const lp = this.layerPane(l.def.id) ?? pane;
             if (lp.collapsed) continue; // blanked by the data frame; nothing to hover
             l.instance.render(this.extLayerArgs(l.def.id, lp.scale, lp.bounds, nowMs));
-            if (this.animZoom && l.instance.animating?.()) this.animator.start();
+            if (!this.motionReduced && this.animZoom && l.instance.animating?.()) this.animator.start();
         }
     }
 
@@ -2990,6 +3057,7 @@ export class NativeRenderer implements IChartRenderer {
             theme: this.theme,
             priceStyle: this.scene.priceStyle,
             nowMs,
+            reducedMotion: this.motionReduced,
             cursor: this.lastPointer,
         };
     }
@@ -3035,6 +3103,13 @@ export class NativeRenderer implements IChartRenderer {
             const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
             let folded: BasePaintingModulation | null = null;
             for (const l of this.extLayers) {
+                // A chart type's same-id, unowned layer is part of the base price
+                // representation. The whole-series eye suppresses it, but never an
+                // unrelated overlay or a layer owned by a native indicator.
+                if (this.baseSeriesHidesLayer(l.def.id)) {
+                    this.clearLayerCanvas(l.canvas);
+                    continue;
+                }
                 const lp: PaneNode = this.layerPane(l.def.id) ?? pane;
                 // A collapsed host pane shows its legend strip only — blank the layer for
                 // the duration (the instance isn't poked, so it can't clear itself).
@@ -3050,7 +3125,7 @@ export class NativeRenderer implements IChartRenderer {
                 // sits over the candles it would be dimming.
                 if (lp === pane) folded = foldBaseModulation(folded, l.instance.modulateBase?.(args) ?? null);
                 // A pulsing/fading layer keeps the animator alive; it stops itself when done.
-                if (this.animZoom && l.instance.animating?.()) this.animator.start();
+                if (!this.motionReduced && this.animZoom && l.instance.animating?.()) this.animator.start();
             }
             if (folded) {
                 if (folded.candleBodyScale != null) this.backend.candleBodyScale = clamp01(folded.candleBodyScale) || 0.01;
@@ -3415,6 +3490,13 @@ export class NativeRenderer implements IChartRenderer {
             if (m.native?.type === layerId) return m;
         }
         return null;
+    }
+
+    /** Whether the whole-price-series visibility gate owns this SDK layer. A same-id
+     * unowned layer is the active chart type's base painting; indicator-owned and
+     * unrelated overlay layers remain independent. */
+    private baseSeriesHidesLayer(layerId: string): boolean {
+        return this.scene.candlesHidden && layerId === this.scene.priceStyle && this.layerOwner(layerId) == null;
     }
 
     /** The pane an SDK layer paints on: its owner's pane, else the price pane. */
@@ -3938,7 +4020,7 @@ function sanitizeHighlights(value: unknown): HighlightArea[] {
  *  phase), or null (no session structure). */
 function sanitizeSessionZones(value: unknown): SessionZones | null {
     if (value == null || typeof value !== 'object') return null;
-    const v = value as { pre?: unknown; post?: unknown; extended?: unknown };
+    const v = value as { pre?: unknown; post?: unknown; extended?: unknown; bands?: unknown };
     const windows = (raw: unknown): Array<readonly [number, number]> => {
         if (!Array.isArray(raw)) return [];
         const out: Array<readonly [number, number]> = [];
@@ -3950,7 +4032,12 @@ function sanitizeSessionZones(value: unknown): SessionZones | null {
         }
         return out.sort((a, b) => a[0] - b[0]);
     };
-    return { pre: windows(v.pre), post: windows(v.post), extended: windows(v.extended) };
+    return {
+        pre: windows(v.pre),
+        post: windows(v.post),
+        extended: windows(v.extended),
+        ...(Array.isArray(v.bands) ? { bands: sanitizeHighlights(v.bands) } : {}),
+    };
 }
 
 /** Whether a value is one of the supported price-series styles (built-ins + SDK-registered). */

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -29,6 +29,7 @@ import {
 } from '../../../ui/components/field';
 import { priceStyleIds, hasOwnCandlePaint } from '../core/chartConfig';
 import { chromeHint } from '../../shared/chrome-tooltip';
+import { applyMotionScope } from '../../shared/motion';
 import {
     filterHiddenHostRows,
     filterHiddenRows,
@@ -60,7 +61,7 @@ type ConfigPatch = Record<string, unknown>;
 export type HostSettingsRow =
     | { kind: 'heading'; label: string; id?: string }
     | { kind: 'toggle'; label: string; get: () => boolean; set: (v: boolean) => void; id?: string }
-    | { kind: 'select'; label: string; options: readonly string[]; get: () => string; set: (v: string) => void; id?: string }
+    | { kind: 'select'; label: string; options: readonly SettingsSelectOption[]; get: () => string; set: (v: string) => void; id?: string }
     | { kind: 'color'; label: string; get: () => string; set: (v: string) => void; id?: string };
 
 /** A host-contributed settings tab (see `RendererControl.setSettingsSections`). */
@@ -205,6 +206,7 @@ export class SettingsDialog {
 
     /** The visibility policy: setting ids hidden by the host (subtree semantics). */
     private hiddenSettings: ReadonlySet<string> = new Set();
+    private reducedMotion: boolean;
 
     /** Host-app sections (e.g. the widget's Status line tab) — re-shown on next open. */
     setHostSections(sections: HostSettingsSection[]): void {
@@ -234,8 +236,16 @@ export class SettingsDialog {
     constructor(
         private readonly container: HTMLElement,
         private theme: VelaTheme,
+        reducedMotion = false,
     ) {
+        this.reducedMotion = reducedMotion;
         if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
+    }
+
+    /** Project the chart policy onto an open portal without affecting its host app. */
+    setReducedMotion(reduced: boolean): void {
+        this.reducedMotion = reduced;
+        if (this.ui) applyMotionScope(this.container, reduced, this.ui.backdrop, this.ui.positioner);
     }
 
     setTheme(theme: VelaTheme): void {
@@ -454,7 +464,7 @@ export class SettingsDialog {
                     if (hr.kind === 'heading') body.append(this.sectionTitle(hr.label));
                     else if (hr.kind === 'toggle') body.append(this.boolRow(hr.label, hr.get(), (v) => hr.set(v)));
                     else if (hr.kind === 'color') body.append(this.colorRow(hr.label, hr.get(), (v) => hr.set(v)));
-                    else body.append(this.selectRowLabeled(hr.label, hr.get(), hr.options.map((o) => [o, o] as const), (v) => hr.set(v)));
+                    else body.append(this.selectRowLabeled(hr.label, hr.get(), normalizeSelectOptions(hr.options), (v) => hr.set(v)));
                 }
             }
         };
@@ -638,6 +648,7 @@ export class SettingsDialog {
             },
             onOpenChange: (open) => { if (!open) this.close(); },
         });
+        applyMotionScope(this.container, this.reducedMotion, ui.backdrop, ui.positioner);
         if (mobile) ui.positioner.classList.add('vela-sd-mobile');
         ui.positioner.style.paddingTop = mobile ? '0' : '8vh';
 
@@ -1263,4 +1274,3 @@ function timezoneOptions(current: string): readonly (readonly [string, string])[
     if (TIMEZONES.some((t) => t.value === normalized)) return options;
     return [[normalized, tzMenuLabel(normalized, normalized)] as const, ...options];
 }
-

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -52,6 +52,17 @@ export interface InputControllerDeps {
      *  the effective magnet. True when it started (the drawings layer then owns the rest
      *  of the gesture). */
     drawingsMeasureStart?(x: number, y: number, snap: SnapMode): boolean;
+    /** Ctrl/Cmd+press on empty data plot: begin a marquee. `additive` (Shift) is latched
+     *  for the gesture. True when the drawings layer accepted it. */
+    drawingsMarqueeStart?(x: number, y: number, additive: boolean): boolean;
+    /** Advance a marquee after the pointer has crossed drag slop. */
+    drawingsMarqueeMove?(x: number, y: number): void;
+    /** Release a dragged marquee and commit its one selection intent. */
+    drawingsMarqueeEnd?(x: number, y: number): void;
+    /** Abort a pending/active marquee without changing selection. */
+    drawingsMarqueeCancel?(): void;
+    /** Resolve a sub-slop marquee gesture as an ordinary empty chart click. */
+    drawingsMarqueeClick?(): void;
     /** Middle-click: delete the drawing under the cursor. True when one was removed. */
     drawingsDeleteAt?(x: number, y: number): boolean;
     /** Right-click: cancel/disarm whatever non-persistent tool is active — an in-progress
@@ -111,7 +122,7 @@ const WHEEL_PRICE_DRAG_PX = 0.25;
  *  time axis, a sub-pane separator (drag to resize the panes above/below it), or one of
  *  the touch-only modes: a two-finger pinch, long-press crosshair inspection, or a
  *  long-press that opened an axis sheet (no further drag for that gesture). */
-type DragRegion = 'data' | 'price' | 'time' | 'separator' | 'drawing' | 'pinch' | 'crosshair' | 'axis-sheet';
+type DragRegion = 'data' | 'price' | 'time' | 'separator' | 'drawing' | 'marquee' | 'pinch' | 'crosshair' | 'axis-sheet';
 
 /**
  * The logical bar + its pixel that a wheel-zoom keeps pinned. `right` (the default)
@@ -290,6 +301,8 @@ export class InputController {
         el.removeEventListener('mousedown', this.onMiddleGuard);
         el.removeEventListener('auxclick', this.onMiddleGuard);
         el.removeEventListener('contextmenu', this.onContextGuard);
+        if (this.dragging && this.region === 'marquee') this.deps.drawingsMarqueeCancel?.();
+        this.dragging = false;
         this.cancelLongPress();
         this.touches.clear();
         this.el = null;
@@ -392,6 +405,25 @@ export class InputController {
             this.region = 'drawing';
             this.deps.drawingsPointerDown?.(x, y, this.snapMode(e), e.shiftKey);
             this.capture(e.pointerId);
+            return;
+        }
+        // Ctrl/Cmd+drag on EMPTY data plot selects drawings by rectangle. Axes/separators
+        // keep their native gestures, touch keeps pan/pinch, and Shift is latched here as union.
+        if (
+            e.pointerType !== 'touch'
+            && (e.ctrlKey || e.metaKey)
+            && x >= 0
+            && x <= this.deps.getCoords().width
+            && y >= 0
+            && y <= this.deps.getCoords().height
+            && this.regionAt(x, y) === 'data'
+            && this.deps.drawingsMarqueeStart?.(x, y, e.shiftKey)
+        ) {
+            const vp = this.deps.getCoords().getViewport();
+            this.deps.apply(vp); // stop an in-flight zoom/fling without moving the viewport
+            this.region = 'marquee';
+            this.capture(e.pointerId);
+            e.preventDefault();
             return;
         }
         // Shift+press on the empty plot starts the measure ruler in one gesture (a press
@@ -534,6 +566,9 @@ export class InputController {
             } else if (this.region === 'drawing') {
                 if (Math.abs(x - this.startX) > slop || Math.abs(y - this.startY) > slop) this.moved = true;
                 this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey);
+            } else if (this.region === 'marquee') {
+                if (Math.abs(x - this.startX) > slop || Math.abs(y - this.startY) > slop) this.moved = true;
+                if (this.moved) this.deps.drawingsMarqueeMove?.(x, y);
             } else {
                 const coords = this.deps.getCoords();
                 const vp = coords.getViewport();
@@ -611,6 +646,21 @@ export class InputController {
         // a gesture that latched `moved` (a one-way 9–14px drag) already panned the
         // chart and must not double as a click/tap on release.
         const tapRelease = this.dragging && !this.moved && (!wasTouch || Math.hypot(x - this.startX, y - this.startY) <= TOUCH_TAP_SLOP);
+        if (this.dragging && this.region === 'marquee') {
+            // A sparse event stream can jump from down straight to an out-of-slop up.
+            if (!this.moved && (Math.abs(x - this.startX) > DRAG_SLOP || Math.abs(y - this.startY) > DRAG_SLOP)) {
+                this.moved = true;
+                this.deps.drawingsMarqueeMove?.(x, y);
+            }
+            if (this.moved) this.deps.drawingsMarqueeEnd?.(x, y);
+            else {
+                if (this.deps.drawingsMarqueeClick) this.deps.drawingsMarqueeClick();
+                else this.deps.drawingsMarqueeCancel?.();
+                this.deps.onClick(x, y); // a modifier-click is still a normal chart click
+            }
+            this.endGesture(e);
+            return;
+        }
         if (this.dragging && this.region === 'drawing') {
             this.deps.drawingsPointerUp?.(x, y, this.snapMode(e));
         } else if (tapRelease && this.region === 'data') {
@@ -663,7 +713,8 @@ export class InputController {
         if (e.pointerType === 'touch') this.touches.delete(e.pointerId);
         this.cancelLongPress();
         if (!this.dragging) return;
-        if (this.region === 'drawing' && !Number.isNaN(this.cursorX)) this.deps.drawingsPointerUp?.(this.cursorX, this.cursorY, this.snapMode(e));
+        if (this.region === 'marquee') this.deps.drawingsMarqueeCancel?.();
+        else if (this.region === 'drawing' && !Number.isNaN(this.cursorX)) this.deps.drawingsPointerUp?.(this.cursorX, this.cursorY, this.snapMode(e));
         if (this.region === 'crosshair' || e.pointerType === 'touch') this.deps.onPointerMove(null, null);
         this.endGesture(e);
     };

--- a/src/renderers/native/core/SceneGraph.ts
+++ b/src/renderers/native/core/SceneGraph.ts
@@ -30,6 +30,8 @@ export interface SessionZones {
     pre: ReadonlyArray<readonly [number, number]>;
     post: ReadonlyArray<readonly [number, number]>;
     extended: ReadonlyArray<readonly [number, number]>;
+    /** Explicit host-defined sessions carry their resolved color per band. */
+    bands?: ReadonlyArray<HighlightArea>;
 }
 
 /** Price-axis display mode: absolute price, percent change vs a visible baseline, or
@@ -237,6 +239,7 @@ export class SceneGraph {
         for (const [from, to] of this.sessionZones.pre) out.push({ from, to, color: this.style.sessions.premarketColor });
         for (const [from, to] of this.sessionZones.post) out.push({ from, to, color: this.style.sessions.postmarketColor });
         for (const [from, to] of this.sessionZones.extended) out.push({ from, to, color: this.style.sessions.extendedColor });
+        for (const band of this.sessionZones.bands ?? []) out.push(band);
         return out;
     }
 

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -288,6 +288,8 @@ export interface ChartConfig {
         baselineLevel: number;
     };
     series: {
+        /** Whether the whole base price series is drawn, independent of its active style. */
+        visible: boolean;
         style: PriceStyle;
         baseline: number | null;
         /** Spacing multiplier for non-connecting styles (candles/bars/HA/plugin types): scales the
@@ -627,6 +629,7 @@ export function mergeConfig(base: ChartConfig, patch: unknown): ChartConfig {
             baselineLevel: isNum(baseline.baselineLevel) ? clampLevel(baseline.baselineLevel) : base.baseline.baselineLevel,
         },
         series: {
+            visible: isBool(series.visible) ? series.visible : base.series.visible,
             style: isPriceStyle(series.style) ? series.style : base.series.style,
             baseline: series.baseline === null ? null : isNum(series.baseline) ? series.baseline : base.series.baseline,
             spacing: isNum(series.spacing) ? clampSpacing(series.spacing) : base.series.spacing,

--- a/src/renderers/native/drawings/DrawingHitTester.ts
+++ b/src/renderers/native/drawings/DrawingHitTester.ts
@@ -3,6 +3,71 @@ import type { Drawing, Projector } from '../../../core/drawings';
 /** Pixel tolerance for grabbing a drawing body / handle. */
 export const HIT_TOLERANCE = 6;
 
+/** A normalized rectangle in plot pixels (`w` and `h` are never negative). */
+export interface PixelRect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
+/** Normalize two corners and clip them to the data plot. Invalid coordinates have no rectangle. */
+export function plotRect(x1: number, y1: number, x2: number, y2: number, proj: Pick<Projector, 'width' | 'height'>): PixelRect | null {
+    if (![x1, y1, x2, y2, proj.width, proj.height].every(Number.isFinite)) return null;
+    const left = Math.max(0, Math.min(proj.width, Math.min(x1, x2)));
+    const right = Math.max(0, Math.min(proj.width, Math.max(x1, x2)));
+    const top = Math.max(0, Math.min(proj.height, Math.min(y1, y2)));
+    const bottom = Math.max(0, Math.min(proj.height, Math.max(y1, y2)));
+    return { x: left, y: top, w: right - left, h: bottom - top };
+}
+
+/** Inclusive intersection: touching an edge or a zero-width line counts as a hit. */
+export function rectsIntersect(a: PixelRect, b: PixelRect): boolean {
+    return a.x <= b.x + b.w && a.x + a.w >= b.x && a.y <= b.y + b.h && a.y + a.h >= b.y;
+}
+
+function normalizedRect(rect: PixelRect): PixelRect | null {
+    if (![rect.x, rect.y, rect.w, rect.h].every(Number.isFinite)) return null;
+    const x2 = rect.x + rect.w;
+    const y2 = rect.y + rect.h;
+    return { x: Math.min(rect.x, x2), y: Math.min(rect.y, y2), w: Math.abs(rect.w), h: Math.abs(rect.h) };
+}
+
+function clippedRect(a: PixelRect, clip: PixelRect): PixelRect | null {
+    const left = Math.max(a.x, clip.x);
+    const right = Math.min(a.x + a.w, clip.x + clip.w);
+    const top = Math.max(a.y, clip.y);
+    const bottom = Math.min(a.y + a.h, clip.y + clip.h);
+    return right < left || bottom < top ? null : { x: left, y: top, w: right - left, h: bottom - top };
+}
+
+/**
+ * Drawing ids whose projected selection bounds intersect `rect`, in ascending paint order.
+ * Bounds and the marquee are clipped to the visible plot/pane before the inclusive test.
+ */
+export function drawingsIntersectingRect(drawings: readonly Drawing[], rect: PixelRect, proj: Projector): string[] {
+    const plot: PixelRect = { x: 0, y: 0, w: proj.width, h: proj.height };
+    const selection = clippedRect(rect, plot);
+    if (!selection) return [];
+    const hits: string[] = [];
+    for (const d of drawings) {
+        if (!d.visible) continue;
+        let clip = plot;
+        if (proj.paneRect) {
+            const pane = proj.paneRect(d.paneId);
+            if (!pane || !Number.isFinite(pane.top) || !Number.isFinite(pane.height) || pane.height <= 0) continue;
+            const paneClip = clippedRect(plot, { x: 0, y: pane.top, w: proj.width, h: pane.height });
+            if (!paneClip) continue;
+            clip = paneClip;
+        }
+        const bounds = d.bounds(proj);
+        const normalized = bounds ? normalizedRect(bounds) : null;
+        const visibleBounds = normalized ? clippedRect(normalized, clip) : null;
+        if (visibleBounds && rectsIntersect(selection, visibleBounds)) hits.push(d.id);
+    }
+    return hits;
+}
+
 /**
  * The topmost drawing whose body is within `tol` px of (x,y), searching front→back
  * (highest z first). Hidden drawings are skipped. `drawings` is expected in ascending

--- a/src/renderers/native/drawings/DrawingInteraction.ts
+++ b/src/renderers/native/drawings/DrawingInteraction.ts
@@ -1,6 +1,6 @@
 import type { Drawing, DrawingIntent, DrawingPoint, DrawingStyle, DrawingTypeKey, FreeAxis, Projector, SnapMode } from '../../../core/drawings';
 import { createDrawing } from '../../../core/drawings';
-import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
+import { drawingsIntersectingRect, plotRect, topDrawingAt, HIT_TOLERANCE, type PixelRect } from './DrawingHitTester';
 
 /** Pixels of motion before a press counts as a drag (vs a click → open settings). */
 const DRAG_SLOP = 3;
@@ -38,7 +38,8 @@ export interface InteractionDeps {
 type State =
     | { kind: 'idle' }
     | { kind: 'placing'; draft: Drawing; need: number; cursor: DrawingPoint | null }
-    | { kind: 'pressed'; id: string; handle: number; grab: DrawingPoint; orig: DrawingPoint[]; px: number; py: number; moved: boolean };
+    | { kind: 'pressed'; id: string; handle: number; grab: DrawingPoint; orig: DrawingPoint[]; px: number; py: number; moved: boolean }
+    | { kind: 'marquee'; x1: number; y1: number; x2: number; y2: number; active: boolean; additive: boolean; baseIds: string[] };
 
 /**
  * The single user-drawing interaction state machine: arm → place (click anchors,
@@ -133,6 +134,56 @@ export class DrawingInteraction {
     claim(x: number, y: number): boolean {
         if (this.deps.activeTool() != null || this.state.kind !== 'idle') return true;
         return this.hitAt(x, y) != null;
+    }
+
+    /** Begin an empty-plot marquee. The visual remains pending until InputController clears its drag slop. */
+    startMarquee(x: number, y: number, additive: boolean): boolean {
+        if (this.deps.activeTool() != null || this.state.kind !== 'idle') return false;
+        this.snapAt = null;
+        this.state = { kind: 'marquee', x1: x, y1: y, x2: x, y2: y, active: false, additive, baseIds: [...this.deps.selectedIds()] };
+        return true;
+    }
+
+    /** Advance a marquee after the input layer has classified the press as a drag. */
+    moveMarquee(x: number, y: number): void {
+        if (this.state.kind !== 'marquee') return;
+        this.state.x2 = x;
+        this.state.y2 = y;
+        this.state.active = true;
+        this.deps.changed();
+    }
+
+    /** The clipped, normalized marquee to paint, or null while it is still inside click slop. */
+    marqueeRect(): PixelRect | null {
+        if (this.state.kind !== 'marquee' || !this.state.active) return null;
+        return plotRect(this.state.x1, this.state.y1, this.state.x2, this.state.y2, this.deps.projector());
+    }
+
+    /** Commit one replacement selection. Additive marquee unions the pointer-down snapshot without toggling. */
+    finishMarquee(x: number, y: number): boolean {
+        if (this.state.kind !== 'marquee' || !this.state.active) return false;
+        this.state.x2 = x;
+        this.state.y2 = y;
+        const proj = this.deps.projector();
+        const rect = plotRect(this.state.x1, this.state.y1, x, y, proj);
+        const hits = rect ? drawingsIntersectingRect(this.deps.drawings(), rect, proj) : [];
+        const existing = new Set(this.deps.drawings().map((d) => d.id));
+        const ids = this.state.additive
+            ? [...new Set([...this.state.baseIds.filter((id) => existing.has(id)), ...hits])]
+            : hits;
+        this.state = { kind: 'idle' };
+        this.deps.emit({ kind: 'select', ids });
+        this.deps.changed();
+        return true;
+    }
+
+    /** Cancel a marquee without changing selection. */
+    cancelMarquee(): boolean {
+        if (this.state.kind !== 'marquee') return false;
+        const hadVisual = this.state.active;
+        this.state = { kind: 'idle' };
+        if (hadVisual) this.deps.changed();
+        return true;
     }
 
     /** A cursor hint for hovering (pointer over a drawing/handle), or null off any drawing. */
@@ -272,9 +323,10 @@ export class DrawingInteraction {
         }
     }
 
-    /** Cancel an in-progress placement or drag (Escape). Returns whether anything was cancelled. */
+    /** Cancel an in-progress placement, drag, or marquee (Escape). Returns whether anything was cancelled. */
     cancel(): boolean {
         this.snapAt = null;
+        if (this.state.kind === 'marquee') return this.cancelMarquee();
         if (this.state.kind === 'placing') {
             const type = this.state.draft.type;
             this.state = { kind: 'idle' };

--- a/src/renderers/native/drawings/DrawingKeys.ts
+++ b/src/renderers/native/drawings/DrawingKeys.ts
@@ -33,6 +33,12 @@ export type DrawingKeyAction =
 const NUDGE_STEP = 1; // px per arrow press; Shift = a coarser jump
 const NUDGE_STEP_COARSE = 10;
 
+/** Keep keyboard deletion non-destructive for locked drawings. Unknown stale ids pass through harmlessly. */
+export function unlockedDrawingIds(drawings: readonly { id: string; locked: boolean }[], ids: readonly string[]): string[] {
+    const locked = new Set(drawings.filter((drawing) => drawing.locked).map((drawing) => drawing.id));
+    return ids.filter((id) => !locked.has(id));
+}
+
 export function keyToDrawingAction(e: DrawingKeyEvent, ctx: DrawingKeyContext): DrawingKeyAction | null {
     if (ctx.editingText) return null; // typing a label → leave the keys alone
     const mod = e.ctrlKey || e.metaKey;

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -7,6 +7,7 @@ import { withAlpha } from '../../../core/color';
 import { barTransformFor } from '../../../core/price-styles/BarTransform';
 import type { OHLCV } from '../../../core/model/ohlcv';
 import { valueDecimals } from '../chrome/ticks';
+import type { PixelRect } from './DrawingHitTester';
 
 const HANDLE_RADIUS = 4.5; // px radius of the round drag handles
 /** Handle chrome is fixed (not the drawing's line color) so tools with atypical accents —
@@ -178,6 +179,18 @@ export class DrawingPainter {
         ctx.lineWidth = 1.5;
         ctx.stroke();
         ctx.globalAlpha = 1;
+    }
+
+    /** Paint the transient drag-selection rectangle above drawing handles. */
+    paintMarquee(ctx: CanvasRenderingContext2D, rect: PixelRect, theme: VelaTheme): void {
+        ctx.save();
+        ctx.fillStyle = withAlpha(theme.textColor, 0.08);
+        ctx.strokeStyle = DEFAULT_DRAWING_COLOR;
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 3]);
+        ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+        ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+        ctx.restore();
     }
 
     private paintOne(ctx: CanvasRenderingContext2D, d: Drawing, proj: Projector, theme: VelaTheme): void {

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -53,7 +53,7 @@ export interface PopupAnchor {
 const BTN = 30; // icon-button side (px)
 const ICON = 21; // icon glyph side (px)
 const STYLE_ID = 'vela-drawing-popup-styles';
-const STYLE_REV = '3';
+const STYLE_REV = '4';
 
 /** Inject the scoped styles that inline cssText can't reach (`:focus`, scrollbar
  *  pseudo-elements). Idempotent — one shared sheet for all popups. */
@@ -68,6 +68,7 @@ function ensureStyles(): void {
 .vela-dpop-btn{background:transparent;color:var(--vela-fg-muted);transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
 .vela-dpop-btn:hover{background:var(--vela-hover-strong);color:var(--vela-fg-bright);}
 .vela-dpop-btn[data-active='1']{background:var(--vela-active);color:var(--vela-fg-bright);}
+.vela-dpop-btn:disabled{opacity:.38;cursor:not-allowed;background:transparent;color:var(--vela-fg-muted);}
 .vela-dpop-item{background:transparent;transition:background var(--vela-dur-fast) ease;}
 .vela-dpop-item:hover{background:var(--vela-hover-strong);}
 .vela-dpop-item[data-active='1']{background:var(--vela-active);}
@@ -302,8 +303,14 @@ export class DrawingSettingsPopup {
         if (isFrvp) bar.appendChild(this.iconBtn('Settings', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'frvp')));
         if (isPosition) bar.appendChild(this.iconBtn('Position size', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'position')));
         if (editableLevels) bar.appendChild(this.iconBtn('Levels', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'levels')));
-        bar.appendChild(this.toggle('Lock', LOCK_ICON, drawing.locked, (v) => actions.setLocked(v)));
+        let deleteButton: HTMLButtonElement | null = null;
+        bar.appendChild(this.toggle('Lock', LOCK_ICON, drawing.locked, (v) => {
+            actions.setLocked(v);
+            if (deleteButton) deleteButton.disabled = v;
+        }));
         const del = this.iconBtn('Delete', TRASH_ICON, () => actions.remove());
+        deleteButton = del;
+        del.disabled = drawing.locked;
         del.style.color = 'var(--vela-danger)';
         bar.appendChild(del);
         bar.appendChild(this.kebabButton(actions));
@@ -994,4 +1001,3 @@ function styleLabel(v: string | number): string {
 function sized(svg: string, size: number = ICON): string {
     return svg.replace('<svg ', `<svg width="${size}" height="${size}" `);
 }
-

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -23,7 +23,7 @@ import { DrawingSettingsPopup } from './DrawingSettingsPopup';
 import { DrawingToolbar, TOOLBAR_WIDTH, TOOLBAR_COLLAPSED_WIDTH } from './DrawingToolbar';
 import { MeasureOverlay } from './MeasureOverlay';
 import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
-import { keyToDrawingAction, isEditingText } from './DrawingKeys';
+import { keyToDrawingAction, isEditingText, unlockedDrawingIds } from './DrawingKeys';
 import type { DrawingSlice } from '../core/SceneGraph';
 
 /** Shown in the inline editor while a label carries no text yet. */
@@ -416,6 +416,38 @@ export class UserDrawingController implements IDrawingsRendererPort {
         return true;
     }
 
+    /** Ctrl/Cmd+press on empty plot starts a renderer-local marquee; Shift latches union mode. */
+    beginMarquee(x: number, y: number, additive: boolean): boolean {
+        if (this.measureMode || this.eraserMode || this.activeTool != null) return false;
+        if (!this.interaction.startMarquee(x, y, additive)) return false;
+        // Remove the outside-pointer listener before this pointerdown bubbles. Otherwise it
+        // clears the selection snapshot that an additive marquee is defined against.
+        this.popup.close();
+        this.hoveredId = null;
+        this.render();
+        return true;
+    }
+
+    moveMarquee(x: number, y: number): void {
+        this.interaction.moveMarquee(x, y);
+    }
+
+    endMarquee(x: number, y: number): void {
+        this.interaction.finishMarquee(x, y);
+    }
+
+    cancelMarquee(): void {
+        this.interaction.cancelMarquee();
+    }
+
+    /** Resolve a modifier press released inside drag slop as the ordinary empty click
+     * it would have been without marquee support: abort the pending rectangle and
+     * dismiss the current drawing selection. */
+    marqueeClick(): void {
+        this.interaction.cancelMarquee();
+        this.clearSelection();
+    }
+
     /** A press landed on the chart: a finished transient measurement clears (the ruler vanishes on the
      *  next press / pan / zoom), and an open inline edit ends. This runs for EVERY press, including the
      *  ones the drawings layer doesn't claim — a press on empty chart is a pan, and the editor may not
@@ -799,7 +831,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.emit({ kind: 'duplicate', ids: this.selectionIds() });
                 break;
             case 'delete': {
-                const ids = this.selectedIds.size ? this.selectionIds() : this.hoveredId ? [this.hoveredId] : [];
+                const targets = this.selectedIds.size ? this.selectionIds() : this.hoveredId ? [this.hoveredId] : [];
+                const ids = unlockedDrawingIds(this.drawings, targets);
                 if (ids.length) {
                     this.popup.close();
                     this.emit({ kind: 'delete', ids });
@@ -958,6 +991,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
         const m = this.interaction.snapMarker();
         const my = m ? proj.yOf(m.point.price, m.paneId) : null;
         if (m && my != null) this.painter.paintSnapRing(ctx, proj.xOf(m.point.time), my, this.deps.theme());
+        const marquee = this.interaction.marqueeRect();
+        if (marquee) this.painter.paintMarquee(ctx, marquee, this.deps.theme());
         // The transient ruler paints on top of everything (until cleared on the next press/pan/zoom).
         if (this.measure.isActive()) this.measure.paint(ctx, proj, this.deps.theme());
     }
@@ -1025,6 +1060,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.emit({ kind: 'edit', doc });
             },
             remove: () => {
+                const d = live();
+                if (!d || d.locked) return;
                 this.closeTextEditor(); // else the editor floats over the deleted label until it loses focus
                 this.popup.close();
                 this.emit({ kind: 'delete', ids: [id] });

--- a/src/renderers/native/layers.ts
+++ b/src/renderers/native/layers.ts
@@ -33,6 +33,8 @@ export interface RendererLayerArgs {
     priceStyle: string;
     /** Frame clock (ms) for pulses/fades; monotonic within a session. */
     nowMs: number;
+    /** True when presentation animation must resolve to a static/final frame. */
+    reducedMotion: boolean;
     /** Plot-relative pointer position, or null when the pointer is off the plot. Layers
      *  that hover-test set `repaintOnCursor` on their definition so pointer moves repaint
      *  them (only data-tier frames repaint layers otherwise). */

--- a/src/renderers/shared/IndicatorInputsDialog.ts
+++ b/src/renderers/shared/IndicatorInputsDialog.ts
@@ -9,6 +9,7 @@ import { Popover, closeOpenPopovers, eventDismissedPopover, isPopoverOpen, openP
 import { Dialog } from '../../ui/components/dialog';
 import { fieldRow, fieldSection, buildFieldControl, fieldGridColumns, FIELD_GAP_PX } from '../../ui/components/field';
 import { overlayScrollbarCss, FIELD_FOCUS_CSS, FIELD_FOCUS_RING } from '../../ui/styles';
+import { applyMotionScope } from './motion';
 
 /** Emitted when the user edits an input in the in-chart settings dialog. */
 export interface InputsUIChange {
@@ -74,11 +75,21 @@ export class IndicatorInputsDialog {
     private choicePop: Popover | null = null;
     private calendarPop: Popover | null = null;
     private calendarAnchor: HTMLElement | null = null;
+    private reducedMotion = false;
 
     constructor(private readonly host: IndicatorDialogHost) {}
 
     isOpen(): boolean {
         return this.dialog !== null;
+    }
+
+    /** Project the chart policy onto an open portal without affecting its host app. */
+    setReducedMotion(reduced: boolean): void {
+        this.reducedMotion = reduced;
+        if (this.uiDialog) {
+            const host = this.host.dialogHost() ?? this.host.container;
+            applyMotionScope(host, reduced, this.uiDialog.backdrop, this.uiDialog.positioner);
+        }
     }
 
     private readonly onDialogKey = (e: KeyboardEvent): void => {
@@ -126,6 +137,7 @@ export class IndicatorInputsDialog {
             // the replacement dialog.
             onOpenChange: (open) => { if (!open && this.uiDialog === ui) this.close(); },
         });
+        applyMotionScope(host, this.reducedMotion, ui.backdrop, ui.positioner);
         applyChromeTokens(ui.panel, t);
         ui.panel.style.colorScheme = this.isDarkTheme() ? 'dark' : 'light';
         this.dialogTips.push(attachChromeTooltip(ui.panel.querySelector('.vela-dialog-close') as HTMLElement, {
@@ -1040,4 +1052,3 @@ function timeParts(ts: number): { date: string; time: string } {
     const mm = String(snapped % 60).padStart(2, '0');
     return { date, time: `${hh}:${mm}` };
 }
-

--- a/src/renderers/shared/InputsUI.ts
+++ b/src/renderers/shared/InputsUI.ts
@@ -205,10 +205,23 @@ export class InputsUI {
      *  shells point this at their root so the dialog centers globally — the inline
      *  pane-anchored rows always stay in the container. */
     private dialogHost: HTMLElement | null = null;
+    private reducedMotion = false;
 
     setDialogHost(host: HTMLElement | null): void {
         this.dialogHost = host;
         if (host && getComputedStyle(host).position === 'static') host.style.position = 'relative';
+    }
+
+    /** Gate presentation-only status animation without changing the status itself. */
+    setReducedMotion(reduced: boolean): void {
+        if (reduced === this.reducedMotion) return;
+        this.reducedMotion = reduced;
+        this.inputsDialog.setReducedMotion(reduced);
+        if (!reduced) return; // existing static indicators stay static; future status writes may animate
+        for (const row of this.rows.values()) {
+            for (const animation of row.statusEl.getAnimations?.({ subtree: true }) ?? []) animation.cancel();
+            row.statusEl.style.animation = 'none';
+        }
     }
 
     constructor(
@@ -901,7 +914,9 @@ export class InputsUI {
                 const dot = document.createElement('span');
                 dot.style.cssText = 'width:4px;height:4px;border-radius:50%;background:currentColor;opacity:0.15;flex:none;';
                 // Staggered phases via negative delays — every dot animates from the first frame.
-                dot.animate?.([{ opacity: 0.12 }, { opacity: 0.55 }], { duration: 800, iterations: Infinity, direction: 'alternate', easing: 'ease-in-out', delay: -i * 260 });
+                if (!this.reducedMotion) {
+                    dot.animate?.([{ opacity: 0.12 }, { opacity: 0.55 }], { duration: 800, iterations: Infinity, direction: 'alternate', easing: 'ease-in-out', delay: -i * 260 });
+                }
                 el.appendChild(dot);
             }
             return;
@@ -911,7 +926,8 @@ export class InputsUI {
         el.style.cssText =
             `display:inline-block;box-sizing:border-box;flex:none;width:8px;height:8px;border-radius:50%;` +
             `margin-left:${LEGEND_TITLE_STATUS_GAP_PX}px;transform:translateY(1px);` +
-            `background:${this.theme.upColor};animation:vela-ind-pulse 1.2s ease-in-out infinite;`;
+            `background:${this.theme.upColor};` +
+            (this.reducedMotion ? '' : 'animation:vela-ind-pulse 1.2s ease-in-out infinite;');
     }
 
     /** Inject the status keyframes once (idempotent). */

--- a/src/renderers/shared/motion.ts
+++ b/src/renderers/shared/motion.ts
@@ -1,0 +1,95 @@
+// Browser-owned reduced-motion preference. The resolver stays in core/options; this
+// adapter is deliberately presentation-side because matchMedia is a DOM capability.
+import type { Unsubscribe } from '../../core/util/types';
+
+const MOTION_STYLE_ID = 'vela-reduced-motion';
+const MOTION_CSS = `
+[data-vela-motion='reduced'],
+[data-vela-motion='reduced'] *,
+[data-vela-motion='reduced'] *::before,
+[data-vela-motion='reduced'] *::after {
+    scroll-behavior: auto !important;
+    transition-delay: 0s !important;
+    transition-duration: 0s !important;
+    animation-delay: 0s !important;
+    animation-duration: 0s !important;
+    animation-iteration-count: 1 !important;
+}
+`;
+
+/** Install the scoped CSS gate in the host root and its document portal root. */
+export function ensureMotionStyles(host: HTMLElement): void {
+    if (typeof host.getRootNode !== 'function') return; // lightweight injected/test hosts
+    const doc = host.ownerDocument;
+    const root = host.getRootNode() as Document | ShadowRoot;
+    const install = (target: Document | ShadowRoot): void => {
+        if (target.querySelector(`#${MOTION_STYLE_ID}`)) return;
+        const style = doc.createElement('style');
+        style.id = MOTION_STYLE_ID;
+        style.textContent = MOTION_CSS;
+        (target === doc ? doc.head : target).appendChild(style);
+    };
+    install(root);
+    // Kit popovers default to document.body. A trigger inside a ShadowRoot therefore
+    // needs the same scoped rule in the document tree that owns its portaled surface.
+    if (root !== doc) install(doc);
+}
+
+/** Apply the effective policy to presentation roots portaled outside the chart tree. */
+export function applyMotionScope(host: HTMLElement, reduced: boolean, ...roots: HTMLElement[]): void {
+    ensureMotionStyles(host);
+    const value = reduced ? 'reduced' : 'full';
+    for (const root of roots) root.dataset.velaMotion = value;
+}
+
+export interface MotionPreferenceSource {
+    readonly reduced: boolean;
+    onChange(cb: (reduced: boolean) => void): Unsubscribe;
+}
+
+/** One live `prefers-reduced-motion` observation, shareable by every chart in a
+ * workspace. Standalone charts own one themselves. */
+export class MotionPreferenceController implements MotionPreferenceSource {
+    private readonly listeners = new Set<(reduced: boolean) => void>();
+    private mql: MediaQueryList | null = null;
+    private current = false;
+    private legacy = false;
+    private readonly onMediaChange = (event: MediaQueryListEvent): void => this.update(event.matches);
+
+    constructor(host: HTMLElement, observe = true) {
+        ensureMotionStyles(host);
+        const win = host.ownerDocument?.defaultView;
+        if (!observe || !win || typeof win.matchMedia !== 'function') return;
+        this.mql = win.matchMedia('(prefers-reduced-motion: reduce)');
+        this.current = this.mql.matches;
+        if (typeof this.mql.addEventListener === 'function') this.mql.addEventListener('change', this.onMediaChange);
+        else if (typeof this.mql.addListener === 'function') {
+            this.legacy = true;
+            this.mql.addListener(this.onMediaChange);
+        }
+    }
+
+    get reduced(): boolean {
+        return this.current;
+    }
+
+    onChange(cb: (reduced: boolean) => void): Unsubscribe {
+        this.listeners.add(cb);
+        return () => this.listeners.delete(cb);
+    }
+
+    destroy(): void {
+        if (this.mql) {
+            if (this.legacy && typeof this.mql.removeListener === 'function') this.mql.removeListener(this.onMediaChange);
+            else if (typeof this.mql.removeEventListener === 'function') this.mql.removeEventListener('change', this.onMediaChange);
+        }
+        this.mql = null;
+        this.listeners.clear();
+    }
+
+    private update(reduced: boolean): void {
+        if (reduced === this.current) return;
+        this.current = reduced;
+        for (const cb of [...this.listeners]) cb(reduced);
+    }
+}

--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -9,6 +9,7 @@
 // the `state:changed` notification); persistence is just an adapter driven through
 // the storage seam. Nothing here touches the URL — hosts wanting shareable links
 // compose them from `getState()` themselves.
+import { normalizeSession } from '../core/options';
 
 /** The linkable dimensions. `crosshair` mirrors the pointer time onto same-group
  *  cells as GHOST crosshairs (renderers without the optional `setExternalCrosshair`
@@ -70,7 +71,8 @@ export interface CellState {
     timeframe?: string;
     priceStyle?: string;
     bars?: number;
-    /** Trading session shown (`'extended'` persisted; absent = regular, the default). */
+    /** Selected provider-facing session id. An explicit host catalog validates it;
+     * without one, any normalized non-empty ID remains provider-facing state. */
     session?: string;
     /** Symbol watermark visibility — a per-chart display pref. */
     watermark?: boolean;
@@ -144,6 +146,33 @@ export function prefixedSymbol(cell: Pick<CellState, 'symbol' | 'provider'> | nu
 
 export function encodeState(state: WorkspaceState): string {
     return JSON.stringify(state);
+}
+
+/** Structural equality for the JSON-compatible opaque values carried by state `ext`
+ * bags. Object key order is irrelevant, while array order remains significant. The
+ * pair map also makes the comparison safe when an untrusted direct `applyState` call
+ * supplies a cyclic value even though persisted values must be JSON-serializable. */
+export function jsonStateEqual(left: unknown, right: unknown): boolean {
+    const pairs = new WeakMap<object, object>();
+    const equal = (a: unknown, b: unknown): boolean => {
+        if (Object.is(a, b)) return true;
+        if (a == null || b == null || typeof a !== 'object' || typeof b !== 'object') return false;
+        if (Array.isArray(a) !== Array.isArray(b)) return false;
+        if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false;
+        if (!Array.isArray(a) && Object.getPrototypeOf(a) !== Object.prototype && Object.getPrototypeOf(a) !== null) return false;
+        const mapped = pairs.get(a);
+        if (mapped) return mapped === b;
+        pairs.set(a, b);
+        const aKeys = Object.keys(a);
+        const bRecord = b as Record<string, unknown>;
+        if (aKeys.length !== Object.keys(bRecord).length) return false;
+        for (const key of aKeys) {
+            if (!Object.prototype.hasOwnProperty.call(bRecord, key)) return false;
+            if (!equal((a as Record<string, unknown>)[key], bRecord[key])) return false;
+        }
+        return true;
+    };
+    return equal(left, right);
 }
 
 /** Parse + sanitize a persisted payload. Null on anything unusable (wrong version,
@@ -222,7 +251,8 @@ function sanitizeCell(raw: unknown): CellState | null {
     if (typeof c.timeframe === 'string') out.timeframe = c.timeframe;
     if (typeof c.priceStyle === 'string') out.priceStyle = c.priceStyle;
     if (typeof c.bars === 'number' && Number.isFinite(c.bars) && c.bars > 0) out.bars = c.bars;
-    if (c.session === 'regular' || c.session === 'extended') out.session = c.session;
+    const session = normalizeSession(c.session);
+    if (session) out.session = session;
     if (typeof c.watermark === 'boolean') out.watermark = c.watermark;
     if (typeof c.indicatorTitles === 'boolean') out.indicatorTitles = c.indicatorTitles;
     if (typeof c.indicatorValues === 'boolean') out.indicatorValues = c.indicatorValues;

--- a/src/ui/components/popover/view.ts
+++ b/src/ui/components/popover/view.ts
@@ -32,6 +32,37 @@ export interface PopoverOptions extends PopoverControllerOptions {
 
 let open: Popover | null = null;
 
+/**
+ * Mirror the trigger's nearest presentation-motion scope onto a portaled root.
+ *
+ * Popovers normally live outside their trigger's DOM tree, so descendant selectors on
+ * a dialog or chart root cannot reach them. Observe only the owning scope's attribute:
+ * a live preference change then updates an already-open portal without marking the
+ * embedding app's portal host.
+ */
+export function mirrorPopoverMotionScope(trigger: HTMLElement, root: HTMLElement): () => void {
+    const scope = typeof trigger.closest === 'function'
+        ? trigger.closest<HTMLElement>('[data-vela-motion]')
+        : null;
+    if (!scope) {
+        root.removeAttribute('data-vela-motion');
+        return () => undefined;
+    }
+
+    const sync = (): void => {
+        const value = scope.dataset.velaMotion;
+        if (value === 'reduced' || value === 'full') root.dataset.velaMotion = value;
+        else root.removeAttribute('data-vela-motion');
+    };
+    sync();
+
+    const Observer = scope.ownerDocument.defaultView?.MutationObserver;
+    if (!Observer) return () => undefined;
+    const observer = new Observer(sync);
+    observer.observe(scope, { attributes: true, attributeFilter: ['data-vela-motion'] });
+    return () => observer.disconnect();
+}
+
 /** Close whichever kit popover is showing (dialog teardown, a second trigger). */
 export function closeOpenPopovers(): void {
     open?.hide();
@@ -76,6 +107,7 @@ export class Popover {
     private onOutside: ((e: Event) => void) | null = null;
     private onKey: ((e: KeyboardEvent) => void) | null = null;
     private onReflow: (() => void) | null = null;
+    private stopMotionScope: (() => void) | null = null;
     private shown = false;
 
     constructor(opts: PopoverOptions) {
@@ -116,6 +148,7 @@ export class Popover {
         }
         if (open && open !== this) open.hide();
         ensureUIHost(this.el, this.theme);
+        this.stopMotionScope = mirrorPopoverMotionScope(this.trigger, this.el);
         this.host.appendChild(this.el);
         this.shown = true;
         open = this;
@@ -158,6 +191,8 @@ export class Popover {
         this.onOutside = null;
         this.onKey = null;
         this.onReflow = null;
+        this.stopMotionScope?.();
+        this.stopMotionScope = null;
         this.el.remove();
         this.shown = false;
         if (open === this) open = null;

--- a/src/widget/bottombar.ts
+++ b/src/widget/bottombar.ts
@@ -2,6 +2,7 @@
 // Range presets switch the timeframe AND frame the matching visible window; the widget
 // owns the rebuild, so the bar only reports the chosen preset upward.
 import type { VisibleRangePreset } from '../core/visible-range';
+import type { MarketSession, MarketSessionDefinition } from '../core/options';
 import { Menu } from '../ui/components/menu';
 import { Tooltip } from '../ui/components/tooltip';
 import { iconEl } from '../ui/icons';
@@ -81,22 +82,24 @@ const CSS = `
     cursor: pointer;
 }
 .vela-bb-tz:hover { background: var(--vela-hover); }
-.vela-bb-session { display: inline-flex; border: 1px solid var(--vela-border-strong); border-radius: 4px; overflow: hidden; margin-left: 6px; }
-.vela-bb-session-btn {
+.vela-bb-session {
     all: unset;
     height: 24px;
     display: inline-flex;
     align-items: center;
+    gap: 5px;
     padding: 0 8px;
+    margin-left: 6px;
+    border: 1px solid var(--vela-border-strong);
+    border-radius: 4px;
     color: var(--vela-fg-muted);
     font-size: 11px;
     font-weight: 600;
     cursor: pointer;
 }
-.vela-bb-session-btn:disabled { cursor: not-allowed; opacity: 0.55; }
-.vela-bb-session-btn:not(:disabled):hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
-.vela-bb-session-btn.is-active { color: var(--vela-fg); background: var(--vela-surface-elev); }
-.vela-bb-session-btn.is-active:disabled { opacity: 0.8; }
+.vela-bb-session[hidden] { display: none !important; }
+.vela-bb-session:not(:disabled):hover { background: var(--vela-hover); color: var(--vela-fg-bright); }
+.vela-bb-session .vela-icon { width: 12px; height: 12px; }
 .vela-bb-settings {
     all: unset;
     display: inline-flex;
@@ -117,8 +120,8 @@ export interface BottombarOptions {
     timezone: string;
     onRange: (preset: RangePreset) => void;
     onTimezone: (zone: string) => void;
-    /** RTH/ETH toggled by the user. Fires only while the toggle is ENABLED (see {@link Bottombar.setSession}). */
-    onSession?: (session: 'regular' | 'extended') => void;
+    /** A declared/metadata-derived session selected from the active cell's menu. */
+    onSession?: (session: MarketSession) => void;
     onSettingsClick?: () => void;
 }
 
@@ -128,10 +131,12 @@ export class Bottombar {
     private readonly tzLabelEl: HTMLElement;
     private readonly tzButton: HTMLElement;
     private readonly tzMenu: Menu;
+    private readonly sessionButton: HTMLButtonElement;
+    private readonly sessionLabelEl: HTMLElement;
+    private readonly sessionMenu: Menu;
     private readonly settingsTip: Tooltip | null = null;
     private readonly rangeButtons = new Map<string, HTMLButtonElement>();
-    private readonly sessionButtons = new Map<'regular' | 'extended', HTMLButtonElement>();
-    private sessionEl: HTMLElement | null = null;
+    private sessionChoices: ReadonlyArray<Pick<MarketSessionDefinition, 'id' | 'label'>> = [];
     private timezone: string;
     private timer: ReturnType<typeof setInterval> | null = null;
 
@@ -165,33 +170,21 @@ export class Bottombar {
         this.tzLabelEl = doc.createElement('span');
         this.tzLabelEl.textContent = tzButtonLabel(this.timezone);
         this.tzButton.append(this.clockEl, this.tzLabelEl);
-        const session = doc.createElement('span');
-        session.className = 'vela-bb-session';
-        this.sessionEl = session;
-        // Boots HIDDEN (sessions only apply to markets that have them); the host reveals
-        // it per active chart via `setSession` once symbol metadata declares sessions.
-        session.style.display = 'none';
-        session.title = 'Session — regular (RTH) vs extended (ETH) hours';
-        for (const [key, label] of [['regular', 'RTH'], ['extended', 'ETH']] as const) {
-            const b = doc.createElement('button');
-            b.className = 'vela-bb-session-btn' + (key === 'regular' ? ' is-active' : '');
-            b.textContent = label;
-            b.disabled = true;
-            b.addEventListener('click', () => {
-                if (b.disabled) return;
-                this.setSession({ session: key, enabled: true }); // optimistic — the reload confirms
-                opts.onSession?.(key);
-            });
-            this.sessionButtons.set(key, b);
-            session.appendChild(b);
-        }
+        this.sessionButton = doc.createElement('button');
+        this.sessionButton.className = 'vela-bb-session';
+        this.sessionButton.hidden = true;
+        this.sessionButton.disabled = true;
+        this.sessionButton.setAttribute('aria-label', 'Trading session');
+        this.sessionLabelEl = doc.createElement('span');
+        this.sessionLabelEl.className = 'vela-bb-session-label';
+        this.sessionButton.append(this.sessionLabelEl, iconEl('chevron-down', doc));
         const settingsBtn = doc.createElement('button');
         settingsBtn.className = 'vela-bb-settings';
         settingsBtn.appendChild(iconEl('gear', doc));
         settingsBtn.setAttribute('aria-label', 'Chart settings');
         if (opts.onSettingsClick) settingsBtn.addEventListener('click', opts.onSettingsClick);
         this.settingsTip = new Tooltip(settingsBtn, { content: 'Chart settings', triggerId: 'vela-bb-settings', host });
-        this.el.append(spacer, this.tzButton, session, settingsBtn);
+        this.el.append(spacer, this.tzButton, this.sessionButton, settingsBtn);
         host.appendChild(this.el);
 
         this.tzMenu = new Menu({
@@ -203,6 +196,19 @@ export class Bottombar {
             onSelect: (zone) => {
                 this.setTimezone(zone);
                 opts.onTimezone(zone);
+            },
+        });
+        this.sessionMenu = new Menu({
+            trigger: this.sessionButton,
+            triggerId: 'vela-bb-session',
+            host,
+            placement: 'top-end',
+            items: [],
+            onSelect: (id) => {
+                const choice = this.sessionChoices.find((candidate) => candidate.id === id);
+                if (!choice) return;
+                this.setSession({ session: choice.id, choices: this.sessionChoices });
+                opts.onSession?.(choice.id);
             },
         });
 
@@ -225,23 +231,29 @@ export class Bottombar {
         }
     }
 
-    /**
-     * Reflect the ACTIVE chart's session posture. `enabled: false` (a continuous
-     * market, or metadata not landed yet) HIDES the toggle entirely — RTH/ETH is
-     * meaningless there. Enabled, the chips appear and the active one tracks the
-     * chart's current session.
-     */
-    setSession(state: { session: 'regular' | 'extended'; enabled: boolean }): void {
-        if (this.sessionEl) this.sessionEl.style.display = state.enabled ? '' : 'none';
-        for (const [key, b] of this.sessionButtons) {
-            b.disabled = !state.enabled;
-            b.classList.toggle('is-active', key === (state.enabled ? state.session : 'regular'));
-        }
+    /** Reflect the active cell's ordered session catalog. Fewer than two choices keep
+     * the picker hidden; a single choice may still drive provider data and shading. */
+    setSession(state: {
+        session: MarketSession;
+        choices: ReadonlyArray<Pick<MarketSessionDefinition, 'id' | 'label'>>;
+    }): void {
+        this.sessionChoices = [...state.choices];
+        const active = this.sessionChoices.find((choice) => choice.id === state.session) ?? this.sessionChoices[0];
+        this.sessionLabelEl.textContent = active?.label ?? '';
+        const visible = this.sessionChoices.length >= 2;
+        this.sessionButton.hidden = !visible;
+        this.sessionButton.disabled = !visible;
+        this.sessionMenu.setItems(this.sessionChoices.map((choice) => ({
+            id: choice.id,
+            label: choice.label,
+            checked: choice.id === active?.id,
+        })));
     }
 
     destroy(): void {
         if (this.timer !== null) clearInterval(this.timer);
         this.tzMenu.destroy();
+        this.sessionMenu.destroy();
         this.settingsTip?.destroy();
         this.el.remove();
     }

--- a/src/widget/glide.ts
+++ b/src/widget/glide.ts
@@ -63,6 +63,11 @@ export class Glider {
         if (!chart || !base) return;
         this.cur ??= { ...base }; // seed from the chart on a fresh glide; keep it while retargeting
         this.target = make(base);
+        if (chart.reducedMotion) {
+            chart.setVisibleRange(this.target);
+            this.stop();
+            return;
+        }
         if (!this.raf) this.tick();
     }
 
@@ -70,6 +75,11 @@ export class Glider {
         this.raf = requestAnimationFrame(() => {
             const chart = this.chart();
             if (!chart || !this.cur || !this.target) {
+                this.stop();
+                return;
+            }
+            if (chart.reducedMotion) {
+                chart.setVisibleRange(this.target);
                 this.stop();
                 return;
             }

--- a/src/widget/indicators.ts
+++ b/src/widget/indicators.ts
@@ -138,3 +138,34 @@ export function indicatorLedger(i: LedgerInputs): { manifest: LedgerManifestEntr
         natives,
     };
 }
+
+/** Whether two persisted ledgers describe the same live indicator set and values.
+ * Manifest order is presentation order; native entries are a multiset because the
+ * convergence path matches them by type. Input/prop record key order is immaterial. */
+export function indicatorLedgersEqual(
+    a: { manifest: readonly LedgerManifestEntry[]; natives: readonly string[] },
+    b: { manifest: readonly LedgerManifestEntry[]; natives: readonly string[] },
+): boolean {
+    if (a.manifest.length !== b.manifest.length || a.natives.length !== b.natives.length) return false;
+    const recordsEqual = (left: Record<string, InputValue> | undefined, right: Record<string, InputValue> | undefined): boolean => {
+        const leftKeys = Object.keys(left ?? {}).sort();
+        const rightKeys = Object.keys(right ?? {}).sort();
+        return leftKeys.length === rightKeys.length
+            && leftKeys.every((key, index) => key === rightKeys[index] && left?.[key] === right?.[key]);
+    };
+    const entriesEqual = (left: LedgerManifestEntry, right: LedgerManifestEntry): boolean => {
+        if (typeof left === 'string' || typeof right === 'string') return left === right;
+        return left.name === right.name
+            && recordsEqual(left.inputs, right.inputs)
+            && recordsEqual(left.props, right.props);
+    };
+    if (!a.manifest.every((entry, index) => entriesEqual(entry, b.manifest[index]!))) return false;
+    const counts = (values: readonly string[]): Map<string, number> => {
+        const out = new Map<string, number>();
+        for (const value of values) out.set(value, (out.get(value) ?? 0) + 1);
+        return out;
+    };
+    const ac = counts(a.natives);
+    const bc = counts(b.natives);
+    return ac.size === bc.size && [...ac].every(([type, count]) => bc.get(type) === count);
+}

--- a/src/widget/market-status.ts
+++ b/src/widget/market-status.ts
@@ -5,6 +5,7 @@
 // provider without the capability) keep the constructor's permanent 'open' — exactly
 // the pre-calendar behavior.
 import type { DataControl } from '../core/DataControl';
+import type { MarketSession } from '../core/options';
 import type { MarketStatus } from './statusline';
 import { parseSessionSpec } from './session-shading';
 
@@ -101,10 +102,14 @@ export class MarketStatusTracker {
     constructor(private readonly onStatus: (status: MarketStatus) => void) {}
 
     /** (Re)bind to a chart's data surface + symbol and start evaluating. */
-    track(data: DataControl, symbol: string): void {
+    track(
+        data: DataControl,
+        symbol: string,
+        options: { explicit?: boolean; session?: MarketSession; sessionTimezone?: string } = {},
+    ): void {
         const my = ++this.epoch;
         this.clearTimer();
-        void this.evaluate(my, data, symbol);
+        void this.evaluate(my, data, symbol, options);
     }
 
     stop(): void {
@@ -112,11 +117,35 @@ export class MarketStatusTracker {
         this.clearTimer();
     }
 
-    private async evaluate(my: number, data: DataControl, symbol: string): Promise<void> {
+    private async evaluate(
+        my: number,
+        data: DataControl,
+        symbol: string,
+        options: { explicit?: boolean; session?: MarketSession; sessionTimezone?: string },
+    ): Promise<void> {
         const resolved = data.resolve(symbol);
         const provider = resolved ? data.providerInstance(resolved.provider) : undefined;
         const si = await data.symbolInfo(symbol).catch(() => undefined);
         if (my !== this.epoch) return;
+        if (options.explicit) {
+            if (!provider?.getCalendar || !resolved || !options.session) {
+                this.onStatus('open');
+                return;
+            }
+            const now = Date.now();
+            const range = { from: now - FETCH_BACK_MS, to: now + FETCH_AHEAD_MS, session: options.session };
+            const windows = await provider.getCalendar(resolved.ticker, range).catch(() => null);
+            if (my !== this.epoch) return;
+            if (!windows) {
+                this.arm(my, data, symbol, options, RETRY_MS);
+                return;
+            }
+            this.onStatus(windows.some(([start, end]) => now >= start && now < end) ? 'open' : 'closed');
+            const boundary = windows.flatMap(([start, end]) => [start, end]).filter((edge) => edge > now).sort((a, b) => a - b)[0];
+            const delay = Math.min(boundary != null ? boundary - now : MAX_TIMER_MS, MAX_TIMER_MS);
+            this.arm(my, data, symbol, options, Math.max(delay, MIN_TIMER_MS));
+            return;
+        }
         const hasSessions = typeof si?.session === 'string' && si.session !== '' && si.session !== '24x7';
         if (!provider?.getCalendar || !hasSessions || !resolved) {
             this.onStatus('open'); // continuous market / no calendar — the legacy badge
@@ -132,7 +161,7 @@ export class MarketStatusTracker {
         if (my !== this.epoch) return;
         if (!regular || !extended) {
             // Transient fetch failure: keep the badge as it stands and retry.
-            this.arm(my, data, symbol, RETRY_MS);
+            this.arm(my, data, symbol, options, RETRY_MS);
             return;
         }
         const w: MarketWindows = { regular, extended };
@@ -142,15 +171,21 @@ export class MarketStatusTracker {
         this.onStatus(deriveMarketStatus(now, w, tz, overnight));
         const boundary = nextStatusBoundary(now, w);
         const delay = Math.min(boundary != null ? boundary - now : MAX_TIMER_MS, MAX_TIMER_MS);
-        this.arm(my, data, symbol, Math.max(delay, MIN_TIMER_MS));
+        this.arm(my, data, symbol, options, Math.max(delay, MIN_TIMER_MS));
     }
 
-    private arm(my: number, data: DataControl, symbol: string, delay: number): void {
+    private arm(
+        my: number,
+        data: DataControl,
+        symbol: string,
+        options: { explicit?: boolean; session?: MarketSession; sessionTimezone?: string },
+        delay: number,
+    ): void {
         this.clearTimer();
         this.timer = setTimeout(() => {
             this.timer = null;
             if (my !== this.epoch) return;
-            void this.evaluate(my, data, symbol);
+            void this.evaluate(my, data, symbol, options);
         }, delay);
     }
 

--- a/src/widget/session-shading.ts
+++ b/src/widget/session-shading.ts
@@ -11,7 +11,7 @@
 // consumers that genuinely need holidays (market-status badges, session profiles).
 // Symbols with no session vocabulary (crypto `24x7`) report null — nothing shaded.
 import type { DataControl } from '../core/DataControl';
-import type { MarketSession } from '../core/options';
+import type { MarketSession, MarketSessionDefinition } from '../core/options';
 import type { VisibleRange } from '../core/ports/IChartRenderer';
 import type { SymbolInfo } from '../core/ports/MarketDataFeed';
 import type { CalendarWindow } from './market-status';
@@ -25,6 +25,9 @@ export interface SessionZonesUpdate {
     pre: CalendarWindow[];
     post: CalendarWindow[];
     extended: CalendarWindow[];
+    /** Host-declared session windows carry their own color. Metadata-derived sessions
+     * keep using the legacy phase buckets above and renderer-configured colors. */
+    bands?: Array<{ from: number; to: number; color: string }>;
 }
 
 /** One `[start, end)` window as minutes into the market's civil day. */
@@ -197,6 +200,76 @@ export function expandSessionZones(spec: SessionSpec, from: number, to: number):
     return { pre, post, extended: mergeAbutting(extended) };
 }
 
+/** Convert a civil date plus an arbitrary minute offset to epoch time in `dtf`'s zone.
+ * Re-resolving the offset at the candidate instant keeps edges on both sides of a DST
+ * transition accurate instead of applying one daily offset to the whole window. */
+function atCivilMinute(dtf: Intl.DateTimeFormat, year: number, month: number, day: number, minute: number): number {
+    const shifted = new Date(Date.UTC(year, month - 1, day) + minute * MINUTE_MS);
+    const y = shifted.getUTCFullYear();
+    const m = shifted.getUTCMonth() + 1;
+    const d = shifted.getUTCDate();
+    const minuteOfDay = shifted.getUTCHours() * 60 + shifted.getUTCMinutes();
+    const naive = Date.UTC(y, m - 1, d);
+    const wall = naive + minuteOfDay * MINUTE_MS;
+    let candidate = wall;
+    for (let i = 0; i < 3; i += 1) {
+        const atCandidate = civilParts(dtf, candidate);
+        const rendered = Date.UTC(
+            atCandidate.year,
+            atCandidate.month - 1,
+            atCandidate.day,
+            atCandidate.hour,
+            atCandidate.minute,
+        );
+        const next = wall - (rendered - candidate);
+        if (next === candidate) break;
+        candidate = next;
+    }
+    return candidate;
+}
+
+/** Expand one explicit definition into colored market-time bands. Windows recur every
+ * civil day; the renderer's bar-slot clipping naturally removes closed-market days.
+ * An overnight window belongs to the civil day on which it ends (`1700-1600` Monday
+ * starts Sunday evening). */
+export function expandSessionDefinition(
+    definition: MarketSessionDefinition,
+    timezone: string,
+    from: number,
+    to: number,
+): Array<{ from: number; to: number; color: string }> {
+    const dtf = civilFormatter(timezone);
+    if (!dtf || !Number.isFinite(from) || !Number.isFinite(to)) return [];
+    const parsed: DayWindow[] = [];
+    for (const window of definition.windows) {
+        const m = /^(\d{2})(\d{2})-(\d{2})(\d{2})$/.exec(window);
+        if (!m) return [];
+        const sh = Number(m[1]);
+        const sm = Number(m[2]);
+        const eh = Number(m[3]);
+        const em = Number(m[4]);
+        if (sh > 23 || sm > 59 || eh > 24 || em > 59 || (eh === 24 && em !== 0) || (sh === eh && sm === em)) return [];
+        parsed.push({ start: sh * 60 + sm, end: eh * 60 + em });
+    }
+    const bands: CalendarWindow[] = [];
+    const seen = new Set<number>();
+    const lo = Math.min(from, to);
+    const hi = Math.max(from, to);
+    for (let cursor = lo - 2 * DAY_MS; cursor < hi + 2 * DAY_MS; cursor += DAY_MS) {
+        const civil = civilParts(dtf, cursor);
+        const key = civil.year * 10_000 + civil.month * 100 + civil.day;
+        if (!Number.isFinite(key) || seen.has(key)) continue;
+        seen.add(key);
+        for (const window of parsed) {
+            const overnight = window.start > window.end;
+            const start = atCivilMinute(dtf, civil.year, civil.month, civil.day, overnight ? window.start - 1440 : window.start);
+            const end = atCivilMinute(dtf, civil.year, civil.month, civil.day, window.end);
+            if (end > start && end > lo && start < hi) bands.push([start, end]);
+        }
+    }
+    return mergeAbutting(bands).map(([start, end]) => ({ from: start, to: end, color: definition.color }));
+}
+
 /** Recompute coverage reaches this far beyond the visible span on each side, so
  *  ordinary panning keeps landing inside the last expansion. */
 const COVER_PAD_MIN_MS = 2 * DAY_MS;
@@ -216,6 +289,9 @@ export class SessionShadingTracker {
     /** Invalidates the one async step (metadata resolution) — bumped by track()/stop(). */
     private epoch = 0;
     private spec: SessionSpec | null = null;
+    /** `undefined` means metadata mode; null is an authoritative empty explicit list. */
+    private definition: MarketSessionDefinition | null | undefined;
+    private sessionTimezone = 'Etc/UTC';
     private ready = false;
     private session: MarketSession = 'regular';
     /** Whether one bar is shorter than a civil day — only then do pre/post bars exist. */
@@ -228,22 +304,49 @@ export class SessionShadingTracker {
     constructor(private readonly onZones: (zones: SessionZonesUpdate | null) => void) {}
 
     /** (Re)bind to a chart's data surface + market and expand once metadata lands. */
-    track(data: DataControl, symbol: string, opts: { session: MarketSession; timeframe: string; range: VisibleRange }): void {
+    track(
+        data: DataControl,
+        symbol: string,
+        opts: {
+            session: MarketSession;
+            timeframe: string;
+            range: VisibleRange;
+            definitions?: readonly MarketSessionDefinition[];
+            sessionTimezone?: string;
+        },
+    ): void {
         const my = ++this.epoch;
         this.ready = false;
         this.spec = null;
         this.covered = null;
+        this.sessionTimezone = 'Etc/UTC';
         this.session = opts.session;
+        this.definition = opts.definitions === undefined ? undefined : (opts.definitions.find((definition) => definition.id === opts.session) ?? null);
         const tfMs = timeframeMs(opts.timeframe);
         this.intraday = Number.isFinite(tfMs) && tfMs < DAY_MS;
         this.lastRange = opts.range;
+        const explicitTimezone = typeof opts.sessionTimezone === 'string' && opts.sessionTimezone.trim() !== '' ? opts.sessionTimezone.trim() : undefined;
+        // An empty catalog is immediately authoritative. Likewise, an explicit
+        // timezone makes a selected definition independent from symbol metadata.
+        if (this.definition === null || (this.definition && explicitTimezone !== undefined)) {
+            this.ready = true;
+            this.sessionTimezone = explicitTimezone ?? 'Etc/UTC';
+            this.emit(opts.range, true);
+            return;
+        }
         void data
             .symbolInfo(symbol)
             .catch(() => undefined)
             .then((si) => {
                 if (my !== this.epoch) return;
                 this.ready = true;
-                this.spec = parseSessionSpec(si);
+                if (opts.definitions === undefined) {
+                    this.spec = parseSessionSpec(si);
+                } else {
+                    this.spec = null;
+                    const metadataTimezone = typeof si?.timezone === 'string' && si.timezone !== '' ? si.timezone : undefined;
+                    this.sessionTimezone = metadataTimezone || 'Etc/UTC';
+                }
                 this.emit(this.lastRange ?? opts.range, true);
             });
     }
@@ -260,11 +363,36 @@ export class SessionShadingTracker {
         this.epoch += 1;
         this.ready = false;
         this.spec = null;
+        this.definition = undefined;
         this.covered = null;
         this.lastRange = null;
     }
 
     private emit(range: VisibleRange, force: boolean): void {
+        if (this.definition !== undefined) {
+            if (!this.definition) {
+                if (force) this.onZones(null);
+                return;
+            }
+            if (!this.intraday) {
+                if (force) this.onZones({ pre: [], post: [], extended: [], bands: [] });
+                return;
+            }
+            const from = Math.min(range.from, range.to);
+            const to = Math.max(range.from, range.to);
+            if (!Number.isFinite(from) || !Number.isFinite(to)) return;
+            if (!force && this.covered && from >= this.covered.from && to <= this.covered.to) return;
+            const pad = Math.max(to - from, COVER_PAD_MIN_MS);
+            const covered = { from: from - pad, to: to + pad };
+            this.covered = covered;
+            this.onZones({
+                pre: [],
+                post: [],
+                extended: [],
+                bands: expandSessionDefinition(this.definition, this.sessionTimezone, covered.from, covered.to),
+            });
+            return;
+        }
         if (!this.spec) {
             if (force) this.onZones(null);
             return;

--- a/src/widget/shortcuts-help.ts
+++ b/src/widget/shortcuts-help.ts
@@ -103,6 +103,8 @@ export class ShortcutsHelp {
         addCategory('Mouse');
         addRow('Scroll through history', ['Shift+Scroll']);
         addRow('Measure from the press point', ['Shift+Click']);
+        addRow('Select drawings in an area', ['Ctrl/Cmd+Drag']);
+        addRow('Add drawings in an area', ['Ctrl/Cmd+Shift+Drag']);
         addRow('Delete the drawing under the cursor', ['Middle-click']);
         // The two type-to-act routes live outside the keymap (any-printable routing).
         const s = doc.createElement('div');

--- a/src/widget/statusline.ts
+++ b/src/widget/statusline.ts
@@ -532,6 +532,9 @@ export class Statusline {
         this.detach();
         this.lastBar = null;
         this.hoverBar = null;
+        const syncChartHidden = (): void => {
+            this.setChartHidden(chart.renderer.get('candleVisible') === false);
+        };
         this.unsubs.push(
             chart.on('bar', (b: OHLCV) => {
                 this.lastBar = b;
@@ -541,7 +544,10 @@ export class Statusline {
                 this.hoverBar = e.ohlc;
                 this.render();
             }),
+            chart.renderer.onConfigChanged(syncChartHidden),
         );
+        // Renderer config may have been restored before the status line was built.
+        syncChartHidden();
         this.render();
     }
 
@@ -565,9 +571,8 @@ export class Statusline {
     }
 
     private render(): void {
-        // Chart visibility has no change event of its own — re-derive it from the live
-        // renderer on every readout refresh (bar ticks, crosshair moves), so a toggle
-        // made anywhere (the object tree's eye) reaches the status line.
+        // Also re-derive on readout refresh for custom renderers that do not publish
+        // config-change notifications.
         if (this.menuHooks) this.setChartHidden(!this.menuHooks.chartVisible());
         const bar = this.hoverBar ?? this.lastBar;
         if (!bar) {

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -7,12 +7,22 @@
 // layout change — its state then round-trips through the workspace pool, so shrinking
 // 4 → 2 → 4 restores the third and fourth exactly, indicators and drawings included).
 import { Vela } from '../Vela';
-import { normalizeSession, type MarketSession, type NativeBackend, type VelaOptions, type VelaTheme } from '../core/options';
+import {
+    normalizeSession,
+    normalizeSessionDefinitions,
+    resolveMarketSession,
+    type MarketSession,
+    type MarketSessionDefinition,
+    type NativeBackend,
+    type VelaOptions,
+    type VelaTheme,
+} from '../core/options';
 import type { OHLCV } from '../core/model/ohlcv';
 import type { VisibleRangePreset } from '../core/visible-range';
 import type { VisibleRange } from '../core/ports/IChartRenderer';
 import type { DrawingsOption } from '../core/drawings';
 import type { MarketDataFeed } from '../core/ports/MarketDataFeed';
+import type { DataControl } from '../core/DataControl';
 import type { ScriptingEngine } from '../core/ports/ScriptingEngine';
 import type { IndicatorHandle } from '../core/IndicatorHandle';
 import { Statusline, statuslineInkOf, type StatuslinePart } from '../widget/statusline';
@@ -24,7 +34,7 @@ import { CellControls } from '../widget/cell-controls';
 import { ChartContextMenu } from '../widget/context-menu';
 import { WidgetHistory } from '../widget/history';
 import type { RangePreset } from '../widget/bottombar';
-import { indicatorLedger, ledgerEntryName, type LedgerManifestEntry, type ResolvedIndicator } from '../widget/indicators';
+import { indicatorLedger, indicatorLedgersEqual, ledgerEntryName, type LedgerManifestEntry, type ResolvedIndicator } from '../widget/indicators';
 import { inputDeltas, type InputValue } from '../core/model/inputs';
 import {
     legendActionsProviderFor,
@@ -35,10 +45,27 @@ import {
     type ExternalIndicatorEntry,
     type WidgetContext,
 } from '../widget/contributions';
-import { prefixedSymbol, type CellState } from '../state/document';
+import { jsonStateEqual, prefixedSymbol, type CellState } from '../state/document';
 import { parseSymbol } from '../data/ProviderRegistry';
 import { normalizeTimezone } from '../core/timezones';
 import { applyPlotOverlayTokens } from '../ui';
+import type { MotionPreferenceSource } from '../renderers/shared/motion';
+
+const LEGACY_SESSION_CHOICES = [
+    { id: 'regular', label: 'Regular hours (RTH)' },
+    { id: 'extended', label: 'Extended hours (ETH)' },
+] as const satisfies ReadonlyArray<Pick<MarketSessionDefinition, 'id' | 'label'>>;
+
+function normalizeLegacySession(value: unknown): 'regular' | 'extended' | undefined {
+    const id = normalizeSession(value);
+    if (id === 'regular') return 'regular';
+    if (id === 'extended') return 'extended';
+    return undefined;
+}
+
+function sessionChoiceSignature(choices: ReadonlyArray<Pick<MarketSessionDefinition, 'id' | 'label'>>): string {
+    return JSON.stringify(choices.map(({ id, label }) => [id, label]));
+}
 
 /** The seed/mutable market state of one cell (all optional — an empty cell parks).
  *  The SAME vocabulary as the widget's chart options: the workspace's top-level chart
@@ -51,7 +78,12 @@ export interface CellSeed {
     priceStyle?: string;
     bars?: number;
     /** Trading session to show (markets that have one; `regular` is the default). */
-    session?: string;
+    session?: MarketSession;
+    /** Explicit per-cell session catalog. `undefined` derives the legacy choices from
+     * symbol metadata; an empty list deliberately disables the session surface. */
+    sessions?: readonly MarketSessionDefinition[];
+    /** IANA market timezone for explicit session windows. */
+    sessionTimezone?: string;
     /** Offline bars for this cell — replaces the provider (boot-only). */
     data?: OHLCV[];
     /** Initial visible window (boot-only). */
@@ -64,17 +96,21 @@ export type PooledCellState = CellState;
 
 /** What a cell BOOTS from: a pooled state (restored slot) or an options seed — plus
  *  the boot-only extras a pooled state never carries (offline bars, initial window). */
-export type CellBoot = PooledCellState & Pick<CellSeed, 'data' | 'visibleRange'>;
+export type CellBoot = PooledCellState & Pick<CellSeed, 'data' | 'visibleRange' | 'sessions' | 'sessionTimezone'>;
 
 /** The per-cell SEED the workspace's top-level chart options provide — same words as
  *  the widget; `cells[id]` spreads over this. */
-export function seedDefaults(opts: Pick<VelaOptions, 'symbol' | 'timeframe' | 'bars' | 'priceStyle' | 'session' | 'data' | 'visibleRange'>): CellSeed {
+export function seedDefaults(
+    opts: Pick<VelaOptions, 'symbol' | 'timeframe' | 'bars' | 'priceStyle' | 'session' | 'sessions' | 'sessionTimezone' | 'data' | 'visibleRange'>,
+): CellSeed {
     return {
         symbol: opts.symbol,
         timeframe: opts.timeframe,
         bars: opts.bars,
         priceStyle: opts.priceStyle,
         session: opts.session,
+        sessions: opts.sessions,
+        sessionTimezone: opts.sessionTimezone,
         data: opts.data,
         visibleRange: opts.visibleRange,
     };
@@ -127,6 +163,8 @@ export interface CellNativeInfo {
 export interface CellDeps {
     /** THE shared market-data feed (one registry, one cache, for every cell). */
     feed: MarketDataFeed;
+    /** Workspace-shared system motion preference (one media-query listener total). */
+    motionPreference?: MotionPreferenceSource;
     /** Scripting-engine factories — instantiated PER CELL (a worker engine per cell). */
     engines: Record<string, () => ScriptingEngine>;
     /** The workspace's top-level chart options every cell's chart starts from. */
@@ -217,8 +255,13 @@ export class ChartCell {
     lastCrossPrice: number | null = null;
     /** The bottombar range chip this cell is framed on (null = none). */
     activeRangeId: string | null = null;
-    /** Latched verdict of {@link sessionAvailable} (async metadata, sticky per symbol). */
+    /** Latched verdict of {@link sessionAvailable} (async in metadata mode). */
     private sessionAvailableFlag = false;
+    private sessionChoices: ReadonlyArray<Pick<MarketSessionDefinition, 'id' | 'label'>> = [];
+    /** `undefined` selects the backward-compatible metadata adapter; an array, including
+     * empty, is the authoritative host catalog. */
+    private readonly explicitSessions: readonly MarketSessionDefinition[] | undefined;
+    private readonly explicitSessionTimezone: string | undefined;
     /** Latched: the symbol's extended tape wraps midnight (an overnight roll market) —
      *  one extended-hours shading phase instead of the pre/post split. */
     private sessionOvernightFlag = false;
@@ -239,7 +282,7 @@ export class ChartCell {
     private readonly offMarket: () => void;
     /** The cell's durable market state — the seed vocabulary plus the venue mirror the
      *  persisted document carries (`provider` = the symbol's parsed prefix). */
-    private state: CellSeed & Pick<CellState, 'provider'>;
+    private state: CellState;
     private manifest: readonly ResolvedIndicator[] = [];
     /** A restored ledger's manifest entry NAMES, waiting for the manifest to resolve
      *  (a pool/persisted cell can be built before the shared manifest has loaded). */
@@ -277,6 +320,13 @@ export class ChartCell {
         private readonly deps: CellDeps,
     ) {
         this.appTheme = deps.theme;
+        this.explicitSessions = seed.sessions === undefined ? undefined : normalizeSessionDefinitions(seed.sessions);
+        this.explicitSessionTimezone = typeof seed.sessionTimezone === 'string' && seed.sessionTimezone.trim() !== '' ? seed.sessionTimezone.trim() : undefined;
+        this.sessionChoices = this.explicitSessions ?? [];
+        this.sessionAvailableFlag = this.sessionChoices.length > 0;
+        const initialSession = this.explicitSessions === undefined
+            ? normalizeSession(seed.session)
+            : resolveMarketSession(seed.session, this.explicitSessions);
         // The canonical symbol form: pre-prefix pooled/persisted states carried the venue
         // in `provider` beside a bare symbol — weld them back together once, at boot.
         const symbol = prefixedSymbol(seed);
@@ -286,7 +336,7 @@ export class ChartCell {
             timeframe: seed.timeframe,
             priceStyle: seed.priceStyle,
             bars: seed.bars,
-            session: normalizeSession(seed.session),
+            session: initialSession,
         };
         const doc = gridHost.ownerDocument;
         this.host = doc.createElement('div');
@@ -307,7 +357,9 @@ export class ChartCell {
                 timeframe: seed.timeframe,
                 bars: seed.bars,
                 priceStyle: seed.priceStyle,
-                session: normalizeSession(seed.session),
+                session: initialSession,
+                sessions: this.explicitSessions,
+                sessionTimezone: this.explicitSessionTimezone,
                 data: seed.data,
                 visibleRange: seed.visibleRange,
                 theme: deps.theme,
@@ -321,7 +373,7 @@ export class ChartCell {
                 // the whole workspace (per-cell bars would cost a 44px gutter each).
                 drawings: cellDrawings(deps.chartDefaults.drawings),
             },
-            { dataFeed: deps.feed },
+            { dataFeed: deps.feed, motionPreference: deps.motionPreference },
         );
         for (const [language, make] of Object.entries(resolveEngines(deps.engines))) this.inner.registerEngine(language, make());
         // ONE attribution mark per WORKSPACE, not per cell: each cell disables its own
@@ -427,7 +479,7 @@ export class ChartCell {
                 this.statusline?.setMeta(this.state.timeframe ?? '60', this.inner.data.displayPrefix(this.state.symbol) ?? this.state.provider ?? '');
             }
             this.refreshSessionAvailable();
-            if (this.inner && this.state.symbol) this.marketStatus?.track(this.inner.data, this.state.symbol);
+            if (this.inner && this.state.symbol) this.trackMarketStatus(this.inner.data, this.state.symbol);
         });
         this.syncStatuslineColors();
         this.cellControls = new CellControls(this.host, {
@@ -520,7 +572,7 @@ export class ChartCell {
             this.projectMarket(symbol, timeframe);
             this.refreshNativeCatalog(); // per-symbol support flags may differ
             this.refreshSessionAvailable(); // the new symbol may (not) have sessions
-            if (this.inner) this.marketStatus?.track(this.inner.data, symbol); // …and its own market clock
+            if (this.inner) this.trackMarketStatus(this.inner.data, symbol); // …and its own market clock
             this.deps.onMarketChanged(this.id);
         });
     }
@@ -543,26 +595,41 @@ export class ChartCell {
         if (this.inner) this.statusline?.onChart(this.inner); // drop the old market's resting OHLC
     }
 
-    /**
-     * Does this cell's market HAVE sessions (RTH/ETH meaningful)? Derived from the
-     * symbol's own metadata (`syminfo.session !== '24x7'`), asynchronously — the
-     * workspace re-projects the shared bottombar when the verdict lands or changes.
-     */
+    /** Whether this cell has an explicit catalog or metadata-derived session structure.
+     * Metadata mode resolves asynchronously; the workspace re-projects the shared
+     * bottombar when the verdict lands or changes. */
     get sessionAvailable(): boolean {
         return this.sessionAvailableFlag;
     }
 
-    /** This cell's shown session (`regular` when unset — the provider default). */
+    /** Ordered choices projected into the shared session dropdown. */
+    get sessions(): ReadonlyArray<Pick<MarketSessionDefinition, 'id' | 'label'>> {
+        return this.sessionChoices;
+    }
+
+    /** Session choice projected into workspace UI (`regular` when the provider default is unset). */
     get session(): MarketSession {
+        if (this.explicitSessions !== undefined) return resolveMarketSession(this.state.session, this.explicitSessions) ?? 'regular';
         return normalizeSession(this.state.session) ?? 'regular';
     }
 
-    /** Switch this cell's shown session in place (a reload — RTH and ETH are different bars). */
+    /** Switch this cell's shown session in place. An explicit catalog validates its IDs;
+     * metadata mode keeps any normalized provider-facing ID. */
     setSession(session: MarketSession): void {
-        if (session === this.session) return;
-        this.state.session = session;
+        const normalized = normalizeSession(session);
+        if (!normalized) return;
+        const allowed = this.explicitSessions === undefined
+            ? normalized
+            : this.explicitSessions.find((definition) => definition.id === normalized)?.id;
+        // The omitted provider default and an explicit `regular` ID can resolve to the
+        // same UI label but remain distinct request/cache identities.
+        const current = this.inner
+            ? normalizeSession(this.inner.market.session)
+            : normalizeSession(this.state.session);
+        if (!allowed || allowed === current) return;
+        this.state.session = allowed;
         this.deps.onStateDirty();
-        void this.inner?.setMarket({ session });
+        void this.inner?.setMarket({ session: allowed });
     }
 
     private refreshSessionAvailable(): void {
@@ -571,15 +638,44 @@ export class ChartCell {
         if (!chart || !symbol) return;
         void chart.data.symbolInfo(symbol).then((si) => {
             if (this.inner !== chart) return;
-            const available = typeof si?.session === 'string' && si.session !== '' && si.session !== '24x7';
-            const overnight = parseSessionSpec(si)?.overnight === true;
-            if (available !== this.sessionAvailableFlag || overnight !== this.sessionOvernightFlag) {
+            const metadataSpec = parseSessionSpec(si);
+            const choices = this.explicitSessions ?? (() => {
+                if (!metadataSpec) return [];
+                const current = normalizeSession(this.state.session);
+                return current && !LEGACY_SESSION_CHOICES.some((choice) => choice.id === current)
+                    ? [...LEGACY_SESSION_CHOICES, { id: current, label: current }]
+                    : LEGACY_SESSION_CHOICES;
+            })();
+            const available = choices.length > 0;
+            const overnight = this.explicitSessions === undefined && metadataSpec?.overnight === true;
+            const choicesChanged = sessionChoiceSignature(choices) !== sessionChoiceSignature(this.sessionChoices);
+            this.sessionChoices = choices;
+            if (available !== this.sessionAvailableFlag || overnight !== this.sessionOvernightFlag || choicesChanged) {
                 this.sessionAvailableFlag = available;
                 this.sessionOvernightFlag = overnight;
                 this.deps.onMarketChanged(this.id); // re-project the shared bottombar toggle
                 this.pushSettingsSections(); // the Trading session group follows the symbol
             }
             this.refreshSessionShading();
+        });
+    }
+
+    private trackMarketStatus(data: DataControl, symbol: string): void {
+        if (this.explicitSessions === undefined) {
+            const session = normalizeSession(this.state.session);
+            this.marketStatus?.track(
+                data,
+                symbol,
+                session && normalizeLegacySession(session) === undefined
+                    ? { explicit: true, session }
+                    : undefined,
+            );
+            return;
+        }
+        this.marketStatus?.track(data, symbol, {
+            explicit: true,
+            session: this.explicitSessions.length > 0 ? this.session : undefined,
+            sessionTimezone: this.explicitSessionTimezone,
         });
     }
 
@@ -594,7 +690,13 @@ export class ChartCell {
         const requestedSpan = Math.max(this.state.bars ?? 1000, this.rangeBars) * timeframeMs(this.state.timeframe ?? '60');
         const fallbackSpan = Number.isFinite(requestedSpan) ? Math.max(3 * 86_400_000, requestedSpan) : 3 * 86_400_000;
         const range = chart.getVisibleRange() ?? { from: now - fallbackSpan, to: now };
-        this.sessionShading.track(chart.data, symbol, { session: this.session, timeframe: this.timeframe, range });
+        this.sessionShading.track(chart.data, symbol, {
+            session: this.session,
+            timeframe: this.timeframe,
+            range,
+            definitions: this.explicitSessions,
+            sessionTimezone: this.explicitSessionTimezone,
+        });
     }
 
     /** The session-shade colors live in the renderer CONFIG (persisted with it, edited
@@ -622,9 +724,9 @@ export class ChartCell {
     private pushSettingsSections(): void {
         const chart = this.inner;
         if (!chart) return;
-        const rth = 'Regular hours (RTH)';
-        const eth = 'Extended hours (ETH)';
-        const shadeRows = this.sessionOvernightFlag
+        const shadeRows = this.explicitSessions !== undefined
+            ? []
+            : this.sessionOvernightFlag
             ? [
                   {
                       kind: 'color' as const,
@@ -652,21 +754,22 @@ export class ChartCell {
               ];
         // The `id` fields are the sections' stable visibility ids (`settings.hidden`,
         // docs/user/options.md) — same reserved ids as the widget's sections.
+        const choiceOptions = this.sessionChoices.map((choice) => [choice.id, choice.label] as const);
+        const choiceRows = choiceOptions.length < 2
+            ? []
+            : [{
+                  kind: 'select' as const,
+                  label: 'Session',
+                  id: 'session',
+                  options: choiceOptions,
+                  get: () => this.session,
+                  set: (id: string) => this.setSession(id),
+              }];
         const sessionSection = {
             title: 'Trading session',
             id: 'trading-session',
             placement: 'symbol' as const,
-            rows: [
-                {
-                    kind: 'select' as const,
-                    label: 'Session',
-                    id: 'session',
-                    options: [rth, eth],
-                    get: () => (this.session === 'extended' ? eth : rth),
-                    set: (v: string) => this.setSession(v === eth ? 'extended' : 'regular'),
-                },
-                ...shadeRows,
-            ],
+            rows: [...choiceRows, ...shadeRows],
         };
         const advanced = {
             title: 'Advanced',
@@ -756,7 +859,7 @@ export class ChartCell {
             });
         }
         sections.push(advanced);
-        if (this.sessionAvailableFlag) sections.push(sessionSection);
+        if (this.sessionAvailableFlag && sessionSection.rows.length > 0) sections.push(sessionSection);
         sections.push(watermarkSection);
         chart.renderer.setSettingsSections(sections);
     }
@@ -1266,22 +1369,44 @@ export class ChartCell {
         // Cosmetics + drawings round-trip (both validate untrusted input).
         if (cs.rendererConfig != null) this.inner.renderer.applyConfig(cs.rendererConfig);
         if (cs.drawings != null) this.inner.drawings.fromJSON(cs.drawings);
-        if (cs.indicators) this.applyIndicatorLedger(cs.indicators as { manifest: LedgerManifestEntry[]; natives: string[] });
-        // Third-party state converges to the document too: the restored bag REPLACES
-        // the baseline (absent in the document = the document carries none), then the
-        // registered handlers re-apply. After the ledger — a handler re-adding external
-        // indicators must land on the converged (external-free) instance set.
-        this.extState = { ...(cs.ext ?? {}) };
-        this.restorePersistedExt();
+        const nextExt = { ...(cs.ext ?? {}) };
+        const extChanged = !jsonStateEqual(this.extState, nextExt);
+        let indicatorLedgerApplied = false;
+        if (cs.indicators) {
+            const ledger = cs.indicators as { manifest: LedgerManifestEntry[]; natives: string[] };
+            // A changed extension payload may describe a different set of external
+            // indicators. Rebuild from the core ledger before its handler re-adds them.
+            if (extChanged || !indicatorLedgersEqual(this.indicatorLedgerSnapshot(), ledger)) {
+                this.applyIndicatorLedger(ledger);
+                indicatorLedgerApplied = true;
+            }
+        }
+        // Third-party state converges to the document too. Equal payloads stay live and
+        // their handlers do not replay unless core-ledger convergence just removed the
+        // external instances they own. This keeps getState()/applyState() idempotent
+        // while also rebuilding plugins after a genuine core-indicator change.
+        if (extChanged || indicatorLedgerApplied) {
+            if (extChanged) this.extState = nextExt;
+            this.restorePersistedExt();
+        }
         // Market last, as ONE in-place switch — `market:changed` re-syncs the cell
         // overlays and notifies the workspace (chrome projection, retention).
         const symbol = prefixedSymbol(cs);
-        const session = normalizeSession(cs.session) ?? 'regular';
+        const savedSession = normalizeSession(cs.session);
+        const session = this.explicitSessions === undefined
+            ? savedSession ?? 'regular'
+            : resolveMarketSession(cs.session, this.explicitSessions);
         const bars = typeof cs.bars === 'number' && Number.isFinite(cs.bars) && cs.bars > 0 ? cs.bars : 0;
         const next: { symbol?: string; timeframe?: string; bars?: number; session?: MarketSession } = {};
         if (symbol && symbol !== this.symbol) next.symbol = symbol;
         if (cs.timeframe && cs.timeframe !== this.timeframe) next.timeframe = cs.timeframe;
-        if (session !== this.session) {
+        // A document that explicitly stores `regular` must move an omitted provider
+        // default onto that exact ID. For legacy documents with no session field, keep
+        // comparing through the UI fallback so an already-default chart stays put.
+        const currentSession = savedSession !== undefined
+            ? normalizeSession(this.inner.market.session)
+            : this.session;
+        if (session && session !== currentSession) {
             this.state.session = session;
             next.session = session;
         }
@@ -1302,7 +1427,14 @@ export class ChartCell {
         const ext = this.inner ? this.dehydrateExt() : Object.keys(this.extState).length > 0 ? { ...this.extState } : undefined;
         return {
             ...this.state,
-            ...(live ? { symbol: live.symbol, provider: live.provider, timeframe: live.timeframe } : {}),
+            ...(live
+                ? {
+                      symbol: live.symbol,
+                      provider: live.provider,
+                      timeframe: live.timeframe,
+                      ...(live.session !== undefined ? { session: live.session } : {}),
+                  }
+                : {}),
             priceStyle: this.priceStyle,
             watermark: this.watermarkOn,
             indicatorTitles: this.indicatorTitlesOn,
@@ -1315,22 +1447,28 @@ export class ChartCell {
             // shared manifest settles. See {@link indicatorLedger}. External instances
             // (`ctx.addIndicator`) stay out: their names would never resolve against the
             // manifest — their plugin persists them via the `ext` seam instead.
-            indicators: indicatorLedger({
-                present: this.inner ? this.inner.presentNativeIndicators() : [],
-                instanceEntries: this.instances
-                    .filter((it) => !it.external)
-                    .map((it) => {
-                        // LIVE deltas from the handle; a handle-less instance (add failed)
-                        // keeps whatever values it was restored with.
-                        const d = it.handle ? instanceDeltas(it.handle) : it.values;
-                        return d ? { name: it.entry.name, ...d } : it.entry.name;
-                    }),
-                pendingManifest: this.pendingManifestNames,
-                manifestSettled: this.deps.manifestSettled(),
-                volumePending: this.volumeMayBePending && this.volumeIntent,
-            }),
+            indicators: this.indicatorLedgerSnapshot(),
             ...(ext ? { ext } : {}),
         };
+    }
+
+    /** Current persistable indicator ledger, shared by state output and idempotent
+     * in-place restoration so applying an unchanged document preserves live handles. */
+    private indicatorLedgerSnapshot(): { manifest: LedgerManifestEntry[]; natives: string[] } {
+        return indicatorLedger({
+            present: this.inner ? this.inner.presentNativeIndicators() : [],
+            instanceEntries: this.instances
+                .filter((it) => !it.external)
+                .map((it) => {
+                    // LIVE deltas from the handle; a handle-less instance (add failed)
+                    // keeps whatever values it was restored with.
+                    const d = it.handle ? instanceDeltas(it.handle) : it.values;
+                    return d ? { name: it.entry.name, ...d } : it.entry.name;
+                }),
+            pendingManifest: this.pendingManifestNames,
+            manifestSettled: this.deps.manifestSettled(),
+            volumePending: this.volumeMayBePending && this.volumeIntent,
+        });
     }
 
     destroy(): void {

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -10,6 +10,7 @@
 import type { DataProvider } from '../core/ports/DataProvider';
 import type { ScriptingEngine } from '../core/ports/ScriptingEngine';
 import type { VelaTheme, NativeBackend, VelaOptions } from '../core/options';
+import { resolveMotionPolicy } from '../core/options';
 import type { VelaShellOptions } from '../widget/shell-options';
 import { resolveTheme } from '../core/theme';
 import { TypedEventBus } from '../core/events/EventBus';
@@ -35,6 +36,7 @@ import { toolShortcutHints } from '../widget/tool-shortcuts';
 import { legendActionsProviderFor, legendCalloutsProviderFor, statePersistenceHandlers, topbarActionOverride, widgetActions, widgetAttachments, type WidgetActionDescriptor } from '../widget/contributions';
 import { resolveTopbarComposition, topbarHas, TOPBAR_BUILTIN_IDS, type ResolvedTopbarComposition } from '../widget/topbar-composition';
 import { LayoutModeController, type LayoutMode } from '../widget/layout-mode';
+import { MotionPreferenceController } from '../renderers/shared/motion';
 import { MobileBar } from '../widget/mobile-bar';
 import { TimeframeDrawer } from '../widget/timeframe-drawer';
 import { DrawingsDrawer } from '../widget/drawings-drawer';
@@ -54,6 +56,7 @@ import { registerBuiltinChartTypes } from '../chart-types/builtins';
 import { parseSymbol } from '../data/ProviderRegistry';
 import { syncTargets, rangesWithin, styleConfigSlice, SYNC_KINDS, type SyncKind, type SyncOptions, type SyncSetting } from './sync';
 import { encodeState, decodeState, sanitizeState, type WorkspaceState, type WorkspaceStorage } from './persist';
+import { jsonStateEqual } from '../state/document';
 import { localStorageAdapter } from '../widget/persist';
 import { ChartCell, seedDefaults, cellChartDefaults, type CellSeed, type CellBoot, type PooledCellState } from './ChartCell';
 import { buildContext, type WorkspaceWidgetContext } from './context';
@@ -320,6 +323,9 @@ export class VelaWorkspace {
     // on the root, the drawers build lazily on first open and act on the ACTIVE cell) ──
     /** Writes `data-layout` on the root and pushes mode flips into every cell's renderer. */
     private layoutCtl!: LayoutModeController;
+    /** One system reduced-motion observer shared by every live and rebuilt cell. */
+    private motionPreference!: MotionPreferenceController;
+    private motionUnsub: (() => void) | null = null;
     private readonly mobileBar: MobileBar | null;
     private readonly drawingPill: DrawingPill | null;
     private tfDrawer: TimeframeDrawer | null = null;
@@ -396,6 +402,12 @@ export class VelaWorkspace {
         this.root = doc.createElement('div');
         this.root.className = 'vela-workspace';
         ensureUIHost(this.root, resolveTheme(opts.theme));
+        this.motionPreference = new MotionPreferenceController(this.root, opts.animations === undefined);
+        const projectMotion = (systemReduced: boolean): void => {
+            this.root.dataset.velaMotion = resolveMotionPolicy(opts.animations, systemReduced).reduced ? 'reduced' : 'full';
+        };
+        projectMotion(this.motionPreference.reduced);
+        if (opts.animations === undefined) this.motionUnsub = this.motionPreference.onChange(projectMotion);
 
         // ONE shared feed: providers registered once; every cell's `chart.data` operates
         // on the same registry, symbol index, and closed-bar cache.
@@ -617,8 +629,8 @@ export class VelaWorkspace {
                           this.bottombar?.setActiveRange(preset.id);
                       },
                       onTimezone: (zone) => this.setTimezone(zone),
-                      // RTH/ETH acts on the ACTIVE cell (like the range chips): sessions
-                      // are a per-chart market dimension, not a shell preference.
+                      // Session selection acts on the ACTIVE cell (like the range chips):
+                      // it is a per-chart market dimension, not a shell preference.
                       onSession: (session) => this.active.setSession(session),
                       onSettingsClick: () => this.active.chart.renderer.openSettings(),
                   })
@@ -975,8 +987,11 @@ export class VelaWorkspace {
             this.refreshRetention();
             // Document-level third-party state converges to the document (absent = none);
             // per-cell `ext` was handled by each cell's rehydrate above.
-            this.extState = { ...(st.ext ?? {}) };
-            this.restoreGlobalExt();
+            const nextExt = { ...(st.ext ?? {}) };
+            if (!jsonStateEqual(this.extState, nextExt)) {
+                this.extState = nextExt;
+                this.restoreGlobalExt();
+            }
             this.markStateDirty();
             return;
         }
@@ -1220,6 +1235,9 @@ export class VelaWorkspace {
         this.timezoneDrawer?.destroy();
         this.priceScaleDrawer?.destroy();
         this.layoutCtl.destroy();
+        this.motionUnsub?.();
+        this.motionUnsub = null;
+        this.motionPreference.destroy();
         this.dock.destroy(); // contributed panels; the two built-ins are ours to drop
         this.objectTree.destroy();
         this.dataWindow.destroy();
@@ -1258,7 +1276,7 @@ export class VelaWorkspace {
         this.objectTree.setSymbol(cell.symbol);
         this.dock.onChart(cell.chart); // every docked panel follows the active cell
         this.bottombar?.setActiveRange(cell.activeRangeId);
-        this.bottombar?.setSession({ session: cell.session, enabled: cell.sessionAvailable });
+        this.bottombar?.setSession({ session: cell.session, choices: cell.sessions });
         this.indicatorPicker?.sync(); // the dialog may be open while the active cell changes
         this.glider.stop(); // a mid-glide switch must not steer the next cell's viewport
         // Shared drawing toolbar ⇄ the active cell: re-apply the GLOBAL tool + magnet + stay
@@ -1449,10 +1467,17 @@ export class VelaWorkspace {
             }
             if (this.cellsById.has(id)) continue;
             const pooled = this.pool.get(id);
-            const seed: CellBoot = pooled ?? { ...seedDefaults(this.opts), ...(this.opts.cells?.[id] ?? {}) };
+            const configured = { ...seedDefaults(this.opts), ...(this.opts.cells?.[id] ?? {}) };
+            // Session definitions are host options, never document state. Re-overlay
+            // them when a durable pooled cell returns so its selected id can resolve
+            // against the current catalog without serializing colors/windows.
+            const seed: CellBoot = pooled
+                ? { ...pooled, sessions: configured.sessions, sessionTimezone: configured.sessionTimezone }
+                : configured;
             this.pool.delete(id); // the slot is live again — its pooled state is consumed
             const cell = new ChartCell(id, this.gridEl, seed, {
                 feed: this.feed,
+                motionPreference: this.motionPreference,
                 engines: this.opts.engines ?? {},
                 chartDefaults: cellChartDefaults(this.opts),
                 theme,
@@ -1592,7 +1617,10 @@ export class VelaWorkspace {
         chart.on('viewport:changed', (range) => this.propagateViewport(cell.id, range));
         // Style sync: any committed config edit (settings dialog, applyConfig) mirrors
         // this cell's Canvas + Scales-and-lines slice onto its same-group followers.
-        chart.renderer.onConfigChanged(() => this.propagateStylePrefs(cell.id));
+        chart.renderer.onConfigChanged(() => {
+            this.propagateStylePrefs(cell.id);
+            this.markStateDirty();
+        });
         // A theme picked in ONE cell (its settings dialog's Canvas → Theme) re-skins the
         // WHOLE workspace — shared chrome plus every other cell.
         chart.on('theme:changed', (t) => this.setTheme(t));
@@ -1895,7 +1923,7 @@ export class VelaWorkspace {
         this.mobileBar?.setSymbol(cell.symbol);
         this.mobileBar?.setTimeframe(cell.timeframe);
         this.objectTree.setSymbol(cell.symbol);
-        this.bottombar?.setSession({ session: cell.session, enabled: cell.sessionAvailable });
+        this.bottombar?.setSession({ session: cell.session, choices: cell.sessions });
         // The chip highlight must track the cell through EVERY market path: a timeframe
         // change (cell API, contribution context, sync link) leaves range mode and a
         // direct `applyRange` enters it — the bar follows the cell's own record.

--- a/test/browser-pixels.test.ts
+++ b/test/browser-pixels.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { countColor } from './browser/pixels';
+
+describe('browser candle pixel classification', () => {
+    it('counts candle colors but excludes the gold indicator and transparent pixels', () => {
+        const pixels = new Uint8ClampedArray([
+            242, 54, 69, 255,
+            241, 55, 68, 128,
+            247, 201, 72, 255,
+            242, 54, 69, 0,
+            8, 153, 129, 255,
+        ]);
+        expect(countColor(pixels, [242, 54, 69])).toBe(2);
+        expect(countColor(pixels, [8, 153, 129])).toBe(1);
+        expect(countColor(pixels, [247, 201, 72])).toBe(1);
+    });
+});

--- a/test/browser/fixtures.ts
+++ b/test/browser/fixtures.ts
@@ -1,0 +1,39 @@
+import { test as base, expect, type Page, type Locator } from '@playwright/test';
+import type {} from '../../playground/browser-fixture';
+
+export const test = base.extend<{ app: Page }>({
+    app: async ({ page }, use, testInfo) => {
+        const errors: string[] = [];
+        page.on('pageerror', error => errors.push(error.message));
+        page.on('console', message => { if (message.type() === 'error') errors.push(message.text()); });
+        await page.goto('/browser-fixture.html');
+        await expect.poll(() => page.evaluate(() => window.fixture?.ready)).toBe(true);
+        await expect.poll(() => page.evaluate(() => window.fixture.paint().bullish)).toBeGreaterThan(100);
+        try {
+            await use(page);
+        } finally {
+            if (testInfo.status !== testInfo.expectedStatus) {
+                await testInfo.attach('fixture-at-failure', { body: await page.screenshot(), contentType: 'image/png' });
+            }
+            await page.evaluate(() => window.fixture?.destroy());
+            await expect(page.locator('#chart canvas')).toHaveCount(0);
+            await expect(page.locator('.vela-dialog-positioner, .vela-dialog-backdrop, .vela-popover')).toHaveCount(0);
+            expect(await page.evaluate(() => window.fixture?.subscribers ?? 0)).toBe(0);
+            expect(errors, 'browser console errors and unhandled exceptions').toEqual([]);
+        }
+    },
+});
+export { expect };
+
+export async function expectPaintedSurface(locator: Locator) {
+    await expect(locator).toBeVisible();
+    const style = await locator.evaluate(element => {
+        const rect = element.getBoundingClientRect();
+        const css = getComputedStyle(element);
+        return { width: rect.width, height: rect.height, background: css.backgroundColor, opacity: css.opacity };
+    });
+    expect(style.width).toBeGreaterThan(0);
+    expect(style.height).toBeGreaterThan(0);
+    expect(style.background).not.toMatch(/^(transparent|rgba\(0, 0, 0, 0\))$/);
+    expect(Number(style.opacity)).toBeGreaterThan(0);
+}

--- a/test/browser/marquee.spec.ts
+++ b/test/browser/marquee.spec.ts
@@ -1,0 +1,90 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+
+async function drawings(page: Page) {
+    const plot = await page.evaluate(() => window.fixture.plot());
+    const point = (x: number, y: number) => ({ x: plot.x + plot.width * x, y: plot.y + plot.height * y });
+    for (let i = 0; i < 3; i++) {
+        await page.evaluate(() => window.fixture.ws.chart.drawings.setTool('box'));
+        const start = point(0.2 + i * 0.18, 0.35);
+        const end = point(0.28 + i * 0.18, 0.5);
+        await page.mouse.click(start.x, start.y);
+        await page.mouse.click(end.x, end.y);
+        await expect.poll(() => page.evaluate(() => window.fixture.ws.chart.drawings.all().length)).toBe(i + 1);
+    }
+    const ids = await page.evaluate(() => {
+        const chart = window.fixture.ws.chart;
+        const ids = chart.drawings.all().map(drawing => drawing.id);
+        chart.drawings.lock(ids[2]!, true);
+        chart.drawings.select(null);
+        return ids;
+    });
+    return { point, ids };
+}
+
+async function startDrag(page: Page, start: { x: number; y: number }, end: { x: number; y: number }, modifier = 'Control', union = false) {
+    await page.keyboard.down(modifier);
+    if (union) await page.keyboard.down('Shift');
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 5 });
+    await expect.poll(() => page.evaluate(() => window.fixture.marquee?.w ?? 0)).toBeGreaterThan(50);
+    await expect.poll(() => page.evaluate(() => window.fixture.marquee?.h ?? 0)).toBeGreaterThan(50);
+    // This strip is inside the marquee and above every fixture drawing.
+    await expect.poll(() => page.evaluate(() => window.fixture.marqueeInk())).toBeGreaterThan(100);
+}
+async function release(page: Page, modifier = 'Control', union = false) {
+    await page.mouse.up();
+    await page.keyboard.up(modifier);
+    if (union) await page.keyboard.up('Shift');
+}
+
+for (const [name, left, top, modifier] of [
+    ['down-right Ctrl', true, true, 'Control'],
+    ['up-left Cmd', false, false, 'Meta'],
+    ['up-right Ctrl', true, false, 'Control'],
+    ['down-left Cmd', false, true, 'Meta'],
+] as const) {
+    test(`marquee ${name} selects boxes without panning and preserves locked drawings through delete/undo`, async ({ app: page }) => {
+        const { point, ids } = await drawings(page);
+        const before = await page.evaluate(() => window.fixture.viewport());
+        await startDrag(page, point(left ? 0.12 : 0.72, top ? 0.25 : 0.6), point(left ? 0.72 : 0.12, top ? 0.6 : 0.25), modifier);
+        expect(await page.evaluate(() => window.fixture.viewport())).toEqual(before);
+        await release(page, modifier);
+        await expect.poll(() => page.evaluate(() => window.fixture.selected)).toEqual(ids);
+        expect(await page.evaluate(() => window.fixture.marquee)).toBeNull();
+        expect(await page.evaluate(() => window.fixture.viewport())).toEqual(before);
+        await page.keyboard.press('Delete');
+        await expect.poll(() => page.evaluate(() => window.fixture.ws.chart.drawings.all().map(d => d.id))).toEqual([ids[2]]);
+        await page.keyboard.press('Control+z');
+        await expect.poll(() => page.evaluate(() => window.fixture.ws.chart.drawings.all().map(d => d.id))).toEqual(ids);
+    });
+}
+
+test('Shift unions the selection; Escape cancels a later marquee without changing selection or viewport', async ({ app: page }) => {
+    const { point, ids } = await drawings(page);
+    await page.evaluate(id => window.fixture.ws.chart.drawings.select(id), ids[2]!);
+    await startDrag(page, point(0.12, 0.25), point(0.49, 0.6), 'Control', true);
+    await release(page, 'Control', true);
+    await expect.poll(() => page.evaluate(() => window.fixture.selected)).toEqual([ids[2], ids[0], ids[1]]);
+    const before = await page.evaluate(() => ({ viewport: window.fixture.viewport(), selected: window.fixture.selected }));
+    await startDrag(page, point(0.12, 0.25), point(0.49, 0.6));
+    await page.keyboard.press('Escape');
+    await release(page);
+    expect(await page.evaluate(() => window.fixture.marquee)).toBeNull();
+    expect(await page.evaluate(() => ({ viewport: window.fixture.viewport(), selected: window.fixture.selected }))).toEqual(before);
+});
+
+
+test('pointer cancellation removes the marquee and preserves selection and viewport', async ({ app: page }) => {
+    const { point, ids } = await drawings(page);
+    await page.evaluate(id => window.fixture.ws.chart.drawings.select(id), ids[2]!);
+    const before = await page.evaluate(() => ({ viewport: window.fixture.viewport(), selected: window.fixture.selected }));
+    await startDrag(page, point(0.12, 0.25), point(0.49, 0.6));
+    // Playwright drives the drag; dispatch the browser cancellation signal because
+    // its mouse API has no OS-level cancel operation.
+    await page.getByRole('application').dispatchEvent('pointercancel', { pointerId: 1, pointerType: 'mouse', bubbles: true });
+    await release(page);
+    expect(await page.evaluate(() => window.fixture.marquee)).toBeNull();
+    expect(await page.evaluate(() => ({ viewport: window.fixture.viewport(), selected: window.fixture.selected }))).toEqual(before);
+});

--- a/test/browser/motion.spec.ts
+++ b/test/browser/motion.spec.ts
@@ -1,0 +1,102 @@
+import type { Page } from '@playwright/test';
+import { test, expect, expectPaintedSurface } from './fixtures';
+
+async function externalDialogHost(page: Page) {
+    await page.evaluate(() => {
+        const host = document.createElement('div');
+        host.id = 'external-dialog-host';
+        host.className = 'vela-ui';
+        host.style.cssText = 'position:fixed;inset:0;z-index:100;';
+        const source = document.querySelector<HTMLElement>('.vela-workspace')!;
+        for (const name of Array.from(source.style)) {
+            if (name.startsWith('--vela-')) host.style.setProperty(name, source.style.getPropertyValue(name));
+        }
+        document.body.append(host);
+        window.fixture.ws.chart.renderer.set('dialogHost', host);
+    });
+}
+
+test('native media changes update a visible external settings dialog and its open Select', async ({ app: page }) => {
+    await externalDialogHost(page);
+    await page.evaluate(() => window.fixture.ws.chart.renderer.openSettings());
+    const panel = page.locator('#external-dialog-host .vela-dialog--settings');
+    await expectPaintedSurface(panel);
+    const button = panel.locator('.vela-sd-btn').first();
+    await panel.evaluate(element => { element.style.transitionDuration = '2s'; element.style.animationDuration = '2s'; });
+    await button.evaluate(element => { element.style.transitionDuration = '2s'; element.style.animationDuration = '2s'; });
+    for (const element of [panel, button]) {
+        await expect(element).toHaveCSS('transition-duration', '0s');
+        await expect(element).toHaveCSS('animation-duration', '0s');
+    }
+    await button.focus();
+    await expect(button).toBeFocused();
+    const select = panel.locator('.vela-select-trigger').first();
+    await select.click();
+    const popover = page.locator('.vela-popover.vela-select-list');
+    await expectPaintedSurface(popover);
+    expect(await popover.evaluate(element => element.parentElement === document.body)).toBe(true);
+    await popover.evaluate(element => { element.style.transitionDuration = '2s'; element.style.animationDuration = '2s'; });
+    for (const reducedMotion of ['no-preference', 'reduce', 'no-preference'] as const) {
+        await page.emulateMedia({ reducedMotion });
+        const reduced = reducedMotion === 'reduce';
+        await expect.poll(() => page.evaluate(() => window.fixture.ws.chart.reducedMotion)).toBe(reduced);
+        for (const element of [panel, button, popover]) {
+            await expect(element).toHaveCSS('transition-duration', reduced ? '0s' : '2s');
+            await expect(element).toHaveCSS('animation-duration', reduced ? '0s' : '2s');
+        }
+        await expectPaintedSurface(popover);
+        expect(await page.locator('#external-dialog-host').getAttribute('data-vela-motion')).toBeNull();
+    }
+});
+
+test('explicit animation options override native reduced-motion preference', async ({ app: page }) => {
+    await page.goto('/browser-fixture.html?animations=true');
+    await expect.poll(() => page.evaluate(() => window.fixture?.ready)).toBe(true);
+    expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true);
+    expect(await page.evaluate(() => window.fixture.ws.chart.reducedMotion)).toBe(false);
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    expect(await page.evaluate(() => window.fixture.ws.chart.reducedMotion)).toBe(false);
+});
+
+
+test('indicator inputs opened through the legend compute zero motion while staying usable', async ({ app: page }) => {
+    await externalDialogHost(page);
+    // The external host only receives input when it contains an open dialog.
+    await page.locator('#external-dialog-host').evaluate(element => { element.style.pointerEvents = 'none'; });
+    const settings = page.getByRole('button', { name: 'Settings', exact: true });
+    await page.getByText('Golden average', { exact: true }).hover();
+    await settings.click();
+    const panel = page.locator('#external-dialog-host .vela-ind-dialog');
+    await expectPaintedSurface(panel);
+    await panel.evaluate(element => { element.style.transitionDuration = '2s'; element.style.animationDuration = '2s'; });
+    await expect(panel).toHaveCSS('transition-duration', '0s');
+    await expect(panel).toHaveCSS('animation-duration', '0s');
+    const input = panel.getByRole('spinbutton').first();
+    await input.fill('5');
+    await expect(input).toHaveValue('5');
+    await expect(input).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(panel).toBeHidden();
+});
+
+test('reduced-motion wheel zoom changes the viewport in the wheel event turn', async ({ app: page }) => {
+    const before = await page.evaluate(() => window.fixture.viewport());
+    const chart = page.getByRole('application');
+    await chart.evaluate(element => {
+        element.addEventListener('wheel', () => {
+            element.setAttribute('data-wheel-viewport', JSON.stringify(window.fixture.viewport()));
+        }, { once: true });
+    });
+    const plot = await page.evaluate(() => window.fixture.plot());
+    await page.mouse.move(plot.x + plot.width * 0.5, plot.y + plot.height * 0.7);
+    await page.mouse.wheel(0, -120);
+    await expect(chart).toHaveAttribute('data-wheel-viewport');
+    const during = JSON.parse((await chart.getAttribute('data-wheel-viewport'))!);
+    expect(during).not.toEqual(before);
+    const after = await page.evaluate(async () => {
+        await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+        return window.fixture.viewport();
+    });
+    expect(after).toEqual(during);
+});

--- a/test/browser/pixels.ts
+++ b/test/browser/pixels.ts
@@ -1,0 +1,11 @@
+export type RGB = readonly [number, number, number];
+
+/** Match unpremultiplied Chromium pixels without confusing a gold study with red candles. */
+export function countColor(pixels: Uint8ClampedArray, color: RGB): number {
+    let count = 0;
+    for (let i = 0; i < pixels.length; i += 4) {
+        if (pixels[i + 3]! < 40) continue;
+        if (color.every((channel, index) => Math.abs(pixels[i + index]! - channel) <= 3)) count++;
+    }
+    return count;
+}

--- a/test/browser/sessions.spec.ts
+++ b/test/browser/sessions.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect, expectPaintedSurface } from './fixtures';
+
+test('keyboard session selection forwards the exact ID, paints its bands, and survives reload', async ({ app: page }) => {
+    await expect.poll(() => page.evaluate(() => window.fixture.subscribers)).toBe(1);
+    const trigger = page.getByRole('button', { name: 'Trading session', exact: true });
+    await expect(trigger).toHaveText('Morning');
+    await page.evaluate(() => { window.fixture.calls.length = 0; });
+    await trigger.click();
+    const menu = page.getByRole('menu').filter({ has: page.getByRole('menuitem', { name: 'Night', exact: true }) });
+    await expectPaintedSurface(menu);
+    await expect(menu.getByRole('menuitem')).toHaveText(['Morning', 'Afternoon', 'Night']);
+    await page.keyboard.press('End');
+    await expect(menu).toBeFocused();
+    await expect(menu).toHaveAttribute('aria-activedescendant', (await page.getByRole('menuitem', { name: 'Night', exact: true }).getAttribute('id'))!);
+    await page.keyboard.press('Enter');
+    await expect(trigger).toHaveText('Night');
+    await expect(menu).toBeHidden();
+    await expect.poll(() => page.evaluate(() => window.fixture.calls.filter(call => call.method === 'subscribe').length)).toBe(1);
+    const calls = await page.evaluate(() => window.fixture.calls);
+    expect(calls.filter(call => call.method === 'history')).toHaveLength(1);
+    expect(calls.some(call => call.method === 'calendar')).toBe(true);
+    expect(calls.every(call => call.session === 'Night-X')).toBe(true);
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().session)).toBeGreaterThan(100);
+    await expect.poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('vela-browser-fixture') ?? '{}').charts?.[0]?.session)).toBe('Night-X');
+    await page.reload();
+    await expect.poll(() => page.evaluate(() => window.fixture?.ready)).toBe(true);
+    await expect(trigger).toHaveText('Night');
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().session)).toBeGreaterThan(100);
+    expect(await page.evaluate(() => window.fixture.calls.every(call => call.session === 'Night-X'))).toBe(true);
+});

--- a/test/browser/visibility.spec.ts
+++ b/test/browser/visibility.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from './fixtures';
+
+test('hiding the price series persists through reload while indicators and drawings stay painted', async ({ app: page }) => {
+    await page.evaluate(() => window.fixture.addDrawing());
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().indicator)).toBeGreaterThan(20);
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().drawings)).toBeGreaterThan(100);
+    await page.locator('.vela-statusline').click({ button: 'right', position: { x: 80, y: 12 } });
+    await page.getByRole('menuitem', { name: 'Hide chart', exact: true }).click();
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().bullish + window.fixture.paint().bearish)).toBe(0);
+    const hidden = await page.evaluate(() => window.fixture.paint());
+    expect(hidden.indicator).toBeGreaterThan(20);
+    expect(hidden.drawings).toBeGreaterThan(100);
+    expect(hidden.chrome).toBeGreaterThan(100);
+    await expect.poll(() => page.evaluate(() => {
+        const saved = JSON.parse(localStorage.getItem('vela-browser-fixture') ?? '{}');
+        return saved.charts?.[0]?.rendererConfig?.series?.visible;
+    })).toBe(false);
+    await page.reload();
+    await expect.poll(() => page.evaluate(() => window.fixture?.ready)).toBe(true);
+    await expect(page.getByRole('button', { name: 'Show chart', exact: true })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().bullish + window.fixture.paint().bearish)).toBe(0);
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().indicator)).toBeGreaterThan(20);
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().drawings)).toBeGreaterThan(100);
+    await page.getByRole('button', { name: 'Show chart', exact: true }).click();
+    await expect.poll(() => page.evaluate(() => window.fixture.paint().bullish)).toBeGreaterThan(100);
+});

--- a/test/caching-data-feed.test.ts
+++ b/test/caching-data-feed.test.ts
@@ -413,21 +413,36 @@ describe('BarStore', () => {
 });
 
 describe('session-keyed series (RTH vs ETH are different bars)', () => {
-    it('seriesKey keys extended apart and leaves regular/absent on the legacy key', () => {
+    it('seriesKey isolates every explicit id from the omitted provider default', () => {
         expect(seriesKey('edgx', 'AAPL', '60')).toBe('edgx|AAPL|60');
-        expect(seriesKey('edgx', 'AAPL', '60', 'regular')).toBe('edgx|AAPL|60'); // default = keyless
+        expect(seriesKey('edgx', 'AAPL', '60', 'regular')).toBe('edgx|AAPL|60|regular');
         expect(seriesKey('edgx', 'AAPL', '60', 'extended')).toBe('edgx|AAPL|60|extended');
     });
 
-    it('the two sessions never share cached bars, and the flag reaches the inner feed', async () => {
+    it('keeps arbitrary provider-facing ids exact and isolated', async () => {
         const { feed, store, cf } = setup(600);
-        const regular = await cf.load({ symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500 });
-        // Extended is a COLD series of its own — a fresh full load, not the cached regular bars.
+        await cf.load({ symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500, session: 'Asia-AM' });
+        const calls = feed.loadCalls;
+        await cf.load({ symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500, session: 'asia-am' });
+        expect(feed.loadCalls).toBe(calls + 1);
+        expect(store.get(seriesKey('binance', 'BTCUSDT', '60', 'Asia-AM'))).toBeDefined();
+        expect(store.get(seriesKey('binance', 'BTCUSDT', '60', 'asia-am'))).toBeDefined();
+    });
+
+    it('omitted, regular, and extended sessions never share cached bars', async () => {
+        const { feed, store, cf } = setup(600);
+        const providerDefault = await cf.load({ symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500 });
+        const callsAfterDefault = feed.loadCalls;
+        const regular = await cf.load({ symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500, session: 'regular' });
+        expect(feed.loadCalls).toBe(callsAfterDefault + 1);
+        // Extended is another COLD series — neither exact ID may borrow provider-default bars.
         const callsAfterRegular = feed.loadCalls;
         const extended = await cf.load({ symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500, session: 'extended' });
         expect(feed.loadCalls).toBe(callsAfterRegular + 1);
-        expect(times(extended)).toEqual(times(regular)); // same fake universe...
+        expect(times(regular)).toEqual(times(providerDefault)); // same fake universe...
+        expect(times(extended)).toEqual(times(providerDefault));
         expect(store.get(seriesKey('binance', 'BTCUSDT', '60'))).toBeDefined();
-        expect(store.get(seriesKey('binance', 'BTCUSDT', '60', 'extended'))).toBeDefined(); // ...two series
+        expect(store.get(seriesKey('binance', 'BTCUSDT', '60', 'regular'))).toBeDefined();
+        expect(store.get(seriesKey('binance', 'BTCUSDT', '60', 'extended'))).toBeDefined();
     });
 });

--- a/test/drawings-controller.test.ts
+++ b/test/drawings-controller.test.ts
@@ -6,6 +6,7 @@ import { DrawingsControl } from '../src/core/DrawingsControl';
 import { buildToolbar } from '../src/core/drawings';
 import type { IDrawingsRendererPort, DrawingIntent, SerializedDrawing } from '../src/core/drawings';
 import type { IChartRenderer } from '../src/core/ports/IChartRenderer';
+import { unlockedDrawingIds } from '../src/renderers/native/drawings/DrawingKeys';
 
 class FakePort implements IDrawingsRendererPort {
     toolbar: unknown = null;
@@ -282,6 +283,24 @@ describe('DrawingController — editing foundation', () => {
         expect(ctrl.all().map((d) => d.anchors[0]!.price)).toEqual([1, 2]);
         ctrl.undo(); // one undo reverts BOTH
         expect(ctrl.all().map((d) => d.anchors[0]!.price)).toEqual([25000, 25000]);
+    });
+
+    it('keyboard deletion skips locked drawings, removes the rest in one undo step, while the explicit API can remove locked drawings', () => {
+        const { port, ctrl } = setup();
+        const first = ctrl.add('hline', { anchors: [{ time: 1, price: 1 }] })!;
+        const second = ctrl.add('hline', { anchors: [{ time: 2, price: 2 }] })!;
+        const locked = ctrl.add('hline', { anchors: [{ time: 3, price: 3 }] })!;
+        ctrl.setLocked(locked.id, true);
+
+        const keyboardIds = unlockedDrawingIds(ctrl.all(), [locked.id, second.id, first.id]);
+        expect(keyboardIds).toEqual([second.id, first.id]);
+        port.fire({ kind: 'delete', ids: keyboardIds });
+        expect(ctrl.all().map((d) => d.id)).toEqual([locked.id]);
+
+        ctrl.undo();
+        expect(ctrl.all().map((d) => d.id)).toEqual([first.id, second.id, locked.id]);
+        ctrl.remove(locked.id);
+        expect(ctrl.all().map((d) => d.id)).toEqual([first.id, second.id]);
     });
 
     it('duplicate clones with a fresh id, selects the clone, emits created, and is one undo step', () => {

--- a/test/drawings-keys.test.ts
+++ b/test/drawings-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { keyToDrawingAction, isEditingText, type DrawingKeyContext } from '../src/renderers/native/drawings/DrawingKeys';
+import { keyToDrawingAction, isEditingText, unlockedDrawingIds, type DrawingKeyContext } from '../src/renderers/native/drawings/DrawingKeys';
 
 const ctx = (over: Partial<DrawingKeyContext> = {}): DrawingKeyContext => ({
     hasSelection: true,
@@ -49,5 +49,15 @@ describe('isEditingText', () => {
         expect(isEditingText({ tagName: 'DIV', isContentEditable: true } as unknown as EventTarget)).toBe(true);
         expect(isEditingText({ tagName: 'CANVAS' } as unknown as EventTarget)).toBe(false);
         expect(isEditingText(null)).toBe(false);
+    });
+});
+
+describe('unlockedDrawingIds', () => {
+    it('keeps unlocked and stale targets in order while excluding locked drawings', () => {
+        const drawings = [
+            { id: 'open', locked: false },
+            { id: 'locked', locked: true },
+        ];
+        expect(unlockedDrawingIds(drawings, ['locked', 'stale', 'open'])).toEqual(['stale', 'open']);
     });
 });

--- a/test/drawings-marquee.test.ts
+++ b/test/drawings-marquee.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDrawing, type Drawing, type DrawingIntent, type Projector } from '../src/core/drawings';
+import type { VelaTheme } from '../src/core/options';
+import { DrawingInteraction } from '../src/renderers/native/drawings/DrawingInteraction';
+import { drawingsIntersectingRect, plotRect, rectsIntersect } from '../src/renderers/native/drawings/DrawingHitTester';
+import { DrawingPainter } from '../src/renderers/native/drawings/DrawingPainter';
+import { UserDrawingController } from '../src/renderers/native/drawings/UserDrawingController';
+
+function projector(panes = false): Projector {
+    return {
+        xOf: (time) => time,
+        yOf: (price, paneId) => (paneId === 'gone' ? null : 100 - price),
+        pxToPoint: (x, y) => ({ time: x, price: 100 - y }),
+        paneIdAtY: (y) => (y < 60 ? 'price' : 'study'),
+        paneRect: panes
+            ? (paneId) => paneId === 'price'
+                ? { top: 0, height: 60 }
+                : paneId === 'study'
+                    ? { top: 60, height: 40 }
+                    : paneId === 'hidden'
+                        ? { top: 60, height: 0 }
+                        : null
+            : undefined,
+        width: 200,
+        height: 100,
+    };
+}
+
+function line(id: string, paneId: string, x1: number, y1: number, x2: number, y2: number): Drawing {
+    return createDrawing('trendline', {
+        id,
+        paneId,
+        anchors: [
+            { time: x1, price: 100 - y1 },
+            { time: x2, price: 100 - y2 },
+        ],
+    })!;
+}
+
+function harness(drawings: Drawing[]) {
+    const intents: DrawingIntent[] = [];
+    const selected = new Set<string>();
+    let changes = 0;
+    const interaction = new DrawingInteraction({
+        projector,
+        activeTool: () => null,
+        drawings: () => drawings,
+        hoveredId: () => null,
+        selectedIds: () => selected,
+        emit: (intent) => intents.push(intent),
+        changed: () => { changes += 1; },
+        openSettings: () => {},
+        snap: (point) => point,
+        lastStyle: () => undefined,
+    });
+    return { interaction, intents, selected, changes: () => changes };
+}
+
+describe('drawing marquee geometry', () => {
+    it('normalizes reverse drags, clips to the plot, and treats edge contact as intersection', () => {
+        expect(plotRect(220, 120, -10, -20, projector())).toEqual({ x: 0, y: 0, w: 200, h: 100 });
+        expect(plotRect(80, 70, 20, 10, projector())).toEqual({ x: 20, y: 10, w: 60, h: 60 });
+        expect(rectsIntersect({ x: 0, y: 0, w: 20, h: 20 }, { x: 20, y: 20, w: 0, h: 0 })).toBe(true);
+    });
+
+    it.each([
+        [20, 10, 80, 70],
+        [80, 10, 20, 70],
+        [20, 70, 80, 10],
+        [80, 70, 20, 10],
+    ])('normalizes a drag from (%d,%d) to (%d,%d)', (x1, y1, x2, y2) => {
+        expect(plotRect(x1, y1, x2, y2, projector())).toEqual({ x: 20, y: 10, w: 60, h: 60 });
+    });
+
+    it('returns visible, finite, projectable hits in paint order and clips each drawing to its pane', () => {
+        const a = line('a', 'price', 10, 10, 30, 30);
+        const b = line('b', 'study', 20, 70, 40, 90);
+        const outsidePane = line('outside-pane', 'price', 20, 70, 40, 80);
+        const hiddenDrawing = line('hidden-drawing', 'study', 20, 70, 40, 80);
+        hiddenDrawing.visible = false;
+        const hiddenPane = line('hidden-pane', 'hidden', 20, 70, 40, 80);
+        const gonePane = line('gone-pane', 'gone', 20, 70, 40, 80);
+        const invalid = line('invalid', 'price', 20, 20, 40, 40);
+        invalid.bounds = () => ({ x: NaN, y: 0, w: 10, h: 10 });
+        const drawings = [a, b, outsidePane, hiddenDrawing, hiddenPane, gonePane, invalid];
+
+        expect(drawingsIntersectingRect(drawings, { x: 25, y: 20, w: 10, h: 60 }, projector(true))).toEqual(['a', 'b']);
+    });
+});
+
+describe('DrawingInteraction marquee', () => {
+    it('stays pending until moved, then paints a clipped rectangle and commits one replacement intent', () => {
+        const h = harness([
+            line('back', 'price', 20, 20, 40, 40),
+            line('front', 'price', 60, 40, 90, 20),
+            line('miss', 'price', 130, 20, 150, 40),
+        ]);
+        expect(h.interaction.startMarquee(100, 80, false)).toBe(true);
+        expect(h.interaction.marqueeRect()).toBeNull();
+        expect(h.intents).toEqual([]);
+
+        h.interaction.moveMarquee(10, -20);
+        expect(h.interaction.marqueeRect()).toEqual({ x: 10, y: 0, w: 90, h: 80 });
+        expect(h.intents).toEqual([]); // selection does not change during the preview
+
+        expect(h.interaction.finishMarquee(10, -20)).toBe(true);
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['back', 'front'] }]);
+        expect(h.interaction.marqueeRect()).toBeNull();
+    });
+
+    it('latches additive union and its base selection at pointer-down without toggling hits', () => {
+        const h = harness([
+            line('base', 'price', 150, 10, 170, 20),
+            line('already-hit', 'price', 20, 20, 40, 40),
+            line('new-hit', 'price', 50, 20, 70, 40),
+        ]);
+        h.selected.add('base');
+        h.selected.add('already-hit');
+        h.interaction.startMarquee(10, 10, true);
+        h.selected.clear(); // live selection changes do not redefine the gesture
+        h.interaction.moveMarquee(80, 50);
+        h.interaction.finishMarquee(80, 50);
+
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['base', 'already-hit', 'new-hit'] }]);
+    });
+
+    it('cancels pending and visible marquees without emitting a selection intent', () => {
+        const pending = harness([]);
+        pending.interaction.startMarquee(10, 10, false);
+        expect(pending.interaction.cancel()).toBe(true);
+        expect(pending.intents).toEqual([]);
+
+        const active = harness([]);
+        active.interaction.startMarquee(10, 10, false);
+        active.interaction.moveMarquee(50, 50);
+        expect(active.interaction.cancelMarquee()).toBe(true);
+        expect(active.intents).toEqual([]);
+        expect(active.interaction.marqueeRect()).toBeNull();
+    });
+});
+
+/** Build only the keyboard-facing slice of the real controller. Its constructor owns
+ * DOM-heavy toolbar and popup views, while handleKey itself depends on these explicit
+ * state collaborators. */
+function keyboardController(fields: Record<string, unknown>): UserDrawingController {
+    const controller = Object.create(UserDrawingController.prototype) as Record<string, unknown>;
+    Object.assign(controller, {
+        textEditor: null,
+        popup: { isOpen: () => false, close: () => {} },
+        measureMode: false,
+        selectedIds: new Set<string>(),
+        hoveredId: null,
+        drawings: [],
+        intentCb: null,
+        ...fields,
+    });
+    return controller as unknown as UserDrawingController;
+}
+
+describe('UserDrawingController marquee keyboard routing', () => {
+    it('resolves a sub-slop marquee as an ordinary empty click that clears selection', () => {
+        const cancelMarquee = vi.fn();
+        const clearSelection = vi.fn();
+        const controller = keyboardController({
+            interaction: { cancelMarquee },
+            clearSelection,
+        });
+
+        controller.marqueeClick();
+
+        expect(cancelMarquee).toHaveBeenCalledOnce();
+        expect(clearSelection).toHaveBeenCalledOnce();
+    });
+
+    it('refuses a settings-popup delete when the drawing is locked after the popup opens', () => {
+        const drawing = line('locked-live', 'price', 10, 10, 20, 20);
+        let remove: (() => void) | undefined;
+        const intents: DrawingIntent[] = [];
+        const controller = keyboardController({
+            drawings: [drawing],
+            deps: { projector: () => projector(), theme: () => ({ background: '#000' }) },
+            popup: {
+                open: (_drawing: Drawing, _anchor: unknown, actions: { remove(): void }) => { remove = actions.remove; },
+                close: vi.fn(),
+                isOpen: () => false,
+            },
+            intentCb: (intent: DrawingIntent) => intents.push(intent),
+        });
+        controller.openSettings(drawing.id);
+        drawing.locked = true;
+
+        remove!();
+
+        expect(intents.filter((intent) => intent.kind === 'delete')).toEqual([]);
+    });
+
+    it('routes Escape through the active marquee cancel without changing the existing selection', () => {
+        const h = harness([line('kept', 'price', 10, 10, 20, 20)]);
+        h.selected.add('kept');
+        h.interaction.startMarquee(30, 30, true);
+        h.interaction.moveMarquee(80, 80);
+        const controller = keyboardController({
+            interaction: h.interaction,
+            selectedIds: h.selected,
+            drawings: [],
+        });
+
+        expect(controller.handleKey({ key: 'Escape', target: null } as unknown as KeyboardEvent)).toBe(true);
+        expect(h.interaction.marqueeRect()).toBeNull();
+        expect([...h.selected]).toEqual(['kept']);
+        expect(h.intents).toEqual([]);
+    });
+
+    it('routes Delete with selected unlocked IDs while retaining locked selections', () => {
+        const first = line('first', 'price', 10, 10, 20, 20);
+        const locked = line('locked', 'price', 30, 10, 40, 20);
+        const second = line('second', 'price', 50, 10, 60, 20);
+        locked.locked = true;
+        const intents: DrawingIntent[] = [];
+        const close = vi.fn();
+        const selectedIds = new Set(['locked', 'second', 'first']);
+        const controller = keyboardController({
+            popup: { isOpen: () => false, close },
+            interaction: { cancel: () => false },
+            selectedIds,
+            drawings: [first, locked, second],
+            intentCb: (intent: DrawingIntent) => intents.push(intent),
+        });
+
+        expect(controller.handleKey({ key: 'Delete', target: null } as unknown as KeyboardEvent)).toBe(true);
+        expect(intents).toEqual([{ kind: 'delete', ids: ['second', 'first'] }]);
+        expect([...selectedIds]).toEqual(['locked', 'second', 'first']);
+        expect(close).toHaveBeenCalledOnce();
+    });
+});
+
+describe('DrawingPainter marquee', () => {
+    it('paints a theme-aware fill and dashed selection outline at the supplied rectangle', () => {
+        const fills: Array<{ args: number[]; style: string }> = [];
+        const strokes: Array<{ args: number[]; style: string }> = [];
+        const dashes: number[][] = [];
+        let fillStyle = '';
+        let strokeStyle = '';
+        const context = {
+            get fillStyle() { return fillStyle; },
+            set fillStyle(value: string) { fillStyle = value; },
+            get strokeStyle() { return strokeStyle; },
+            set strokeStyle(value: string) { strokeStyle = value; },
+            lineWidth: 0,
+            save() {},
+            restore() {},
+            setLineDash(dash: number[]) { dashes.push(dash); },
+            fillRect(...args: number[]) { fills.push({ args, style: fillStyle }); },
+            strokeRect(...args: number[]) { strokes.push({ args, style: strokeStyle }); },
+        } as unknown as CanvasRenderingContext2D;
+        const theme = { textColor: '#ffffff' } as VelaTheme;
+
+        new DrawingPainter().paintMarquee(context, { x: 10, y: 20, w: 30, h: 40 }, theme);
+
+        expect(fills).toEqual([{ args: [10, 20, 30, 40], style: 'rgba(255,255,255,0.08)' }]);
+        expect(strokes).toEqual([{ args: [10, 20, 30, 40], style: '#38c0fd' }]);
+        expect(dashes).toEqual([[4, 3]]);
+    });
+});

--- a/test/input-marquee.test.ts
+++ b/test/input-marquee.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
+import { InputController, type InputControllerDeps } from '../src/renderers/native/core/InputController';
+
+function fakeElement() {
+    const listeners = new Map<string, Set<(event: Record<string, unknown>) => void>>();
+    return {
+        addEventListener(type: string, fn: (event: Record<string, unknown>) => void) {
+            (listeners.get(type) ?? listeners.set(type, new Set()).get(type)!).add(fn);
+        },
+        removeEventListener(type: string, fn: (event: Record<string, unknown>) => void) {
+            listeners.get(type)?.delete(fn);
+        },
+        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+        style: { setProperty() {} } as unknown as CSSStyleDeclaration,
+        setPointerCapture() {},
+        releasePointerCapture() {},
+        fire(type: string, event: Record<string, unknown>) {
+            for (const fn of [...(listeners.get(type) ?? [])]) fn(event);
+        },
+    };
+}
+
+function harness(options: { claim?: boolean; marquee?: boolean; separator?: boolean } = {}) {
+    const coords = new CoordinateSystem();
+    coords.setSize(200, 100, 1);
+    coords.setBars([1, 2, 3]);
+    coords.setViewport({ barSpacing: 10, rightOffset: 2 });
+    const deps = {
+        getCoords: () => coords,
+        apply: vi.fn(),
+        zoomTo: vi.fn(),
+        fling: vi.fn(),
+        onPointerMove: vi.fn(),
+        onClick: vi.fn(),
+        beginPriceScale: vi.fn(),
+        priceScaleBy: vi.fn(),
+        beginPricePan: vi.fn(() => false),
+        pricePanBy: vi.fn(),
+        resetPriceScale: vi.fn(),
+        dataDblClick: vi.fn(),
+        paneSeparatorAt: vi.fn(() => options.separator ?? false),
+        beginPaneResize: vi.fn(),
+        paneResizeBy: vi.fn(),
+        resetPaneSize: vi.fn(),
+        resetView: vi.fn(),
+        drawingsClaim: vi.fn(() => options.claim ?? false),
+        drawingsPointerDown: vi.fn(),
+        drawingsPointerMove: vi.fn(),
+        drawingsPointerUp: vi.fn(),
+        drawingsMeasureStart: vi.fn(() => true),
+        drawingsMarqueeStart: vi.fn(() => options.marquee ?? true),
+        drawingsMarqueeMove: vi.fn(),
+        drawingsMarqueeEnd: vi.fn(),
+        drawingsMarqueeCancel: vi.fn(),
+        drawingsMarqueeClick: vi.fn(),
+    } satisfies InputControllerDeps;
+    const input = new InputController(deps);
+    const element = fakeElement();
+    input.attach(element as unknown as HTMLElement);
+    const pointer = (
+        type: string,
+        x: number,
+        y: number,
+        overrides: Partial<Record<string, unknown>> = {},
+    ) => {
+        const state = { prevented: false };
+        element.fire(type, {
+            button: 0,
+            buttons: type === 'pointerup' ? 0 : 1,
+            pointerId: 1,
+            pointerType: 'mouse',
+            clientX: x,
+            clientY: y,
+            timeStamp: type === 'pointerdown' ? 0 : 10,
+            ctrlKey: true,
+            metaKey: false,
+            shiftKey: false,
+            preventDefault: () => { state.prevented = true; },
+            ...overrides,
+        });
+        return state;
+    };
+    return { coords, deps, input, element, pointer };
+}
+
+describe('InputController drawing marquee', () => {
+    it('keeps a modifier press pending through slop, then forwards a normal chart click', () => {
+        const h = harness();
+        const down = h.pointer('pointerdown', 20, 20);
+        h.pointer('pointermove', 22, 22);
+        h.pointer('pointerup', 22, 22);
+
+        expect(down.prevented).toBe(true);
+        expect(h.deps.drawingsMarqueeStart).toHaveBeenCalledWith(20, 20, false);
+        expect(h.deps.drawingsMarqueeMove).not.toHaveBeenCalled();
+        expect(h.deps.drawingsMarqueeEnd).not.toHaveBeenCalled();
+        expect(h.deps.drawingsMarqueeClick).toHaveBeenCalledTimes(1);
+        expect(h.deps.drawingsMarqueeCancel).not.toHaveBeenCalled();
+        expect(h.deps.onClick).toHaveBeenCalledWith(22, 22);
+    });
+
+    it('latches Ctrl/Cmd+Shift union, freezes the current viewport, and owns the drag without pan or fling', () => {
+        const h = harness();
+        const viewport = h.coords.getViewport();
+        h.pointer('pointerdown', 20, 20, { ctrlKey: false, metaKey: true, shiftKey: true });
+        h.pointer('pointermove', 80, 70, { ctrlKey: false, metaKey: false, shiftKey: false });
+        h.pointer('pointerup', 90, 80, { ctrlKey: false, metaKey: false, shiftKey: false });
+
+        expect(h.deps.drawingsMarqueeStart).toHaveBeenCalledWith(20, 20, true);
+        expect(h.deps.apply).toHaveBeenCalledTimes(1);
+        expect(h.deps.apply).toHaveBeenCalledWith(viewport);
+        expect(h.deps.drawingsMarqueeMove).toHaveBeenCalledWith(80, 70);
+        expect(h.deps.drawingsMarqueeEnd).toHaveBeenCalledTimes(1);
+        expect(h.deps.drawingsMarqueeEnd).toHaveBeenCalledWith(90, 80);
+        expect(h.deps.beginPricePan).not.toHaveBeenCalled();
+        expect(h.deps.fling).not.toHaveBeenCalled();
+        expect(h.deps.drawingsMeasureStart).not.toHaveBeenCalled();
+    });
+
+    it('lets a drawing hit or active drawing mode claim the gesture first', () => {
+        const h = harness({ claim: true });
+        h.pointer('pointerdown', 20, 20, { shiftKey: true });
+        h.pointer('pointermove', 80, 70);
+        h.pointer('pointerup', 80, 70);
+
+        expect(h.deps.drawingsPointerDown).toHaveBeenCalledTimes(1);
+        expect(h.deps.drawingsPointerDown).toHaveBeenCalledWith(20, 20, 'strong', true);
+        expect(h.deps.drawingsPointerUp).toHaveBeenCalledTimes(1);
+        expect(h.deps.drawingsMarqueeStart).not.toHaveBeenCalled();
+        expect(h.deps.drawingsMeasureStart).not.toHaveBeenCalled();
+    });
+
+    it('does not start on an axis or touch, preserving axis and touch-pan behavior', () => {
+        const axis = harness();
+        axis.pointer('pointerdown', 210, 50);
+        expect(axis.deps.drawingsMarqueeStart).not.toHaveBeenCalled();
+        expect(axis.deps.beginPriceScale).toHaveBeenCalledWith(210, 50);
+
+        const touch = harness();
+        touch.pointer('pointerdown', 20, 20, { pointerType: 'touch' });
+        expect(touch.deps.drawingsMarqueeStart).not.toHaveBeenCalled();
+        expect(touch.deps.beginPricePan).toHaveBeenCalledWith(20);
+    });
+
+    it('lets a pane separator keep its resize gesture ahead of a modified marquee', () => {
+        const h = harness({ separator: true });
+        h.pointer('pointerdown', 20, 50);
+
+        expect(h.deps.drawingsMarqueeStart).not.toHaveBeenCalled();
+        expect(h.deps.beginPaneResize).toHaveBeenCalledWith(50);
+        expect(h.deps.beginPricePan).not.toHaveBeenCalled();
+    });
+
+    it('cancels on pointercancel without ending or clicking', () => {
+        const h = harness();
+        const viewport = h.coords.getViewport();
+        h.pointer('pointerdown', 20, 20);
+        h.pointer('pointermove', 80, 70);
+        h.pointer('pointercancel', 80, 70);
+
+        expect(h.deps.drawingsMarqueeCancel).toHaveBeenCalledTimes(1);
+        expect(h.deps.drawingsMarqueeEnd).not.toHaveBeenCalled();
+        expect(h.deps.onClick).not.toHaveBeenCalled();
+        expect(h.deps.apply).toHaveBeenCalledTimes(1);
+        expect(h.deps.apply).toHaveBeenCalledWith(viewport);
+        expect(h.coords.getViewport()).toEqual(viewport);
+    });
+
+    it('leaves an ordinary unmodified data drag on the existing pan path', () => {
+        const h = harness();
+        h.pointer('pointerdown', 20, 20, { ctrlKey: false });
+        h.pointer('pointermove', 80, 20, { ctrlKey: false });
+        h.pointer('pointerup', 80, 20, { ctrlKey: false });
+
+        expect(h.deps.drawingsMarqueeStart).not.toHaveBeenCalled();
+        expect(h.deps.beginPricePan).toHaveBeenCalledWith(20);
+        expect(h.deps.apply).toHaveBeenCalled();
+    });
+
+    it('falls back to the existing Shift-measure gesture when marquee support declines', () => {
+        const h = harness({ marquee: false });
+        h.pointer('pointerdown', 20, 20, { shiftKey: true });
+        expect(h.deps.drawingsMarqueeStart).toHaveBeenCalledTimes(1);
+        expect(h.deps.drawingsMeasureStart).toHaveBeenCalledTimes(1);
+    });
+});

--- a/test/market-status.test.ts
+++ b/test/market-status.test.ts
@@ -87,6 +87,25 @@ afterEach(() => {
 });
 
 describe('MarketStatusTracker', () => {
+    it('forwards the exact explicit session id to the calendar provider', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(D(11, 18));
+        const sessions: Array<string | undefined> = [];
+        const provider: FakeProvider = {
+            getCalendar: (_ticker, range) => {
+                sessions.push(range.session);
+                return Promise.resolve([[D(11, 17), D(11, 19)]]);
+            },
+        };
+        const statuses: string[] = [];
+        const tracker = new MarketStatusTracker((status) => statuses.push(status));
+        tracker.track(fakeData(provider, { ticker: 'CUSTOM' }), 'CUSTOM', { explicit: true, session: 'Asia-AM' });
+        await vi.advanceTimersByTimeAsync(1);
+        expect(sessions).toEqual(['Asia-AM']);
+        expect(statuses).toEqual(['open']);
+        tracker.stop();
+    });
+
     it('derives the status from the provider calendar and re-derives at the boundary', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(D(11, 19, 59)); // Tue 15:59 ET — one minute before the close

--- a/test/motion-policy.test.ts
+++ b/test/motion-policy.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Vela } from '../src/Vela';
+import { resolveMotionPolicy } from '../src/core/options';
+import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+import { applyMotionScope, ensureMotionStyles, MotionPreferenceController } from '../src/renderers/shared/motion';
+import { mirrorPopoverMotionScope } from '../src/ui/components/popover/view';
+import type { IChartRenderer } from '../src/core/ports/IChartRenderer';
+import type { MotionPreferenceSource } from '../src/renderers/shared/motion';
+
+function recordingRenderer() {
+    const policies: unknown[] = [];
+    const renderer = {
+        name: 'motion-probe',
+        features: [] as readonly string[],
+        capabilities: {
+            panes: true, paneManagement: false, fills: 'native', bgcolor: 'native', hline: 'native', markers: true,
+            barcolor: 'native', perPointColor: true, drawings: true, userDrawings: false, tables: true, inputsUI: true,
+        },
+        applyMotionPolicy: (policy: unknown) => policies.push(policy),
+        applyFeature() {}, readFeature: () => undefined,
+        mount() {}, setTheme() {}, resize() {}, destroy() {},
+        setBars() {}, updateBar() {}, ensurePane() {}, removePane() {},
+        mountIndicator: (model: { id: string }) => ({ id: model.id }),
+        updateIndicator() {}, removeIndicator() {}, setIndicatorInputs() {},
+        onInputChange: () => () => {}, onRemoveIndicator: () => () => {},
+        onCrosshairMove: () => () => {}, onClick: () => () => {},
+        getVisibleRange: () => null, setVisibleRange() {}, onViewportChange: () => () => {},
+    } as unknown as IChartRenderer;
+    return { renderer, policies };
+}
+
+describe('motion policy', () => {
+    it('uses the system preference only when animations is omitted', () => {
+        expect(resolveMotionPolicy(undefined, false)).toEqual({ reduced: false, animZoom: true, animPan: true, animLiveBar: 0, intro: true });
+        expect(resolveMotionPolicy(undefined, true)).toEqual({ reduced: true, animZoom: false, animPan: false, animLiveBar: 0, intro: false });
+        expect(resolveMotionPolicy(false, false).reduced).toBe(true);
+        expect(resolveMotionPolicy(false, true).reduced).toBe(true);
+        expect(resolveMotionPolicy(true, true)).toEqual({ reduced: false, animZoom: true, animPan: true, animLiveBar: 0, intro: true });
+    });
+
+    it('treats an object, including a partial one, as a whole host override', () => {
+        expect(resolveMotionPolicy({}, true)).toEqual({ reduced: false, animZoom: true, animPan: true, animLiveBar: 0, intro: true });
+        expect(resolveMotionPolicy({ pan: false, liveBar: 250 }, true)).toEqual({
+            reduced: false,
+            animZoom: true,
+            animPan: false,
+            animLiveBar: 250,
+            intro: true,
+        });
+    });
+});
+
+describe('MotionPreferenceController', () => {
+    it('observes live changes exactly once and removes the listener on destroy', () => {
+        let listener: ((event: MediaQueryListEvent) => void) | null = null;
+        const add = vi.fn((_type: string, cb: (event: MediaQueryListEvent) => void) => {
+            listener = cb;
+        });
+        const remove = vi.fn();
+        const mql = { matches: true, addEventListener: add, removeEventListener: remove } as unknown as MediaQueryList;
+        const host = { ownerDocument: { defaultView: { matchMedia: vi.fn(() => mql) } } } as unknown as HTMLElement;
+        const controller = new MotionPreferenceController(host);
+        const seen: boolean[] = [];
+        controller.onChange((value) => seen.push(value));
+
+        expect(controller.reduced).toBe(true);
+        listener!({ matches: false } as MediaQueryListEvent);
+        listener!({ matches: false } as MediaQueryListEvent);
+        expect(seen).toEqual([false]);
+
+        controller.destroy();
+        expect(remove).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+
+    it('does not touch matchMedia for an explicit host policy', () => {
+        const matchMedia = vi.fn();
+        const host = { ownerDocument: { defaultView: { matchMedia } } } as unknown as HTMLElement;
+        const controller = new MotionPreferenceController(host, false);
+        expect(controller.reduced).toBe(false);
+        expect(matchMedia).not.toHaveBeenCalled();
+    });
+});
+
+describe('portaled motion scope', () => {
+    it('installs the scoped rule in both a trigger ShadowRoot and the document portal root', () => {
+        const shadowStyles: Array<{ id?: string; textContent?: string }> = [];
+        const documentStyles: Array<{ id?: string; textContent?: string }> = [];
+        const shadow = {
+            querySelector: () => shadowStyles[0] ?? null,
+            appendChild: vi.fn((style: { id?: string; textContent?: string }) => { shadowStyles.push(style); }),
+        };
+        const doc = {
+            head: {
+                appendChild: vi.fn((style: { id?: string; textContent?: string }) => { documentStyles.push(style); }),
+            },
+            querySelector: () => documentStyles[0] ?? null,
+            createElement: () => ({}),
+        } as unknown as Document;
+        const host = {
+            ownerDocument: doc,
+            getRootNode: () => shadow,
+        } as unknown as HTMLElement;
+
+        ensureMotionStyles(host);
+        ensureMotionStyles(host);
+
+        expect(shadowStyles).toHaveLength(1);
+        expect(documentStyles).toHaveLength(1);
+        expect(shadowStyles[0]?.textContent).toContain("[data-vela-motion='reduced']");
+        expect(documentStyles[0]?.textContent).toContain("[data-vela-motion='reduced']");
+    });
+
+    it('installs CSS and projects reduced motion onto external dialog roots without marking the host', () => {
+        const styles: Array<{ id?: string; textContent?: string }> = [];
+        const appendChild = vi.fn((next: { id?: string; textContent?: string }) => { styles.push(next); });
+        const doc = {
+            head: { appendChild },
+            querySelector: () => styles[0] ?? null,
+            createElement: () => ({}),
+        } as unknown as Document;
+        const host = {
+            ownerDocument: doc,
+            getRootNode: () => doc,
+        } as unknown as HTMLElement;
+        const backdrop = { dataset: {} } as unknown as HTMLElement;
+        const positioner = { dataset: {} } as unknown as HTMLElement;
+
+        applyMotionScope(host, true, backdrop, positioner);
+        expect(appendChild).toHaveBeenCalledOnce();
+        expect(styles[0]).toMatchObject({ id: 'vela-reduced-motion' });
+        expect(styles[0]?.textContent).toContain("[data-vela-motion='reduced']");
+        expect(backdrop.dataset.velaMotion).toBe('reduced');
+        expect(positioner.dataset.velaMotion).toBe('reduced');
+        expect(host.dataset).toBeUndefined();
+
+        applyMotionScope(host, false, backdrop, positioner);
+        expect(appendChild).toHaveBeenCalledOnce();
+        expect(backdrop.dataset.velaMotion).toBe('full');
+        expect(positioner.dataset.velaMotion).toBe('full');
+    });
+
+    it('projects live reduced and full modes onto an open nested popover', () => {
+        let notify: (() => void) | null = null;
+        const observe = vi.fn();
+        const disconnect = vi.fn();
+        class FakeMutationObserver {
+            constructor(cb: () => void) { notify = cb; }
+            observe = observe;
+            disconnect = disconnect;
+        }
+        const externalHost = { dataset: {} };
+        const scope = {
+            dataset: { velaMotion: 'full' },
+            ownerDocument: { defaultView: { MutationObserver: FakeMutationObserver } },
+        };
+        const trigger = { closest: vi.fn(() => scope) };
+        const popup = {
+            dataset: {} as Record<string, string>,
+            removeAttribute: vi.fn((name: string) => {
+                if (name === 'data-vela-motion') delete popup.dataset.velaMotion;
+            }),
+        };
+
+        const stop = mirrorPopoverMotionScope(
+            trigger as unknown as HTMLElement,
+            popup as unknown as HTMLElement,
+        );
+
+        expect(trigger.closest).toHaveBeenCalledWith('[data-vela-motion]');
+        expect(observe).toHaveBeenCalledWith(scope, {
+            attributes: true,
+            attributeFilter: ['data-vela-motion'],
+        });
+        expect(popup.dataset.velaMotion).toBe('full');
+        expect(externalHost.dataset).toEqual({});
+
+        scope.dataset.velaMotion = 'reduced';
+        notify!();
+        expect(popup.dataset.velaMotion).toBe('reduced');
+
+        scope.dataset.velaMotion = 'full';
+        notify!();
+        expect(popup.dataset.velaMotion).toBe('full');
+
+        stop();
+        expect(disconnect).toHaveBeenCalledOnce();
+    });
+});
+
+describe('Vela motion preference lifecycle', () => {
+    it('applies live changes and unsubscribes from an injected host-owned source', async () => {
+        let reduced = true;
+        let listener: ((value: boolean) => void) | null = null;
+        const unsubscribe = vi.fn(() => { listener = null; });
+        const emit = (value: boolean) => listener?.(value);
+        const preference: MotionPreferenceSource = {
+            get reduced() { return reduced; },
+            onChange(cb) {
+                listener = cb;
+                return unsubscribe;
+            },
+        };
+        const { renderer, policies } = recordingRenderer();
+        const removeAttribute = vi.fn();
+        const host = { dataset: {}, removeAttribute } as unknown as HTMLElement;
+        const chart = new Vela(host, { volume: false }, {
+            renderer,
+            engines: [],
+            dataFeed: {
+                load: () => Promise.resolve([]),
+                subscribe: () => () => {},
+            },
+            motionPreference: preference,
+        });
+        await chart.ready();
+
+        expect(chart.reducedMotion).toBe(true);
+        expect(policies).toEqual([resolveMotionPolicy(undefined, true)]);
+        reduced = false;
+        emit(false);
+        expect(chart.reducedMotion).toBe(false);
+        expect(policies).toEqual([
+            resolveMotionPolicy(undefined, true),
+            resolveMotionPolicy(undefined, false),
+        ]);
+
+        chart.destroy();
+        expect(unsubscribe).toHaveBeenCalledOnce();
+        expect(removeAttribute).toHaveBeenCalledWith('data-vela-motion');
+        emit(true);
+        expect(policies).toHaveLength(2);
+    });
+});
+
+type AnyNativeRenderer = Record<string, any>;
+
+function nativeMotionHarness(): {
+    renderer: NativeRenderer;
+    native: AnyNativeRenderer;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    invalidate: ReturnType<typeof vi.fn>;
+} {
+    const renderer = new NativeRenderer();
+    // Apply the policy before installing mount-owned collaborators. This is the same
+    // ordering as Vela's constructor and keeps the harness free of DOM dependencies.
+    renderer.applyMotionPolicy(resolveMotionPolicy(false, false));
+    const native = renderer as unknown as AnyNativeRenderer;
+    native.coords.setSize(800, 200, 1);
+    native.coords.setBars(Array.from({ length: 100 }, (_, index) => (index + 1) * 1_000));
+    native.coords.setViewport({ barSpacing: 10, rightOffset: 5 });
+    const start = vi.fn();
+    const stop = vi.fn();
+    const invalidate = vi.fn();
+    native.animator = { active: false, start, stop };
+    native.scheduler = { invalidate, flushNow: vi.fn() };
+    native.emitViewportChange = vi.fn();
+    return { renderer, native, start, stop, invalidate };
+}
+
+describe('NativeRenderer reduced-motion gates', () => {
+    it('forwards live policy changes to both dialog controllers', () => {
+        const renderer = new NativeRenderer();
+        const native = renderer as unknown as AnyNativeRenderer;
+        const setSettingsReduced = vi.fn();
+        const setInputsReduced = vi.fn();
+        native.settingsDialog = { setReducedMotion: setSettingsReduced };
+        native.inputsUI = { setReducedMotion: setInputsReduced };
+
+        renderer.applyMotionPolicy(resolveMotionPolicy(false, false));
+
+        expect(setSettingsReduced).toHaveBeenCalledWith(true);
+        expect(setInputsReduced).toHaveBeenCalledWith(true);
+    });
+
+    it('makes zoom, pan glides, fling, and intro immediate while preserving configured animation values', () => {
+        const { renderer, native, start, invalidate } = nativeMotionHarness();
+        const playIntro = vi.fn();
+        native.playIntro = playIntro;
+        const configured = renderer.getConfig();
+
+        renderer.applyFeature('intro', 'wave');
+        renderer.setBars(Array.from({ length: 100 }, (_, index) => ({
+            time: (index + 1) * 1_000,
+            open: 100,
+            high: 101,
+            low: 99,
+            close: 100,
+            volume: 1,
+        })));
+        native.coords.setViewport({ barSpacing: 10, rightOffset: 5 });
+        native.zoomTo(20, 99, 800);
+        expect(native.coords.getViewport()).toEqual({ barSpacing: 20, rightOffset: 0 });
+        native.fling(0.5);
+        native.glideRightOffset(6);
+        expect(native.coords.getViewport()).toEqual({ barSpacing: 20, rightOffset: 6 });
+
+        expect(start).not.toHaveBeenCalled();
+        expect(invalidate).toHaveBeenCalledTimes(3);
+        expect(playIntro).not.toHaveBeenCalled();
+        expect(renderer.readFeature('animZoom')).toBe(true);
+        expect(renderer.readFeature('animPan')).toBe(true);
+        expect(renderer.readFeature('intro')).toBe('wave');
+        expect(renderer.getConfig()).toEqual(configured);
+
+        renderer.applyMotionPolicy(resolveMotionPolicy(true, true));
+        native.zoomTo(30, 99, 800);
+        native.fling(0.5);
+        native.glideRightOffset(4);
+        renderer.applyFeature('intro', 'wave');
+
+        expect(start).toHaveBeenCalledTimes(3);
+        expect(playIntro).toHaveBeenCalledOnce();
+        expect(renderer.getConfig()).toEqual(configured);
+    });
+
+    it('settles active viewport targets and recomputes scales with the animator stopped', () => {
+        const renderer = new NativeRenderer();
+        const native = renderer as unknown as AnyNativeRenderer;
+        native.coords.setSize(800, 200, 1);
+        native.coords.setBars(Array.from({ length: 100 }, (_, index) => (index + 1) * 1_000));
+        native.coords.setViewport({ barSpacing: 10, rightOffset: 5 });
+        native.targetBarSpacing = 20;
+        native.zoomAnchorLogical = 99;
+        native.zoomAnchorX = 800;
+        native.scrollTargetRO = 6;
+        native.panVelocity = 0.5;
+        const animator = { active: true, start: vi.fn(), stop: vi.fn() };
+        animator.stop.mockImplementation(() => { animator.active = false; });
+        const flushNow = vi.fn();
+        const computeScales = vi.fn(() => expect(animator.active).toBe(false));
+        native.animator = animator;
+        native.scheduler = { invalidate: vi.fn(), flushNow };
+        native.computeScales = computeScales;
+        native.emitViewportChange = vi.fn();
+
+        renderer.applyMotionPolicy(resolveMotionPolicy(undefined, true));
+
+        expect(native.coords.getViewport()).toEqual({ barSpacing: 20, rightOffset: 6 });
+        expect(native.targetBarSpacing).toBe(20);
+        expect(native.scrollTargetRO).toBeNull();
+        expect(native.panVelocity).toBe(0);
+        expect(animator.stop).toHaveBeenCalledOnce();
+        expect(computeScales).toHaveBeenCalledOnce();
+        expect(flushNow).toHaveBeenCalledOnce();
+    });
+
+    it('marks SDK layer frames reduced and does not let an animating layer restart the animator', () => {
+        const renderer = new NativeRenderer();
+        renderer.applyMotionPolicy(resolveMotionPolicy(false, false));
+        const native = renderer as unknown as AnyNativeRenderer;
+        const pane = native.scene.ensurePane('price', 'price', 0, 3);
+        pane.bounds = { top: 0, height: 200 };
+        const reducedFlags: boolean[] = [];
+        const start = vi.fn();
+        native.extLayers = [{
+            def: { id: 'motion-probe', repaintOnCursor: true },
+            instance: {
+                render: (args: { reducedMotion: boolean }) => reducedFlags.push(args.reducedMotion),
+                animating: () => true,
+            },
+            canvas: {},
+        }];
+        native.animator = { active: false, start, stop: vi.fn() };
+        native.syncLayerCanvasOrder = () => undefined;
+        native.stampScaleInvert = () => undefined;
+        native.backend = {
+            modelAlpha: 1,
+            candleBodyAlpha: 1,
+            candleStructureAlpha: 1,
+            candleBodyScale: 1,
+            render: vi.fn(),
+        };
+        native.volumeRenderer = { render: vi.fn() };
+        native.vpvrRenderer = { render: vi.fn() };
+        native.indicatorSlices = { prepare: () => new Map() };
+        native.dataCanvas = {};
+        native.backdropRenderer = { render: vi.fn() };
+        native.chrome = { render: vi.fn() };
+        native.axisSurface = () => ({});
+
+        native.paintData();
+        native.repaintCursorLayers();
+        expect(reducedFlags).toEqual([true, true]);
+        expect(start).not.toHaveBeenCalled();
+
+        renderer.applyMotionPolicy(resolveMotionPolicy(true, true));
+        native.paintData();
+        native.repaintCursorLayers();
+        expect(reducedFlags).toEqual([true, true, false, false]);
+        expect(start).toHaveBeenCalledTimes(2);
+    });
+});

--- a/test/multi-provider-feed.test.ts
+++ b/test/multi-provider-feed.test.ts
@@ -597,13 +597,20 @@ describe('listing-prefix resolution (TradingView parity)', () => {
 });
 
 describe('session flag propagation (provider seam)', () => {
-    it('rides getBars ranges (load, loadRange, poll) and the subscribe opts', async () => {
+    it('forwards a custom id exactly through progressive, load, range, and subscribe paths', async () => {
         const ranges: Array<Record<string, unknown>> = [];
+        const progressiveRanges: Array<Record<string, unknown>> = [];
         const subOpts: unknown[] = [];
         const provider: DataProvider = {
             getBars(_t, _tf, range) {
                 ranges.push({ ...range });
                 return Promise.resolve(makeBars(range.limit ?? 10));
+            },
+            getBarsProgressive(_t, _tf, range, onBatch) {
+                progressiveRanges.push({ ...range });
+                const bars = makeBars(range.limit ?? 10);
+                onBatch(bars);
+                return Promise.resolve(bars);
             },
             listSymbols: () => Promise.resolve([{ ticker: 'AAPL', prefix: 'NASDAQ' }]),
             subscribe(_t, _tf, _onBar, opts) {
@@ -615,15 +622,19 @@ describe('session flag propagation (provider seam)', () => {
         feed.registerProvider('edgx', provider);
         await feed.ready();
 
-        await feed.load({ symbol: 'NASDAQ:AAPL', timeframe: '60', bars: 5, session: 'extended' });
-        expect(ranges[ranges.length - 1]!.session).toBe('extended');
+        const session = 'Asia-AM';
+        await feed.loadProgressive({ symbol: 'NASDAQ:AAPL', timeframe: '60', bars: 5, session }, () => {});
+        expect(progressiveRanges).toEqual([{ limit: 5, session }]);
 
-        await feed.loadRange!({ symbol: 'NASDAQ:AAPL', timeframe: '60', session: 'extended' }, { from: 0, limit: 5 });
-        expect(ranges[ranges.length - 1]).toMatchObject({ from: 0, session: 'extended' });
+        await feed.load({ symbol: 'NASDAQ:AAPL', timeframe: '60', bars: 5, session });
+        expect(ranges[ranges.length - 1]!.session).toBe(session);
 
-        const off = feed.subscribe({ symbol: 'NASDAQ:AAPL', timeframe: '60', session: 'extended' }, () => {});
+        await feed.loadRange!({ symbol: 'NASDAQ:AAPL', timeframe: '60', session }, { from: 0, limit: 5 });
+        expect(ranges[ranges.length - 1]).toMatchObject({ from: 0, session });
+
+        const off = feed.subscribe({ symbol: 'NASDAQ:AAPL', timeframe: '60', session }, () => {});
         off();
-        expect(subOpts).toEqual([{ session: 'extended' }]);
+        expect(subOpts).toEqual([{ session }]);
 
         // No session set -> nothing invented: the flag is simply absent.
         await feed.load({ symbol: 'NASDAQ:AAPL', timeframe: '60', bars: 5 });

--- a/test/native-axis-bundle.test.ts
+++ b/test/native-axis-bundle.test.ts
@@ -3,6 +3,7 @@ import { paneAxisTicks, formatAxisValue, formatPct, timeTicks } from '../src/ren
 import { tzOffsetMs, zonedDate } from '../src/renderers/native/chrome/tz';
 import { keyToAction } from '../src/renderers/native/core/KeyboardController';
 import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
+import type { SceneGraph } from '../src/renderers/native/core/SceneGraph';
 
 describe('percent-scale ticks + labels (item 14a)', () => {
     it('formatPct signs and fixes to 2 decimals', () => {
@@ -193,5 +194,25 @@ describe('NativeRenderer new feature defaults + setters (items 9, 11, 14)', () =
         expect(hs.map((h) => h.from)).toEqual([100, 300]);
         expect(hs[0]!.color).toMatch(/rgba\(/); // default fill
         expect(hs[1]!.color).toBe('#abc');
+    });
+
+    it('session zones preserve validated per-band colors alongside legacy phase bands', () => {
+        const r = new NativeRenderer();
+        r.applyFeature('sessionZones', {
+            pre: [[100, 200]],
+            post: [],
+            extended: [],
+            bands: [
+                { from: 500, to: 600, color: '#custom' },
+                { from: 300, to: 400, color: 'rgba(1, 2, 3, 0.1)' },
+                { from: 700, to: 700, color: '#drop' },
+            ],
+        });
+        const scene = (r as unknown as { scene: SceneGraph }).scene;
+        expect(scene.sessionHighlightBands()).toEqual([
+            { from: 100, to: 200, color: scene.style.sessions.premarketColor },
+            { from: 300, to: 400, color: 'rgba(1, 2, 3, 0.1)' },
+            { from: 500, to: 600, color: '#custom' },
+        ]);
     });
 });

--- a/test/native-chart-config.test.ts
+++ b/test/native-chart-config.test.ts
@@ -1,11 +1,133 @@
-import { afterEach, describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
 import { registerChartType, unregisterChartType } from '../src/chart-types/registry';
 import { CHART_CONFIG_VERSION, defaultChartStyle, factoryResetConfig, mergeConfig, type ChartConfig } from '../src/renderers/native/core/chartConfig';
+import { VelaWorkspace } from '../src/workspace/VelaWorkspace';
 
 /** A known-good baseline config for the pure mergeConfig tests. */
 function baseConfig(): ChartConfig {
     return new NativeRenderer().getConfig();
+}
+
+type FeatureConformance =
+    | { configPath: string; set: unknown; expected: unknown; readExpected: unknown }
+    | { runtimeOnly: string };
+
+/**
+ * Every native renderer feature is classified here. Config-backed rows must prove
+ * their feature write, JSON serialization, validation, and restore path. The other
+ * rows document why persisting them in ChartConfig would cross an ownership boundary
+ * or capture transient runtime state.
+ */
+const FEATURE_CONFORMANCE = {
+    logScale: { configPath: 'priceScale.log', set: true, expected: true, readExpected: true },
+    currentPriceLine: { configPath: 'priceScale.currentPriceLine', set: false, expected: false, readExpected: false },
+    priceLabel: { configPath: 'priceScale.priceLabel', set: false, expected: false, readExpected: false },
+    countdown: { configPath: 'priceScale.countdown', set: false, expected: false, readExpected: false },
+    upColor: { configPath: 'candles.upColor', set: '#010203', expected: '#010203', readExpected: '#010203' },
+    downColor: { configPath: 'candles.downColor', set: '#040506', expected: '#040506', readExpected: '#040506' },
+    glow: { runtimeOnly: 'Renderer display option; ChartConfig stores chart cosmetics.' },
+    animZoom: { runtimeOnly: 'Host interaction preference.' },
+    animPan: { runtimeOnly: 'Host interaction preference.' },
+    animLiveBar: { configPath: 'priceScale.animateLastPrice', set: 90, expected: true, readExpected: 90 },
+    intro: { runtimeOnly: 'One-shot renderer lifecycle effect.' },
+    zoomAnchor: { runtimeOnly: 'Host interaction preference.' },
+    axisDrag: { runtimeOnly: 'Host interaction preference.' },
+    paneResize: { runtimeOnly: 'Host interaction preference.' },
+    candleZOrder: { configPath: 'stacking.candles', set: 4, expected: 4, readExpected: 4 },
+    candleVisible: { configPath: 'series.visible', set: false, expected: false, readExpected: false },
+    seriesOrder: {
+        configPath: 'stacking.series.conformance',
+        set: { id: 'conformance', z: 5 },
+        expected: 5,
+        readExpected: [{ id: 'conformance', z: 5 }],
+    },
+    highlights: { runtimeOnly: 'Transient host-supplied time ranges.' },
+    sessionZones: { runtimeOnly: 'Host-derived market-calendar data; ChartConfig stores only its colors.' },
+    gridlines: { runtimeOnly: 'Runtime master switch; ChartConfig stores independent vertical and horizontal choices.' },
+    axisLabels: { configPath: 'priceScale.labelsVisible', set: false, expected: false, readExpected: false },
+    scaleMode: { configPath: 'priceScale.mode', set: 'percent', expected: 'percent', readExpected: 'percent' },
+    invertScale: { configPath: 'priceScale.invert', set: true, expected: true, readExpected: true },
+    paneScales: { runtimeOnly: 'Read-only view of live pane scales.' },
+    autoScale: { runtimeOnly: 'Transient viewport scale state.' },
+    timezone: {
+        configPath: 'timeScale.timezone',
+        set: 'America/New_York',
+        expected: 'America/New_York',
+        readExpected: 'America/New_York',
+    },
+    keyboard: { runtimeOnly: 'Host input and accessibility policy.' },
+    historyChords: { runtimeOnly: 'Host keyboard-routing policy.' },
+    priceStyle: { configPath: 'series.style', set: 'line', expected: 'line', readExpected: 'line' },
+    priceBaseline: { configPath: 'series.baseline', set: 123, expected: 123, readExpected: 123 },
+    baselinePrice: { runtimeOnly: 'Read-only value derived from the live price scale.' },
+    settings: { runtimeOnly: 'Host UI availability policy.' },
+    attribution: { runtimeOnly: 'Host attribution policy and optional markup.' },
+    dialogHost: { runtimeOnly: 'Live DOM mount point.' },
+    tradeMarkers: {
+        configPath: 'trades.visible',
+        set: { visible: false },
+        expected: false,
+        readExpected: {
+            visible: false,
+            labels: true,
+            qty: true,
+            colors: { long: '#2962ff', short: '#f23645', exit: '#d500f9' },
+        },
+    },
+    indicatorTitles: { runtimeOnly: 'Workspace display state, persisted outside ChartConfig.' },
+    indicatorValues: { runtimeOnly: 'Workspace display state, persisted outside ChartConfig.' },
+} as const satisfies Record<string, FeatureConformance>;
+
+function valueAtPath(value: unknown, path: string): unknown {
+    return path.split('.').reduce<unknown>((current, key) => {
+        if (!current || typeof current !== 'object') return undefined;
+        return (current as Record<string, unknown>)[key];
+    }, value);
+}
+
+/** Drive the real public workspace state methods without constructing DOM chrome. The
+ * cell adapters isolate the contract under test: the workspace must carry the opaque
+ * renderer config from a live cell into the matching cell's in-place rehydrate path. */
+function roundTripFeatureThroughWorkspace(source: NativeRenderer, restored: NativeRenderer): {
+    state: ReturnType<VelaWorkspace['getState']>;
+    rehydrate: ReturnType<typeof vi.fn>;
+} {
+    const rehydrate = vi.fn((cell: { rendererConfig?: unknown }) => {
+        if (cell.rendererConfig != null) restored.applyConfig(cell.rendererConfig);
+    });
+    const workspace = Object.create(VelaWorkspace.prototype) as VelaWorkspace;
+    Object.assign(workspace, {
+        destroyed: false,
+        monoLayout: true,
+        def: { id: '1', cells: [{ id: 'c1' }] },
+        pool: new Map(),
+        cellsById: new Map([['c1', { dehydrate: () => ({ rendererConfig: source.getConfig() }) }]]),
+        order: ['c1'],
+        timezone: '',
+        syncOpts: {},
+        activeId: 'c1',
+        favs: [],
+        tfFavs: [],
+        trackSizes: new Map(),
+        dock: { getState: () => undefined, applyState: () => undefined },
+        extState: {},
+        drawingLinks: new Map(),
+        applySyncSetting: () => undefined,
+        clearMaximized: () => undefined,
+        applyGrid: () => undefined,
+        refreshCellControls: () => undefined,
+        projectActiveCell: () => undefined,
+        setActiveCell: () => undefined,
+        refreshRetention: () => undefined,
+        markStateDirty: () => undefined,
+        context: () => ({}),
+    });
+
+    const state = workspace.getState();
+    Object.assign(workspace, { cellsById: new Map([['c1', { rehydrate }]]) });
+    workspace.applyState(JSON.parse(JSON.stringify(state)));
+    return { state, rehydrate };
 }
 
 describe('mergeConfig — validating reducer (item 15)', () => {
@@ -66,6 +188,14 @@ describe('mergeConfig — validating reducer (item 15)', () => {
         expect(mergeConfig(base, { series: { spacing: -3 } }).series.spacing).toBe(0.1);
         expect(mergeConfig(base, { series: { spacing: 999 } }).series.spacing).toBe(10);
         expect(mergeConfig(base, { series: { spacing: 'x' } }).series.spacing).toBe(base.series.spacing);
+    });
+
+    it('series.visible accepts booleans and keeps the known-good base for older or malformed documents', () => {
+        const base = baseConfig();
+        base.series.visible = false;
+        expect(mergeConfig(base, {}).series.visible).toBe(false);
+        expect(mergeConfig(base, { series: { visible: 'no' } }).series.visible).toBe(false);
+        expect(mergeConfig(base, { series: { visible: true } }).series.visible).toBe(true);
     });
 
     it('trades: applies valid fields, drops malformed ones', () => {
@@ -130,7 +260,7 @@ describe('NativeRenderer.getConfig — defaults resolve to concrete values', () 
         expect(cfg.candles.downColor).toBe('#f23645');
         expect(cfg.candles.borderUpColor).toBe('#089981'); // inherits the body color
         expect(cfg.candles.wickDownColor).toBe('#f23645');
-        expect(cfg.series).toEqual({ style: 'candles', baseline: null, spacing: 1 });
+        expect(cfg.series).toEqual({ visible: true, style: 'candles', baseline: null, spacing: 1 });
     });
 
     it('is fully JSON-serializable (round-trips through stringify/parse)', () => {
@@ -139,7 +269,63 @@ describe('NativeRenderer.getConfig — defaults resolve to concrete values', () 
     });
 });
 
+describe('native renderer feature/config conformance', () => {
+    it('classifies every advertised feature as config-backed or deliberately runtime-only', () => {
+        const rendererFeatures = [...new NativeRenderer().features].sort();
+        expect(Object.keys(FEATURE_CONFORMANCE).sort()).toEqual(rendererFeatures);
+        for (const entry of Object.values(FEATURE_CONFORMANCE)) {
+            if ('runtimeOnly' in entry) expect(entry.runtimeOnly.trim().length).toBeGreaterThan(0);
+        }
+    });
+
+    it('round-trips every config-backed feature through workspace getState/applyState into live behavior', () => {
+        for (const [feature, entry] of Object.entries(FEATURE_CONFORMANCE)) {
+            if ('runtimeOnly' in entry) continue;
+            const source = new NativeRenderer();
+            source.applyFeature(feature, entry.set);
+            const restored = new NativeRenderer();
+            const { state, rehydrate } = roundTripFeatureThroughWorkspace(source, restored);
+            const saved = state.charts[0]?.rendererConfig;
+
+            expect(valueAtPath(saved, entry.configPath), `${feature} write -> ${entry.configPath}`).toEqual(entry.expected);
+            expect(rehydrate, `${feature} workspace in-place restore`).toHaveBeenCalledOnce();
+            expect(valueAtPath(restored.getConfig(), entry.configPath), `${feature} restore <- ${entry.configPath}`).toEqual(entry.expected);
+            expect(restored.readFeature(feature), `${feature} restored live value`).toEqual(entry.readExpected);
+        }
+    });
+});
+
 describe('NativeRenderer.applyConfig — applies + syncs the live scene fields', () => {
+    it('round-trips whole price-series visibility through JSON into a fresh renderer', () => {
+        const source = new NativeRenderer();
+        expect(source.getConfig().series.visible).toBe(true);
+
+        source.applyFeature('candleVisible', false);
+        const saved = JSON.parse(JSON.stringify(source.getConfig()));
+        const restored = new NativeRenderer();
+        restored.applyConfig(saved);
+
+        expect(saved.series.visible).toBe(false);
+        expect(restored.readFeature('candleVisible')).toBe(false);
+    });
+
+    it('notifies config subscribers once for a real visibility flip and not for a repeat', () => {
+        const r = new NativeRenderer();
+        const changed = vi.fn();
+        const unsubscribe = r.onConfigChanged(changed);
+
+        r.applyFeature('candleVisible', true);
+        expect(changed).not.toHaveBeenCalled();
+        r.applyFeature('candleVisible', false);
+        expect(changed).toHaveBeenCalledTimes(1);
+        r.applyFeature('candleVisible', false);
+        expect(changed).toHaveBeenCalledTimes(1);
+
+        unsubscribe();
+        r.applyFeature('candleVisible', true);
+        expect(changed).toHaveBeenCalledTimes(1);
+    });
+
     it('applies a partial config and reflects it in getConfig', () => {
         const r = new NativeRenderer();
         r.applyConfig({

--- a/test/native-live-bar-ease.test.ts
+++ b/test/native-live-bar-ease.test.ts
@@ -4,7 +4,7 @@
 // the first tick of a bar and every NEW bar still snap — only same-bar ticks glide.
 import { describe, it, expect } from 'vitest';
 import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
-import { resolveAnimations, resolveLiveBarEaseMs, LIVE_BAR_EASE_DEFAULT_MS, LIVE_BAR_EASE_MAX_MS } from '../src/core/options';
+import { resolveAnimations, resolveLiveBarEaseMs, resolveMotionPolicy, LIVE_BAR_EASE_DEFAULT_MS, LIVE_BAR_EASE_MAX_MS } from '../src/core/options';
 import type { OHLCV } from '../src/core/model/ohlcv';
 
 const bar = (time: number, close: number): OHLCV => ({ time, open: 100, high: Math.max(100, close), low: Math.min(100, close), close, volume: 1 });
@@ -18,7 +18,7 @@ function makeRenderer(animLiveBar: number) {
     const anyR = r as any;
     anyR.coords.setSize(800, 200, 1); // unmounted, but sized — the bar/ease math is pure
     let starts = 0;
-    anyR.scheduler = { invalidate: () => {} }; // mount-owned; stubbed for the unmounted path
+    anyR.scheduler = { invalidate: () => {}, flushNow: () => {} }; // mount-owned; stubbed for the unmounted path
     anyR.animator = { active: false, start: () => { starts += 1; }, stop: () => {} };
     anyR.introPlayed = true;
     return { r, anyR, starts: () => starts };
@@ -127,5 +127,20 @@ describe('NativeRenderer forming-bar glide', () => {
         expect(r.readFeature('animLiveBar')).toBe(LIVE_BAR_EASE_DEFAULT_MS);
         r.applyFeature('animLiveBar', 99_999);
         expect(r.readFeature('animLiveBar')).toBe(LIVE_BAR_EASE_MAX_MS);
+    });
+
+    it('reduced motion snaps live bars without destroying the configured duration', () => {
+        const { r, anyR, starts } = makeRenderer(90);
+        r.setBars([bar(1000, 100), bar(2000, 101)]);
+        r.updateBar(bar(2000, 105));
+        r.applyMotionPolicy(resolveMotionPolicy(undefined, true));
+        r.updateBar(bar(2000, 110));
+        expect(anyR.liveEaseClose).toBe(110);
+        expect(starts()).toBe(0);
+        expect(r.readFeature('animLiveBar')).toBe(90); // configured state survives the runtime gate
+
+        r.applyMotionPolicy(resolveMotionPolicy(undefined, false));
+        r.updateBar(bar(2000, 115));
+        expect(starts()).toBe(1); // future ticks use the restored configured behavior
     });
 });

--- a/test/native-series-visibility-backends.test.ts
+++ b/test/native-series-visibility-backends.test.ts
@@ -1,0 +1,230 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { IndicatorModel } from '../src/core/model/indicator';
+import type { VelaTheme } from '../src/core/options';
+import { Canvas2dBackend } from '../src/renderers/native/backend/Canvas2dBackend';
+import { WebGL2Backend } from '../src/renderers/native/backend/WebGL2Backend';
+import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
+import { SceneGraph } from '../src/renderers/native/core/SceneGraph';
+
+const WIDTH = 320;
+const HEIGHT = 180;
+const BASE_COLOR = '#ff0000';
+const OVERLAY_COLOR = '#00ff00';
+const PRICE_LINE_COLOR = '#0000ff';
+const VERTEX_STRIDE = 8;
+
+const THEME: VelaTheme = {
+    background: '#000000',
+    textColor: '#ffffff',
+    gridColor: '#222222',
+    borderColor: '#333333',
+    upColor: BASE_COLOR,
+    downColor: '#aa0000',
+    fontFamily: 'sans-serif',
+};
+
+function makeScene(hidden: boolean): { scene: SceneGraph; coords: CoordinateSystem } {
+    const bars = [
+        { time: 0, open: 100, high: 108, low: 98, close: 105 },
+        { time: 60_000, open: 105, high: 112, low: 103, close: 110 },
+        { time: 120_000, open: 110, high: 116, low: 107, close: 114 },
+    ];
+    const scene = new SceneGraph();
+    scene.bars = bars;
+    scene.candlesHidden = hidden;
+    scene.showGrid = false;
+    const pane = scene.ensurePane('price', 'price', 0, 3);
+    pane.bounds = { top: 0, height: HEIGHT };
+    pane.scale = { min: 90, max: 120 };
+
+    const overlay: IndicatorModel = {
+        id: 'overlay',
+        title: 'Overlay',
+        overlay: true,
+        paneHint: 'price',
+        paneId: 'price',
+        series: [{
+            id: 'overlay:line',
+            title: 'Overlay line',
+            paneId: 'price',
+            kind: 'line',
+            points: bars.map((bar, i) => ({ time: bar.time, value: 101 + i })),
+            style: { color: OVERLAY_COLOR, width: 2, lineStyle: 'solid' },
+        }],
+        fills: [],
+        backgrounds: [],
+        priceLines: [{ id: 'overlay:hline', paneId: 'price', price: 106, color: PRICE_LINE_COLOR }],
+        inputs: [],
+        inputValues: {},
+    };
+    scene.indicators.set(overlay.id, overlay);
+    scene.assignIndicatorZ(overlay.id);
+
+    const coords = new CoordinateSystem();
+    coords.setSize(WIDTH, HEIGHT, 1);
+    coords.setBars(bars.map((bar) => bar.time));
+    coords.setViewport({ barSpacing: 20, rightOffset: 2 });
+    return { scene, coords };
+}
+
+interface CanvasPaint {
+    color: string;
+    kind: 'fill' | 'stroke';
+}
+
+function canvasPaints(hidden: boolean): CanvasPaint[] {
+    const paints: CanvasPaint[] = [];
+    const state = { fillStyle: '', strokeStyle: '' };
+    const noop = (): void => undefined;
+    const ctx = {
+        set fillStyle(value: string) { state.fillStyle = value; },
+        get fillStyle() { return state.fillStyle; },
+        set strokeStyle(value: string) { state.strokeStyle = value; },
+        get strokeStyle() { return state.strokeStyle; },
+        globalAlpha: 1,
+        lineWidth: 1,
+        lineJoin: 'miter',
+        lineCap: 'butt',
+        setTransform: noop,
+        clearRect: noop,
+        save: noop,
+        restore: noop,
+        beginPath: noop,
+        closePath: noop,
+        rect: noop,
+        clip: noop,
+        moveTo: noop,
+        lineTo: noop,
+        arcTo: noop,
+        arc: noop,
+        setLineDash: noop,
+        drawImage: noop,
+        fill: () => paints.push({ kind: 'fill', color: state.fillStyle }),
+        stroke: () => paints.push({ kind: 'stroke', color: state.strokeStyle }),
+        fillRect: () => paints.push({ kind: 'fill', color: state.fillStyle }),
+        strokeRect: () => paints.push({ kind: 'stroke', color: state.strokeStyle }),
+        createLinearGradient: () => ({ addColorStop: noop }),
+    } as unknown as CanvasRenderingContext2D;
+    const canvas = { width: WIDTH, height: HEIGHT, getContext: () => ctx } as unknown as HTMLCanvasElement;
+    const backend = new Canvas2dBackend();
+    backend.mount(canvas);
+    const { scene, coords } = makeScene(hidden);
+    backend.render(scene, coords, THEME);
+    return paints;
+}
+
+interface GlCapture {
+    buffers: Float32Array[];
+    draws: number[];
+}
+
+function webGlPaints(hidden: boolean): GlCapture {
+    const capture: GlCapture = { buffers: [], draws: [] };
+    const noop = (): void => undefined;
+    const gl = {
+        BLEND: 1,
+        SCISSOR_TEST: 2,
+        COLOR_BUFFER_BIT: 4,
+        SRC_ALPHA: 5,
+        ONE_MINUS_SRC_ALPHA: 6,
+        ONE: 7,
+        ARRAY_BUFFER: 8,
+        DYNAMIC_DRAW: 9,
+        TRIANGLES: 10,
+        isContextLost: () => false,
+        viewport: noop,
+        disable: noop,
+        clearColor: noop,
+        clear: noop,
+        enable: noop,
+        scissor: noop,
+        blendFuncSeparate: noop,
+        useProgram: noop,
+        bindVertexArray: noop,
+        uniform2f: noop,
+        bindBuffer: noop,
+        bufferData: (_target: number, data: Float32Array) => capture.buffers.push(data.slice()),
+        drawArrays: (_mode: number, _first: number, count: number) => capture.draws.push(count),
+        deleteTexture: noop,
+    } as unknown as WebGL2RenderingContext;
+    const canvas = { width: WIDTH, height: HEIGHT } as HTMLCanvasElement;
+    const backend = new WebGL2Backend();
+    Object.assign(backend as unknown as Record<string, unknown>, {
+        canvas,
+        gl,
+        program: {},
+        vao: {},
+        vbo: {},
+        uRes: {},
+    });
+    const { scene, coords } = makeScene(hidden);
+    backend.render(scene, coords, THEME);
+    return capture;
+}
+
+function glHasColor(capture: GlCapture, [r, g, b]: readonly [number, number, number]): boolean {
+    return capture.buffers.some((buffer) => {
+        for (let i = 0; i < buffer.length; i += VERTEX_STRIDE) {
+            if (
+                Math.abs(buffer[i + 2]! - r) < 1e-6
+                && Math.abs(buffer[i + 3]! - g) < 1e-6
+                && Math.abs(buffer[i + 4]! - b) < 1e-6
+            ) return true;
+        }
+        return false;
+    });
+}
+
+describe('native backend base-series visibility', () => {
+    beforeAll(() => {
+        // WebGL color normalization uses one 2D readback pixel. Keep this backend test
+        // browser-free while preserving exact RGB evidence in the captured GL vertices.
+        const state = { fillStyle: '#000000' };
+        const probe = {
+            clearRect: (): void => undefined,
+            fillRect: (): void => undefined,
+            set fillStyle(value: string) { state.fillStyle = value; },
+            get fillStyle() { return state.fillStyle; },
+            getImageData: () => {
+                const hex = state.fillStyle.match(/^#([0-9a-f]{6})$/i)?.[1] ?? '000000';
+                return { data: new Uint8ClampedArray([
+                    Number.parseInt(hex.slice(0, 2), 16),
+                    Number.parseInt(hex.slice(2, 4), 16),
+                    Number.parseInt(hex.slice(4, 6), 16),
+                    255,
+                ]) };
+            },
+        };
+        vi.stubGlobal('document', { createElement: () => ({ width: 0, height: 0, getContext: () => probe }) });
+    });
+
+    afterAll(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('Canvas2D suppresses candle paint while preserving an indicator overlay and price line', () => {
+        const visible = canvasPaints(false);
+        expect(visible.some((paint) => paint.color === BASE_COLOR)).toBe(true);
+        expect(visible.some((paint) => paint.color === OVERLAY_COLOR)).toBe(true);
+        expect(visible.some((paint) => paint.color === PRICE_LINE_COLOR)).toBe(true);
+
+        const hidden = canvasPaints(true);
+        expect(hidden.some((paint) => paint.color === BASE_COLOR)).toBe(false);
+        expect(hidden.some((paint) => paint.color === OVERLAY_COLOR)).toBe(true);
+        expect(hidden.some((paint) => paint.color === PRICE_LINE_COLOR)).toBe(true);
+    });
+
+    it('WebGL2 suppresses candle vertices while preserving overlay and price-line vertices', () => {
+        const visible = webGlPaints(false);
+        expect(visible.draws.some((count) => count > 0)).toBe(true);
+        expect(glHasColor(visible, [1, 0, 0])).toBe(true);
+        expect(glHasColor(visible, [0, 1, 0])).toBe(true);
+        expect(glHasColor(visible, [0, 0, 1])).toBe(true);
+
+        const hidden = webGlPaints(true);
+        expect(hidden.draws.some((count) => count > 0)).toBe(true);
+        expect(glHasColor(hidden, [1, 0, 0])).toBe(false);
+        expect(glHasColor(hidden, [0, 1, 0])).toBe(true);
+        expect(glHasColor(hidden, [0, 0, 1])).toBe(true);
+    });
+});

--- a/test/renderer-layers.test.ts
+++ b/test/renderer-layers.test.ts
@@ -1,12 +1,16 @@
 // The SDK renderer-layer seam (src/renderers/native/layers.ts): registry semantics and the
 // generic native-data channel routing on the renderer (unmounted — mounted painting is
 // exercised in the browser playground; the channel/scene plumbing is the unit-testable part).
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { registerRendererLayer, unregisterRendererLayer, rendererLayers, foldBaseModulation, type RendererLayerArgs, type RendererLayerInstance } from '../src/renderers/native/layers';
 import { NativeRenderer } from '../src/renderers/native/NativeRenderer';
 import { SceneGraph } from '../src/renderers/native/core/SceneGraph';
+import { registerChartType, unregisterChartType } from '../src/chart-types/registry';
 
-afterEach(() => unregisterRendererLayer('demo'));
+afterEach(() => {
+    unregisterRendererLayer('demo');
+    unregisterChartType('demo');
+});
 
 describe('renderer-layer registry', () => {
     it('register / replace-by-id / unregister / list', () => {
@@ -76,6 +80,67 @@ describe('generic native-data channels', () => {
         r.setNativeData('volume', { upColor: 'x' });
         expect(scene.volumeLayer).toEqual({ upColor: 'x' });
         expect(scene.nativeData.has('volume')).toBe(false);
+    });
+});
+
+describe('price-series visibility for SDK renderer layers', () => {
+    it('blanks the active custom chart-type layer while overlay and indicator layers keep painting', () => {
+        registerChartType({ id: 'demo', basePainting: 'none' });
+        const renderer = new NativeRenderer();
+        const r = renderer as unknown as Record<string, any>;
+        const scene = r.scene as SceneGraph;
+        scene.ensurePane('price', 'price', 0, 3);
+        renderer.applyFeature('priceStyle', 'demo');
+
+        const chartTypeRender = vi.fn();
+        const overlayRender = vi.fn();
+        const indicatorRender = vi.fn();
+        const clearChartType = vi.fn();
+        const canvas = (clear = vi.fn()) => ({
+            width: 10,
+            height: 10,
+            getContext: () => ({ clearRect: clear }),
+        });
+        r.extLayers = [
+            { def: { id: 'demo', repaintOnCursor: true }, instance: { render: chartTypeRender }, canvas: canvas(clearChartType) },
+            { def: { id: 'overlay', repaintOnCursor: true }, instance: { render: overlayRender }, canvas: canvas() },
+            { def: { id: 'study-layer', repaintOnCursor: true }, instance: { render: indicatorRender }, canvas: canvas() },
+        ];
+        scene.indicators.set('study', {
+            id: 'study',
+            title: 'Study',
+            series: [],
+            paneId: 'price',
+            native: { type: 'study-layer' },
+        } as never);
+        r.syncLayerCanvasOrder = () => undefined;
+        r.stampScaleInvert = () => undefined;
+        r.backend = { modelAlpha: 1, candleBodyAlpha: 1, candleStructureAlpha: 1, candleBodyScale: 1, render: vi.fn() };
+        r.volumeRenderer = { render: vi.fn() };
+        r.vpvrRenderer = { render: vi.fn() };
+        r.animator = { start: vi.fn() };
+        r.indicatorSlices = { prepare: () => new Map() };
+        r.dataCanvas = {};
+        r.backdropRenderer = { render: vi.fn() };
+        r.chrome = { render: vi.fn() };
+        r.axisSurface = () => ({});
+
+        r.paintData();
+        expect(chartTypeRender).toHaveBeenCalledOnce();
+        expect(overlayRender).toHaveBeenCalledOnce();
+        expect(indicatorRender).toHaveBeenCalledOnce();
+
+        renderer.applyFeature('candleVisible', false);
+        r.paintData();
+        expect(chartTypeRender).toHaveBeenCalledOnce();
+        expect(clearChartType).toHaveBeenCalledOnce();
+        expect(overlayRender).toHaveBeenCalledTimes(2);
+        expect(indicatorRender).toHaveBeenCalledTimes(2);
+
+        r.repaintCursorLayers();
+        expect(chartTypeRender).toHaveBeenCalledOnce();
+        expect(overlayRender).toHaveBeenCalledTimes(3);
+        expect(indicatorRender).toHaveBeenCalledTimes(3);
     });
 });
 

--- a/test/session-definitions.test.ts
+++ b/test/session-definitions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSession, normalizeSessionDefinitions, resolveMarketSession } from '../src/core/options';
+
+describe('explicit market session definitions', () => {
+    it('keeps valid definitions in order, copies windows, and lets the first duplicate id win', () => {
+        const windows = ['0930-1130', '1230-1600'];
+        const definitions = normalizeSessionDefinitions([
+            { id: 'day', label: 'Day', windows, color: ' rgba(41, 98, 255, 0.12) ' },
+            { id: 'night', label: 'Night', windows: ['1700-1600'], color: '#123456' },
+            { id: 'day', label: 'Duplicate', windows: ['0000-0100'], color: '#fff' },
+        ]);
+
+        windows.push('1800-1900');
+        expect(definitions).toEqual([
+            { id: 'day', label: 'Day', windows: ['0930-1130', '1230-1600'], color: 'rgba(41, 98, 255, 0.12)' },
+            { id: 'night', label: 'Night', windows: ['1700-1600'], color: '#123456' },
+        ]);
+    });
+
+    it('drops a whole malformed definition deterministically', () => {
+        expect(normalizeSessionDefinitions([
+            null,
+            { id: '', label: 'Empty id', windows: ['0900-1000'], color: '#fff' },
+            { id: 'empty-label', label: ' ', windows: ['0900-1000'], color: '#fff' },
+            { id: 'no-window', label: 'No window', windows: [], color: '#fff' },
+            { id: 'bad-hour', label: 'Bad hour', windows: ['2500-2600'], color: '#fff' },
+            { id: 'bad-minute', label: 'Bad minute', windows: ['0960-1000'], color: '#fff' },
+            { id: 'empty-window', label: 'Empty window', windows: ['0900-0900'], color: '#fff' },
+            { id: 'bad-2400', label: 'Bad midnight', windows: ['2400-0100'], color: '#fff' },
+            { id: 'empty-color', label: 'Empty color', windows: ['0900-1000'], color: ' ' },
+            { id: 'valid', label: 'Valid', windows: ['0000-2400'], color: 'red' },
+        ])).toEqual([{ id: 'valid', label: 'Valid', windows: ['0000-2400'], color: 'red' }]);
+    });
+
+    it('preserves exact case, resolves a known id, and falls back to the first choice', () => {
+        const definitions = normalizeSessionDefinitions([
+            { id: 'Asia-AM', label: 'Asia AM', windows: ['0900-1200'], color: '#111' },
+            { id: 'Asia-PM', label: 'Asia PM', windows: ['1300-1600'], color: '#222' },
+        ]);
+        expect(normalizeSession('  Asia-AM  ')).toBe('Asia-AM');
+        expect(resolveMarketSession('Asia-PM', definitions)).toBe('Asia-PM');
+        expect(resolveMarketSession('asia-pm', definitions)).toBe('Asia-AM');
+        expect(resolveMarketSession(undefined, definitions)).toBe('Asia-AM');
+        expect(resolveMarketSession('anything', [])).toBeUndefined();
+    });
+});

--- a/test/session-shading.test.ts
+++ b/test/session-shading.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { expandSessionZones, parseSessionSpec, SessionShadingTracker, type SessionZonesUpdate } from '../src/widget/session-shading';
+import { expandSessionDefinition, expandSessionZones, parseSessionSpec, SessionShadingTracker, type SessionZonesUpdate } from '../src/widget/session-shading';
 import { bandEdgeSlot, clipHighlightRect } from '../src/renderers/native/backdrop/BackdropRenderer';
 import { barTimeToLogical } from '../src/renderers/native/core/bar-time';
 import type { DataControl } from '../src/core/DataControl';
@@ -120,6 +120,70 @@ describe('expandSessionZones', () => {
     });
 });
 
+describe('expandSessionDefinition', () => {
+    it('expands multiple windows around a lunch break in declaration order', () => {
+        const monday = Date.UTC(2024, 2, 11, 0);
+        const bands = expandSessionDefinition(
+            { id: 'tokyo', label: 'Tokyo', windows: ['0930-1130', '1230-1600'], color: '#123456' },
+            'America/New_York',
+            monday,
+            monday + DAY,
+        );
+        expect(bands).toContainEqual({ from: Date.UTC(2024, 2, 11, 13, 30), to: Date.UTC(2024, 2, 11, 15, 30), color: '#123456' });
+        expect(bands).toContainEqual({ from: Date.UTC(2024, 2, 11, 16, 30), to: Date.UTC(2024, 2, 11, 20), color: '#123456' });
+    });
+
+    it('tracks DST and treats an overnight window as the following trading day', () => {
+        const definition = { id: 'night', label: 'Night', windows: ['1700-1600'], color: 'rgba(1,2,3,.2)' };
+        const bands = expandSessionDefinition(definition, 'America/New_York', Date.UTC(2024, 2, 7), Date.UTC(2024, 2, 13));
+        expect(bands).toContainEqual({
+            from: Date.UTC(2024, 2, 7, 22),
+            to: Date.UTC(2024, 2, 8, 21),
+            color: definition.color,
+        });
+        // Monday's trading session starts Sunday evening after the DST transition.
+        expect(bands).toContainEqual({
+            from: Date.UTC(2024, 2, 10, 21),
+            to: Date.UTC(2024, 2, 11, 20),
+            color: definition.color,
+        });
+    });
+
+    it('resolves each edge independently when a window crosses the DST transition', () => {
+        const spring = expandSessionDefinition(
+            { id: 'sunday', label: 'Sunday', windows: ['0100-0400'], color: '#123456' },
+            'America/New_York',
+            Date.UTC(2024, 2, 10),
+            Date.UTC(2024, 2, 11),
+        );
+        expect(spring).toContainEqual({
+            from: Date.UTC(2024, 2, 10, 6),
+            to: Date.UTC(2024, 2, 10, 8),
+            color: '#123456',
+        });
+
+        const fall = expandSessionDefinition(
+            { id: 'sunday', label: 'Sunday', windows: ['0000-0300'], color: '#123456' },
+            'America/New_York',
+            Date.UTC(2024, 10, 3),
+            Date.UTC(2024, 10, 4),
+        );
+        expect(fall).toContainEqual({
+            from: Date.UTC(2024, 10, 3, 4),
+            to: Date.UTC(2024, 10, 3, 8),
+            color: '#123456',
+        });
+    });
+
+    it('recurs on weekends for continuous-market operational windows', () => {
+        const definition = { id: 'maintenance', label: 'Maintenance', windows: ['0200-0300'], color: '#123456' };
+        const saturday = Date.UTC(2024, 2, 9);
+        const bands = expandSessionDefinition(definition, 'Etc/UTC', saturday, saturday + 2 * DAY);
+        expect(bands).toContainEqual({ from: saturday + 2 * H, to: saturday + 3 * H, color: definition.color });
+        expect(bands).toContainEqual({ from: saturday + DAY + 2 * H, to: saturday + DAY + 3 * H, color: definition.color });
+    });
+});
+
 describe('expandSessionZones — overnight roll tapes', () => {
     const spec = parseSessionSpec(OVERNIGHT_MARKET)!;
 
@@ -150,6 +214,100 @@ describe('expandSessionZones — overnight roll tapes', () => {
 });
 
 describe('SessionShadingTracker', () => {
+    it('uses the selected definition without metadata and carries that definition\'s color', async () => {
+        const data = { symbolInfo: () => new Promise<never>(() => {}) } as unknown as DataControl;
+        const updates: Array<SessionZonesUpdate | null> = [];
+        const tracker = new SessionShadingTracker((zones) => updates.push(zones));
+        const monday = Date.UTC(2024, 2, 11);
+        const definitions = [
+            { id: 'first', label: 'First', windows: ['0100-0200'], color: '#111111' },
+            { id: 'split', label: 'Split', windows: ['0900-1100', '1200-1500'], color: '#abcdef' },
+        ];
+        tracker.track(data, 'CUSTOM', {
+            session: 'split',
+            timeframe: '60',
+            range: { from: monday, to: monday + DAY },
+            definitions,
+            sessionTimezone: 'Etc/UTC',
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const zones = updates[updates.length - 1]!;
+        expect(zones).not.toBeNull();
+        expect(zones!.pre).toEqual([]);
+        expect(zones!.post).toEqual([]);
+        expect(zones!.extended).toEqual([]);
+        expect(zones!.bands).toContainEqual({ from: monday + 9 * H, to: monday + 11 * H, color: '#abcdef' });
+        expect(zones!.bands).not.toContainEqual({ from: monday + H, to: monday + 2 * H, color: '#111111' });
+        tracker.stop();
+    });
+
+    it('uses a non-empty explicit catalog instead of conflicting legacy metadata', async () => {
+        const data = { symbolInfo: () => Promise.resolve<SymbolInfo>(US_EQUITIES) } as unknown as DataControl;
+        const updates: Array<SessionZonesUpdate | null> = [];
+        const tracker = new SessionShadingTracker((zones) => updates.push(zones));
+        const monday = Date.UTC(2024, 2, 11);
+        tracker.track(data, 'AAPL', {
+            session: 'custom-day',
+            timeframe: '60',
+            range: { from: monday, to: monday + DAY },
+            definitions: [{ id: 'custom-day', label: 'Custom day', windows: ['0100-0200'], color: '#abcdef' }],
+            sessionTimezone: 'Etc/UTC',
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const zones = updates[updates.length - 1]!;
+        expect(zones.pre).toEqual([]);
+        expect(zones.post).toEqual([]);
+        expect(zones.extended).toEqual([]);
+        expect(zones.bands).toContainEqual({ from: monday + H, to: monday + 2 * H, color: '#abcdef' });
+        expect((zones.bands ?? []).every((band) => band.color === '#abcdef')).toBe(true);
+        tracker.stop();
+    });
+
+    it('treats an explicit empty catalog as authoritative over session metadata', async () => {
+        const data = { symbolInfo: () => Promise.resolve<SymbolInfo>(US_EQUITIES) } as unknown as DataControl;
+        const updates: Array<SessionZonesUpdate | null> = [];
+        const tracker = new SessionShadingTracker((zones) => updates.push(zones));
+        tracker.track(data, 'AAPL', {
+            session: 'regular',
+            timeframe: '60',
+            range: { from: Date.UTC(2024, 2, 11), to: Date.UTC(2024, 2, 12) },
+            definitions: [],
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(updates).toEqual([null]);
+        tracker.stop();
+    });
+
+    it('resolves explicit timezone, metadata timezone, UTC fallback, and invalid timezone in order', async () => {
+        const monday = Date.UTC(2024, 2, 11);
+        const definitions = [{ id: 'day', label: 'Day', windows: ['0900-1000'], color: '#abcdef' }];
+        const run = async (symbolInfo: SymbolInfo, sessionTimezone?: string): Promise<SessionZonesUpdate> => {
+            const updates: Array<SessionZonesUpdate | null> = [];
+            const data = { symbolInfo: () => Promise.resolve(symbolInfo) } as unknown as DataControl;
+            const tracker = new SessionShadingTracker((zones) => updates.push(zones));
+            tracker.track(data, symbolInfo.ticker, {
+                session: 'day',
+                timeframe: '60',
+                range: { from: monday, to: monday + DAY },
+                definitions,
+                sessionTimezone,
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            tracker.stop();
+            return updates[updates.length - 1]!;
+        };
+
+        const explicit = await run({ ticker: 'CUSTOM', timezone: 'America/New_York' }, 'Etc/UTC');
+        expect(explicit.bands).toContainEqual({ from: monday + 9 * H, to: monday + 10 * H, color: '#abcdef' });
+        const metadata = await run({ ticker: 'CUSTOM', timezone: 'America/New_York' });
+        expect(metadata.bands).toContainEqual({ from: monday + 13 * H, to: monday + 14 * H, color: '#abcdef' });
+        const utc = await run({ ticker: 'CUSTOM' });
+        expect(utc.bands).toContainEqual({ from: monday + 9 * H, to: monday + 10 * H, color: '#abcdef' });
+        const invalid = await run({ ticker: 'CUSTOM', timezone: 'America/New_York' }, 'Not/AZone');
+        expect(invalid.bands).toEqual([]);
+    });
+
     it('expands the NEWEST range when the viewport moves while metadata resolves', async () => {
         let resolveSi!: (si: SymbolInfo) => void;
         const data = { symbolInfo: () => new Promise<SymbolInfo>((r) => { resolveSi = r; }) } as unknown as DataControl;

--- a/test/set-market.test.ts
+++ b/test/set-market.test.ts
@@ -294,7 +294,10 @@ describe('setMarket — in-place market switch', () => {
         const chart = make({ symbol: 'AAA', timeframe: '60', volume: false }, { renderer, engines: [], dataFeed: feed });
         await chart.ready();
         const events: unknown[] = [];
+        const loads: unknown[] = [];
         chart.on('market:changed', (e) => events.push(e));
+        chart.on('load:start', (e) => loads.push({ event: 'start', ...e }));
+        chart.on('load:end', (e) => loads.push({ event: 'end', ...e }));
 
         await chart.setMarket({ session: 'extended' });
 
@@ -303,11 +306,77 @@ describe('setMarket — in-place market switch', () => {
         expect(feed.loads[feed.loads.length - 1]).toMatchObject({ symbol: 'AAA', session: 'extended' });
         expect(chart.market.session).toBe('extended');
         expect(events).toHaveLength(1); // an identity change — the chrome must re-sync
+        expect(events[0]).toEqual({
+            symbol: 'AAA',
+            timeframe: '60',
+            session: 'extended',
+            prev: { symbol: 'AAA', timeframe: '60' },
+        });
+        expect(loads).toEqual([
+            { event: 'start', symbol: 'AAA', timeframe: '60', session: 'extended', firstLoad: false },
+            { event: 'end', symbol: 'AAA', timeframe: '60', session: 'extended', bars: 50 },
+        ]);
 
         // Same session again: a no-op, no reload.
         const loadsBefore = feed.loads.length;
         await chart.setMarket({ session: 'extended' });
         expect(feed.loads.length).toBe(loadsBefore);
+    });
+
+    it('an explicit catalog forwards its first or selected arbitrary id on the initial load', async () => {
+        const definitions = [
+            { id: 'Asia-AM', label: 'Asia AM', windows: ['0900-1200'], color: '#111' },
+            { id: 'Asia-PM', label: 'Asia PM', windows: ['1300-1600'], color: '#222' },
+        ];
+        const firstFeed = new SwitchFeed();
+        const first = make(
+            { symbol: 'AAA', timeframe: '60', sessions: definitions, session: 'unknown', volume: false },
+            { renderer: new FakeRenderer(), engines: [], dataFeed: firstFeed },
+        );
+        await first.ready();
+        expect(firstFeed.loads[0]!.session).toBe('Asia-AM');
+        expect(first.market.session).toBe('Asia-AM');
+
+        const selectedFeed = new SwitchFeed();
+        const selected = make(
+            { symbol: 'AAA', timeframe: '60', sessions: definitions, session: 'Asia-PM', volume: false },
+            { renderer: new FakeRenderer(), engines: [], dataFeed: selectedFeed },
+        );
+        await selected.ready();
+        expect(selectedFeed.loads[0]!.session).toBe('Asia-PM');
+
+        await selected.setMarket({ session: 'unknown' });
+        expect(selected.market.session).toBe('Asia-AM');
+        expect(selectedFeed.loads[selectedFeed.loads.length - 1]!.session).toBe('Asia-AM');
+        await selected.setMarket({ session: 'Asia-PM' });
+        expect(selectedFeed.loads[selectedFeed.loads.length - 1]!.session).toBe('Asia-PM');
+
+        const disabledFeed = new SwitchFeed();
+        const disabled = make(
+            { symbol: 'AAA', timeframe: '60', sessions: [], session: 'extended', volume: false },
+            { renderer: new FakeRenderer(), engines: [], dataFeed: disabledFeed },
+        );
+        await disabled.ready();
+        expect(disabledFeed.loads[0]!.session).toBeUndefined();
+        await disabled.setMarket({ session: 'Asia-AM' });
+        expect(disabled.market.session).toBeUndefined();
+    });
+
+    it('normalizes open provider-facing ids on every switch and ignores an empty id', async () => {
+        const feed = new SwitchFeed();
+        const chart = make(
+            { symbol: 'AAA', timeframe: '60', session: '  Asia-AM  ', volume: false },
+            { renderer: new FakeRenderer(), engines: [], dataFeed: feed },
+        );
+        await chart.ready();
+        expect(feed.loads[0]!.session).toBe('Asia-AM');
+
+        await chart.setMarket({ session: '  Asia-PM  ' });
+        expect(feed.loads[feed.loads.length - 1]!.session).toBe('Asia-PM');
+        const loadCount = feed.loads.length;
+        await chart.setMarket({ session: '   ' });
+        expect(feed.loads).toHaveLength(loadCount);
+        expect(chart.market.session).toBe('Asia-PM');
     });
 
     it('a session-only flip carries the current zoom/position over the reload', async () => {

--- a/test/statusline-visibility.test.ts
+++ b/test/statusline-visibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Vela } from '../src/Vela';
+import { Statusline } from '../src/widget/statusline';
+
+describe('Statusline price-series visibility projection', () => {
+    it('reads restored config immediately and follows later renderer config changes', () => {
+        let onConfigChanged: (() => void) | undefined;
+        const visible = { value: false };
+        const chart = {
+            on: vi.fn(() => () => undefined),
+            renderer: {
+                get: vi.fn(() => visible.value),
+                onCrosshairMove: vi.fn(() => () => undefined),
+                onConfigChanged: vi.fn((cb: () => void) => {
+                    onConfigChanged = cb;
+                    return () => undefined;
+                }),
+            },
+        } as unknown as Vela;
+
+        // Exercise the real binding method without constructing DOM chrome. Own-method
+        // spies isolate the visibility projection from the status line's paint details.
+        const statusline = Object.create(Statusline.prototype) as Statusline;
+        const setChartHidden = vi.fn();
+        Object.assign(statusline, {
+            unsubs: [],
+            detach: vi.fn(),
+            render: vi.fn(),
+            setChartHidden,
+        });
+
+        Statusline.prototype.onChart.call(statusline, chart);
+        expect(setChartHidden).toHaveBeenLastCalledWith(true);
+
+        visible.value = true;
+        onConfigChanged?.();
+        expect(setChartHidden).toHaveBeenLastCalledWith(false);
+    });
+});

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { parseTimeframe, timeframeMs, timeframeLabel, favoriteTimeframeChips } from '../src/widget/timeframe';
 import { inputDeltas } from '../src/core/model/inputs';
-import { indicatorLedger, resolveIndicators } from '../src/widget/indicators';
+import { indicatorLedger, indicatorLedgersEqual, resolveIndicators } from '../src/widget/indicators';
 import { fmtPrice, fmtChange, decimalsFor } from '../src/widget/format';
 import { tzMenuLabel, tzButtonLabel } from '../src/widget/timezones';
 import { priceStyleLabel } from '../src/widget/topbar';
@@ -290,6 +290,19 @@ describe('indicatorLedger', () => {
         expect(indicatorLedger({ ...base, volumePending: true, present: ['volume'] })).toEqual({ manifest: [], natives: ['volume'] });
         // After the first load the registry is the whole truth: no intent padding.
         expect(indicatorLedger({ ...base, volumePending: false, present: ['vpvr'] })).toEqual({ manifest: [], natives: ['vpvr'] });
+    });
+
+    it('recognizes an unchanged ledger without depending on record or native order', () => {
+        const current = {
+            manifest: ['EMA', { name: 'RSI', inputs: { source: 'close', length: 21 }, props: { precision: 3 } }],
+            natives: ['volume', 'sma', 'sma'],
+        };
+        expect(indicatorLedgersEqual(current, {
+            manifest: ['EMA', { name: 'RSI', inputs: { length: 21, source: 'close' }, props: { precision: 3 } }],
+            natives: ['sma', 'volume', 'sma'],
+        })).toBe(true);
+        expect(indicatorLedgersEqual(current, { ...current, manifest: [...current.manifest].reverse() })).toBe(false);
+        expect(indicatorLedgersEqual(current, { ...current, natives: ['volume', 'sma'] })).toBe(false);
     });
 });
 

--- a/test/widget-glider.test.ts
+++ b/test/widget-glider.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 
 /** A chart whose READ-BACK clamps like the renderer's: the reported span never drops
  *  below `minSpanMs` (the zoom-in limit). Records every applied range. */
-function clampingChart(from: number, to: number, minSpanMs = 0) {
+function clampingChart(from: number, to: number, minSpanMs = 0, reducedMotion = false) {
     const applied: Array<{ from: number; to: number }> = [];
     const state = { from, to };
     const chart = {
@@ -43,6 +43,9 @@ function clampingChart(from: number, to: number, minSpanMs = 0) {
             state.from = r.from;
             state.to = r.to;
             applied.push({ ...r });
+        },
+        get reducedMotion() {
+            return reducedMotion;
         },
     } as unknown as Vela;
     return { chart, applied };
@@ -86,5 +89,13 @@ describe('Glider under renderer clamping', () => {
         glider.stop();
         pump(50);
         expect(applied.length).toBe(n); // nothing applied after stop
+    });
+
+    it('applies the final target synchronously when motion is reduced', () => {
+        const { chart, applied } = clampingChart(100 * HOUR, 200 * HOUR, 0, true);
+        const glider = new Glider(() => chart);
+        glider.zoom(0.5);
+        expect(applied).toEqual([{ from: 150 * HOUR, to: 200 * HOUR }]);
+        expect(frameQueue).toHaveLength(0);
     });
 });

--- a/test/workspace-core.test.ts
+++ b/test/workspace-core.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../src/workspace/layouts';
 import { evenTracks, resizeTracks, trackOffsets, seamSegments, segmentSpanPx } from '../src/workspace/splitters';
 import { seedDefaults, cellChartDefaults, cellDrawings } from '../src/workspace/ChartCell';
-import { declaredOrder, nextAutoCellId } from '../src/workspace/VelaWorkspace';
+import { declaredOrder, nextAutoCellId, VelaWorkspace } from '../src/workspace/VelaWorkspace';
 import { parseSymbol } from '../src/data/ProviderRegistry';
 
 registerBuiltinLayouts();
@@ -336,15 +336,16 @@ describe('sync model (pure)', () => {
 
 describe('unified options — the cell seed/defaults merge (pure)', () => {
     it('seedDefaults picks exactly the widget market/view vocabulary', () => {
+        const sessions = [{ id: 'Asia-AM', label: 'Asia AM', windows: ['0900-1200'], color: '#abc' }];
         const seed = seedDefaults({
             symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500,
             priceStyle: 'footprint', data: [{ time: 1, open: 1, high: 1, low: 1, close: 1, volume: 1 }],
-            visibleRange: '1M',
+            visibleRange: '1M', session: 'Asia-AM', sessions, sessionTimezone: 'Asia/Tokyo',
         });
         expect(seed).toEqual({
             symbol: 'binance:BTCUSDT', timeframe: '60', bars: 500,
             priceStyle: 'footprint', data: [{ time: 1, open: 1, high: 1, low: 1, close: 1, volume: 1 }],
-            visibleRange: '1M',
+            visibleRange: '1M', session: 'Asia-AM', sessions, sessionTimezone: 'Asia/Tokyo',
         });
     });
 
@@ -401,6 +402,38 @@ describe('cell identity ↔ slot position (declaredOrder / nextAutoCellId)', () 
         expect(nextAutoCellId(new Set())).toBe('c1');
         expect(nextAutoCellId(new Set(['c1', 'c2']))).toBe('c3');
         expect(nextAutoCellId(new Set(['btc', 'c1', 'c3']))).toBe('c2'); // holes fill first
+    });
+});
+
+describe('workspace renderer-config integration', () => {
+    it('marks cell state dirty when the renderer reports a committed config change', () => {
+        let configChanged: (() => void) | undefined;
+        const workspace = Object.create(VelaWorkspace.prototype) as unknown as {
+            wireCell(cell: unknown): void;
+            propagateStylePrefs: ReturnType<typeof vi.fn>;
+            markStateDirty: ReturnType<typeof vi.fn>;
+        };
+        workspace.propagateStylePrefs = vi.fn();
+        workspace.markStateDirty = vi.fn();
+        const chart = {
+            on: vi.fn(),
+            renderer: {
+                onCrosshairMove: vi.fn(),
+                onConfigChanged: vi.fn((cb: () => void) => {
+                    configChanged = cb;
+                    return () => undefined;
+                }),
+                onAxisLongPress: vi.fn(),
+            },
+        };
+
+        workspace.wireCell({ id: 'c1', chart });
+        expect(configChanged).toBeTypeOf('function');
+        configChanged!();
+
+        expect(workspace.propagateStylePrefs).toHaveBeenCalledOnce();
+        expect(workspace.propagateStylePrefs).toHaveBeenCalledWith('c1');
+        expect(workspace.markStateDirty).toHaveBeenCalledOnce();
     });
 });
 

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -4,6 +4,7 @@
 // applyState / persist plumbing is verified in the browser (playground probes).
 import { describe, it, expect } from 'vitest';
 import { encodeState, decodeState, sanitizeState, memoryStorageAdapter, type WorkspaceState } from '../src/workspace/persist';
+import { jsonStateEqual } from '../src/state/document';
 import { localStorageAdapter } from '../src/widget/persist';
 import { ensureLayout, registerBuiltinLayouts } from '../src/workspace/layouts';
 
@@ -63,6 +64,25 @@ describe('state codec round-trip', () => {
     });
 });
 
+describe('jsonStateEqual', () => {
+    it('ignores object-key order but preserves nested values and array order', () => {
+        expect(jsonStateEqual(
+            { plugin: { enabled: true, inputs: { length: 20, source: 'close' } }, ids: ['a', 'b'] },
+            { ids: ['a', 'b'], plugin: { inputs: { source: 'close', length: 20 }, enabled: true } },
+        )).toBe(true);
+        expect(jsonStateEqual({ ids: ['a', 'b'] }, { ids: ['b', 'a'] })).toBe(false);
+        expect(jsonStateEqual({ value: 1 }, { value: 2 })).toBe(false);
+    });
+
+    it('does not recurse forever on cyclic values from an untrusted direct call', () => {
+        const left: Record<string, unknown> = { value: 1 };
+        const right: Record<string, unknown> = { value: 1 };
+        left.self = left;
+        right.self = right;
+        expect(jsonStateEqual(left, right)).toBe(true);
+    });
+});
+
 describe('sanitizeState (the applyState gate)', () => {
     it('drops malformed fields but keeps the healthy remainder', () => {
         const doc = sanitizeState({
@@ -98,18 +118,26 @@ describe('sanitizeState (the applyState gate)', () => {
         });
     });
 
-    it('keeps a valid session value and drops anything else', () => {
+    it('keeps syntactically valid custom session ids for catalog-aware resolution', () => {
         const doc = sanitizeState({
             version: 1,
             layout: '1',
             charts: [
                 { id: 'c1', symbol: 'NASDAQ:AAPL', session: 'extended' },
-                { id: 'c2', symbol: 'BTCUSDT', session: 'after-hours' }, // not a session → dropped
+                {
+                    id: 'c2',
+                    symbol: 'BTCUSDT',
+                    session: ' after-hours ',
+                    sessions: [{ id: 'after-hours', label: 'After hours', windows: ['1600-2000'], color: '#abc' }],
+                    sessionTimezone: 'America/New_York',
+                },
+                { id: 'c3', symbol: 'BTCUSDT', session: ' ' },
             ],
         });
         expect(doc?.charts).toEqual([
             { id: 'c1', symbol: 'NASDAQ:AAPL', session: 'extended' },
-            { id: 'c2', symbol: 'BTCUSDT' },
+            { id: 'c2', symbol: 'BTCUSDT', session: 'after-hours' },
+            { id: 'c3', symbol: 'BTCUSDT' },
         ]);
     });
 
@@ -172,6 +200,16 @@ describe('sanitizeState (the applyState gate)', () => {
         // requires object-ness so JSON primitives cannot masquerade as documents.
         expect(doc!.charts[0]!.rendererConfig).toEqual(config);
         expect(doc!.charts[0]!.drawings).toEqual(config);
+    });
+
+    it('round-trips hidden price-series state inside the renderer config', () => {
+        const doc = sanitizeState({
+            version: 1,
+            layout: '1',
+            charts: [{ id: 'c1', rendererConfig: { series: { visible: false } } }],
+        });
+        const restored = decodeState(encodeState(doc!));
+        expect(restored!.charts[0]!.rendererConfig).toEqual({ series: { visible: false } });
     });
 
     it('keeps sync group records only when at least one valid member remains', () => {

--- a/test/workspace-sessions.test.ts
+++ b/test/workspace-sessions.test.ts
@@ -1,0 +1,326 @@
+// Workspace session identity: metadata supplies optional UI structure, but an omitted
+// host catalog must leave the provider-facing ID open. These tests construct the real
+// ChartCell while replacing only its chart/UI dependencies with small recording fakes.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MarketSession } from '../src/core/options';
+import { DARK_THEME } from '../src/core/theme';
+import type { CellBoot, CellDeps } from '../src/workspace/ChartCell';
+import type { CellState } from '../src/state/document';
+import { registerStatePersistence } from '../src/widget/contributions';
+
+const velaRecorder = vi.hoisted(() => ({
+    options: [] as Array<Record<string, unknown>>,
+    instances: [] as Array<{
+        market: Record<string, unknown>;
+        setMarket: ReturnType<typeof vi.fn>;
+    }>,
+    symbolInfo: { session: '0930-1600', session_extended: '0400-2000', timezone: 'America/New_York' } as Record<string, unknown>,
+}));
+
+vi.mock('../src/Vela', () => {
+    class RecordingVela {
+        readonly renderer = {
+            set: vi.fn(),
+            get: vi.fn((key: string) => key === 'priceStyle' ? 'candles' : undefined),
+            getConfig: vi.fn(() => null),
+            applyConfig: vi.fn(),
+            supports: vi.fn(() => false),
+            setLegendActions: vi.fn(),
+            setLegendCallouts: vi.fn(),
+            setSettingsSections: vi.fn(),
+            onConfigChanged: vi.fn(() => () => undefined),
+            onCrosshairMove: vi.fn(() => () => undefined),
+        };
+        readonly drawings = {
+            fromJSON: vi.fn(),
+            toJSON: vi.fn(() => undefined),
+            undo: vi.fn(),
+            redo: vi.fn(),
+        };
+        readonly data = {
+            ready: vi.fn(async () => undefined),
+            symbolInfo: vi.fn(async () => velaRecorder.symbolInfo),
+            displayPrefix: vi.fn(() => undefined),
+            symbolIcon: vi.fn(async () => undefined),
+        };
+        readonly addIndicator = vi.fn(() => ({
+            id: 'external-script',
+            title: 'External script',
+            inputs: [],
+            props: [],
+            visible: true,
+            inputValues: () => ({}),
+            propValues: () => ({}),
+            setInput: vi.fn(),
+            setInputs: vi.fn(),
+            setProp: vi.fn(),
+            setProps: vi.fn(),
+            setVisible: vi.fn(),
+            moveTo: vi.fn(),
+            on: vi.fn(() => () => undefined),
+            context: vi.fn(async () => null),
+            remove: vi.fn(),
+        }));
+        readonly market: Record<string, unknown>;
+        readonly setMarket = vi.fn(async (next: Record<string, unknown>) => {
+            Object.assign(this.market, next);
+        });
+
+        constructor(_host: HTMLElement, options: Record<string, unknown>) {
+            this.market = {
+                symbol: options.symbol,
+                provider: undefined,
+                timeframe: options.timeframe ?? '60',
+                session: options.session,
+            };
+            velaRecorder.options.push(options);
+            velaRecorder.instances.push(this);
+        }
+
+        registerEngine(): this { return this; }
+        on(): () => void { return () => undefined; }
+        getVisibleRange(): null { return null; }
+        indicators(): never[] { return []; }
+        presentNativeIndicators(): string[] { return []; }
+        availableNativeIndicators(): Promise<never[]> { return Promise.resolve([]); }
+        destroy(): void {}
+    }
+
+    return { Vela: RecordingVela };
+});
+
+vi.mock('../src/widget/cell-controls', () => ({
+    CellControls: class {
+        refresh(): void {}
+        setSuspended(): void {}
+        destroy(): void {}
+    },
+}));
+
+vi.mock('../src/widget/context-menu', () => ({
+    ChartContextMenu: class {
+        onChart(): void {}
+        destroy(): void {}
+    },
+}));
+
+import { ChartCell } from '../src/workspace/ChartCell';
+
+interface StubElement {
+    ownerDocument: { createElement(tag: string): StubElement };
+    className: string;
+    dataset: Record<string, string>;
+    style: { cssText: string; setProperty(name: string, value: string): void };
+    children: StubElement[];
+    addEventListener(): void;
+    appendChild(child: StubElement): StubElement;
+    remove(): void;
+}
+
+function stubGrid(): StubElement {
+    const doc = {
+        createElement(_tag: string): StubElement {
+            const el: StubElement = {
+                ownerDocument: doc,
+                className: '',
+                dataset: {},
+                style: { cssText: '', setProperty: () => undefined },
+                children: [],
+                addEventListener: () => undefined,
+                appendChild: (child) => (el.children.push(child), child),
+                remove: () => undefined,
+            };
+            return el;
+        },
+    };
+    return doc.createElement('div');
+}
+
+function deps(onStateDirty = vi.fn()): CellDeps {
+    const noOp = (): void => undefined;
+    return {
+        feed: {} as CellDeps['feed'],
+        engines: {},
+        chartDefaults: {},
+        theme: DARK_THEME,
+        live: false,
+        volume: false,
+        statusline: false,
+        watermark: false,
+        nativeBackend: 'canvas2d',
+        dialogHost: stubGrid() as unknown as HTMLElement,
+        timezone: () => 'Etc/UTC',
+        setTimezone: noOp,
+        context: () => ({}) as ReturnType<CellDeps['context']>,
+        manifestSettled: () => true,
+        activate: noOp,
+        multiCell: () => false,
+        isMaximized: () => false,
+        toggleMaximize: noOp,
+        cellDragTarget: () => null,
+        previewDropTarget: noOp,
+        dropCell: noOp,
+        onMarketChanged: noOp,
+        onPriceStyleChanged: noOp,
+        onIndicatorsChanged: noOp,
+        onStatusPrefsChanged: noOp,
+        onStateDirty,
+        toast: noOp,
+    };
+}
+
+function makeCell(seed: CellBoot, cellDeps = deps()): {
+    cell: ChartCell;
+    chart: (typeof velaRecorder.instances)[number];
+} {
+    const cell = new ChartCell('c1', stubGrid() as unknown as HTMLElement, seed, cellDeps);
+    return { cell, chart: velaRecorder.instances[velaRecorder.instances.length - 1]! };
+}
+
+async function settle(): Promise<void> {
+    for (let i = 0; i < 4; i += 1) await Promise.resolve();
+}
+
+beforeEach(() => {
+    velaRecorder.options.length = 0;
+    velaRecorder.instances.length = 0;
+});
+
+describe('ChartCell provider-facing sessions without an explicit catalog', () => {
+    it('normalizes and preserves an arbitrary constructor session in the chart and getter', () => {
+        const { cell } = makeCell({ session: '  Tokyo-AM  ' });
+
+        expect(velaRecorder.options[0]?.session).toBe('Tokyo-AM');
+        expect(velaRecorder.options[0]?.sessions).toBeUndefined();
+        expect(cell.session).toBe('Tokyo-AM');
+        cell.destroy();
+    });
+
+    it('accepts arbitrary setter IDs exactly once while ignoring empty and repeated IDs', () => {
+        const dirty = vi.fn();
+        const { cell, chart } = makeCell({ session: 'Tokyo-AM' }, deps(dirty));
+
+        cell.setSession('  Tokyo-PM  ');
+        expect(chart.setMarket).toHaveBeenCalledOnce();
+        expect(chart.setMarket).toHaveBeenLastCalledWith({ session: 'Tokyo-PM' });
+        expect(cell.session).toBe('Tokyo-PM');
+        expect(dirty).toHaveBeenCalledOnce();
+
+        cell.setSession('Tokyo-PM');
+        cell.setSession('   ' as MarketSession);
+        expect(chart.setMarket).toHaveBeenCalledOnce();
+        expect(dirty).toHaveBeenCalledOnce();
+        cell.destroy();
+    });
+
+    it('keeps an explicit regular ID distinct from the omitted provider default', () => {
+        const dirty = vi.fn();
+        const { cell, chart } = makeCell({}, deps(dirty));
+
+        expect(chart.market.session).toBeUndefined();
+        expect(cell.session).toBe('regular');
+
+        cell.setSession('regular');
+        expect(chart.setMarket).toHaveBeenCalledOnce();
+        expect(chart.setMarket).toHaveBeenLastCalledWith({ session: 'regular' });
+        expect(chart.market.session).toBe('regular');
+        expect(dirty).toHaveBeenCalledOnce();
+
+        cell.setSession('regular');
+        expect(chart.setMarket).toHaveBeenCalledOnce();
+        expect(dirty).toHaveBeenCalledOnce();
+        cell.destroy();
+    });
+
+    it('rehydrates an arbitrary saved ID in place and converges on repeat application', () => {
+        const { cell, chart } = makeCell({ session: 'Tokyo-AM' });
+        const restored: CellState = { session: '  Tokyo-Night  ' };
+
+        cell.rehydrate(restored);
+        expect(chart.setMarket).toHaveBeenCalledOnce();
+        expect(chart.setMarket).toHaveBeenLastCalledWith({ session: 'Tokyo-Night' });
+        expect(cell.session).toBe('Tokyo-Night');
+
+        chart.setMarket.mockClear();
+        cell.rehydrate(restored);
+        expect(chart.setMarket).not.toHaveBeenCalled();
+        cell.destroy();
+    });
+
+    it('rehydrates an explicitly saved regular ID over an omitted provider default', () => {
+        const { cell, chart } = makeCell({});
+        const restored: CellState = { session: 'regular' };
+
+        cell.rehydrate(restored);
+        expect(chart.setMarket).toHaveBeenCalledOnce();
+        expect(chart.setMarket).toHaveBeenLastCalledWith({ session: 'regular' });
+        expect(chart.market.session).toBe('regular');
+
+        chart.setMarket.mockClear();
+        cell.rehydrate(restored);
+        expect(chart.setMarket).not.toHaveBeenCalled();
+        cell.destroy();
+    });
+
+    it('round-trips an arbitrary live ID through the dormant-cell pool state', () => {
+        const first = makeCell({ session: 'Tokyo-AM' });
+        first.cell.setSession('Tokyo-Night');
+        const pooled = first.cell.dehydrate();
+        expect(pooled.session).toBe('Tokyo-Night');
+        first.cell.destroy();
+
+        const restored = makeCell(pooled);
+        expect(velaRecorder.options[velaRecorder.options.length - 1]?.session).toBe('Tokyo-Night');
+        expect(restored.cell.session).toBe('Tokyo-Night');
+        restored.cell.destroy();
+    });
+
+    it('adds the active arbitrary ID to metadata-derived workspace choices', async () => {
+        const { cell } = makeCell({ symbol: 'TEST', session: 'Tokyo-AM' });
+        await settle();
+
+        expect(cell.sessionAvailable).toBe(true);
+        expect(cell.sessions).toEqual([
+            { id: 'regular', label: 'Regular hours (RTH)' },
+            { id: 'extended', label: 'Extended hours (ETH)' },
+            { id: 'Tokyo-AM', label: 'Tokyo-AM' },
+        ]);
+        cell.destroy();
+    });
+});
+
+describe('ChartCell state rehydration convergence', () => {
+    it('keeps equal plugin state live, but restores it after a changed core ledger rebuild', () => {
+        const restore = vi.fn((_payload, context) => {
+            context.addIndicator({ name: 'External script', script: 'plot(close)' });
+        });
+        const unregister = registerStatePersistence({
+            key: 'test.external-script',
+            scope: 'cell',
+            serialize: () => ({ enabled: true }),
+            restore,
+        });
+
+        try {
+            const { cell } = makeCell({
+                session: 'regular',
+                indicators: { manifest: [], natives: [] },
+                ext: { 'test.external-script': { enabled: true } },
+            });
+            cell.restorePersistedExt();
+            const unchanged = cell.dehydrate();
+
+            cell.rehydrate(unchanged);
+            expect(restore).toHaveBeenCalledOnce();
+
+            cell.rehydrate({
+                ...unchanged,
+                indicators: { manifest: ['Changed core entry'], natives: [] },
+            });
+            expect(restore).toHaveBeenCalledTimes(2);
+            cell.destroy();
+        } finally {
+            unregister();
+        }
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["src", "test"],
+  "include": ["src", "test", "playwright.config.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Chart visibility, market sessions, and interaction preferences now survive workspace restoration and remain usable across the widget UI.

- Persist base price-series visibility while keeping indicators and drawings visible.
- Support arbitrary named market sessions with validated catalogs, exact provider-facing IDs, accessible selection, multi-window shading, and restoration.
- Honor reduced-motion preferences across the renderer, workspace, dialogs, and portaled UI. Add Ctrl/Cmd drag selection with locked-drawing protection and one-step delete/undo.
- Add 12 maintained Chromium regressions, deterministic source-playground fixtures, a browser-test CI workflow, and contributor instructions. Tests assert rendered pixels, computed styles, saved state, focus, real input, and teardown.

## Verification

- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run test` — 133 files, 1,616 tests passed.
- `npm run build` — ESM, CJS, browser bundles, and declarations passed.
- `npm run test:browser` — 12 Chromium tests passed, with no retries.
- Four deliberate mutations were detected: incorrect visibility serialization, removal of the reduced-motion duration override, ignored named-session selection, and omitted marquee painting. All mutations were restored before the final passing run.

Chromium verifies native reduced-motion emulation and the numeric computed-duration override, including live changes in open dialogs and Select content. Named-session tests assert exact provider IDs and rendered bands; visibility tests assert persistence and surviving indicator/drawing pixels. Marquee tests cover selection, cancellation, and locked-drawing delete/undo. The pointer-cancellation case dispatches a synthetic browser `pointercancel` after a real drag because Playwright has no OS-level mouse cancellation command.

Earlier Obscura probes passed 80 functional assertions and an independent worker smoke check. Obscura 0.2.1 did not expose the authored reduced-motion `!important` duration override through `getComputedStyle` with an inline duration sentinel; Chromium now supplies the maintained coverage for that assertion.

Closes #125
Closes #126
Closes #131
