### PR TITLE
Correct build, testing, and screenshot documentation

### DIFF
--- a/docs/architecture/adr/0006-workspace-composes-charts.md
+++ b/docs/architecture/adr/0006-workspace-composes-charts.md
@@ -68,10 +68,11 @@ The load-bearing rules:
   v1 — the measurements do not justify it**. Create/destroy cycles are clean
   (DOM/canvas counts return to baseline; the WebGL backend explicitly releases its
   context on destroy so churn cannot evict live charts' contexts).
-- The workspace duplicates ~a few hundred lines of the widget's chrome glue.
-  Accepted for v1. **Future work:** `VelaWidget` should delegate to a one-cell
-  workspace; the unified state document already makes the two interchangeable
-  (a widget document restores into a workspace slot verbatim, and back).
+- At introduction, the workspace duplicated a few hundred lines of the widget's chrome
+  glue. This was accepted for v1, with delegation to a one-cell workspace planned as a
+  follow-up. **Follow-up completed:** `VelaWidget` is now a deprecated wrapper over
+  `VelaWorkspace` with `layout: false`. The unified state document supports this
+  delegation; see the [single-chart migration notes](../../user/workspace.md#single-chart-layout-false).
 - Crosshair sync shipped as the port's first OPTIONAL interaction seam:
   `setExternalCrosshair?(time, price?)`, detected by presence (no capability flag).
   Followers show a dimmed data-space ghost; the contract's one rule — a ghost never

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -231,9 +231,9 @@ Two rules keep actions portable:
 
 - **Everything through `ctx`, no outer references.** `when`/`run` must not close over a
   widget or chart instance — the context is rebuilt per invocation, so it always binds
-  the widget that projected the action (and, in a future multi-chart shell, the
-  **active** chart). Every member of the context is LIVE — `ctx.chart` resolves the
-  current chart at call time, and `ctx.symbol` / `ctx.timeframe` / `ctx.priceStyle`
+  the shell that projected the action and its **active** chart. Every member of the
+  context is LIVE — `ctx.chart` resolves the current chart at call time, and
+  `ctx.symbol` / `ctx.timeframe` / `ctx.priceStyle`
   (and a workspace's `ctx.cells` / `ctx.activeCellId`) are getters that follow every
   market and active-cell switch. Read them at the point of use; copying one into a
   variable at mount freezes it (an attachment once named screenshot files after the

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -38,7 +38,10 @@ The four scripts that define "done" — **typecheck, lint, test, build** — are
 
 A single source tree produces **two different build artifacts**, and knowing which is which prevents a lot of confusion:
 
-- **The library build** is what application code consumes. It ships ESM, CJS, and type definitions, and **externalizes the backends** (the scripting engine and the renderer dependency are left as external imports rather than inlined). Externalized does **not** mean the consumer must hand-wire those backends: the renderer dependency remains a **required runtime dependency** that the consumer's package manager resolves normally, and the default backends still wire themselves automatically through the composition root. You only supply your own backend when you deliberately want to replace a default (see [workflow.md](./workflow.md#where-to-make-a-change-by-layer)).
-- **The self-contained browser bundle** is a single IIFE that **bundles everything** — the renderer dependency, the scripting engine, and the **inlined worker** — and exposes the library as a global (`window.Vela`).
+- **The library build** ships ESM, CJS, and type definitions for the public package entries. It includes the native renderer, which the composition root uses by default. Providers are available through their package subpaths. You can replace the renderer or data feed through dependency injection (see [workflow.md](./workflow.md#where-to-make-a-change-by-layer)).
+- **The self-contained browser bundle** exposes `window.Vela` as an IIFE, with readable and minified variants. It includes the native renderer and bundled providers for script-tag consumers.
+
+Neither build includes a scripting engine or a scripting worker. Install and register an
+engine addon separately when you need scripts (see [Scripting engines](../user/scripting-engines.md)).
 
 The **playground serves `src/` directly** (vite): changes appear on save with no build step. The browser bundle exists for CDN-style consumers of the library, not for development.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -17,22 +17,21 @@ These run under vitest in Node, with no browser. Run them once with **`npm test`
 The ports exist precisely so the core can be exercised without real backends. The tests lean on this through the **dependency-injection constructor**, substituting:
 
 - a **fake renderer** in place of a real one,
-- a **fake worker that records the messages it receives**, so the worker request/response protocol can be asserted without a real worker, and
+- a **fake scripting engine** that produces controlled models and execution callbacks, and
 - **injected fake feeds** that hand the core whatever bars a scenario needs.
 
 Because the only thing crossing a port is the neutral model, a double only has to honor the contract — it never needs backend-specific behavior.
 
-### Engine output is pinned with captured fixtures
+### Engine integration uses controlled execution
 
-Scripting-engine output is verified against **captured JSON fixtures**. The rule:
+The orchestrator tests use fake `ScriptingEngine` implementations to control preparation,
+execution, updates, and failures. They verify how Vela passes market data to an engine,
+applies its output, and releases its execution sessions. These tests exercise Vela's
+integration contract; they do not validate a scripting language runtime.
 
-> **Regenerate fixtures deliberately; never hand-edit them.**
-
-A fixture is a recorded, trusted run. Editing one by hand quietly changes what "correct" means and defeats the test. When engine behavior legitimately changes, regenerate the fixture as an intentional step and review the diff.
-
-### The inlined worker is stubbed
-
-The browser bundle inlines the worker (see [setup.md](./setup.md#two-artifacts-from-one-source)), which is not appropriate to load in Node. In the unit suite the inline-worker import is **stubbed**, and worker behavior is driven through the fake worker described above. This keeps the worker's port contract testable without a real worker thread.
+Scripting runtimes and their workers belong to engine addons and need tests in those
+packages. Vela's builds include neither an engine nor an inlined scripting worker
+(see [setup.md](./setup.md#two-artifacts-from-one-source)).
 
 ## Tier 2 — browser smoke testing
 
@@ -46,7 +45,7 @@ The playground serves the **source directly** (vite): `npm run playground`, then
 ## Which tier for which change
 
 - Logic in the core, or a port contract: **Tier 1**. Add or update unit tests with the appropriate test double.
-- Anything you need to *see* render — a new indicator, a renderer change, an interaction: **Tier 2**, after rebuilding the bundle.
-- A change to engine output: update the relevant **fixture** (regenerate, don't edit) and smoke-test the affected indicator.
+- Anything you need to *see* render — a new indicator, a renderer change, an interaction: **Tier 2**, using the source playground with no build step.
+- A change to how Vela handles engine output: add a controlled engine regression in **Tier 1** and smoke-test the affected indicator in **Tier 2**. Validate changes to an engine's own output in the addon that implements it.
 
 For isolating *why* a test or smoke run is wrong, see [debugging.md](./debugging.md).

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -264,7 +264,7 @@ chart is never left half-changed.
 | `supports(feature)` | Whether a feature is available — use to show/hide a UI control. |
 | `get(feature)` | Read a feature's current value (`undefined` if unsupported). |
 | `set(feature, value)` / `set({ … })` | Apply one feature, or several at once (one repaint). |
-| `screenshot()` | Export the chart as a PNG data URL, or `null` if unsupported. Composites the geometry and chrome layers only — the crosshair, DOM overlays (tables, legend), user drawings, and the volume-profile layer are not included. |
+| `screenshot()` | Export the chart as a PNG data URL, or `null` if unsupported. The native renderer includes the plot canvas stack, volume profile, chrome, and user drawings, plus best-effort text/chip replicas of indicator legends and marked host overlays. The crosshair is excluded. See [Screenshot export](./renderer-features.md#screenshot-export) for DOM capture limits. |
 | `getConfig()` | Snapshot the renderer's full cosmetics as a serializable, versioned JSON document (or `null`). |
 | `applyConfig(config)` | Apply a full or partial config document from `getConfig()`; malformed/unknown fields are ignored. |
 | `onConfigChanged(cb)` | Subscribe to cosmetic-config changes — the in-chart settings dialog commits through `applyConfig`, so this is how host chrome mirroring a config value (a time-zone display, a saved template) learns about in-chart edits. Re-pull `get(…)`/`getConfig()` in the callback. Returns an unsubscribe fn; silent no-op unsubscribe on a renderer without a rich config. |

--- a/docs/user/renderer-features.md
+++ b/docs/user/renderer-features.md
@@ -105,11 +105,16 @@ Available on every renderer:
 ## Screenshot export
 
 `chart.renderer.screenshot()` returns a **PNG data URL** of the current chart (or `null`
-on a renderer that doesn't support it, with a warning). It composites the canvas layers in the
-order you see them: the series geometry — with any drawings stacked among the series already
-inside it — then the chrome layer that carries script-drawn shapes, then the drawings that sit
-over everything. The crosshair, the DOM overlays (tables, legend, data window) and the
-volume-profile layer are **not** included.
+on a renderer that doesn't support it, with a warning). The native renderer paints a fresh
+frame and composites the plot canvas stack in display order, including plugin layers,
+series geometry, volume columns, the volume profile, chrome, and user drawings. The
+crosshair is excluded.
+
+Indicator legends and host overlays marked with `data-vela-screenshot` inside the chart's
+mount container are included as best-effort text/chip replicas. A marker value of `"under"`
+places the replica below the canvases, as used by the symbol watermark. This is not an
+arbitrary HTML capture: unmarked host overlays, such as a separate data-window panel,
+are not included.
 
 ```js
 const url = chart.renderer.screenshot();


### PR DESCRIPTION
The guides still describe an external renderer dependency, a bundled scripting worker, and screenshot exclusions that no longer match the implementation. This updates them to describe the current builds, fake-engine contract tests, source playground workflow, and native screenshot composition with its DOM capture limits.

The architecture decision records widget-to-workspace delegation as completed, and the plugin SDK guide describes the existing active-chart context.

This documentation-only change is based directly on upstream `main` and can merge independently of #132 and #134. It changes six documentation files; no runtime code or public API changes.

Validation on this PR branch:

- `npm run typecheck`, `npm run lint`, `npm run test` (1,539 tests across 125 files), and `npm run build`.
- Cross-checked descriptions against source and existing tests; checked 37 relative file links and `git diff --check`.

No new browser run was needed for these documentation corrections.
