### PR TITLE
Keep fast-typed keys for the symbol and timeframe menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **The symbol menu and the timeframe menu no longer lose keystrokes when you type
+  fast.** Typing straight onto the chart opens the symbol menu (letters) or the
+  timeframe menu (digits) seeded with what you typed. The second key used to vanish
+  when it arrived before the menu's field had taken focus, leaving only the first
+  character; every key now reaches the menu.
+
 ## [v0.6.16]
 
 ### Added

--- a/src/widget/symbol-picker.ts
+++ b/src/widget/symbol-picker.ts
@@ -384,6 +384,22 @@ export class SymbolPicker {
         this.dialog.show();
     }
 
+    get isOpen(): boolean {
+        return this.dialog.open;
+    }
+
+    /** Text typed at the picker that never reached its field: closed, it opens seeded
+     *  with the text; open (the field takes focus a tick after the dialog does, and a
+     *  fast typist's next key lands in that tick), it extends the query. */
+    type(text: string): void {
+        if (!this.isOpen) {
+            this.open(text);
+            return;
+        }
+        this.input.value = (this.input.value + text).toUpperCase();
+        this.refresh();
+    }
+
     close(): void {
         this.dialog.hide(); // onOpenChange(false) blurs the field (iOS focus-zoom)
     }

--- a/src/widget/timeframe-quick.ts
+++ b/src/widget/timeframe-quick.ts
@@ -75,6 +75,22 @@ export class TimeframeQuick {
         }, 0);
     }
 
+    get isOpen(): boolean {
+        return this.dialog.open;
+    }
+
+    /** Text typed at the entry that never reached its field: closed, it opens seeded
+     *  with the text; open (the field takes focus a tick after the dialog does, and a
+     *  fast typist's next key lands in that tick), it extends the entry. */
+    type(text: string): void {
+        if (!this.isOpen) {
+            this.open(text);
+            return;
+        }
+        this.input.value += text;
+        this.renderHint();
+    }
+
     close(): void {
         this.dialog.hide();
     }

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -222,6 +222,32 @@ export function nextAutoCellId(taken: ReadonlySet<string>): string {
     }
 }
 
+/** Which dialogs are up when a bare keystroke reaches the workspace root. */
+export interface TypingState {
+    dialogs: number;
+    symbolSearch: boolean;
+    timeframeEntry: boolean;
+}
+
+/**
+ * What a bare keystroke on the workspace root does. Nothing open: a letter seeds symbol
+ * search, a digit the timeframe entry. An ENTRY dialog open: its field takes focus a
+ * tick after the dialog reports open, so the next key of a fast typist (`NQ`, `15`)
+ * still lands on the root — it is handed to that dialog as more typed text instead of
+ * dropped. Any other open dialog swallows bare typing. Pure — unit-tested.
+ */
+export function resolveTyping(key: string, open: TypingState): { target: 'symbol' | 'timeframe'; text: string } | null {
+    if (open.dialogs > 0) {
+        if (key.length !== 1) return null; // a printable character, not a control key
+        if (open.symbolSearch) return { target: 'symbol', text: key.toUpperCase() };
+        if (open.timeframeEntry) return { target: 'timeframe', text: key };
+        return null;
+    }
+    if (/^[a-zA-Z]$/.test(key)) return { target: 'symbol', text: key.toUpperCase() };
+    if (/^[0-9]$/.test(key)) return { target: 'timeframe', text: key };
+    return null;
+}
+
 export class VelaWorkspace {
     readonly root: HTMLElement;
     /** The shortcut system — one manager for the whole workspace, routed to the active cell. */
@@ -2199,17 +2225,14 @@ export class VelaWorkspace {
 
     /** Bare-typing router: letters → symbol search (seeded), digits → timeframe entry. */
     private routeTyping(ev: KeyboardEvent): void {
-        if (this.destroyed || this.openDialogs > 0) return;
+        if (this.destroyed) return;
         if (ev.ctrlKey || ev.metaKey || ev.altKey) return;
         if (isEditableTarget(ev)) return; // never hijack a keystroke someone is TYPING
-        const key = ev.key;
-        if (/^[a-zA-Z]$/.test(key)) {
-            ev.preventDefault();
-            this.symbolPicker.open(key.toUpperCase());
-        } else if (/^[0-9]$/.test(key)) {
-            ev.preventDefault();
-            this.tfQuick.open(key);
-        }
+        const hit = resolveTyping(ev.key, { dialogs: this.openDialogs, symbolSearch: this.symbolPicker.isOpen, timeframeEntry: this.tfQuick.isOpen });
+        if (!hit) return;
+        ev.preventDefault();
+        if (hit.target === 'symbol') this.symbolPicker.type(hit.text);
+        else this.tfQuick.type(hit.text);
     }
 
     private trackDialog(open: boolean): void {

--- a/test/workspace-core.test.ts
+++ b/test/workspace-core.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../src/workspace/layouts';
 import { evenTracks, resizeTracks, trackOffsets, seamSegments, segmentSpanPx } from '../src/workspace/splitters';
 import { seedDefaults, cellChartDefaults, cellDrawings } from '../src/workspace/ChartCell';
-import { declaredOrder, nextAutoCellId } from '../src/workspace/VelaWorkspace';
+import { declaredOrder, nextAutoCellId, resolveTyping } from '../src/workspace/VelaWorkspace';
 import { parseSymbol } from '../src/data/ProviderRegistry';
 
 registerBuiltinLayouts();
@@ -401,6 +401,33 @@ describe('cell identity ↔ slot position (declaredOrder / nextAutoCellId)', () 
         expect(nextAutoCellId(new Set())).toBe('c1');
         expect(nextAutoCellId(new Set(['c1', 'c2']))).toBe('c3');
         expect(nextAutoCellId(new Set(['btc', 'c1', 'c3']))).toBe('c2'); // holes fill first
+    });
+});
+
+describe('resolveTyping — bare keystrokes on the workspace root', () => {
+    const idle = { dialogs: 0, symbolSearch: false, timeframeEntry: false };
+
+    it('with nothing open: a letter seeds symbol search, a digit the timeframe entry', () => {
+        expect(resolveTyping('n', idle)).toEqual({ target: 'symbol', text: 'N' });
+        expect(resolveTyping('Q', idle)).toEqual({ target: 'symbol', text: 'Q' });
+        expect(resolveTyping('1', idle)).toEqual({ target: 'timeframe', text: '1' });
+        expect(resolveTyping('Escape', idle)).toBeNull();
+        expect(resolveTyping(' ', idle)).toBeNull();
+    });
+
+    it('hands the next keystroke to the entry dialog that just opened (fast typing `NQ`, `15`)', () => {
+        // The dialog reports open before its field takes focus; the second key lands
+        // on the root in that gap and must extend the query, not vanish.
+        expect(resolveTyping('q', { dialogs: 1, symbolSearch: true, timeframeEntry: false })).toEqual({ target: 'symbol', text: 'Q' });
+        expect(resolveTyping('2', { dialogs: 1, symbolSearch: true, timeframeEntry: false })).toEqual({ target: 'symbol', text: '2' });
+        expect(resolveTyping('5', { dialogs: 1, symbolSearch: false, timeframeEntry: true })).toEqual({ target: 'timeframe', text: '5' });
+        expect(resolveTyping('m', { dialogs: 1, symbolSearch: false, timeframeEntry: true })).toEqual({ target: 'timeframe', text: 'm' });
+        expect(resolveTyping('Enter', { dialogs: 1, symbolSearch: true, timeframeEntry: false })).toBeNull();
+    });
+
+    it('any other open dialog swallows bare typing', () => {
+        expect(resolveTyping('n', { dialogs: 1, symbolSearch: false, timeframeEntry: false })).toBeNull();
+        expect(resolveTyping('1', { dialogs: 2, symbolSearch: false, timeframeEntry: false })).toBeNull();
     });
 });
 


