### PR TITLE
Fix workspace sizing and preserve offline data across layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Offline workspace charts survive layout changes.** Cells keep their current inline
+  data and visible window when they disappear and return, including data replaced
+  after construction. Cells switched to a provider continue using that provider.
+
+- **Workspace charts keep their full size in affected rendering environments.** They
+  continue to fill their cells when you resize the workspace or switch layouts.
+
 ## [v0.6.17]
 
 ### Changed

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -38,8 +38,15 @@ The browser bundle inlines the worker (see [setup.md](./setup.md#two-artifacts-f
 
 This is the end-to-end tier: **real indicators run all the way through the playground** in a real browser with a real renderer. It is the check that the whole pipeline — feed to engine to neutral model to renderer — actually produces the right picture.
 
-- **Today it is MANUAL.** You run it by hand in the playground (`npm run playground`) and look at the result.
-- The **intended direction is an automated harness** for these runs. Treat manual smoke testing as the current state, not the end state.
+- Most browser checks remain manual: run the playground (`npm run playground`) and
+  exercise the affected surface.
+- Workspace sizing has an automated Obscura smoke test. With the playground running,
+  run `npm run test:browser:workspace`. Set `OBSCURA_WORKER` if `obscura-worker` is not
+  on `PATH`. The test uses deterministic candles and checks computed and backing-store
+  sizes plus painted price pixels in every visible cell through layout changes,
+  resizing, hiding and showing, and maximize and restore. It also checks that named
+  cells retain their current inline data and visible ranges when they leave and return
+  to a layout, without reviving inline data after a switch back to a provider.
 
 The playground serves the **source directly** (vite): `npm run playground`, then exercise the change live — no build step. See [workflow.md](./workflow.md#the-playground).
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:browser:workspace": "node scripts/workspace-browser-smoke.mjs",
     "test:watch": "vitest",
     "lint": "eslint .",
     "playground": "vite"

--- a/scripts/workspace-browser-smoke.mjs
+++ b/scripts/workspace-browser-smoke.mjs
@@ -1,0 +1,411 @@
+// Start the source playground first (`npm run playground`), then run this script.
+// Override APP_URL for another dev server or OBSCURA_WORKER for a non-default binary.
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+const worker = spawn(process.env.OBSCURA_WORKER ?? 'obscura-worker', [], {
+    env: { ...process.env, OBSCURA_ALLOW_PRIVATE_NETWORK: '1' },
+    stdio: ['pipe', 'pipe', 'inherit'],
+});
+const lines = createInterface({ input: worker.stdout });
+let pending;
+
+function settle(error, result) {
+    if (!pending) return;
+    const request = pending;
+    pending = undefined;
+    clearTimeout(request.timer);
+    if (error) request.reject(error);
+    else request.resolve(result);
+}
+
+lines.on('line', (line) => {
+    try {
+        const reply = JSON.parse(line);
+        settle(reply.ok ? null : new Error(reply.error), reply.result);
+    } catch (error) {
+        settle(error);
+    }
+});
+worker.on('error', (error) => settle(error));
+worker.on('exit', (code, signal) => settle(new Error(`Browser worker exited: ${code ?? signal}`)));
+
+function command(input) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            settle(new Error(`Browser command timed out: ${input.cmd}`));
+            worker.kill();
+        }, 45_000);
+        pending = { resolve, reject, timer };
+        worker.stdin.write(`${JSON.stringify(input)}\n`);
+    });
+}
+
+async function scenario() {
+    const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const until = async (condition, description) => {
+        const deadline = Date.now() + 20_000;
+        while (!condition()) {
+            if (Date.now() > deadline) throw new Error(`Timed out: ${description}`);
+            await pause(25);
+        }
+    };
+    let assertions = 0;
+    const check = (condition, message) => {
+        if (!condition) throw new Error(message);
+        assertions += 1;
+    };
+    const paintedPixels = (cell) => [...cell.querySelectorAll('canvas')].reduce((total, canvas) => {
+        const rect = canvas.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0 || getComputedStyle(canvas).visibility === 'hidden') return total;
+        const context = canvas.getContext('2d');
+        if (!context) return total;
+        const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+        for (let i = 0; i < pixels.length; i += 16) {
+            const red = pixels[i];
+            const green = pixels[i + 1];
+            const blue = pixels[i + 2];
+            const alpha = pixels[i + 3];
+            if (alpha && ((green > red * 1.25 && green > blue * 1.1) || (red > green * 1.25 && red > blue * 1.1))) total += 1;
+        }
+        return total;
+    }, 0);
+    const backingStoreMatches = (canvas) => {
+        const rect = canvas.getBoundingClientRect();
+        const dpr = window.devicePixelRatio || 1;
+        // NativeRenderer prefers the browser's device-pixel box when available; its
+        // snapped integer size may differ from rect × DPR by at most one device pixel.
+        return Math.abs(canvas.width - rect.width * dpr) <= 1
+            && Math.abs(canvas.height - rect.height * dpr) <= 1;
+    };
+
+    await until(() => window.__ws, 'source workspace');
+    const Workspace = window.__ws.constructor;
+    window.__ws.destroy();
+    const host = document.querySelector('#workspace');
+    host.replaceChildren();
+    host.style.cssText = 'position:absolute;inset:0;overflow:hidden;';
+    const first = Date.UTC(2026, 0, 1);
+    const data = Array.from({ length: 120 }, (_, index) => {
+        const open = 100 + index * 0.1;
+        const close = open + (index % 2 === 0 ? -2 : 2);
+        return {
+            time: first + index * 60 * 60 * 1000,
+            open,
+            high: Math.max(open, close) + 1,
+            low: Math.min(open, close) - 1,
+            close,
+            volume: 1000 + index,
+        };
+    });
+    const provider = {
+        async getBars(_ticker, _timeframe, range) {
+            let bars = data.filter((bar) => (range.from === undefined || bar.time >= range.from)
+                && (range.to === undefined || bar.time <= range.to));
+            if (range.limit !== undefined) {
+                const limit = Math.max(0, Math.floor(range.limit));
+                bars = limit === 0 ? [] : bars.slice(-limit);
+            }
+            return bars.map((bar) => ({ ...bar }));
+        },
+    };
+    const workspace = new Workspace(host, {
+        layout: '4',
+        symbol: 'fixture:TEST',
+        timeframe: '60',
+        providers: { fixture: () => provider },
+        live: false,
+        nativeBackend: 'canvas2d',
+        animations: false,
+        volume: false,
+        statusline: false,
+        watermark: false,
+    });
+    const root = host.querySelector('.vela-workspace');
+    root.style.width = '1000px';
+    root.style.height = '640px';
+
+    const visibleCells = () => [...root.querySelectorAll('.vela-cell')]
+        .filter((cell) => getComputedStyle(cell).visibility !== 'hidden');
+    const geometryReady = (expectedCells) => {
+        const cells = visibleCells();
+        if (cells.length !== expectedCells) return false;
+        return cells.every((cell) => {
+            const cellRect = cell.getBoundingClientRect();
+            const renderer = cell.firstElementChild;
+            if (!renderer || cellRect.width <= 100 || cellRect.height <= 100) return false;
+            const rendererRect = renderer.getBoundingClientRect();
+            if (Math.abs(rendererRect.width - cellRect.width) > 1 || Math.abs(rendererRect.height - cellRect.height) > 1) return false;
+            const canvases = [...renderer.querySelectorAll('canvas')];
+            return canvases.length > 0 && canvases.every((canvas) => {
+                const rect = canvas.getBoundingClientRect();
+                return Math.abs(rect.width - cellRect.width) <= 1
+                    && Math.abs(rect.height - cellRect.height) <= 1
+                    && backingStoreMatches(canvas);
+            });
+        });
+    };
+    const geometry = (label, expectedCells) => {
+        const cells = visibleCells();
+        check(cells.length === expectedCells, `${label}: expected ${expectedCells} visible cells, got ${cells.length}`);
+        const heights = [];
+        for (const cell of cells) {
+            const cellRect = cell.getBoundingClientRect();
+            const renderer = cell.firstElementChild;
+            const rendererRect = renderer.getBoundingClientRect();
+            const canvases = [...renderer.querySelectorAll('canvas')];
+            check(cellRect.width > 100 && cellRect.height > 100, `${label}: grid cell has no usable area`);
+            check(Math.abs(rendererRect.width - cellRect.width) <= 1, `${label}: renderer width does not fill its cell`);
+            check(Math.abs(rendererRect.height - cellRect.height) <= 1, `${label}: renderer height does not fill its cell`);
+            check(canvases.length > 0, `${label}: renderer has no canvases`);
+            check(canvases.every((canvas) => {
+                const rect = canvas.getBoundingClientRect();
+                return Math.abs(rect.width - cellRect.width) <= 1 && Math.abs(rect.height - cellRect.height) <= 1;
+            }), `${label}: a canvas does not fill its cell`);
+            check(canvases.every(backingStoreMatches), `${label}: a canvas backing store does not match its displayed size`);
+            heights.push(cellRect.height);
+        }
+        return heights;
+    };
+    const painted = async (label) => {
+        try {
+            await until(() => visibleCells().every((cell) => paintedPixels(cell) > 100), `${label} painted price geometry in every cell`);
+        } catch {
+            throw new Error(`${label}: painted price pixels by cell: ${visibleCells().map(paintedPixels).join(', ')}`);
+        }
+        const pixels = visibleCells().map(paintedPixels);
+        check(pixels.every((count) => count > 100), `${label}: a cell has no painted price geometry`);
+        return pixels;
+    };
+
+    await until(() => geometryReady(4), 'initial grid layout');
+    const initial = { heights: geometry('initial 2x2 layout', 4), pixels: await painted('initial 2x2 layout') };
+
+    workspace.setLayout('1');
+    await until(() => geometryReady(1), 'single-cell layout');
+    const single = { heights: geometry('single-cell layout', 1), pixels: await painted('single-cell layout') };
+
+    root.style.width = '860px';
+    root.style.height = '520px';
+    await until(() => geometryReady(1) && visibleCells()[0].getBoundingClientRect().height < single.heights[0], 'workspace resize');
+    const resized = { heights: geometry('resized workspace', 1), pixels: await painted('resized workspace') };
+
+    host.style.display = 'none';
+    await until(() => [...root.querySelectorAll('canvas')].every((canvas) => canvas.getBoundingClientRect().height === 0), 'hidden workspace');
+    host.style.display = 'block';
+    await until(() => geometryReady(1), 'shown workspace');
+    const shown = { heights: geometry('shown workspace', 1), pixels: await painted('shown workspace') };
+
+    workspace.setLayout('4');
+    await until(() => geometryReady(4), 'restored 2x2 layout');
+    const multi = { heights: geometry('restored 2x2 layout', 4), pixels: await painted('restored 2x2 layout') };
+
+    const maximizedId = workspace.cells()[1].id;
+    workspace.maximizeCell(maximizedId);
+    await until(() => geometryReady(1), 'maximized cell');
+    const maximized = { heights: geometry('maximized cell', 1), pixels: await painted('maximized cell') };
+    workspace.maximizeCell(null);
+    await until(() => geometryReady(4), 'restored maximized cell');
+    const restored = { heights: geometry('restored maximized cell', 4), pixels: await painted('restored maximized cell') };
+
+    workspace.destroy();
+    check(!host.querySelector('.vela-workspace'), 'workspace destroy left its root mounted');
+    return JSON.stringify({ assertions, initial, single, resized, shown, multi, maximized, restored });
+}
+
+async function inlineDataScenario() {
+    const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const until = async (condition, description) => {
+        const deadline = Date.now() + 20_000;
+        while (!condition()) {
+            if (Date.now() > deadline) throw new Error(`Timed out: ${description}`);
+            await pause(25);
+        }
+    };
+    let assertions = 0;
+    const check = (condition, message) => {
+        if (!condition) throw new Error(message);
+        assertions += 1;
+    };
+    const sameRange = (actual, expected) => actual?.from === expected.from && actual?.to === expected.to;
+    const closeOf = (cell) => Number(cell.chart.renderer.dataWindowReadout()?.ohlc?.c?.replaceAll(',', ''));
+    const paintedPixels = (cell) => [...cell.host.querySelectorAll('canvas')].reduce((total, canvas) => {
+        const context = canvas.getContext('2d');
+        if (!context || canvas.width <= 0 || canvas.height <= 0) return total;
+        const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+        for (let i = 0; i < pixels.length; i += 16) {
+            const red = pixels[i];
+            const green = pixels[i + 1];
+            const blue = pixels[i + 2];
+            const alpha = pixels[i + 3];
+            if (alpha && ((green > red * 1.25 && green > blue * 1.1) || (red > green * 1.25 && red > blue * 1.1))) total += 1;
+        }
+        return total;
+    }, 0);
+    const awaitRanges = async (expected, label) => {
+        try {
+            await until(() => Object.entries(expected).every(([id, range]) => sameRange(workspace.cell(id)?.chart.getVisibleRange(), range)), `${label} visible ranges`);
+        } catch {
+            const actual = Object.fromEntries(Object.keys(expected).map((id) => [id, workspace.cell(id)?.chart.getVisibleRange()]));
+            throw new Error(`${label}: visible ranges ${JSON.stringify(actual)}`);
+        }
+        for (const [id, range] of Object.entries(expected)) {
+            check(sameRange(workspace.cell(id)?.chart.getVisibleRange(), range), `${label}: ${id} lost its visible range`);
+        }
+    };
+    const awaitPainted = async (label) => {
+        await until(() => workspace.cells().every((cell) => paintedPixels(cell) > 100), `${label} painted price geometry in every cell`);
+        const pixels = Object.fromEntries(workspace.cells().map((cell) => [cell.id, paintedPixels(cell)]));
+        check(Object.values(pixels).every((count) => count > 100), `${label}: a cell has no painted price geometry`);
+        return pixels;
+    };
+    const assertDocumentExcludesRuntimeData = (label, expectedOrder) => {
+        const state = workspace.getState();
+        check(JSON.stringify(state.charts.map((chart) => chart.id)) === JSON.stringify(expectedOrder), `${label}: state lost dormant cell identities`);
+        check(!Object.hasOwn(state, 'data') && !Object.hasOwn(state, 'visibleRange') && !Object.hasOwn(state, 'offline'), `${label}: workspace state leaked runtime market data`);
+        check(state.charts.every((chart) => !Object.hasOwn(chart, 'data')), `${label}: chart state persisted inline bars`);
+        check(state.charts.every((chart) => !Object.hasOwn(chart, 'visibleRange')), `${label}: chart state persisted a boot-only visible range`);
+        check(state.charts.every((chart) => !Object.hasOwn(chart, 'offline')), `${label}: chart state persisted the runtime offline flag`);
+        check(JSON.parse(JSON.stringify(state)).charts.length === expectedOrder.length, `${label}: workspace state is not JSON serializable`);
+    };
+
+    const Workspace = window.__ws.constructor;
+    const host = document.querySelector('#workspace');
+    host.replaceChildren();
+    host.style.cssText = 'position:absolute;inset:0;overflow:hidden;';
+    const first = Date.UTC(2026, 0, 1);
+    const hour = 60 * 60 * 1000;
+    const makeBars = (close) => Array.from({ length: 120 }, (_, index) => ({
+        time: first + index * hour,
+        open: close + (index % 2 === 0 ? 2 : -2),
+        high: close + 3,
+        low: close - 3,
+        close,
+        volume: 1000 + index,
+    }));
+    const specs = [
+        { id: 'alpha', symbol: 'fixture:INLINE_ALPHA', close: 111, range: { from: first + 20 * hour, to: first + 60 * hour } },
+        { id: 'beta', symbol: 'fixture:INLINE_BETA', close: 222, range: { from: first + 25 * hour, to: first + 65 * hour } },
+        { id: 'gamma', symbol: 'fixture:INLINE_GAMMA', close: 333, range: { from: first + 30 * hour, to: first + 70 * hour } },
+        { id: 'delta', symbol: 'fixture:INLINE_DELTA', close: 444, range: { from: first + 35 * hour, to: first + 75 * hour } },
+    ];
+    const providerClose = 909;
+    const providerBars = makeBars(providerClose);
+    const provider = {
+        async getBars(_ticker, _timeframe, range) {
+            let bars = providerBars.filter((bar) => (range.from === undefined || bar.time >= range.from)
+                && (range.to === undefined || bar.time <= range.to));
+            if (range.limit !== undefined) {
+                const limit = Math.max(0, Math.floor(range.limit));
+                bars = limit === 0 ? [] : bars.slice(-limit);
+            }
+            return bars.map((bar) => ({ ...bar }));
+        },
+    };
+    const cells = Object.fromEntries(specs.map((spec) => [spec.id, {
+        symbol: spec.symbol,
+        timeframe: '60',
+        data: makeBars(spec.close),
+        visibleRange: spec.range,
+    }]));
+    const workspace = new Workspace(host, {
+        layout: '4',
+        cells,
+        providers: { fixture: () => provider },
+        live: false,
+        nativeBackend: 'canvas2d',
+        animations: false,
+        volume: false,
+        statusline: false,
+        watermark: false,
+    });
+    const root = host.querySelector('.vela-workspace');
+    root.style.width = '1000px';
+    root.style.height = '640px';
+
+    await Promise.all(workspace.cells().map((cell) => cell.chart.ready()));
+    check(JSON.stringify(workspace.cells().map((cell) => cell.id)) === JSON.stringify(specs.map((spec) => spec.id)), 'inline data: configured cell identity order changed');
+    for (const spec of specs) {
+        const cell = workspace.cell(spec.id);
+        check(cell?.chart.market.symbol === spec.symbol, `inline data: ${spec.id} lost its configured symbol`);
+        check(cell?.chart.market.timeframe === '60', `inline data: ${spec.id} lost its configured timeframe`);
+        check(cell?.chart.market.offline === true, `inline data: ${spec.id} did not boot offline`);
+        check(closeOf(cell) === spec.close, `inline data: ${spec.id} loaded the wrong close`);
+    }
+    await awaitRanges(Object.fromEntries(specs.map((spec) => [spec.id, spec.range])), 'initial inline data');
+    const initialPixels = await awaitPainted('initial inline data');
+
+    const replacementClose = 777;
+    const replacementRange = { from: first + 45 * hour, to: first + 85 * hour };
+    const beta = workspace.cell('beta');
+    await beta.chart.setMarket({ data: makeBars(replacementClose) });
+    beta.chart.setVisibleRange(replacementRange);
+    await awaitRanges({ beta: replacementRange }, 'replacement inline data');
+    check(closeOf(beta) === replacementClose, 'replacement inline data did not paint before pooling');
+
+    const delta = workspace.cell('delta');
+    await delta.chart.setMarket({ symbol: 'fixture:PROVIDER' });
+    check(delta.chart.market.offline === false, 'provider switch remained offline before pooling');
+    check(closeOf(delta) === providerClose, 'provider switch did not paint provider data before pooling');
+    const providerRange = delta.chart.getVisibleRange();
+    check(providerRange !== null, 'provider switch has no visible range before pooling');
+    const rangesBeforePool = Object.fromEntries(workspace.cells().map((cell) => [cell.id, cell.chart.getVisibleRange()]));
+    check(['alpha', 'beta', 'delta'].every((id) => rangesBeforePool[id] != null), 'a cell has no visible range before pooling');
+
+    const gammaChart = workspace.cell('gamma').chart;
+    workspace.setActiveCell('gamma');
+    check(workspace.active.id === 'gamma', 'non-first active identity was not selected');
+    workspace.setLayout('1');
+    check(workspace.cells().length === 1 && workspace.active.id === 'gamma', 'active identity did not survive the layout shrink');
+    check(workspace.active.chart === gammaChart, 'the surviving active chart was rebuilt');
+    assertDocumentExcludesRuntimeData('pooled inline data', ['gamma', 'alpha', 'beta', 'delta']);
+
+    workspace.setLayout('4');
+    await Promise.all(workspace.cells().map((cell) => cell.chart.ready()));
+    const restoredOrder = workspace.cells().map((cell) => cell.id);
+    check(JSON.stringify(restoredOrder) === JSON.stringify(['gamma', 'alpha', 'beta', 'delta']), 'restored cells followed positions instead of durable identities');
+    const expectedCloses = { gamma: 333, alpha: 111, beta: replacementClose, delta: providerClose };
+    for (const [id, close] of Object.entries(expectedCloses)) {
+        check(closeOf(workspace.cell(id)) === close, `restored ${id} loaded the wrong close`);
+    }
+    check(workspace.cell('alpha').chart.market.offline === true, 'restored alpha lost its inline data');
+    check(workspace.cell('beta').chart.market.offline === true, 'restored beta lost its replacement inline data');
+    check(workspace.cell('gamma').chart.market.offline === true, 'surviving gamma lost its inline data');
+    check(workspace.cell('delta').chart.market.offline === false, 'restored delta resurrected configured inline data');
+    check(workspace.cell('delta').chart.market.symbol === 'fixture:PROVIDER', 'restored delta lost its provider-backed identity');
+    await awaitRanges({ alpha: rangesBeforePool.alpha, beta: rangesBeforePool.beta, delta: providerRange }, 'restored inline data');
+    check(workspace.cell('gamma').chart.getVisibleRange() !== null, 'surviving gamma lost its visible range');
+    const restoredPixels = await awaitPainted('restored inline data');
+    const restoredCloses = Object.fromEntries(restoredOrder.map((id) => [id, closeOf(workspace.cell(id))]));
+    assertDocumentExcludesRuntimeData('restored inline data', restoredOrder);
+
+    workspace.destroy();
+    check(!host.querySelector('.vela-workspace'), 'inline-data workspace destroy left its root mounted');
+    return JSON.stringify({ assertions, restoredOrder, restoredCloses, initialPixels, restoredPixels });
+}
+
+try {
+    await command({ cmd: 'navigate', url: process.env.APP_URL ?? 'http://127.0.0.1:5190/workspace.html' });
+    const expression = `(async () => {
+        try {
+            const sizing = JSON.parse(await (${scenario.toString()})());
+            const inlineData = JSON.parse(await (${inlineDataScenario.toString()})());
+            return JSON.stringify({ assertions: sizing.assertions + inlineData.assertions, sizing, inlineData });
+        } catch (error) {
+            return JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+                stack: error instanceof Error ? error.stack : undefined,
+            });
+        }
+    })()`;
+    const result = JSON.parse(await command({ cmd: 'evaluate', expression }));
+    if (!result || typeof result !== 'object') throw new Error('Browser smoke returned no result');
+    if (result.error) throw new Error(result.stack ?? result.error);
+    if (typeof result.assertions !== 'number' || result.assertions < 1) throw new Error('Browser smoke ran no assertions');
+    console.log(JSON.stringify(result, null, 2));
+    await command({ cmd: 'shutdown' });
+} finally {
+    lines.close();
+    worker.stdin.end();
+    if (worker.exitCode === null) worker.kill();
+}

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -6,7 +6,8 @@
 // chart instance survives every market change and only dies with the cell itself, on a
 // layout change — its state then round-trips through the workspace pool, so shrinking
 // 4 → 2 → 4 restores the third and fourth exactly, indicators and drawings included).
-import { Vela } from '../Vela';
+import type { Vela } from '../Vela';
+import { CellChart } from './cell-boot';
 import { normalizeSession, type MarketSession, type NativeBackend, type VelaOptions, type VelaTheme } from '../core/options';
 import type { OHLCV } from '../core/model/ohlcv';
 import type { VisibleRangePreset } from '../core/visible-range';
@@ -299,7 +300,7 @@ export class ChartCell {
         this.host.addEventListener('focusin', () => this.deps.activate(id));
         gridHost.appendChild(this.host);
 
-        this.inner = new Vela(
+        this.inner = new CellChart(
             this.host,
             {
                 ...deps.chartDefaults,

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -56,6 +56,7 @@ import { syncTargets, rangesWithin, styleConfigSlice, SYNC_KINDS, type SyncKind,
 import { encodeState, decodeState, sanitizeState, type WorkspaceState, type WorkspaceStorage } from './persist';
 import { localStorageAdapter } from '../widget/persist';
 import { ChartCell, seedDefaults, cellChartDefaults, type CellSeed, type CellBoot, type PooledCellState } from './ChartCell';
+import { snapshotCellBoot, type CellRuntimeBoot } from './cell-boot';
 import { buildContext, type WorkspaceWidgetContext } from './context';
 import {
     registerBuiltinLayouts,
@@ -156,7 +157,7 @@ const CSS = `
 .vela-ws-main { position: relative; display: flex; flex-direction: row; flex: 1 1 auto; min-height: 0; }
 .vela-ws-toolbar { position: relative; flex: none; }
 .vela-ws-grid { position: relative; flex: 1 1 auto; min-width: 0; display: grid; gap: ${GAP_PX}px; background: var(--vela-border-soft); }
-.vela-cell { background: var(--vela-bg); position: relative; }
+.vela-cell { background: var(--vela-bg); position: relative; display: flex; }
 /* Active-cell highlight: an overlay ring ABOVE the chart's own canvas stack (a plain
    outline on the cell is painted under them) — inert to the pointer. Scoped to
    multi-cell grids ([data-multi]): a single-cell layout always has an active cell,
@@ -232,6 +233,8 @@ export class VelaWorkspace {
     private readonly feed = new MultiProviderFeed();
     private readonly cellsById = new Map<string, ChartCell>();
     private readonly pool = new Map<string, PooledCellState>();
+    /** Arrays and viewports belong to live pool entries, never the saved document. */
+    private readonly poolBoot = new WeakMap<PooledCellState, CellRuntimeBoot>();
     private readonly trackSizes = new Map<string, TrackSizes>(); // per layout id (splitter drags)
     private readonly splitters: SplitterLayer;
     private readonly resizeObserver: ResizeObserver | null = null;
@@ -1086,7 +1089,7 @@ export class VelaWorkspace {
         const preexisting = new Set(this.cellsById.keys());
         for (const [id, cell] of [...this.cellsById]) {
             if (!keep.has(id) || rebuildAll) {
-                this.poolSet(id, cell.dehydrate());
+                this.poolSet(id, cell.dehydrate(), snapshotCellBoot(cell.chart));
                 cell.destroy();
                 this.cellsById.delete(id);
                 this.events.emit('cell:destroyed', { id });
@@ -1199,6 +1202,7 @@ export class VelaWorkspace {
             cell.destroy();
             this.cellsById.delete(id);
         }
+        this.pool.clear();
         for (const dispose of this.attachmentDisposers.values()) {
             try {
                 dispose();
@@ -1449,7 +1453,9 @@ export class VelaWorkspace {
             }
             if (this.cellsById.has(id)) continue;
             const pooled = this.pool.get(id);
-            const seed: CellBoot = pooled ?? { ...seedDefaults(this.opts), ...(this.opts.cells?.[id] ?? {}) };
+            const seed: CellBoot = pooled
+                ? { ...pooled, ...this.poolBoot.get(pooled) }
+                : { ...seedDefaults(this.opts), ...(this.opts.cells?.[id] ?? {}) };
             this.pool.delete(id); // the slot is live again — its pooled state is consumed
             const cell = new ChartCell(id, this.gridEl, seed, {
                 feed: this.feed,
@@ -2219,7 +2225,8 @@ export class VelaWorkspace {
     }
 
     /** Pool a dehydrated slot state (bounded — oldest entries drop past the cap). */
-    private poolSet(id: string, state: PooledCellState): void {
+    private poolSet(id: string, state: PooledCellState, boot: CellRuntimeBoot): void {
+        this.poolBoot.set(state, boot);
         this.pool.delete(id);
         this.pool.set(id, state);
         if (this.pool.size > POOL_CAP) {

--- a/src/workspace/cell-boot.ts
+++ b/src/workspace/cell-boot.ts
@@ -1,0 +1,48 @@
+import { Vela, type VelaDeps } from '../Vela';
+import type { MarketConfig, MarketSwitch, VelaOptions } from '../core/options';
+import type { OHLCV } from '../core/model/ohlcv';
+
+export type CellRuntimeBoot = Pick<MarketConfig, 'data' | 'visibleRange'>;
+
+const inlineData = new WeakMap<Vela, OHLCV[]>();
+
+/** Tracks host-supplied arrays without exposing them through persisted chart state. */
+export class CellChart extends Vela {
+    private marketRevision = 0;
+
+    constructor(element: HTMLElement, options: VelaOptions, deps: VelaDeps) {
+        super(element, options, deps);
+        if (options.data !== undefined) inlineData.set(this, options.data);
+    }
+
+    override setMarket(next: MarketSwitch): Promise<void> {
+        const revision = ++this.marketRevision;
+        const previousData = inlineData.get(this);
+        // A synchronous load listener can pool this cell or request another market.
+        // Publish the incoming array before delegating, and never overwrite a nested
+        // request with this call's array when the delegation returns.
+        if (next.data !== undefined) inlineData.set(this, next.data);
+        let result: Promise<void>;
+        try {
+            result = super.setMarket(next);
+        } catch (error) {
+            if (revision === this.marketRevision) {
+                if (previousData !== undefined) inlineData.set(this, previousData);
+                else inlineData.delete(this);
+            }
+            throw error;
+        }
+        // The public snapshot reflects the accepted request before its load resolves.
+        // A same-symbol no-op can leave the chart offline even with a symbol argument.
+        if (!this.market.offline) inlineData.delete(this);
+        return result;
+    }
+}
+
+/** Runtime-only inputs for rebuilding a live cell after a layout/backend change. */
+export function snapshotCellBoot(chart: Vela): CellRuntimeBoot {
+    return {
+        data: chart.market.offline ? inlineData.get(chart) : undefined,
+        visibleRange: chart.getVisibleRange() ?? undefined,
+    };
+}

--- a/test/workspace-offline.test.ts
+++ b/test/workspace-offline.test.ts
@@ -1,0 +1,312 @@
+// Exercise the real workspace pool and ChartCell with recording chart/UI dependencies.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OHLCV } from '../src/core/model/ohlcv';
+import { VelaWorkspace, type VelaWorkspaceOptions } from '../src/workspace/VelaWorkspace';
+import { layoutDefinition, registerBuiltinLayouts } from '../src/workspace/layouts';
+
+const velaRecorder = vi.hoisted(() => ({
+    options: [] as Array<Record<string, unknown>>,
+    symbolInfo: { session: '0930-1600', session_extended: '0400-2000', timezone: 'America/New_York' } as Record<string, unknown>,
+    onMarketLoad: undefined as (() => void) | undefined,
+}));
+
+vi.mock('../src/Vela', () => {
+    class RecordingVela {
+        readonly renderer = {
+            set: vi.fn(),
+            get: vi.fn((key: string) => key === 'priceStyle' ? 'candles' : undefined),
+            getConfig: vi.fn(() => null),
+            applyConfig: vi.fn(),
+            supports: vi.fn(() => false),
+            setLegendActions: vi.fn(),
+            setLegendCallouts: vi.fn(),
+            setSettingsSections: vi.fn(),
+            onConfigChanged: vi.fn(() => () => undefined),
+            onCrosshairMove: vi.fn(() => () => undefined),
+            setLayoutMode: vi.fn(),
+        };
+        readonly drawings = {
+            fromJSON: vi.fn(),
+            toJSON: vi.fn(() => undefined),
+            undo: vi.fn(),
+            redo: vi.fn(),
+        };
+        readonly data = {
+            ready: vi.fn(async () => undefined),
+            symbolInfo: vi.fn(async () => velaRecorder.symbolInfo),
+            displayPrefix: vi.fn(() => undefined),
+            symbolIcon: vi.fn(async () => undefined),
+        };
+        readonly addIndicator = vi.fn(() => ({
+            id: 'external-script',
+            title: 'External script',
+            inputs: [],
+            props: [],
+            visible: true,
+            inputValues: () => ({}),
+            propValues: () => ({}),
+            setInput: vi.fn(),
+            setInputs: vi.fn(),
+            setProp: vi.fn(),
+            setProps: vi.fn(),
+            setVisible: vi.fn(),
+            moveTo: vi.fn(),
+            on: vi.fn(() => () => undefined),
+            context: vi.fn(async () => null),
+            remove: vi.fn(),
+        }));
+        readonly market: Record<string, unknown>;
+        private readonly recordSetMarket = vi.fn(async (next: Record<string, unknown>) => {
+            const changed = next.data !== undefined
+                || ['symbol', 'timeframe', 'session', 'bars'].some((key) => next[key] !== undefined && next[key] !== this.market[key]);
+            if (!changed) return;
+            Object.assign(this.market, next);
+            if (next.data !== undefined) this.market.offline = true;
+            else if (next.symbol !== undefined) this.market.offline = false;
+            velaRecorder.onMarketLoad?.();
+        });
+
+        setMarket(next: Record<string, unknown>): Promise<void> {
+            return this.recordSetMarket(next);
+        }
+
+        constructor(_host: HTMLElement, options: Record<string, unknown>) {
+            this.market = {
+                symbol: options.symbol,
+                provider: undefined,
+                timeframe: options.timeframe ?? '60',
+                session: options.session,
+                offline: options.data !== undefined,
+            };
+            velaRecorder.options.push(options);
+        }
+
+        registerEngine(): this { return this; }
+        on(): () => void { return () => undefined; }
+        getVisibleRange(): null { return null; }
+        indicators(): never[] { return []; }
+        presentNativeIndicators(): string[] { return []; }
+        availableNativeIndicators(): Promise<never[]> { return Promise.resolve([]); }
+        destroy(): void {}
+    }
+
+    return { Vela: RecordingVela };
+});
+
+vi.mock('../src/widget/cell-controls', () => ({
+    CellControls: class {
+        refresh(): void {}
+        setSuspended(): void {}
+        destroy(): void {}
+    },
+}));
+
+vi.mock('../src/widget/context-menu', () => ({
+    ChartContextMenu: class {
+        onChart(): void {}
+        destroy(): void {}
+    },
+}));
+
+
+interface StubElement {
+    ownerDocument: { createElement(tag: string): StubElement };
+    className: string;
+    dataset: Record<string, string>;
+    style: { cssText: string; setProperty(name: string, value: string): void };
+    children: StubElement[];
+    addEventListener(): void;
+    appendChild(child: StubElement): StubElement;
+    remove(): void;
+}
+
+function stubGrid(): StubElement {
+    const doc = {
+        createElement(_tag: string): StubElement {
+            const el: StubElement = {
+                ownerDocument: doc,
+                className: '',
+                dataset: {},
+                style: { cssText: '', setProperty: () => undefined },
+                children: [],
+                addEventListener: () => undefined,
+                appendChild: (child) => (el.children.push(child), child),
+                remove: () => undefined,
+            };
+            return el;
+        },
+    };
+    return doc.createElement('div');
+}
+
+beforeEach(() => {
+    velaRecorder.options.length = 0;
+    velaRecorder.onMarketLoad = undefined;
+});
+
+function makePoolWorkspace(options: VelaWorkspaceOptions): VelaWorkspace {
+    registerBuiltinLayouts();
+    const grid = stubGrid();
+    const workspace = Object.assign(Object.create(VelaWorkspace.prototype) as object, {
+        opts: { statusline: false, watermark: false, volume: false, nativeBackend: 'canvas2d', ...options },
+        order: Object.keys(options.cells ?? { first: {}, second: {} }),
+        def: layoutDefinition('2h')!,
+        pool: new Map(),
+        poolBoot: new WeakMap(),
+        cellsById: new Map(),
+        trackSizes: new Map(),
+        activeId: 'first',
+        gridEl: grid,
+        root: grid,
+        feed: {},
+        cellBackend: 'canvas2d',
+        manifest: [],
+        favs: [],
+        tfFavs: [],
+        extState: {},
+        syncOpts: {},
+        timezone: 'Etc/UTC',
+        layoutCtl: { current: 'desktop' },
+        dock: { getState: () => undefined },
+        topbar: { setLayout: vi.fn() },
+        events: { emit: vi.fn() },
+        wireCell: vi.fn(),
+        mountAttributionMark: vi.fn(),
+        clearMaximized: vi.fn(),
+        applyGrid: vi.fn(),
+        alignNewCellStyles: vi.fn(),
+        syncCellPresentation: vi.fn(),
+        refreshCellControls: vi.fn(),
+        refreshRetention: vi.fn(),
+        projectActiveCell: vi.fn(),
+        markStateDirty: vi.fn(),
+        onCellIndicatorsChanged: vi.fn(),
+        onCellMarketChanged: vi.fn(),
+    }) as unknown as VelaWorkspace;
+    workspace.setLayout('2h');
+    return workspace;
+}
+
+function latestChartOptions(): Record<string, unknown> {
+    return velaRecorder.options[velaRecorder.options.length - 1]!;
+}
+
+describe('ChartCell inline data in the workspace pool', () => {
+    it('restores per-cell inline data after a layout round trip without serializing it', () => {
+        const first: OHLCV[] = [{ time: 1_000, open: 1, high: 2, low: 1, close: 2 }];
+        const second: OHLCV[] = [{ time: 1_000, open: 10, high: 20, low: 10, close: 20 }];
+        const workspace = makePoolWorkspace({ data: first, cells: { first: {}, second: { data: second } } });
+
+        workspace.setLayout('1');
+        expect(workspace.getState().charts.every((state) => !('data' in state) && !('visibleRange' in state))).toBe(true);
+        workspace.setLayout('2h');
+
+        expect(latestChartOptions().data).toBe(second);
+        expect(workspace.cell('second')?.chart.market.offline).toBe(true);
+        for (const cell of workspace.cells()) cell.destroy();
+    });
+
+    it('restores the latest inline replacement and current viewport instead of construction defaults', async () => {
+        const initial: OHLCV[] = [{ time: 1_000, open: 1, high: 2, low: 1, close: 2 }];
+        const replacement: OHLCV[] = [
+            { time: 2_000, open: 10, high: 20, low: 10, close: 20 },
+            { time: 3_000, open: 20, high: 30, low: 20, close: 30 },
+        ];
+        const workspace = makePoolWorkspace({ data: initial, visibleRange: '1M' });
+        const chart = workspace.cell('second')!.chart;
+        const currentRange = { from: 2_000, to: 3_000 };
+        await chart.setMarket({ data: replacement });
+        vi.spyOn(chart, 'getVisibleRange').mockReturnValue(currentRange);
+
+        workspace.setLayout('1');
+        workspace.setLayout('2h');
+
+        expect(latestChartOptions().data).toBe(replacement);
+        expect(latestChartOptions().visibleRange).toEqual(currentRange);
+        expect(workspace.getState().charts.every((state) => !('data' in state) && !('visibleRange' in state))).toBe(true);
+        for (const cell of workspace.cells()) cell.destroy();
+    });
+
+    it('keeps a requested provider switch when pooling before its promise resolves', async () => {
+        const data: OHLCV[] = [{ time: 1_000, open: 1, high: 2, low: 1, close: 2 }];
+        const workspace = makePoolWorkspace({ data, symbol: 'fixture:ORIGINAL' });
+        const pending = workspace.cell('second')!.chart.setMarket({ symbol: 'fixture:LIVE' });
+
+        workspace.setLayout('1');
+        workspace.setLayout('2h');
+
+        expect(latestChartOptions().symbol).toBe('fixture:LIVE');
+        expect(latestChartOptions().data).toBeUndefined();
+        expect(workspace.cell('second')?.chart.market.offline).toBe(false);
+        await pending;
+        for (const cell of workspace.cells()) cell.destroy();
+    });
+
+    it('retains inline data when a same-symbol request is a no-op', async () => {
+        const data: OHLCV[] = [{ time: 1_000, open: 1, high: 2, low: 1, close: 2 }];
+        const workspace = makePoolWorkspace({ data, symbol: 'fixture:ORIGINAL' });
+        await workspace.cell('second')!.chart.setMarket({ symbol: 'fixture:ORIGINAL' });
+
+        workspace.setLayout('1');
+        workspace.setLayout('2h');
+
+        expect(latestChartOptions().data).toBe(data);
+        expect(workspace.cell('second')?.chart.market.offline).toBe(true);
+        for (const cell of workspace.cells()) cell.destroy();
+    });
+
+    it('captures replacement data when a synchronous loading callback pools the cell', async () => {
+        const initial: OHLCV[] = [{ time: 1_000, open: 1, high: 2, low: 1, close: 2 }];
+        const replacement: OHLCV[] = [{ time: 2_000, open: 10, high: 20, low: 10, close: 20 }];
+        const workspace = makePoolWorkspace({ data: initial });
+        velaRecorder.onMarketLoad = () => workspace.setLayout('1');
+
+        await workspace.cell('second')!.chart.setMarket({ data: replacement });
+        velaRecorder.onMarketLoad = undefined;
+        workspace.setLayout('2h');
+
+        expect(latestChartOptions().data).toBe(replacement);
+        for (const cell of workspace.cells()) cell.destroy();
+    });
+
+    it('keeps the latest replacement when a loading callback requests another inline dataset', async () => {
+        const initial: OHLCV[] = [{ time: 1_000, open: 1, high: 2, low: 1, close: 2 }];
+        const superseded: OHLCV[] = [{ time: 2_000, open: 10, high: 20, low: 10, close: 20 }];
+        const latest: OHLCV[] = [{ time: 3_000, open: 20, high: 30, low: 20, close: 30 }];
+        const workspace = makePoolWorkspace({ data: initial });
+        const chart = workspace.cell('second')!.chart;
+        let innerLoad: Promise<void> | undefined;
+        velaRecorder.onMarketLoad = () => {
+            velaRecorder.onMarketLoad = undefined;
+            innerLoad = chart.setMarket({ data: latest });
+        };
+
+        await chart.setMarket({ data: superseded });
+        await innerLoad;
+        workspace.setLayout('1');
+        workspace.setLayout('2h');
+
+        expect(latestChartOptions().data).toBe(latest);
+        for (const cell of workspace.cells()) cell.destroy();
+    });
+
+    it('preserves every inline dataset when a layout change rebuilds the renderer backend', () => {
+        const first: OHLCV[] = [{ time: 1_000, open: 1, high: 2, low: 1, close: 2 }];
+        const second: OHLCV[] = [{ time: 1_000, open: 10, high: 20, low: 10, close: 20 }];
+        const workspace = makePoolWorkspace({
+            data: first,
+            nativeBackend: 'auto',
+            maxWebglCells: 1,
+            cells: { first: {}, second: { data: second } },
+        });
+
+        workspace.setLayout('1');
+        expect(latestChartOptions().nativeBackend).toBe('auto');
+        expect(latestChartOptions().data).toBe(first);
+        workspace.setLayout('2h');
+
+        expect(velaRecorder.options.slice(-2).map((options) => options.data)).toEqual([first, second]);
+        expect(velaRecorder.options.slice(-2).map((options) => options.nativeBackend)).toEqual(['canvas2d', 'canvas2d']);
+        for (const cell of workspace.cells()) cell.destroy();
+    });
+});


### PR DESCRIPTION
## Summary

- Keep workspace charts at their full cell size in rendering environments affected by the existing percentage-height layout. The compatibility fix makes each cell a flex container; it does not change the public API.
- Preserve each cell's current inline data and visible window when layout changes or renderer-backend rebuilds remove and restore it. Replacement arrays, nested market changes, and intentional switches back to a provider retain their current behavior.
- Keep runtime arrays and viewport metadata separate from saved workspace documents. Add regression tests and a repeatable Obscura browser smoke test.

This PR is based directly on upstream `main` and does not include the state/session/interaction work in #132.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run test`, and `npm run build` pass on this clean upstream base: 1,546 tests across 126 files, including seven targeted pool regressions.
- Six of the new regressions fail against the unmodified upstream base.
- `npm run test:browser:workspace` passes 170 Obscura assertions: 111 sizing checks and 59 inline-data lifecycle checks.
- The browser scenario exercises `4 → 1 → 4` with named cells, replacement data, a provider switch, and reordered cell identities. Restored cells have the expected candles, visible windows, nonzero canvas geometry, and painted price pixels.
- Public exports and saved-document schemas remain unchanged.

The zero-height reproduction is specific to affected rendering environments, including Obscura; it is not a claim that all browsers resolve the original grid layout incorrectly.