### PR DESCRIPTION
## Summary

Typing a letter or digit on the chart opens the symbol menu or the timeframe menu seeded with that key. When the next key was typed quickly, it vanished: only the first character reached the menu (`N` instead of `NQ`, `1` instead of `15`).

## Root cause

The menu's field takes focus on a `setTimeout(0)` after the dialog reports open. A key arriving in that gap lands on the workspace root, where `routeTyping` discarded it because a dialog was already open (`openDialogs > 0`). Reproduced in the browser by dispatching the second key after the dialog's open transition but before the focus timer.

## Fix

- `VelaWorkspace.routeTyping` now hands a printable key to whichever entry dialog is open (symbol search or timeframe entry) instead of dropping it. Any other open dialog still swallows bare typing. The decision lives in a pure, exported `resolveTyping()` helper.
- `SymbolPicker` and `TimeframeQuick` gain `isOpen` and `type(text)`: seeds when closed, extends the entry when open.
- Unit tests for `resolveTyping` (failing before the fix); changelog entry under `[Unreleased]`.

## Verification

- Browser (widget playground): the race now yields `NQ` / `15` with the field focused; normal typing unchanged.
- Gate: typecheck, lint, tests (1533), build — all green on `dev`.
- Workspace oracle suite `oracle-tests/vela`: 23/23.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard-routing and dialog query handling; pure helper is unit-tested and behavior is unchanged except fixing the focus-gap race.
> 
> **Overview**
> **Fast typing on the chart no longer drops the second character** when opening symbol search (letters) or timeframe entry (digits). The first key still opens the menu seeded with that character; keys that arrive before the input focuses are now appended instead of being ignored because `openDialogs > 0`.
> 
> Routing moves into exported **`resolveTyping()`** with **`TypingState`**: with no dialogs, letters/digits open the right menu; with symbol search or timeframe entry open, single printable keys extend that dialog; other open dialogs still swallow bare typing. **`VelaWorkspace.routeTyping`** calls **`symbolPicker.type()`** / **`tfQuick.type()`** instead of only **`open()`** on the first key.
> 
> **`SymbolPicker`** and **`TimeframeQuick`** add **`isOpen`** and **`type(text)`** (open+seed when closed, append when open). Unit tests cover **`resolveTyping`**; changelog updated under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae280eecab67d33e8fcc8eee77a1c7526065b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->