### PR TITLE
Drawing cloning, multi-selection shortcuts and unified multi-selection popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ All notable changes to Vela, newest first.
   cursor passes over). Dragging the body of any selected drawing then moves the whole
   selection together (locked drawings stay put), Ctrl/Cmd+dragging it copies the whole
   selection, and Delete, the arrow keys, copy, duplicate and a middle-click on a selected
-  drawing act on all of them, each as a single undo step.
+  drawing act on all of them, each as a single undo step. A lock protects a drawing inside
+  a group: deleting a multi-selection removes only its unlocked members and leaves the
+  locked ones in place, still selected. The object tree highlights every selected drawing,
+  not just the first, and the `drawing:selected` event now carries the full list as `ids`
+  alongside the primary `id`.
 - **One settings popup for a whole selection.** Selecting several drawings opens a single
   quick-settings popup for all of them, showing only the controls every one of them
   supports — three trend lines get the full trend-line bar; a trend line, a box and a text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Duplicate drawings by dragging, and select several at once.** Hold **Ctrl/Cmd** and
+  drag a drawing's body to pull a copy away from it: the original stays where it is, the
+  copy follows the cursor and is committed when you release — selected, with its
+  quick-settings popup open — as one undo step; press **Escape** mid-drag and nothing is
+  left behind. The quick-settings popup's overflow
+  menu gains a **Duplicate** entry that clones the drawing in place and hands it the
+  selection, ready to drag. Selection also grows beyond one drawing: **Ctrl/Cmd+click**
+  adds a drawing to (or removes it from) the selection, just as Shift+click does, and
+  **Ctrl/Cmd+drag on an empty spot** sweeps a selection box that picks up every drawing
+  it touches — successive boxes accumulate, and a click on an empty spot clears the
+  selection (while Ctrl/Cmd is held, handles mark only what is selected, not what the
+  cursor passes over). Dragging the body of any selected drawing then moves the whole
+  selection together (locked drawings stay put), Ctrl/Cmd+dragging it copies the whole
+  selection, and Delete, the arrow keys, copy, duplicate and a middle-click on a selected
+  drawing act on all of them, each as a single undo step.
+- **One settings popup for a whole selection.** Selecting several drawings opens a single
+  quick-settings popup for all of them, showing only the controls every one of them
+  supports — three trend lines get the full trend-line bar; a trend line, a box and a text
+  annotation share just their common ground, and anything a member lacks disappears rather
+  than showing disabled. Where the drawings agree a control reads normally; where they
+  differ it reads as mixed — a swatch striped with every color in use, a dash in a
+  dropdown, a half-lit toggle. Any edit applies to every selected drawing as one undo step,
+  and opening a mixed swatch lists the colors currently in use first, so unifying onto one
+  of them is a single click.
+
 ## [v0.6.17]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ All notable changes to Vela, newest first.
   drag a drawing's body to pull a copy away from it: the original stays where it is, the
   copy follows the cursor and is committed when you release — selected, with its
   quick-settings popup open — as one undo step; press **Escape** mid-drag and nothing is
-  left behind. The quick-settings popup's overflow
-  menu gains a **Duplicate** entry that clones the drawing in place and hands it the
-  selection, ready to drag. Selection also grows beyond one drawing: **Ctrl/Cmd+click**
+  left behind. The quick-settings popup's overflow menu gains a **Duplicate** entry that
+  clones the drawing in place and hands it the selection, ready to drag. Selection also
+  grows beyond one drawing: **Ctrl/Cmd+click**
   adds a drawing to (or removes it from) the selection, just as Shift+click does, and
   **Ctrl/Cmd+drag on an empty spot** sweeps a selection box that picks up every drawing
   it touches — successive boxes accumulate, and a click on an empty spot clears the
@@ -34,7 +34,7 @@ All notable changes to Vela, newest first.
   dropdown, a half-lit toggle. Any edit applies to every selected drawing as one undo step,
   and opening a mixed swatch lists the colors currently in use first, so unifying onto one
   of them is a single click.
-  
+
 ### Changed
 
 - **The built-in VWAP now carries standard-deviation bands.** Volume Weighted Average

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -367,7 +367,8 @@ can't paint drawings — `chart.drawings.supported` reports this), while the **m
 | `getConfig()` / `applyConfig(doc)` | no | Aliases of `toJSON` / `fromJSON`, mirroring `chart.renderer`. |
 
 Drawing lifecycle is also surfaced as chart events (`drawing:created` / `drawing:edited` /
-`drawing:removed` / `drawing:selected` / `drawing:settings`), and the tool/mode state as
+`drawing:removed` / `drawing:selected` / `drawing:settings` — `drawing:selected` carries the
+primary `id` plus `ids`, every member of a multi-selection), and the tool/mode state as
 `drawing:tool` / `drawing:snap` / `drawing:stay` / `drawing:mode` — the seam an external toolbar mirrors. See
 [Drawing tools](./drawing-tools.md) for the tool catalogue, toolbar UX, and keyboard shortcuts.
 

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -70,8 +70,10 @@ the magnet so the locked angle is kept exactly.
 Select a drawing (click it) to show its **handles** and a compact **quick-settings popup** floating
 beside it. The popup is built from each tool's own schema, so it shows only the controls that tool
 supports — line color/width/style, fill, text, and (for Fibonacci tools) a **gear** panel to
-enable/recolor/label each level. The popup also locks, reorders (bring-to-front /
-send-to-back), and deletes the drawing.
+enable/recolor/label each level. The popup also locks and deletes the drawing, and its overflow
+menu (the `⋮` button) duplicates it in place, reorders it (bring-to-front / send-to-back), or
+resets its settings. A duplicate lands exactly on its source and becomes the selection, ready to
+drag away.
 
 **Text is typed on the chart.** Placing a text annotation opens a blinking caret at the click point
 next to an `Enter Text` placeholder, framed by a thin gray box that marks the text as being edited,
@@ -93,6 +95,41 @@ field behind the popup's **Text** button, next to the text they format. On shape
 label (a trend line, a box), all four controls stay in that panel with the label field.
 
 Drag a handle to reshape; drag the body to move the whole drawing.
+
+### Selecting several drawings
+
+- **Shift+click** or **Ctrl/Cmd+click** a drawing to add it to (or remove it from) the selection.
+- **Ctrl/Cmd+drag on an empty spot** sweeps a selection box: every drawing it touches joins the
+  selection. Successive boxes accumulate.
+- While Ctrl/Cmd is held, handles mark only what is selected — hovering a drawing no longer shows
+  them — so the selection you are building is what you see.
+- Dragging the body of a selected drawing then moves the **whole selection** together, as one
+  undo step; a handle drag still reshapes just that one drawing. Locked members stay where they
+  are. Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on
+  the whole selection too.
+- Click an empty spot to clear the selection (a drag to pan keeps it).
+
+### One popup for several drawings
+
+Selecting several drawings opens a **single quick-settings popup** for all of them, floating
+above their combined extent. It shows only the controls every selected drawing supports: three
+trend lines get the full trend-line bar, while a trend line, a box and a text annotation share
+just their common ground (text styling, lock, delete, the overflow menu) — controls a member
+lacks disappear rather than showing disabled. Where the drawings agree the control reads
+normally; where they differ it reads as **mixed**: a color swatch striped with every color in
+use, a dash in a dropdown, a half-lit toggle. Any edit applies to every selected drawing as one
+undo step, so picking blue from a mixed swatch turns them all blue. Opening a mixed swatch lists
+the colors currently in use first, so unifying onto one of them is a single click. The per-drawing
+panels — Fibonacci levels, position sizing, volume-profile rows, the text field — stay with a
+single selection.
+
+### Duplicating by dragging
+
+**Ctrl/Cmd+drag** a drawing's body to drag a **copy** away from it — the original stays put, the
+copy follows the cursor and is committed when you release, with its quick-settings popup open
+(one undo step; **Escape** mid-drag leaves nothing behind). With several drawings selected, the
+whole selection is copied at once and stays selected as a group.
+Ctrl/Cmd on a **handle** keeps its usual meaning — a strong magnet snap while reshaping.
 
 ### Keyboard shortcuts
 
@@ -366,7 +403,8 @@ the next load.
   snapshot history. A multi-target action (multi-drag, multi-delete, duplicate, paste) is one
   undo step.
 - **Clipboard.** `copyToClipboard(ids)` + `paste()`, or `duplicate(ids)` / `clone(id)`, mint fresh
-  copies (new ids) and select them — an in-memory, per-chart clipboard.
+  copies (new ids) and select them — an in-memory, per-chart clipboard. On the chart, the
+  popup's overflow menu, **Ctrl/Cmd+D**, and a **Ctrl/Cmd+drag** of the body do the same.
 
 ---
 

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -105,7 +105,9 @@ Drag a handle to reshape; drag the body to move the whole drawing.
   them — so the selection you are building is what you see.
 - Dragging the body of a selected drawing then moves the **whole selection** together, as one
   undo step; a handle drag still reshapes just that one drawing. Locked members stay where they
-  are. Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on
+  are. The selection survives the drag, and its popup comes back over the moved drawings.
+- A **lock protects a drawing inside a group**: deleting a multi-selection — Delete, middle-click,
+  or the popup's trash — removes only its unlocked members; the locked ones stay, still selected. Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on
   the whole selection too.
 - Click an empty spot to clear the selection (a drag to pan keeps it).
 

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -106,9 +106,10 @@ Drag a handle to reshape; drag the body to move the whole drawing.
 - Dragging the body of a selected drawing then moves the **whole selection** together, as one
   undo step; a handle drag still reshapes just that one drawing. Locked members stay where they
   are. The selection survives the drag, and its popup comes back over the moved drawings.
+- Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on the
+  whole selection too, each as one undo step.
 - A **lock protects a drawing inside a group**: deleting a multi-selection — Delete, middle-click,
-  or the popup's trash — removes only its unlocked members; the locked ones stay, still selected. Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on
-  the whole selection too.
+  or the popup's trash — removes only its unlocked members; the locked ones stay, still selected.
 - Click an empty spot to clear the selection (a drag to pan keeps it).
 
 ### One popup for several drawings

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -438,7 +438,8 @@ they work from the very first keystroke, before any click.
   the stack together. Drawings can be multi-selected
   (Ctrl/Cmd-click) and bundled into a named group that hides, locks, deletes and drags as one
   block; groups live for as long as the chart and are not persisted. Kept in sync with the
-  chart's events.
+  chart's events — a selection made on the chart (Ctrl/Cmd-click, a marquee) lights up every
+  row it covers, and a pick made in the panel selects the same drawings on the chart.
 - **Data window** — the other docked panel: the date and time of the bar under the crosshair,
   its OHLCV tinted with the bar's direction, then one section per indicator showing each plot's
   value in its own color. It follows the crosshair and falls back to the latest bar when the

--- a/src/core/drawings/DrawingController.ts
+++ b/src/core/drawings/DrawingController.ts
@@ -385,16 +385,20 @@ export class DrawingController {
             next = [...ids];
         }
         this.selectedIds = next.filter((id) => this.store.has(id));
+        this.announceSelection();
+    }
+
+    /** Push the selection to the renderer and announce it (primary + the full list). */
+    private announceSelection(): void {
         this.port?.setSelection(this.selectedIds);
-        this.events.emit('drawing:selected', { id: this.selectedIds[0] ?? null });
+        this.events.emit('drawing:selected', { id: this.selectedIds[0] ?? null, ids: [...this.selectedIds] });
     }
 
     /** Restore a history snapshot, reconciling selection against what survived. */
     private restoreSnapshot(doc: DrawingsDocument): void {
         this.store.load(doc); // fires onChange → sync() + autoscale
         this.selectedIds = this.selectedIds.filter((id) => this.store.has(id));
-        this.port?.setSelection(this.selectedIds);
-        this.events.emit('drawing:selected', { id: this.selectedIds[0] ?? null });
+        this.announceSelection();
     }
 
     /** Delete drawings as one undo step; prune them from the selection. */

--- a/src/core/drawings/DrawingController.ts
+++ b/src/core/drawings/DrawingController.ts
@@ -544,6 +544,9 @@ export class DrawingController {
             case 'duplicate':
                 this.duplicate(i.ids);
                 break;
+            case 'clone':
+                if (this.enabled && i.docs.length) this.insertClones(i.docs);
+                break;
             case 'copy':
                 this.copy(i.ids);
                 break;

--- a/src/core/drawings/port.ts
+++ b/src/core/drawings/port.ts
@@ -47,6 +47,11 @@ export type DrawingIntent =
     | { kind: 'undo' }
     | { kind: 'redo' }
     | { kind: 'duplicate'; ids: string[] } // clone in place + select the clones
+    /** Commit COPIES carrying the geometry given (the end of a drag-to-duplicate: the
+     *  sources never moved, the docs are their serialized twins already translated).
+     *  Ids are reassigned; the copies keep their sources' depth and become the selection.
+     *  One undo step. */
+    | { kind: 'clone'; docs: SerializedDrawing[] }
     | { kind: 'copy'; ids: string[] }
     | { kind: 'paste' };
 

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -70,8 +70,9 @@ export interface VelaEventMap extends Record<string, unknown> {
   "drawing:draft": { doc: SerializedDrawing | null };
   /** A user drawing's anchors/style/text changed. */
   "drawing:edited": { id: string };
-  /** Selection changed (`id` is null when nothing is selected). */
-  "drawing:selected": { id: string | null };
+  /** Selection changed. `ids` is every selected drawing in selection order; `id` is the
+   *  primary (`ids[0]`, the one a settings popup edits), null when nothing is selected. */
+  "drawing:selected": { id: string | null; ids: string[] };
   /** The favorite-tool set changed (star toggles or a bulk restore). */
   "drawing:favorites": { favorites: string[] };
   /** The armed drawing tool changed — toolbar click, one-shot tool finishing (back to

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1362,7 +1362,10 @@ export class NativeRenderer implements IChartRenderer {
             zoomTo: (target, anchorLogical, anchorX) => this.zoomTo(target, anchorLogical, anchorX),
             fling: (v) => this.fling(v),
             onPointerMove: (x, y) => this.handlePointerMove(x, y),
-            onClick: (x) => this.handleClick(x),
+            onClick: (x) => {
+                this.userDrawings?.deselect(); // a click on the empty plot ends a (multi-)selection
+                this.handleClick(x);
+            },
             onAxisLongPress: (axis, x, y) => {
                 for (const cb of this.axisLongPressCbs) cb({ axis, x, y });
             },
@@ -1380,11 +1383,12 @@ export class NativeRenderer implements IChartRenderer {
             // User drawings claim a gesture before pan when armed / over a drawing.
             drawingsClaim: (x, y) => this.userDrawings?.claim(x, y) ?? false,
             drawingsMeasureStart: (x, y, snap) => this.userDrawings?.beginMeasureAt(x, y, snap) ?? false,
-            drawingsDeleteAt: (x, y) => this.userDrawings?.deleteAt(x, y) ?? false,
+            drawingsMarqueeStart: (x, y) => this.userDrawings?.beginMarqueeAt(x, y) ?? false,
+            drawingsDeleteAt: (x, y) => this.userDrawings?.deleteAt(x, y, true) ?? false, // middle-click: a selected hit takes the whole selection
             drawingsCancelPlacement: () => this.userDrawings?.cancelPlacement() ?? false,
             drawingsSnapMode: () => this.snapMode,
-            drawingsPointerDown: (x, y, snap, shift) => this.userDrawings?.pointerDown(x, y, snap, shift),
-            drawingsPointerMove: (x, y, snap, shift) => this.userDrawings?.pointerMove(x, y, snap, shift),
+            drawingsPointerDown: (x, y, snap, shift, mod) => this.userDrawings?.pointerDown(x, y, snap, shift, mod),
+            drawingsPointerMove: (x, y, snap, shift, mod) => this.userDrawings?.pointerMove(x, y, snap, shift, mod),
             drawingsPointerUp: (x, y, snap) => this.userDrawings?.pointerUp(x, y, snap),
             drawingsCursor: (x, y) => this.userDrawings?.cursorAt(x, y) ?? null,
             drawingsDblClick: (x, y) => this.userDrawings?.dblClick(x, y) ?? false,

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -52,6 +52,9 @@ export interface InputControllerDeps {
      *  the effective magnet. True when it started (the drawings layer then owns the rest
      *  of the gesture). */
     drawingsMeasureStart?(x: number, y: number, snap: SnapMode): boolean;
+    /** Ctrl/Cmd+press on empty plot: start sweeping a selection box at (x,y). True when it
+     *  started (the drawings layer then owns the rest of the gesture). */
+    drawingsMarqueeStart?(x: number, y: number): boolean;
     /** Middle-click: delete the drawing under the cursor. True when one was removed. */
     drawingsDeleteAt?(x: number, y: number): boolean;
     /** Right-click: cancel/disarm whatever non-persistent tool is active — an in-progress
@@ -59,11 +62,13 @@ export interface InputControllerDeps {
      *  revert to the pointer. True when consumed — the companion contextmenu is then
      *  suppressed. */
     drawingsCancelPlacement?(): boolean;
-    /** A claimed press began. `snap` = effective magnet mode; `shift` = additive (multi-) select. */
-    drawingsPointerDown?(x: number, y: number, snap: SnapMode, shift: boolean): void;
+    /** A claimed press began. `snap` = effective magnet mode; `shift` = additive (multi-) select;
+     *  `mod` = Ctrl/Cmd held (a click toggles the selection, a body drag duplicates). */
+    drawingsPointerDown?(x: number, y: number, snap: SnapMode, shift: boolean, mod: boolean): void;
     /** Pointer moved (forwarded for the placing ghost / drag preview). `snap` = effective magnet
-     *  mode; `shift` = lock a line tool's segment angle to 45° steps. */
-    drawingsPointerMove?(x: number, y: number, snap: SnapMode, shift: boolean): void;
+     *  mode; `shift` = lock a line tool's segment angle to 45° steps; `mod` = Ctrl/Cmd held
+     *  (the cursor is picking a selection — no hover handles). */
+    drawingsPointerMove?(x: number, y: number, snap: SnapMode, shift: boolean, mod: boolean): void;
     /** Cursor to show while hovering the drawings layer (e.g. `'pointer'` over a drawing), or null. */
     drawingsCursor?(x: number, y: number): string | null;
     /** The sticky magnet mode set on the toolbar (off/weak/strong) — Ctrl/Cmd overrides it to strong. */
@@ -322,7 +327,7 @@ export class InputController {
         if (e.repeat || (e.key !== 'Shift' && e.key !== 'Control' && e.key !== 'Meta')) return;
         if (Number.isNaN(this.cursorX)) return; // pointer is not over the chart
         if (this.dragging && this.region !== 'drawing') return; // mid pan/axis gesture — nothing to re-shape
-        this.deps.drawingsPointerMove?.(this.cursorX, this.cursorY, this.snapMode(e), e.shiftKey);
+        this.deps.drawingsPointerMove?.(this.cursorX, this.cursorY, this.snapMode(e), e.shiftKey, e.ctrlKey || e.metaKey);
     };
 
     private local(e: PointerEvent | WheelEvent | MouseEvent): { x: number; y: number } {
@@ -390,13 +395,19 @@ export class InputController {
         // over a drawing/handle it claims the WHOLE gesture (no pan/fling), atomically.
         if (this.deps.drawingsClaim?.(x, y)) {
             this.region = 'drawing';
-            this.deps.drawingsPointerDown?.(x, y, this.snapMode(e), e.shiftKey);
+            this.deps.drawingsPointerDown?.(x, y, this.snapMode(e), e.shiftKey, e.ctrlKey || e.metaKey);
             this.capture(e.pointerId);
             return;
         }
         // Shift+press on the empty plot starts the measure ruler in one gesture (a press
         // over a drawing keeps the additive-select meaning of shift, via the claim above).
         if (e.shiftKey && this.regionAt(x, y) === 'data' && this.deps.drawingsMeasureStart?.(x, y, this.snapMode(e))) {
+            this.region = 'drawing';
+            this.capture(e.pointerId);
+            return;
+        }
+        // Ctrl/Cmd+press on the empty plot sweeps a selection box over the drawings.
+        if ((e.ctrlKey || e.metaKey) && this.regionAt(x, y) === 'data' && this.deps.drawingsMarqueeStart?.(x, y)) {
             this.region = 'drawing';
             this.capture(e.pointerId);
             return;
@@ -533,7 +544,7 @@ export class InputController {
                 this.deps.apply({ barSpacing, rightOffset: this.startRightOffset });
             } else if (this.region === 'drawing') {
                 if (Math.abs(x - this.startX) > slop || Math.abs(y - this.startY) > slop) this.moved = true;
-                this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey);
+                this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey, e.ctrlKey || e.metaKey);
             } else {
                 const coords = this.deps.getCoords();
                 const vp = coords.getViewport();
@@ -563,7 +574,7 @@ export class InputController {
             this.el.style.cursor = drawCursor ?? (r === 'price' ? 'ns-resize' : r === 'time' ? 'ew-resize' : r === 'separator' ? 'row-resize' : '');
             // Forward hover moves so the drawings layer can advance a placing ghost
             // (placing is click-based, so the cursor follow happens with no button down).
-            this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey);
+            this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey, e.ctrlKey || e.metaKey);
         }
         // Hover crosshair is a MOUSE affordance. A touch never hovers: its crosshair
         // comes only from the long-press inspect path (region 'crosshair' above) —

--- a/src/renderers/native/drawings/DrawingHitTester.ts
+++ b/src/renderers/native/drawings/DrawingHitTester.ts
@@ -26,3 +26,24 @@ export function topDrawingAt(
     }
     return null;
 }
+
+/**
+ * What a selection-wide delete removes: a lone selected drawing goes regardless, but inside a
+ * multi-selection a LOCKED drawing is protected — the others go and it stays (selected).
+ */
+export function deletableSelection(selected: Iterable<string>, drawings: readonly Drawing[]): string[] {
+    const ids = [...selected];
+    if (ids.length < 2) return ids;
+    return ids.filter((id) => !drawings.find((d) => d.id === id)?.locked);
+}
+
+/**
+ * What a delete-at-cursor press removes when `hit` is the drawing under it. A hit on a member of
+ * a multi-selection (with `withSelection`) takes the selection's deletable members — even when
+ * the hit itself is locked, so a middle-click on the locked one still clears the rest of the
+ * group. Any other locked hit is protected and nothing is removed.
+ */
+export function deleteTargets(hit: Drawing, selected: ReadonlySet<string>, drawings: readonly Drawing[], withSelection: boolean): string[] {
+    if (withSelection && selected.size >= 2 && selected.has(hit.id)) return deletableSelection(selected, drawings);
+    return hit.locked ? [] : [hit.id];
+}

--- a/src/renderers/native/drawings/DrawingInteraction.ts
+++ b/src/renderers/native/drawings/DrawingInteraction.ts
@@ -197,6 +197,11 @@ export class DrawingInteraction {
         return this.state.kind === 'pressed' && this.state.moved ? this.state.id : null;
     }
 
+    /** The drawing under a press that has not been released yet (drag or click undecided), or null. */
+    pressedId(): string | null {
+        return this.state.kind === 'pressed' ? this.state.id : null;
+    }
+
     /** The copies a Ctrl-drag is moving (transient — not yet in the store), or null. */
     dragClones(): readonly Drawing[] | null {
         return this.state.kind === 'pressed' && this.state.moved && this.state.clones ? this.state.clones.map((c) => c.d) : null;

--- a/src/renderers/native/drawings/DrawingInteraction.ts
+++ b/src/renderers/native/drawings/DrawingInteraction.ts
@@ -1,5 +1,5 @@
 import type { Drawing, DrawingIntent, DrawingPoint, DrawingStyle, DrawingTypeKey, FreeAxis, Projector, SnapMode } from '../../../core/drawings';
-import { createDrawing } from '../../../core/drawings';
+import { createDrawing, deserializeDrawing } from '../../../core/drawings';
 import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
 
 /** Pixels of motion before a press counts as a drag (vs a click → open settings). */
@@ -35,16 +35,59 @@ export interface InteractionDeps {
     lastStyle(): DrawingStyle | undefined;
 }
 
+/** A drawing riding along with a body drag, with its anchors as they were at the press. */
+interface Rider {
+    id: string;
+    orig: DrawingPoint[];
+}
+
+/** A drawing a body drag moves (a source or its transient copy), with the anchors to translate from. */
+interface DragTarget {
+    d: Drawing;
+    orig: DrawingPoint[];
+}
+
+/** An axis-aligned pixel rectangle. */
+export interface PxRect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
 type State =
     | { kind: 'idle' }
     | { kind: 'placing'; draft: Drawing; need: number; cursor: DrawingPoint | null }
-    | { kind: 'pressed'; id: string; handle: number; grab: DrawingPoint; orig: DrawingPoint[]; px: number; py: number; moved: boolean };
+    | {
+          kind: 'pressed';
+          id: string;
+          handle: number;
+          orig: DrawingPoint[];
+          px: number;
+          py: number;
+          moved: boolean;
+          /** The OTHER selected drawings a body drag carries along (a multi-selection moves as one). */
+          riders: Rider[];
+          /** Ctrl/Cmd was held at the press: a click toggles the selection, a body drag moves copies. */
+          mod: boolean;
+          /** The transient copies a Ctrl-drag moves (built at drag start); the sources stay put. */
+          clones: DragTarget[] | null;
+      }
+    /** Ctrl/Cmd-drag on the empty plot: a rubber-band box from the press to the cursor. */
+    | { kind: 'marquee'; x0: number; y0: number; x1: number; y1: number };
 
 /**
  * The single user-drawing interaction state machine: arm → place (click anchors,
  * live ghost) → press a drawing → release-without-moving opens its settings, or
  * drag (whole body / a handle) to move/resize. Built with a deps closure so it is
  * unit-testable without a canvas. `locked` drawings open settings but never drag.
+ *
+ * Modifiers at the press: Shift or Ctrl/Cmd over a drawing make the click a selection
+ * toggle (multi-select); Ctrl/Cmd plus a body drag DUPLICATES — the copies follow the
+ * cursor and are committed on release (`clone` intent), so the drag is one undo step and
+ * cancelling it leaves nothing behind. Ctrl/Cmd-drag on the empty plot sweeps a marquee
+ * that adds the drawings it touches to the selection. A body drag of a drawing that is
+ * part of a multi-selection moves (or copies) the whole selection.
  */
 export class DrawingInteraction {
     private state: State = { kind: 'idle' };
@@ -154,10 +197,31 @@ export class DrawingInteraction {
         return this.state.kind === 'pressed' && this.state.moved ? this.state.id : null;
     }
 
+    /** The copies a Ctrl-drag is moving (transient — not yet in the store), or null. */
+    dragClones(): readonly Drawing[] | null {
+        return this.state.kind === 'pressed' && this.state.moved && this.state.clones ? this.state.clones.map((c) => c.d) : null;
+    }
+
+    /** The marquee box being swept, normalized (or null when none is in progress). */
+    marqueeRect(): PxRect | null {
+        if (this.state.kind !== 'marquee') return null;
+        const { x0, y0, x1, y1 } = this.state;
+        return { x: Math.min(x0, x1), y: Math.min(y0, y1), w: Math.abs(x1 - x0), h: Math.abs(y1 - y0) };
+    }
+
+    /** Ctrl/Cmd-press on the empty plot: start sweeping a selection box. False when a tool is
+     *  armed or a gesture is in flight (that path owns the press). */
+    beginMarquee(x: number, y: number): boolean {
+        if (this.state.kind !== 'idle' || this.deps.activeTool() != null) return false;
+        this.state = { kind: 'marquee', x0: x, y0: y, x1: x, y1: y };
+        return true;
+    }
+
     /** A press: place the next anchor, or grab a drawing/handle (resolved as click or drag on release).
      *  `shift` over a drawing toggles it in/out of the selection (multi-select) instead of dragging;
-     *  while placing a line tool it locks the segment angle to 45° steps. */
-    down(x: number, y: number, mode: SnapMode = 'off', shift = false): void {
+     *  while placing a line tool it locks the segment angle to 45° steps. `mod` (Ctrl/Cmd) over a
+     *  drawing also toggles on a click, but a body drag then moves a COPY. */
+    down(x: number, y: number, mode: SnapMode = 'off', shift = false, mod = false): void {
         const proj = this.deps.projector();
         if (this.state.kind === 'placing') {
             if (this.state.draft.placementMode() !== 'click') return; // drag/freehand finalize on release, not extra clicks
@@ -190,9 +254,57 @@ export class DrawingInteraction {
                 return;
             }
             const handle = hit.hitHandle(x, y, proj, HIT_TOLERANCE); // -1 = body, ≥0 = a handle
-            this.state = { kind: 'pressed', id: hit.id, handle, grab: proj.pxToPoint(x, y, hit.paneId), orig: cloneAnchors(hit), px: x, py: y, moved: false };
+            // A body drag of a SELECTED drawing carries the rest of the selection along; a handle
+            // drag reshapes just the one, and an unselected drawing drags alone.
+            const riders: Rider[] = [];
+            if (handle < 0 && this.deps.selectedIds().has(hit.id)) {
+                for (const id of this.deps.selectedIds()) {
+                    const d = id === hit.id ? null : this.byId(id);
+                    if (d && !d.locked && d.visible) riders.push({ id, orig: cloneAnchors(d) });
+                }
+            }
+            this.state = { kind: 'pressed', id: hit.id, handle, orig: cloneAnchors(hit), px: x, py: y, moved: false, riders, mod, clones: null };
         }
         // empty space → nothing here: the popup self-dismisses + hover already cleared handles.
+    }
+
+    /** The data-space delta a body drag from the press to (x, y) means on `paneId` — resolved per
+     *  pane so drawings riding along on another pane move by the same PIXELS, not the same price. */
+    private bodyDelta(paneId: string, x: number, y: number): { dt: number; dp: number } {
+        if (this.state.kind !== 'pressed') return { dt: 0, dp: 0 };
+        const proj = this.deps.projector();
+        const from = proj.pxToPoint(this.state.px, this.state.py, paneId);
+        const to = proj.pxToPoint(x, y, paneId);
+        return { dt: to.time - from.time, dp: to.price - from.price };
+    }
+
+    /** The pressed drawing and its riders, each with its anchors at the press. */
+    private dragSources(d: Drawing): DragTarget[] {
+        if (this.state.kind !== 'pressed') return [];
+        const out: DragTarget[] = [{ d, orig: this.state.orig }];
+        for (const r of this.state.riders) {
+            const rd = this.byId(r.id);
+            if (rd) out.push({ d: rd, orig: r.orig });
+        }
+        return out;
+    }
+
+    /** Move the pressed drawing's body (and its riders) — or, on a Ctrl-drag, their copies — to the
+     *  cursor. The copies are built on the first move (so a Ctrl-click never creates anything), from
+     *  sources that have not moved yet, so their own anchors are the origin to translate from. */
+    private dragBody(d: Drawing, x: number, y: number): void {
+        if (this.state.kind !== 'pressed') return;
+        this.snapAt = null; // whole-body moves stay smooth (no snap)
+        if (this.state.mod && !this.state.clones) {
+            this.state.clones = this.dragSources(d).flatMap((s) => {
+                const c = deserializeDrawing(s.d.serialize());
+                return c ? [{ d: c, orig: cloneAnchors(c) }] : [];
+            });
+        }
+        for (const t of this.state.clones ?? this.dragSources(d)) {
+            const { dt, dp } = this.bodyDelta(t.d.paneId, x, y);
+            t.d.anchors = t.d.translateBody(dt, dp, t.orig); // a callout pins its tip + moves only the box
+        }
     }
 
     /** Pointer move: advance the placing ghost, or live-preview a drag once past the slop.
@@ -219,12 +331,20 @@ export class DrawingInteraction {
             this.deps.changed();
             return;
         }
+        if (this.state.kind === 'marquee') {
+            this.state.x1 = x;
+            this.state.y1 = y;
+            this.deps.changed();
+            return;
+        }
         if (this.state.kind !== 'pressed') return;
         const d = this.byId(this.state.id);
         if (!d || d.locked) return; // locked → never drags (stays a click)
         if (!this.state.moved && Math.abs(x - this.state.px) <= DRAG_SLOP && Math.abs(y - this.state.py) <= DRAG_SLOP) return;
         this.state.moved = true;
-        if (this.state.handle >= 0) {
+        if (this.state.handle < 0) {
+            this.dragBody(d, x, y);
+        } else {
             const a = d.anchors[this.state.handle]; // a handle snaps to the candle
             if (a) {
                 // Shift on a two-point line re-locks the dragged endpoint's angle around the other one.
@@ -233,12 +353,6 @@ export class DrawingInteraction {
                 applyFree(a, point, d.anchorSchema().slots[this.state.handle]?.free ?? 'both');
             }
             d.constrainHandleDrag(this.state.handle); // e.g. a position flips its reward/stop to stay opposed
-        } else {
-            const pt = this.deps.projector().pxToPoint(x, y, d.paneId); // whole-body move stays smooth (no snap)
-            this.snapAt = null;
-            const dt = pt.time - this.state.grab.time;
-            const dp = pt.price - this.state.grab.price;
-            d.anchors = d.translateBody(dt, dp, this.state.orig); // a callout pins its tip + moves only the box
         }
         this.deps.changed();
     }
@@ -260,16 +374,48 @@ export class DrawingInteraction {
             }
             return; // click placement: releasing a click adds nothing (the press already placed the anchor)
         }
+        if (this.state.kind === 'marquee') {
+            const rect = this.marqueeRect()!;
+            this.state = { kind: 'idle' };
+            if (rect.w > DRAG_SLOP || rect.h > DRAG_SLOP) this.selectWithin(rect);
+            this.deps.changed();
+            return;
+        }
         if (this.state.kind !== 'pressed') return;
-        const { id, moved } = this.state;
+        const { id, moved, riders, mod, clones } = this.state;
         this.state = { kind: 'idle' };
         const d = this.byId(id);
-        if (moved) {
-            if (d) this.deps.emit({ kind: 'edit', doc: d.serialize() });
-            this.deps.changed();
-        } else {
-            this.deps.openSettings(id, x, y); // a click opens the settings popup
+        if (!moved) {
+            // A click: Ctrl/Cmd toggles the drawing in/out of the selection; plain opens its settings.
+            if (mod) this.deps.emit({ kind: 'select', ids: [id], additive: true });
+            else this.deps.openSettings(id, x, y);
+            return;
         }
+        if (clones) {
+            this.deps.emit({ kind: 'clone', docs: clones.map((c) => c.d.serialize()) });
+        } else if (d) {
+            const docs = [d.serialize()];
+            for (const r of riders) {
+                const rd = this.byId(r.id);
+                if (rd) docs.push(rd.serialize());
+            }
+            if (docs.length > 1) this.deps.emit({ kind: 'edit-many', docs });
+            else this.deps.emit({ kind: 'edit', doc: docs[0]! });
+        }
+        this.deps.changed();
+    }
+
+    /** Add every visible drawing whose on-screen bounds touch `rect` to the selection (a union,
+     *  so successive sweeps accumulate). No change when the box touches nothing new. */
+    private selectWithin(rect: PxRect): void {
+        const proj = this.deps.projector();
+        const ids = [...this.deps.selectedIds()];
+        for (const d of this.deps.drawings()) {
+            if (!d.visible || ids.includes(d.id)) continue;
+            const b = d.bounds(proj);
+            if (b && rectsIntersect(rect, b)) ids.push(d.id);
+        }
+        if (ids.length > this.deps.selectedIds().size) this.deps.emit({ kind: 'select', ids });
     }
 
     /** Cancel an in-progress placement or drag (Escape). Returns whether anything was cancelled. */
@@ -283,8 +429,16 @@ export class DrawingInteraction {
             return true;
         }
         if (this.state.kind === 'pressed') {
-            const d = this.byId(this.state.id);
-            if (d && this.state.moved) d.anchors = this.state.orig.map((o) => ({ time: o.time, price: o.price }));
+            // A Ctrl-drag moved copies only — dropping them is the whole rollback.
+            if (this.state.moved && !this.state.clones) {
+                const d = this.byId(this.state.id);
+                if (d) for (const s of this.dragSources(d)) s.d.anchors = s.orig.map((o) => ({ time: o.time, price: o.price }));
+            }
+            this.state = { kind: 'idle' };
+            this.deps.changed();
+            return true;
+        }
+        if (this.state.kind === 'marquee') {
             this.state = { kind: 'idle' };
             this.deps.changed();
             return true;
@@ -413,6 +567,11 @@ export class DrawingInteraction {
 
 function cloneAnchors(d: Drawing): DrawingPoint[] {
     return d.anchors.map((a) => ({ time: a.time, price: a.price }));
+}
+
+/** Closed-interval overlap, so a zero-thickness bound (a horizontal line's) still counts. */
+function rectsIntersect(a: PxRect, b: PxRect): boolean {
+    return a.x <= b.x + b.w && b.x <= a.x + a.w && a.y <= b.y + b.h && b.y <= a.y + a.h;
 }
 
 /** Move an anchor toward `pt`, honoring which axes its handle is free to move along. */

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -168,6 +168,19 @@ export class DrawingPainter {
         this.paintHandles(ctx, pts);
     }
 
+    /** The selection box a Ctrl/Cmd-drag on the empty plot sweeps: a faint fill in the handle
+     *  accent under a thin dashed outline. */
+    paintMarquee(ctx: CanvasRenderingContext2D, rect: { x: number; y: number; w: number; h: number }): void {
+        ctx.save();
+        ctx.fillStyle = withAlpha(HANDLE_BORDER, 0.08);
+        ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+        ctx.strokeStyle = HANDLE_BORDER;
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 3]);
+        ctx.strokeRect(rect.x + 0.5, rect.y + 0.5, rect.w, rect.h);
+        ctx.restore();
+    }
+
     /** A hollow ring marking the candle point the magnet (Ctrl) will snap the next anchor to. */
     paintSnapRing(ctx: CanvasRenderingContext2D, x: number, y: number, theme: VelaTheme): void {
         ctx.setLineDash([]);

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -29,17 +29,47 @@ import { DrawingSettingsDialog } from './DrawingSettingsDialog';
 /** A `{ path: value }` patch emitted as the user edits a control. */
 export type SettingsPatch = Record<string, unknown>;
 
-/** The actions a settings popup can invoke (wired by the controller to intents). */
+/** The actions a settings popup can invoke (wired by the controller to intents). With several
+ *  drawings selected every action applies to all of them. */
 export interface SettingsActions {
-    /** The current live instance (sync rebuilds instances, so panels re-read through this). */
+    /** The current live PRIMARY instance (sync rebuilds instances, so panels re-read through this). */
     resolve(): Drawing | null;
     patch(p: SettingsPatch): void;
     setLocked(v: boolean): void;
     reorder(to: 'front' | 'back'): void;
+    /** Clone the drawing(s) in place (the copies become the selection). */
+    duplicate(): void;
     resetSettings(): void;
     remove(): void;
     /** Restore a serialized snapshot (Cancel in the settings dialog). */
     restore?(doc: SerializedDrawing): void;
+}
+
+/** The value of a control whose drawings disagree — the bar shows it as "mixed" and the first
+ *  edit unifies them. */
+export const MIXED: unique symbol = Symbol('mixed');
+export type Mixed = typeof MIXED;
+
+/** The settings paths every one of `drawings` supports — what a multi-selection bar can edit. */
+export function sharedPaths(drawings: readonly Drawing[]): Set<string> {
+    const [first, ...rest] = drawings;
+    const paths = new Set(first?.schema().fields.map((f) => f.path) ?? []);
+    for (const d of rest) {
+        const own = new Set(d.schema().fields.map((f) => f.path));
+        for (const p of paths) if (!own.has(p)) paths.delete(p);
+    }
+    return paths;
+}
+
+/** One value read off every drawing: the shared value when they all agree, else {@link MIXED}. */
+export function commonValue<T>(drawings: readonly Drawing[], read: (d: Drawing) => T): T | Mixed {
+    const first = read(drawings[0]!);
+    return drawings.every((d) => read(d) === first) ? first : MIXED;
+}
+
+/** The distinct values a mixed control spans (first-seen order) — the "in use" shortcuts. */
+function distinctValues<T>(drawings: readonly Drawing[], read: (d: Drawing) => T): T[] {
+    return [...new Set(drawings.map(read))];
 }
 
 /** The drawing's pixel bounding box, so the toolbar floats clear of it (not over it). */
@@ -53,7 +83,7 @@ export interface PopupAnchor {
 const BTN = 30; // icon-button side (px)
 const ICON = 21; // icon glyph side (px)
 const STYLE_ID = 'vela-drawing-popup-styles';
-const STYLE_REV = '3';
+const STYLE_REV = '4';
 
 /** Inject the scoped styles that inline cssText can't reach (`:focus`, scrollbar
  *  pseudo-elements). Idempotent — one shared sheet for all popups. */
@@ -68,6 +98,8 @@ function ensureStyles(): void {
 .vela-dpop-btn{background:transparent;color:var(--vela-fg-muted);transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
 .vela-dpop-btn:hover{background:var(--vela-hover-strong);color:var(--vela-fg-bright);}
 .vela-dpop-btn[data-active='1']{background:var(--vela-active);color:var(--vela-fg-bright);}
+/* Mixed (a multi-selection disagrees): the active fill at half strength behind a dashed ring. */
+.vela-dpop-btn[data-active='mixed']{background:var(--vela-hover-strong);color:var(--vela-fg-bright);outline:1px dashed var(--vela-fg-muted);outline-offset:-2px;}
 .vela-dpop-item{background:transparent;transition:background var(--vela-dur-fast) ease;}
 .vela-dpop-item:hover{background:var(--vela-hover-strong);}
 .vela-dpop-item[data-active='1']{background:var(--vela-active);}
@@ -96,7 +128,7 @@ export class DrawingSettingsPopup {
     private menuPop: Popover | null = null;
     private menuOwner: HTMLElement | null = null;
     private theme: VelaTheme;
-    private onClose: (() => void) | null = null;
+    private onClose: ((e?: PointerEvent) => void) | null = null;
 
     constructor(
         private readonly host: HTMLElement,
@@ -132,18 +164,32 @@ export class DrawingSettingsPopup {
         return node != null && (this.isOwnChrome(node) || this.settingsDialog.contains(node));
     }
 
-    /** Open the quick toolbar for `drawing`, floating clear of its `anchor` box.
-     *  `onClose` fires on an outside-click dismissal (not a programmatic close). */
-    open(drawing: Drawing, anchor: PopupAnchor | null, actions: SettingsActions, onClose?: () => void): void {
+    /** Open the quick toolbar for `drawings` (one, or a whole multi-selection), floating clear of
+     *  their `anchor` box. With several drawings the bar shows only the controls they ALL support,
+     *  a control whose values differ reads as mixed, and every edit applies to all of them —
+     *  per-drawing panels (levels, position sizing, the text field) stay single-drawing only.
+     *  `onClose` fires on a dismissal (an outside press, or Escape in the text field — not a
+     *  programmatic close), with the dismissing press when there is one, so the caller can tell a
+     *  modifier press (multi-select) from a plain one. */
+    open(drawings: readonly Drawing[], anchor: PopupAnchor | null, actions: SettingsActions, onClose?: (e?: PointerEvent) => void): void {
         this.close();
+        const drawing = drawings[0];
+        if (!drawing) return;
         ensureStyles();
         this.onClose = onClose ?? null;
         const t = this.theme;
+        const multi = drawings.length > 1;
         const schema = drawing.schema();
-        const paths = new Set(schema.fields.map((f) => f.path));
+        const paths = sharedPaths(drawings);
+        const common = <T>(read: (d: Drawing) => T): T | Mixed => commonValue(drawings, read);
+        const every = (pred: (d: Drawing) => boolean): boolean => drawings.every(pred);
+        /** A color swatch over the drawings: shared color, or striped with the colors in use. */
+        const swatch = (tip: string, glyph: string, read: (d: Drawing) => string, path: string, iconSize?: number): HTMLButtonElement =>
+            this.colorButton(tip, glyph, common(read), (v) => actions.patch({ [path]: v }), iconSize, distinctValues(drawings, read));
         // Text-first annotations (and computed labels) wear their text controls on the bar; on a
-        // shape that merely CAN carry a label they stay beside the label field.
-        const textOnBar = schema.textIsContent === true || !paths.has('text.value');
+        // shape that merely CAN carry a label they stay beside the label field — and a
+        // multi-selection has no label field, so its text styling always sits on the bar.
+        const textOnBar = multi || schema.textIsContent === true || !paths.has('text.value');
 
         const el = document.createElement('div');
         el.className = 'vela-dpop';
@@ -166,92 +212,96 @@ export class DrawingSettingsPopup {
         bar.appendChild(this.dragHandle());
 
         if (paths.has('glyph')) {
-            const cur = (drawing as unknown as { glyph?: string }).glyph ?? GLYPH_OPTIONS[0];
+            const cur = common((d) => (d as unknown as { glyph?: string }).glyph ?? GLYPH_OPTIONS[0]!);
             bar.appendChild(this.dropdown('Icon', GLYPH_OPTIONS, cur, (g) => glyphIcon(g), (v) => actions.patch({ glyph: v })));
         }
         if (paths.has('size')) {
-            const sz = (drawing as unknown as { size?: string }).size ?? 'normal';
+            const sz = common((d) => (d as unknown as { size?: string }).size ?? 'normal');
             bar.appendChild(this.dropdown('Icon size', STAMP_SIZE_OPTIONS, sz, (s) => stampSizeIcon(s), (v) => actions.patch({ size: v }), { label: sizeLabel }));
         }
         // Magnifier: the lower-timeframe pick is the tool's one behavior control — it leads the
         // bar (text-only: the label IS the glyph); the inset candles' up/down colors ride along.
         // Only timeframes strictly below the chart's are offered; unset colors show the theme's
         // series colors (the inset follows the chart series until the user recolors it).
-        if (paths.has('magnifier.timeframe') && drawing instanceof Magnifier) {
+        if (paths.has('magnifier.timeframe') && every((d) => d instanceof Magnifier)) {
+            const mag = (d: Drawing): Magnifier => d as Magnifier;
             const options = this.lowerTimeframeOptions();
             if (options.length > 0) {
                 bar.appendChild(
-                    this.dropdown('Lower timeframe', options.map((o) => o.value), drawing.magnifier.timeframe, () => '', (v) => actions.patch({ 'magnifier.timeframe': v }), {
+                    this.dropdown('Lower timeframe', options.map((o) => o.value), common((d) => mag(d).magnifier.timeframe), () => '', (v) => actions.patch({ 'magnifier.timeframe': v }), {
                         label: (v) => magnifierTimeframeLabel(String(v)),
                         labelInTrigger: true,
                     }),
                 );
             }
-            bar.appendChild(this.colorButton('Up candles', BUCKET_ICON, drawing.magnifier.upColor || t.upColor, (v) => actions.patch({ 'magnifier.upColor': v })));
-            bar.appendChild(this.colorButton('Down candles', BUCKET_ICON, drawing.magnifier.downColor || t.downColor, (v) => actions.patch({ 'magnifier.downColor': v })));
+            bar.appendChild(swatch('Up candles', BUCKET_ICON, (d) => mag(d).magnifier.upColor || t.upColor, 'magnifier.upColor'));
+            bar.appendChild(swatch('Down candles', BUCKET_ICON, (d) => mag(d).magnifier.downColor || t.downColor, 'magnifier.downColor'));
         }
         // The magnifier's unset border means the theme's contrast ink — the swatch shows that
         // effective color (same idea as effectiveFillColor below), not the generic blue default.
-        if (paths.has('style.lineColor')) bar.appendChild(this.colorButton('Line color', BRUSH_ICON, drawing.style.lineColor || (drawing instanceof Magnifier ? contrastColor(this.theme.background) : DEFAULT_DRAWING_COLOR), (v) => actions.patch({ 'style.lineColor': v })));
+        if (paths.has('style.lineColor')) bar.appendChild(swatch('Line color', BRUSH_ICON, (d) => d.style.lineColor || (d instanceof Magnifier ? contrastColor(this.theme.background) : DEFAULT_DRAWING_COLOR), 'style.lineColor'));
         if (paths.has('style.lineWidth')) {
             // A marker-width field (floor above the hairline ladder, e.g. the
             // highlighter's 4–60) can't live in the 1–4 dropdown — a free numeric
             // input honoring the schema's declared range replaces it.
             const wf = schema.fields.find((f) => f.path === 'style.lineWidth');
+            const width = common((d) => d.style.lineWidth);
             if (wf?.kind === 'number' && (wf.min ?? 1) > 1) {
-                bar.appendChild(this.widthInput('Line width', drawing.style.lineWidth, wf.min ?? 1, wf.max ?? 60, wf.step ?? 1, (v) => actions.patch({ 'style.lineWidth': v })));
+                bar.appendChild(this.widthInput('Line width', width, wf.min ?? 1, wf.max ?? 60, wf.step ?? 1, (v) => actions.patch({ 'style.lineWidth': v })));
             } else {
-                bar.appendChild(this.dropdown('Line width', [1, 2, 3, 4], drawing.style.lineWidth, (w) => lineIcon(w, 'solid'), (v) => actions.patch({ 'style.lineWidth': v }), { label: (v) => `${v}px`, labelInTrigger: true }));
+                bar.appendChild(this.dropdown('Line width', [1, 2, 3, 4], width, (w) => lineIcon(w, 'solid'), (v) => actions.patch({ 'style.lineWidth': v }), { label: (v) => `${v}px`, labelInTrigger: true }));
             }
         }
-        if (paths.has('style.lineStyle')) bar.appendChild(this.dropdown('Line style', LINE_STYLE_OPTIONS.map((o) => o.value), drawing.style.lineStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'style.lineStyle': v }), { label: styleLabel }));
+        if (paths.has('style.lineStyle')) bar.appendChild(this.dropdown('Line style', LINE_STYLE_OPTIONS.map((o) => o.value), common((d) => d.style.lineStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'style.lineStyle': v }), { label: styleLabel }));
         // initialize the Fill swatch to the color actually painted (validity tint / line-color wash /
         // background fallback), not a stale default — same source the renderer fills with.
-        if (paths.has('style.fillColor')) bar.appendChild(this.colorButton('Fill', BUCKET_ICON, effectiveFillColor(drawing, this.theme) ?? drawing.style.fillColor ?? DEFAULT_DRAWING_COLOR, (v) => actions.patch({ 'style.fillColor': v })));
+        if (paths.has('style.fillColor')) bar.appendChild(swatch('Fill', BUCKET_ICON, (d) => effectiveFillColor(d, this.theme) ?? d.style.fillColor ?? DEFAULT_DRAWING_COLOR, 'style.fillColor'));
         // Fixed-range VP: all settings live in the gear panel (nothing inline on the quick bar).
         const isFrvp = paths.has('frvp.rows') && drawing instanceof FixedRangeVolumeProfile;
         // Position tool: zone colors sit on the bar; risk/reward numbers + display toggles live
         // in the gear panel (they drive the loss/size labels).
-        const isPosition = paths.has('riskPercent') && drawing instanceof PositionTool;
+        const isPosition = paths.has('riskPercent') && every((d) => d instanceof PositionTool);
         if (isPosition) {
-            const pos = drawing as PositionTool;
-            bar.appendChild(this.colorButton('Profit zone', BUCKET_ICON, pos.profitColor, (v) => actions.patch({ profitColor: v })));
-            bar.appendChild(this.colorButton('Loss zone', BUCKET_ICON, pos.lossColor, (v) => actions.patch({ lossColor: v })));
+            const pos = (d: Drawing): PositionTool => d as PositionTool;
+            bar.appendChild(swatch('Profit zone', BUCKET_ICON, (d) => pos(d).profitColor, 'profitColor'));
+            bar.appendChild(swatch('Loss zone', BUCKET_ICON, (d) => pos(d).lossColor, 'lossColor'));
         }
         // Regression channel: per-line color + style, the two area fills, and the R² toggle.
-        const reg = (drawing as unknown as { reg?: RegressionStyle }).reg;
-        if (paths.has('reg.midColor') && reg) {
+        const regOf = (d: Drawing): RegressionStyle | undefined => (d as unknown as { reg?: RegressionStyle }).reg;
+        if (paths.has('reg.midColor') && every((d) => regOf(d) != null)) {
+            const reg = (d: Drawing): RegressionStyle => regOf(d)!;
             const styles = LINE_STYLE_OPTIONS.map((o) => o.value);
-            bar.appendChild(this.colorButton('Midline color', BRUSH_ICON, reg.midColor, (v) => actions.patch({ 'reg.midColor': v })));
-            bar.appendChild(this.dropdown('Midline style', styles, reg.midStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.midStyle': v }), { label: styleLabel }));
-            bar.appendChild(this.colorButton('Upper line color', BRUSH_ICON, reg.upperColor, (v) => actions.patch({ 'reg.upperColor': v })));
-            bar.appendChild(this.dropdown('Upper line style', styles, reg.upperStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.upperStyle': v }), { label: styleLabel }));
-            bar.appendChild(this.colorButton('Lower line color', BRUSH_ICON, reg.lowerColor, (v) => actions.patch({ 'reg.lowerColor': v })));
-            bar.appendChild(this.dropdown('Lower line style', styles, reg.lowerStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.lowerStyle': v }), { label: styleLabel }));
-            bar.appendChild(this.colorButton('Upper fill', BUCKET_ICON, reg.upperFill, (v) => actions.patch({ 'reg.upperFill': v })));
-            bar.appendChild(this.colorButton('Lower fill', BUCKET_ICON, reg.lowerFill, (v) => actions.patch({ 'reg.lowerFill': v })));
-            bar.appendChild(this.toggle('Show R²', R2_ICON, reg.showR2, (v) => actions.patch({ 'reg.showR2': v })));
+            bar.appendChild(swatch('Midline color', BRUSH_ICON, (d) => reg(d).midColor, 'reg.midColor'));
+            bar.appendChild(this.dropdown('Midline style', styles, common((d) => reg(d).midStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.midStyle': v }), { label: styleLabel }));
+            bar.appendChild(swatch('Upper line color', BRUSH_ICON, (d) => reg(d).upperColor, 'reg.upperColor'));
+            bar.appendChild(this.dropdown('Upper line style', styles, common((d) => reg(d).upperStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.upperStyle': v }), { label: styleLabel }));
+            bar.appendChild(swatch('Lower line color', BRUSH_ICON, (d) => reg(d).lowerColor, 'reg.lowerColor'));
+            bar.appendChild(this.dropdown('Lower line style', styles, common((d) => reg(d).lowerStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.lowerStyle': v }), { label: styleLabel }));
+            bar.appendChild(swatch('Upper fill', BUCKET_ICON, (d) => reg(d).upperFill, 'reg.upperFill'));
+            bar.appendChild(swatch('Lower fill', BUCKET_ICON, (d) => reg(d).lowerFill, 'reg.lowerFill'));
+            bar.appendChild(this.toggle('Show R²', R2_ICON, common((d) => reg(d).showR2), (v) => actions.patch({ 'reg.showR2': v })));
         }
         // Anchored VWAP: midline color + style, band σ-multiplier, the two band-line colors, and the fill.
-        const vwap = (drawing as unknown as { vwap?: VwapStyle }).vwap;
-        if (paths.has('vwap.midColor') && vwap) {
+        const vwapOf = (d: Drawing): VwapStyle | undefined => (d as unknown as { vwap?: VwapStyle }).vwap;
+        if (paths.has('vwap.midColor') && every((d) => vwapOf(d) != null)) {
+            const vwap = (d: Drawing): VwapStyle => vwapOf(d)!;
             const styles = LINE_STYLE_OPTIONS.map((o) => o.value);
             const MULTS = [0.5, 1, 1.5, 2, 2.5, 3, 4, 5];
-            bar.appendChild(this.colorButton('VWAP color', BRUSH_ICON, vwap.midColor, (v) => actions.patch({ 'vwap.midColor': v })));
-            bar.appendChild(this.dropdown('VWAP style', styles, vwap.midStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'vwap.midStyle': v }), { label: styleLabel }));
+            bar.appendChild(swatch('VWAP color', BRUSH_ICON, (d) => vwap(d).midColor, 'vwap.midColor'));
+            bar.appendChild(this.dropdown('VWAP style', styles, common((d) => vwap(d).midStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'vwap.midStyle': v }), { label: styleLabel }));
             bar.appendChild(
-                this.dropdown('Band multiplier', MULTS, vwap.multiplier, () => BANDS_ICON, (v) => actions.patch({ 'vwap.multiplier': v }), {
+                this.dropdown('Band multiplier', MULTS, common((d) => vwap(d).multiplier), () => BANDS_ICON, (v) => actions.patch({ 'vwap.multiplier': v }), {
                     label: (v) => `${v}σ`,
                     labelInTrigger: true,
                 }),
             );
-            bar.appendChild(this.colorButton('Upper band color', BRUSH_ICON, vwap.upperColor, (v) => actions.patch({ 'vwap.upperColor': v })));
-            bar.appendChild(this.colorButton('Lower band color', BRUSH_ICON, vwap.lowerColor, (v) => actions.patch({ 'vwap.lowerColor': v })));
-            bar.appendChild(this.colorButton('Band fill', BUCKET_ICON, vwap.bandFill, (v) => actions.patch({ 'vwap.bandFill': v })));
+            bar.appendChild(swatch('Upper band color', BRUSH_ICON, (d) => vwap(d).upperColor, 'vwap.upperColor'));
+            bar.appendChild(swatch('Lower band color', BRUSH_ICON, (d) => vwap(d).lowerColor, 'vwap.lowerColor'));
+            bar.appendChild(swatch('Band fill', BUCKET_ICON, (d) => vwap(d).bandFill, 'vwap.bandFill'));
         }
         // Dedekind tessellation: max circle curvature (tessellation density).
         if (paths.has('maxCurvature')) {
-            const cur = (drawing as unknown as { maxCurvature?: number }).maxCurvature ?? 24;
+            const cur = common((d) => (d as unknown as { maxCurvature?: number }).maxCurvature ?? 24);
             bar.appendChild(
                 this.dropdown('Max curvature', DEDEKIND_CURVATURE_OPTIONS, cur, () => DEDEKIND_ICON, (v) => actions.patch({ maxCurvature: v }), {
                     label: (v) => `n=${v}`,
@@ -261,7 +311,7 @@ export class DrawingSettingsPopup {
         }
         // Mach figures: wave count + (supersonic) Mach number.
         if (paths.has('mach')) {
-            const cur = (drawing as unknown as { mach?: number }).mach ?? 2;
+            const cur = common((d) => (d as unknown as { mach?: number }).mach ?? 2);
             bar.appendChild(
                 this.dropdown('Mach number', MACH_NUMBER_OPTIONS, cur, () => SUPERSONIC_ICON, (v) => actions.patch({ mach: v }), {
                     label: (v) => `M=${v}`,
@@ -270,7 +320,7 @@ export class DrawingSettingsPopup {
             );
         }
         if (paths.has('waveCount')) {
-            const cur = (drawing as unknown as { waveCount?: number }).waveCount ?? 6;
+            const cur = common((d) => (d as unknown as { waveCount?: number }).waveCount ?? 6);
             bar.appendChild(
                 this.dropdown('Waves', MACH_WAVE_COUNT_OPTIONS, cur, () => SONIC_ICON, (v) => actions.patch({ waveCount: v }), {
                     label: (v) => `${v}`,
@@ -279,30 +329,33 @@ export class DrawingSettingsPopup {
             );
         }
         // Range toggles + computed-label text styling (drawings whose label is computed, not typed).
-        const toggles = drawing as unknown as { showPrice?: boolean; showDate?: boolean };
-        if (paths.has('showPrice')) bar.appendChild(this.toggle('Show price', PRICE_DELTA_ICON, toggles.showPrice !== false, (v) => actions.patch({ showPrice: v })));
-        if (paths.has('showDate')) bar.appendChild(this.toggle('Show date', DATE_DELTA_ICON, toggles.showDate !== false, (v) => actions.patch({ showDate: v })));
-        if (paths.has('text.color') && textOnBar) bar.appendChild(this.colorButton('Text color', TYPE_ICON, drawing.text?.color || t.textColor, (v) => actions.patch({ 'text.color': v })));
-        if (paths.has('text.size') && textOnBar) bar.appendChild(this.dropdown('Text size', TEXT_SIZE_OPTIONS.map((o) => o.value), drawing.text?.size ?? 'normal', (s) => labelSizeIcon(s), (v) => actions.patch({ 'text.size': v }), { label: sizeLabel }));
-        // Bold/italic live under the text field; a computed label has no field, so they go on the bar.
-        if (paths.has('text.bold') && !paths.has('text.value')) bar.appendChild(this.toggle('Bold', BOLD_ICON, !!drawing.text?.bold, (v) => actions.patch({ 'text.bold': v })));
-        if (paths.has('text.italic') && !paths.has('text.value')) bar.appendChild(this.toggle('Italic', ITALIC_ICON, !!drawing.text?.italic, (v) => actions.patch({ 'text.italic': v })));
-        if (paths.has('text.value')) bar.appendChild(this.iconBtn('Text', TYPE_ICON, () => this.toggleTextPanel(drawing, actions, !textOnBar)));
+        const flags = (d: Drawing): { showPrice?: boolean; showDate?: boolean } => d as unknown as { showPrice?: boolean; showDate?: boolean };
+        if (paths.has('showPrice')) bar.appendChild(this.toggle('Show price', PRICE_DELTA_ICON, common((d) => flags(d).showPrice !== false), (v) => actions.patch({ showPrice: v })));
+        if (paths.has('showDate')) bar.appendChild(this.toggle('Show date', DATE_DELTA_ICON, common((d) => flags(d).showDate !== false), (v) => actions.patch({ showDate: v })));
+        if (paths.has('text.color') && textOnBar) bar.appendChild(swatch('Text color', TYPE_ICON, (d) => d.text?.color || t.textColor, 'text.color'));
+        if (paths.has('text.size') && textOnBar) bar.appendChild(this.dropdown('Text size', TEXT_SIZE_OPTIONS.map((o) => o.value), common((d) => d.text?.size ?? 'normal'), (s) => labelSizeIcon(s), (v) => actions.patch({ 'text.size': v }), { label: sizeLabel }));
+        // Bold/italic live under the text field; a computed label has no field (nor does a
+        // multi-selection), so they go on the bar.
+        const textField = !multi && paths.has('text.value');
+        if (paths.has('text.bold') && !textField) bar.appendChild(this.toggle('Bold', BOLD_ICON, common((d) => !!d.text?.bold), (v) => actions.patch({ 'text.bold': v })));
+        if (paths.has('text.italic') && !textField) bar.appendChild(this.toggle('Italic', ITALIC_ICON, common((d) => !!d.text?.italic), (v) => actions.patch({ 'text.italic': v })));
+        if (textField) bar.appendChild(this.iconBtn('Text', TYPE_ICON, () => this.toggleTextPanel(drawing, actions, !textOnBar)));
         const editableLevels = drawing.editableLevels();
-        if (editableLevels && !(drawing instanceof MachFigure)) {
-            const fib = drawing as unknown as { numbersSize?: string; labelsSize?: string };
+        if (editableLevels && every((d) => d.editableLevels() != null && !(d instanceof MachFigure))) {
+            const fib = (d: Drawing): { numbersSize?: string; labelsSize?: string } => d as unknown as { numbersSize?: string; labelsSize?: string };
             const sizes = TEXT_SIZE_OPTIONS.map((o) => o.value);
-            bar.appendChild(this.dropdown('Numbers size', sizes, fib.numbersSize ?? 'small', (s) => numbersSizeIcon(s), (v) => actions.patch({ numbersSize: v }), { label: sizeLabel }));
-            bar.appendChild(this.dropdown('Label size', sizes, fib.labelsSize ?? 'normal', (s) => labelSizeIcon(s), (v) => actions.patch({ labelsSize: v }), { label: sizeLabel }));
+            bar.appendChild(this.dropdown('Numbers size', sizes, common((d) => fib(d).numbersSize ?? 'small'), (s) => numbersSizeIcon(s), (v) => actions.patch({ numbersSize: v }), { label: sizeLabel }));
+            bar.appendChild(this.dropdown('Label size', sizes, common((d) => fib(d).labelsSize ?? 'normal'), (s) => labelSizeIcon(s), (v) => actions.patch({ labelsSize: v }), { label: sizeLabel }));
         }
 
         // Trailing group: settings wheel (when the tool has one) sits just left of the lock,
-        // and a kebab overflow (z-order + reset) sits just right of delete.
+        // and a kebab overflow (z-order + reset) sits just right of delete. The gear panels edit
+        // one drawing's own data (levels, sizing, profile rows) — they stay off a multi-selection.
         bar.appendChild(this.divider());
-        if (isFrvp) bar.appendChild(this.iconBtn('Settings', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'frvp')));
-        if (isPosition) bar.appendChild(this.iconBtn('Position size', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'position')));
-        if (editableLevels) bar.appendChild(this.iconBtn('Levels', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'levels')));
-        bar.appendChild(this.toggle('Lock', LOCK_ICON, drawing.locked, (v) => actions.setLocked(v)));
+        if (!multi && isFrvp) bar.appendChild(this.iconBtn('Settings', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'frvp')));
+        if (!multi && isPosition) bar.appendChild(this.iconBtn('Position size', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'position')));
+        if (!multi && editableLevels) bar.appendChild(this.iconBtn('Levels', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'levels')));
+        bar.appendChild(this.toggle('Lock', LOCK_ICON, common((d) => d.locked), (v) => actions.setLocked(v)));
         const del = this.iconBtn('Delete', TRASH_ICON, () => actions.remove());
         del.style.color = 'var(--vela-danger)';
         bar.appendChild(del);
@@ -350,7 +403,7 @@ export class DrawingSettingsPopup {
         if (this.isOwnChrome(node)) return;
         const cb = this.onClose;
         this.close();
-        cb?.();
+        cb?.(e as PointerEvent);
     };
 
     /** Bar, host-floated shells, and kit popovers (select list / color chip) portaled into `host`. */
@@ -526,7 +579,7 @@ export class DrawingSettingsPopup {
         return b;
     }
 
-    /** The trailing kebab overflow — z-order actions + reset settings. */
+    /** The trailing kebab overflow — duplicate, z-order actions, reset settings. */
     private kebabButton(actions: SettingsActions): HTMLButtonElement {
         const b = this.base('More');
         b.innerHTML = sized(KEBAB_ICON);
@@ -540,6 +593,7 @@ export class DrawingSettingsPopup {
                 return;
             }
             this.openActionMenu(b, [
+                { icon: CLONE_ICON, label: 'Duplicate', onClick: () => actions.duplicate() },
                 { icon: FRONT_ICON, label: 'Bring to front', onClick: () => actions.reorder('front') },
                 { icon: BACK_ICON, label: 'Send to back', onClick: () => actions.reorder('back') },
                 { icon: RESET_ICON, label: 'Reset settings', onClick: () => actions.resetSettings() },
@@ -699,17 +753,19 @@ export class DrawingSettingsPopup {
         this.tipEl = null;
     }
 
-    private toggle(tip: string, icon: string, active: boolean, onChange: (v: boolean) => void): HTMLButtonElement {
+    /** An on/off button. A mixed state (the selected drawings disagree) reads as half-lit and
+     *  the first click turns it ON for all of them. */
+    private toggle(tip: string, icon: string, active: boolean | Mixed, onChange: (v: boolean) => void): HTMLButtonElement {
         const b = this.base(tip);
         b.innerHTML = sized(icon);
-        // `data-active` alone drives the fill — the stylesheet owns idle/hover/active.
-        const set = (on: boolean): void => {
-            b.dataset.active = on ? '1' : '0';
+        // `data-active` alone drives the fill — the stylesheet owns idle/hover/active/mixed.
+        const set = (on: boolean | Mixed): void => {
+            b.dataset.active = on === MIXED ? 'mixed' : on ? '1' : '0';
         };
         set(active);
         let on = active;
         b.addEventListener('click', () => {
-            on = !on;
+            on = on === MIXED ? true : !on;
             set(on);
             onChange(on);
         });
@@ -717,10 +773,11 @@ export class DrawingSettingsPopup {
     }
 
     /** An inline numeric width field for tools whose stroke range outgrows the 1–4px
-     *  ladder — the value is clamped to the schema's declared min/max on commit. */
-    private widthInput(tip: string, value: number, min: number, max: number, step: number, onChange: (v: number) => void): HTMLElement {
+     *  ladder — the value is clamped to the schema's declared min/max on commit. A mixed
+     *  value shows an empty field with a dash until a number is typed for all. */
+    private widthInput(tip: string, value: number | Mixed, min: number, max: number, step: number, onChange: (v: number) => void): HTMLElement {
         const ni = new NumberInput({
-            value,
+            value: value === MIXED ? min : value,
             min,
             max,
             step,
@@ -732,6 +789,10 @@ export class DrawingSettingsPopup {
             title: tip,
             onChange,
         });
+        if (value === MIXED) {
+            ni.input.value = '';
+            ni.input.placeholder = '—';
+        }
         ni.el.dataset.tip = tip;
         trapChartKeys(ni.el);
         return ni.el;
@@ -739,11 +800,12 @@ export class DrawingSettingsPopup {
 
     /** A pick-one dropdown: the trigger shows the current value's glyph (plus an optional inline
      *  text label — e.g. `2px` — for controls that would otherwise look alike), and clicking it
-     *  opens a floating list of every option so a value is one click away (no cycling through). */
+     *  opens a floating list of every option so a value is one click away (no cycling through).
+     *  A mixed value shows a dash in the trigger and highlights no row. */
     private dropdown(
         tip: string,
         values: readonly (string | number)[],
-        current: string | number,
+        current: string | number | Mixed,
         render: (v: string | number) => string,
         onChange: (v: string | number) => void,
         opts: { label?: (v: string | number) => string; labelInTrigger?: boolean } = {},
@@ -754,9 +816,15 @@ export class DrawingSettingsPopup {
         b.style.padding = '0 4px';
         b.style.gap = '2px';
         let cur = current;
-        const paint = (v: string | number): void => {
+        const paint = (v: string | number | Mixed): void => {
             b.replaceChildren();
-            const glyph = render(v);
+            if (v === MIXED) {
+                const dash = document.createElement('span');
+                dash.textContent = '—';
+                dash.style.cssText = 'min-width:18px;text-align:center;opacity:0.85;';
+                b.appendChild(dash);
+            }
+            const glyph = v === MIXED ? '' : render(v);
             if (glyph) {
                 // An empty glyph means a text-only control (e.g. the magnifier's timeframe) —
                 // the trigger then shows just the label + chevron.
@@ -765,7 +833,7 @@ export class DrawingSettingsPopup {
                 ic.innerHTML = sized(glyph);
                 b.appendChild(ic);
             }
-            if (opts.label && opts.labelInTrigger) {
+            if (opts.label && opts.labelInTrigger && v !== MIXED) {
                 const tx = document.createElement('span');
                 tx.textContent = opts.label(v);
                 tx.style.cssText = 'font-size:11px;opacity:0.85;font-variant-numeric:tabular-nums;';
@@ -800,7 +868,7 @@ export class DrawingSettingsPopup {
     private openMenu(
         anchor: HTMLElement,
         values: readonly (string | number)[],
-        current: string | number,
+        current: string | number | Mixed,
         render: (v: string | number) => string,
         label: ((v: string | number) => string) | undefined,
         onPick: (v: string | number) => void,
@@ -847,8 +915,10 @@ export class DrawingSettingsPopup {
 
     /** A color control: an `icon` over a thin **colored underline** showing the current
      *  value (the common idiom), with an invisible native picker overlaid to edit it.
-     *  `iconSize` shrinks it for the floating text controls. */
-    private colorButton(tip: string, icon: string, color: string, onChange: (v: string) => void, iconSize = 17): HTMLButtonElement {
+     *  `iconSize` shrinks it for the floating text controls. A mixed color paints the
+     *  underline striped with the colors `used` across the selection, and the picker then
+     *  leads with those colors so unifying onto one of them is a single click. */
+    private colorButton(tip: string, icon: string, color: string | Mixed, onChange: (v: string) => void, iconSize = 17, used: readonly string[] = []): HTMLButtonElement {
         const b = document.createElement('button');
         b.type = 'button';
         b.dataset.tip = tip;
@@ -858,7 +928,7 @@ export class DrawingSettingsPopup {
         ic.style.cssText = 'display:flex;';
         ic.innerHTML = sized(icon, iconSize);
         const bar = document.createElement('span');
-        bar.style.cssText = `display:block;height:3px;width:${Math.round(iconSize * 0.85)}px;border-radius:2px;background:${color};`;
+        bar.style.cssText = `display:block;height:3px;width:${Math.round(iconSize * 0.85)}px;border-radius:2px;background:${color === MIXED ? stripes(used) : color};`;
         b.append(ic, bar);
         let cur = color;
         // Stop the swatch's own pointerdown from reaching `el` (which would pre-close the popover),
@@ -866,7 +936,9 @@ export class DrawingSettingsPopup {
         b.addEventListener('pointerdown', (e) => e.stopPropagation());
         b.addEventListener('click', (e) => {
             e.stopPropagation();
-            this.toggleColorPopover(b, cur, (v) => {
+            // A mixed picker starts from the first color in use — some real value must seed the sliders.
+            const seed = cur === MIXED ? used[0] ?? DEFAULT_DRAWING_COLOR : cur;
+            this.toggleColorPopover(b, seed, cur === MIXED ? used : [], (v) => {
                 cur = v;
                 bar.style.background = v;
                 onChange(v);
@@ -876,21 +948,45 @@ export class DrawingSettingsPopup {
     }
 
     /** Open the color popover for `anchor`, or close it if it's already this anchor's (toggle). */
-    private toggleColorPopover(anchor: HTMLElement, color: string, onChange: (v: string) => void): void {
+    private toggleColorPopover(anchor: HTMLElement, color: string, used: readonly string[], onChange: (v: string) => void): void {
         if (this.colorOwner === anchor) {
             this.closeColorPopover();
             return;
         }
-        this.openColorPopover(anchor, color, onChange);
+        this.openColorPopover(anchor, color, used, onChange);
     }
 
-    /** A floating RGB picker + opacity slider anchored to a color swatch — emits `#RRGGBB(AA)`. */
-    private openColorPopover(anchor: HTMLElement, color: string, onChange: (v: string) => void): void {
+    /** A floating RGB picker + opacity slider anchored to a color swatch — emits `#RRGGBB(AA)`.
+     *  `used` (a mixed swatch's colors) leads the picker as one-click unify shortcuts. */
+    private openColorPopover(anchor: HTMLElement, color: string, used: readonly string[], onChange: (v: string) => void): void {
         const t = this.theme;
         this.colorPop = this.hostFloat(anchor, {
             zIndex: 25,
             padding: '10px',
-            fill: (el) => { el.appendChild(buildColorPicker(color, t, onChange)); },
+            fill: (el, pop) => {
+                if (used.length > 1) {
+                    const row = document.createElement('div');
+                    row.style.cssText = 'display:flex;align-items:center;gap:6px;padding-bottom:9px;border-bottom:1px solid var(--vela-border);';
+                    const lbl = document.createElement('span');
+                    lbl.textContent = 'In use';
+                    lbl.style.cssText = 'font:var(--vela-font-size-sm) inherit;opacity:0.7;margin-right:2px;';
+                    row.appendChild(lbl);
+                    for (const c of used) {
+                        const sw = document.createElement('button');
+                        sw.type = 'button';
+                        sw.dataset.tip = c;
+                        sw.style.cssText = `width:18px;height:18px;border-radius:4px;border:1px solid var(--vela-border-strong);cursor:pointer;background:${c};padding:0;`;
+                        sw.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            pop.hide();
+                            onChange(c);
+                        });
+                        row.appendChild(sw);
+                    }
+                    el.appendChild(row);
+                }
+                el.appendChild(buildColorPicker(color, t, onChange));
+            },
         });
         this.colorOwner = anchor;
     }
@@ -922,6 +1018,7 @@ const BOLD_ICON = icon('bold');
 const ITALIC_ICON = icon('italic');
 const GRIP_ICON = icon('grip');
 const KEBAB_ICON = icon('kebab');
+const CLONE_ICON = icon('clone');
 const RESET_ICON = icon('reset');
 const GEAR_ICON = icon('gear');
 const CHEVRON_ICON = icon('chevron-down');
@@ -930,6 +1027,15 @@ const BANDS_ICON = icon('bands');
 const DEDEKIND_ICON = icon('dedekind');
 const SONIC_ICON = icon('sonic');
 const SUPERSONIC_ICON = icon('supersonic');
+
+/** A striped underline for a mixed color swatch: equal bands of every color in use (a neutral
+ *  gray pair when nothing concrete is known), so the mix itself is visible without opening it. */
+function stripes(colors: readonly string[]): string {
+    const bands = colors.length > 1 ? colors : ['var(--vela-fg-faint)', 'var(--vela-fg-muted)'];
+    const step = 100 / bands.length;
+    const stops = bands.map((c, i) => `${c} ${i * step}% ${(i + 1) * step}%`).join(',');
+    return `linear-gradient(90deg,${stops})`;
+}
 
 /** A line glyph at a given width + style (for the width/style dropdown glyphs). The stroke IS
  *  the value being previewed, so it overrides the tier's weight. */

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -243,10 +243,17 @@ export class DrawingSettingsPopup {
         if (paths.has('style.lineWidth')) {
             // A marker-width field (floor above the hairline ladder, e.g. the
             // highlighter's 4–60) can't live in the 1–4 dropdown — a free numeric
-            // input honoring the schema's declared range replaces it.
-            const wf = schema.fields.find((f) => f.path === 'style.lineWidth');
+            // input honoring the schema's declared range replaces it. Only when EVERY
+            // selected drawing is a marker, though: mixed with a hairline tool the
+            // ladder is the range they all accept.
+            const widthField = (d: Drawing) => d.schema().fields.find((f) => f.path === 'style.lineWidth');
+            const wf = widthField(drawing);
             const width = common((d) => d.style.lineWidth);
-            if (wf?.kind === 'number' && (wf.min ?? 1) > 1) {
+            const markers = every((d) => {
+                const f = widthField(d);
+                return f?.kind === 'number' && (f.min ?? 1) > 1;
+            });
+            if (markers && wf?.kind === 'number') {
                 bar.appendChild(this.widthInput('Line width', width, wf.min ?? 1, wf.max ?? 60, wf.step ?? 1, (v) => actions.patch({ 'style.lineWidth': v })));
             } else {
                 bar.appendChild(this.dropdown('Line width', [1, 2, 3, 4], width, (w) => lineIcon(w, 'solid'), (v) => actions.patch({ 'style.lineWidth': v }), { label: (v) => `${v}px`, labelInTrigger: true }));

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -184,8 +184,8 @@ export class DrawingSettingsPopup {
         const common = <T>(read: (d: Drawing) => T): T | Mixed => commonValue(drawings, read);
         const every = (pred: (d: Drawing) => boolean): boolean => drawings.every(pred);
         /** A color swatch over the drawings: shared color, or striped with the colors in use. */
-        const swatch = (tip: string, glyph: string, read: (d: Drawing) => string, path: string, iconSize?: number): HTMLButtonElement =>
-            this.colorButton(tip, glyph, common(read), (v) => actions.patch({ [path]: v }), iconSize, distinctValues(drawings, read));
+        const swatch = (tip: string, glyph: string, read: (d: Drawing) => string, path: string): HTMLButtonElement =>
+            this.colorButton(tip, glyph, common(read), (v) => actions.patch({ [path]: v }), undefined, distinctValues(drawings, read));
         // Text-first annotations (and computed labels) wear their text controls on the bar; on a
         // shape that merely CAN carry a label they stay beside the label field — and a
         // multi-selection has no label field, so its text styling always sits on the bar.

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -362,7 +362,7 @@ export class DrawingSettingsPopup {
         if (!multi && isFrvp) bar.appendChild(this.iconBtn('Settings', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'frvp')));
         if (!multi && isPosition) bar.appendChild(this.iconBtn('Position size', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'position')));
         if (!multi && editableLevels) bar.appendChild(this.iconBtn('Levels', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'levels')));
-        bar.appendChild(this.toggle('Lock', LOCK_ICON, common((d) => d.locked), (v) => actions.setLocked(v)));
+        bar.appendChild(this.toggle('Lock', LOCK_ICON, common((d) => d.locked), (v) => actions.setLocked(v), UNLOCK_ICON));
         const del = this.iconBtn('Delete', TRASH_ICON, () => actions.remove());
         del.style.color = 'var(--vela-danger)';
         bar.appendChild(del);
@@ -761,13 +761,14 @@ export class DrawingSettingsPopup {
     }
 
     /** An on/off button. A mixed state (the selected drawings disagree) reads as half-lit and
-     *  the first click turns it ON for all of them. */
-    private toggle(tip: string, icon: string, active: boolean | Mixed, onChange: (v: boolean) => void): HTMLButtonElement {
+     *  the first click turns it ON for all of them. `off` swaps in a distinct glyph while the
+     *  toggle is off (a lock reads as an open padlock until it is engaged); mixed shows `icon`. */
+    private toggle(tip: string, icon: string, active: boolean | Mixed, onChange: (v: boolean) => void, off?: string): HTMLButtonElement {
         const b = this.base(tip);
-        b.innerHTML = sized(icon);
         // `data-active` alone drives the fill — the stylesheet owns idle/hover/active/mixed.
         const set = (on: boolean | Mixed): void => {
             b.dataset.active = on === MIXED ? 'mixed' : on ? '1' : '0';
+            b.innerHTML = sized(off && on === false ? off : icon);
         };
         set(active);
         let on = active;
@@ -1018,6 +1019,7 @@ const TYPE_ICON = icon('type');
 const PRICE_DELTA_ICON = icon('price-delta');
 const DATE_DELTA_ICON = icon('date-delta');
 const LOCK_ICON = icon('lock');
+const UNLOCK_ICON = icon('unlock');
 const FRONT_ICON = icon('bring-front');
 const BACK_ICON = icon('send-back');
 const TRASH_ICON = icon('trash');

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -19,7 +19,7 @@ import { withAlpha } from '../core/chartConfig';
 import { blendOver, splitColor } from '../../../ui/components/color-picker';
 import { DrawingPainter, handleIdsFor, type PaintTargets } from './DrawingPainter';
 import { DrawingInteraction } from './DrawingInteraction';
-import { DrawingSettingsPopup } from './DrawingSettingsPopup';
+import { DrawingSettingsPopup, type PopupAnchor } from './DrawingSettingsPopup';
 import { DrawingToolbar, TOOLBAR_WIDTH, TOOLBAR_COLLAPSED_WIDTH } from './DrawingToolbar';
 import { MeasureOverlay } from './MeasureOverlay';
 import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
@@ -136,6 +136,9 @@ export class UserDrawingController implements IDrawingsRendererPort {
     private readonly painter = new DrawingPainter();
     private readonly interaction: DrawingInteraction;
     private readonly popup: DrawingSettingsPopup;
+    /** The open popup is the multi-selection bar (vs one drawing's own) — decides what a
+     *  shrinking selection does with it. */
+    private popupMulti = false;
     private readonly toolbar: DrawingToolbar;
 
     constructor(
@@ -343,6 +346,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     setSelection(ids: readonly string[]): void {
         this.selectedIds = new Set(ids);
+        // A multi-selection gets ONE bar for all of its drawings; when it shrinks back to a single
+        // drawing that drawing's own bar takes over, and an emptied selection takes the bar away.
+        if (ids.length >= 2) this.openSettingsForSelection(ids);
+        else if (this.popupMulti) {
+            this.popupMulti = false;
+            this.popup.close();
+            if (ids.length === 1) this.openSettingsById(ids[0]!, 0, 0);
+        }
         this.render();
     }
 
@@ -394,12 +405,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
     }
 
     /** Delete the (unlocked) drawing under the cursor. True when one was removed.
-     *  Shared by the eraser (click + drag) and the middle-click shortcut. */
-    deleteAt(x: number, y: number): boolean {
+     *  Shared by the eraser (click + drag) and the middle-click shortcut; the latter passes
+     *  `withSelection` so a hit on a SELECTED drawing removes the whole selection with it. */
+    deleteAt(x: number, y: number, withSelection = false): boolean {
         const hit = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE);
         if (!hit || hit.locked) return false;
         this.popup.close();
-        this.emit({ kind: 'delete', ids: [hit.id] });
+        const ids = withSelection && this.selectedIds.has(hit.id) ? this.selectionIds() : [hit.id];
+        this.emit({ kind: 'delete', ids });
         return true;
     }
 
@@ -428,7 +441,15 @@ export class UserDrawingController implements IDrawingsRendererPort {
         }
     }
 
-    pointerDown(x: number, y: number, snap: SnapMode = 'off', shift = false): void {
+    /** Ctrl/Cmd+press on the empty plot: sweep a selection box (adds the drawings it touches to
+     *  the selection). Returns false when a mode/tool is active (the normal press path owns it). */
+    beginMarqueeAt(x: number, y: number): boolean {
+        if (this.measureMode || this.eraserMode || !this.interaction.beginMarquee(x, y)) return false;
+        this.render();
+        return true;
+    }
+
+    pointerDown(x: number, y: number, snap: SnapMode = 'off', shift = false, mod = false): void {
         if (this.eraserMode) {
             this.erasing = true; // hold to drag-erase across multiple drawings
             this.deleteAt(x, y);
@@ -451,10 +472,10 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 return;
             }
         }
-        this.interaction.down(x, y, snap, shift); // the popup self-dismisses on any outside press
+        this.interaction.down(x, y, snap, shift, mod); // the popup self-dismisses on any outside press
     }
 
-    pointerMove(x: number, y: number, snap: SnapMode = 'off', shift = false): void {
+    pointerMove(x: number, y: number, snap: SnapMode = 'off', shift = false, mod = false): void {
         if (this.eraserMode) {
             if (this.erasing) this.deleteAt(x, y); // erase only while the button is held (not on hover)
             return;
@@ -466,13 +487,15 @@ export class UserDrawingController implements IDrawingsRendererPort {
             return;
         }
         this.interaction.move(x, y, snap, shift);
-        this.updateHover(x, y); // show handles for the drawing under the cursor
+        this.updateHover(x, y, mod); // show handles for the drawing under the cursor
     }
 
-    /** Track which drawing is hovered so its handles appear on hover (and only then). */
-    private updateHover(x: number, y: number): void {
+    /** Track which drawing is hovered so its handles appear on hover (and only then). While
+     *  Ctrl/Cmd is held the cursor is picking a selection — handles then mark only what IS
+     *  selected, so a hovered candidate doesn't already read as selected. */
+    private updateHover(x: number, y: number, mod = false): void {
         let id: string | null = null;
-        if (this.activeTool == null && !this.interaction.isPlacing() && !this.interaction.isDragging()) {
+        if (!mod && this.activeTool == null && !this.interaction.isPlacing() && !this.interaction.isDragging()) {
             id = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE)?.id ?? null;
         }
         if (id !== this.hoveredId) {
@@ -936,6 +959,10 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.painter.seriesLook = this.deps.seriesLook();
         this.painter.paintAll(ctx, this.drawings.filter((d) => !this.isInterleaved(d)), proj, this.deps.theme(), targets);
         this.painter.paintHighlights(ctx, this.drawings.filter((d) => this.isInterleaved(d)), proj, handleIdsFor(targets));
+        // A Ctrl-drag moves COPIES that are not in the store yet: paint them here, in full and with
+        // handles, so they read as the real drawings they are about to become.
+        const clones = this.interaction.dragClones();
+        if (clones) this.painter.paintAll(ctx, clones, proj, this.deps.theme(), { selected: new Set(clones.map((c) => c.id)) });
         this.layoutTextEditor();
         const ghost = this.interaction.ghost();
         if (ghost) this.painter.paintGhost(ctx, ghost, proj, this.deps.theme());
@@ -960,6 +987,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
         if (m && my != null) this.painter.paintSnapRing(ctx, proj.xOf(m.point.time), my, this.deps.theme());
         // The transient ruler paints on top of everything (until cleared on the next press/pan/zoom).
         if (this.measure.isActive()) this.measure.paint(ctx, proj, this.deps.theme());
+        const marquee = this.interaction.marqueeRect();
+        if (marquee) this.painter.paintMarquee(ctx, marquee);
     }
 
     destroy(): void {
@@ -980,15 +1009,87 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.render();
     }
 
+    /** Dismiss-on-outside-press also clears the selection — except when the press carries a
+     *  multi-select modifier (Shift / Ctrl / Cmd): that press is about to ADD to the selection
+     *  (or sweep a marquee onto it), so the drawings whose bar just closed must stay selected. */
+    private readonly onPopupDismissed = (e?: PointerEvent): void => {
+        if (!(e && (e.shiftKey || e.ctrlKey || e.metaKey))) this.clearSelection();
+    };
+
+    /** Report the live drawings' current state as one edit (one undo step, however many). */
+    private emitEdits(drawings: readonly Drawing[]): void {
+        const docs = drawings.map((d) => d.serialize());
+        if (docs.length === 1) this.emit({ kind: 'edit', doc: docs[0]! });
+        else if (docs.length > 1) this.emit({ kind: 'edit-many', docs });
+    }
+
+    /** The one bar for a multi-selection: it shows the controls all of its drawings share and
+     *  every action applies to all of them. Floats clear of their combined bounds. */
+    private openSettingsForSelection(ids: readonly string[]): void {
+        const live = (): Drawing[] => ids.map((id) => this.drawings.find((d) => d.id === id)).filter((d): d is Drawing => d != null);
+        const drawings = live();
+        if (drawings.length < 2) return;
+        const proj = this.deps.projector();
+        let anchor: PopupAnchor | null = null;
+        for (const d of drawings) {
+            const b = d.bounds(proj);
+            if (!b) continue;
+            if (!anchor) anchor = { ...b };
+            else {
+                const right = Math.max(anchor.x + anchor.w, b.x + b.w);
+                const bottom = Math.max(anchor.y + anchor.h, b.y + b.h);
+                anchor.x = Math.min(anchor.x, b.x);
+                anchor.y = Math.min(anchor.y, b.y);
+                anchor.w = right - anchor.x;
+                anchor.h = bottom - anchor.y;
+            }
+        }
+        this.popupMulti = true;
+        this.emit({ kind: 'settings', id: drawings[0]!.id });
+        this.popup.open(drawings, anchor, {
+            resolve: () => live()[0] ?? null,
+            patch: (p) => {
+                const ds = live();
+                for (const d of ds) d.applySettings(p);
+                this.render();
+                this.emitEdits(ds);
+            },
+            setLocked: (v) => {
+                const ds = live();
+                for (const d of ds) d.locked = v;
+                this.emitEdits(ds);
+            },
+            reorder: (to) => {
+                for (const d of live()) this.emit({ kind: 'reorder', id: d.id, to });
+            },
+            duplicate: () => {
+                this.popup.close();
+                this.emit({ kind: 'duplicate', ids: live().map((d) => d.id) });
+            },
+            resetSettings: () => {
+                const ds = live();
+                for (const d of ds) resetDrawingSettings(d);
+                this.render();
+                this.emitEdits(ds);
+                this.openSettingsForSelection(ids); // rebuild so the controls reflect the restored defaults
+            },
+            remove: () => {
+                this.popup.close();
+                this.emit({ kind: 'delete', ids: live().map((d) => d.id) });
+            },
+        }, this.onPopupDismissed);
+    }
+
     /** A click on a drawing opens its settings toolbar (text labels edit text here too). */
     private openSettingsById(id: string, _x: number, _y: number): void {
         const drawing = this.drawings.find((d) => d.id === id);
         if (!drawing) return;
         const live = (): Drawing | undefined => this.drawings.find((d) => d.id === id);
+        this.popupMulti = false;
         this.emit({ kind: 'select', ids: [id] }); // editing this drawing → it stays highlighted while the popup is open
         this.emit({ kind: 'settings', id });
         const anchor = drawing.bounds(this.deps.projector()); // float the toolbar clear of the drawing
-        this.popup.open(drawing, anchor, {
+        this.popup.open([drawing], anchor, {
             // Sync rebuilds instances, so a panel that reads values back after a patch (e.g. the
             // position tool's price fields, where one edit can flip another level) resolves fresh.
             resolve: () => live() ?? null,
@@ -1006,6 +1107,13 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.emit({ kind: 'edit', doc: d.serialize() });
             },
             reorder: (to) => this.emit({ kind: 'reorder', id, to }),
+            duplicate: () => {
+                // The copy lands on its source and becomes the selection (same as Ctrl/Cmd+D) —
+                // ready to drag away; the source's popup would otherwise outlive its selection.
+                this.finishTextEditor(true); // typed text is part of what gets copied
+                this.popup.close();
+                this.emit({ kind: 'duplicate', ids: [id] });
+            },
             resetSettings: () => {
                 const d = live();
                 if (!d) return;
@@ -1029,7 +1137,13 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.popup.close();
                 this.emit({ kind: 'delete', ids: [id] });
             },
-        }, () => this.clearSelection()); // dismiss-on-outside-click also clears the selection/highlight
+        }, this.onPopupDismissed);
+    }
+
+    /** A plain click on the empty plot: drop the selection (the multi-select twin of the popup's
+     *  dismiss-on-outside-press, which only covers the single-drawing case). */
+    deselect(): void {
+        this.clearSelection();
     }
 
     /** Report placement progress upstream (`draft` intent) so the drawings sync can
@@ -1067,6 +1181,15 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.openSettingsById(fresh.id, 0, 0);
                 if (isInlineEditable(fresh)) this.editTextInline(fresh.id); // focus lands in the editor, not the bar
             }, 0);
+            return;
+        }
+        if (i.kind === 'clone') {
+            // A drag-to-duplicate ends like a click on the copy: its settings bar opens so it can be
+            // restyled right away. Several copies stay a plain multi-selection (one bar edits one drawing).
+            const before = new Set(this.drawings.map((d) => d.id));
+            this.intentCb?.(i);
+            const fresh = this.drawings.filter((d) => !before.has(d.id));
+            if (fresh.length === 1) this.openSettingsById(fresh[0]!.id, 0, 0);
             return;
         }
         this.intentCb?.(i);

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -406,12 +406,13 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     /** Delete the (unlocked) drawing under the cursor. True when one was removed.
      *  Shared by the eraser (click + drag) and the middle-click shortcut; the latter passes
-     *  `withSelection` so a hit on a SELECTED drawing removes the whole selection with it. */
+     *  `withSelection` so a hit on a SELECTED drawing removes the selection with it (its
+     *  locked members excepted). */
     deleteAt(x: number, y: number, withSelection = false): boolean {
         const hit = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE);
         if (!hit || hit.locked) return false;
         this.popup.close();
-        const ids = withSelection && this.selectedIds.has(hit.id) ? this.selectionIds() : [hit.id];
+        const ids = withSelection && this.selectedIds.has(hit.id) ? this.deletableSelection() : [hit.id];
         this.emit({ kind: 'delete', ids });
         return true;
     }
@@ -516,7 +517,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
             this.render();
             return;
         }
+        // A drag of a SELECTED drawing dismissed its bar on the press (but kept the selection —
+        // see onPopupDismissed); once the drag lands, bring the bar back over the moved drawings.
+        const dragged = this.interaction.isDragging() ? this.interaction.pressedId() : null;
         this.interaction.up(x, y); // commit a drag, or open settings on a no-move click
+        if (dragged && this.selectedIds.has(dragged) && !this.popup.isOpen()) {
+            if (this.selectedIds.size >= 2) this.openSettingsForSelection(this.selectionIds());
+            else this.openSettingsById(dragged, x, y);
+        }
     }
 
     /** Toggle the transient ruler. Arming it clears any drawing tool + selection. */
@@ -822,7 +830,7 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.emit({ kind: 'duplicate', ids: this.selectionIds() });
                 break;
             case 'delete': {
-                const ids = this.selectedIds.size ? this.selectionIds() : this.hoveredId ? [this.hoveredId] : [];
+                const ids = this.selectedIds.size ? this.deletableSelection() : this.hoveredId ? [this.hoveredId] : [];
                 if (ids.length) {
                     this.popup.close();
                     this.emit({ kind: 'delete', ids });
@@ -838,6 +846,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     private selectionIds(): string[] {
         return [...this.selectedIds];
+    }
+
+    /** What a selection-wide delete removes: a lone selected drawing goes regardless, but inside
+     *  a multi-selection a LOCKED drawing is protected — the others go and it stays (selected). */
+    private deletableSelection(): string[] {
+        const ids = this.selectionIds();
+        if (ids.length < 2) return ids;
+        return ids.filter((id) => !this.drawings.find((d) => d.id === id)?.locked);
     }
 
     /** Move every selected (unlocked) drawing by a pixel delta — one edit/edit-many → one undo step. */
@@ -1009,11 +1025,16 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.render();
     }
 
-    /** Dismiss-on-outside-press also clears the selection — except when the press carries a
-     *  multi-select modifier (Shift / Ctrl / Cmd): that press is about to ADD to the selection
-     *  (or sweep a marquee onto it), so the drawings whose bar just closed must stay selected. */
+    /** Dismiss-on-outside-press also clears the selection — except when the press is ABOUT the
+     *  selection: it carries a multi-select modifier (Shift / Ctrl / Cmd — it will add to the
+     *  selection or sweep a marquee onto it), or it landed on a drawing that is already selected
+     *  (the canvas handler ran first and is holding it for a drag or a click), so the drawings
+     *  whose bar just closed must stay selected. */
     private readonly onPopupDismissed = (e?: PointerEvent): void => {
-        if (!(e && (e.shiftKey || e.ctrlKey || e.metaKey))) this.clearSelection();
+        if (e && (e.shiftKey || e.ctrlKey || e.metaKey)) return;
+        const pressed = this.interaction.pressedId();
+        if (pressed && this.selectedIds.has(pressed)) return;
+        this.clearSelection();
     };
 
     /** Report the live drawings' current state as one edit (one undo step, however many). */
@@ -1074,8 +1095,11 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.openSettingsForSelection(ids); // rebuild so the controls reflect the restored defaults
             },
             remove: () => {
+                // Locked members are protected: they stay behind (still selected) while the rest go.
+                const ids = live().filter((d) => !d.locked).map((d) => d.id);
+                if (ids.length === 0) return;
                 this.popup.close();
-                this.emit({ kind: 'delete', ids: live().map((d) => d.id) });
+                this.emit({ kind: 'delete', ids });
             },
         }, this.onPopupDismissed);
     }

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -22,7 +22,7 @@ import { DrawingInteraction } from './DrawingInteraction';
 import { DrawingSettingsPopup, type PopupAnchor } from './DrawingSettingsPopup';
 import { DrawingToolbar, TOOLBAR_WIDTH, TOOLBAR_COLLAPSED_WIDTH } from './DrawingToolbar';
 import { MeasureOverlay } from './MeasureOverlay';
-import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
+import { topDrawingAt, deletableSelection, deleteTargets, HIT_TOLERANCE } from './DrawingHitTester';
 import { keyToDrawingAction, isEditingText } from './DrawingKeys';
 import type { DrawingSlice } from '../core/SceneGraph';
 
@@ -406,13 +406,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     /** Delete the (unlocked) drawing under the cursor. True when one was removed.
      *  Shared by the eraser (click + drag) and the middle-click shortcut; the latter passes
-     *  `withSelection` so a hit on a SELECTED drawing removes the selection with it (its
-     *  locked members excepted). */
+     *  `withSelection` so a hit on a member of a multi-selection removes the selection's
+     *  unlocked members — whichever member was hit, locked or not. */
     deleteAt(x: number, y: number, withSelection = false): boolean {
         const hit = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE);
-        if (!hit || hit.locked) return false;
+        if (!hit) return false;
+        const ids = deleteTargets(hit, this.selectedIds, this.drawings, withSelection);
+        if (ids.length === 0) return false;
         this.popup.close();
-        const ids = withSelection && this.selectedIds.has(hit.id) ? this.deletableSelection() : [hit.id];
         this.emit({ kind: 'delete', ids });
         return true;
     }
@@ -848,12 +849,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
         return [...this.selectedIds];
     }
 
-    /** What a selection-wide delete removes: a lone selected drawing goes regardless, but inside
-     *  a multi-selection a LOCKED drawing is protected — the others go and it stays (selected). */
     private deletableSelection(): string[] {
-        const ids = this.selectionIds();
-        if (ids.length < 2) return ids;
-        return ids.filter((id) => !this.drawings.find((d) => d.id === id)?.locked);
+        return deletableSelection(this.selectedIds, this.drawings);
     }
 
     /** Move every selected (unlocked) drawing by a pixel delta — one edit/edit-many → one undo step. */

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -1161,8 +1161,9 @@ export class UserDrawingController implements IDrawingsRendererPort {
         }, this.onPopupDismissed);
     }
 
-    /** A plain click on the empty plot: drop the selection (the multi-select twin of the popup's
-     *  dismiss-on-outside-press, which only covers the single-drawing case). */
+    /** A plain click on the empty plot: drop the selection. The popup's dismiss-on-outside-press
+     *  does the same, but a selection can exist with no bar open (a lone Ctrl-click pick, a
+     *  selection whose bar was dismissed by a modifier press) — this covers those. */
     deselect(): void {
         this.clearSelection();
     }
@@ -1206,7 +1207,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
         }
         if (i.kind === 'clone') {
             // A drag-to-duplicate ends like a click on the copy: its settings bar opens so it can be
-            // restyled right away. Several copies stay a plain multi-selection (one bar edits one drawing).
+            // restyled right away. Several copies need nothing here — the selection they become
+            // brings up the multi-selection bar on its own (see setSelection).
             const before = new Set(this.drawings.map((d) => d.id));
             this.intentCb?.(i);
             const fresh = this.drawings.filter((d) => !before.has(d.id));

--- a/src/widget/object-tree.ts
+++ b/src/widget/object-tree.ts
@@ -142,9 +142,13 @@ const CSS = `
 .vela-ot-empty { padding: 20px 10px; text-align: center; color: var(--vela-fg-muted); font-size: 12px; }
 
 /* ── drawing groups ── */
-/* One top-level entry in a pane's drawing list: a lone drawing, or a whole group block. The
-   transparent border reserves the outline used when a drawing is dropped into the group. */
-.vela-ot-unit { border: 1px solid transparent; border-radius: 6px; }
+/* One top-level entry in a pane's drawing list: a lone drawing, or a whole group block. No
+   border of its own — units stack flush, so consecutive highlighted rows read as one block; the
+   drop-into-group outline is drawn inside the box instead (see the drag-and-drop rules). */
+.vela-ot-unit { border-radius: 6px; }
+/* Adjacent picked rows merge into one contiguous highlight: the shared edge loses its rounding. */
+.vela-ot-unit:has(> .vela-ot-row[data-picked]) + .vela-ot-unit > .vela-ot-row[data-picked] { border-top-left-radius: 0; border-top-right-radius: 0; }
+.vela-ot-unit:has(+ .vela-ot-unit > .vela-ot-row[data-picked]) > .vela-ot-row[data-picked] { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
 .vela-ot-row[data-row-kind='group'] > .vela-icon { width: 12px; font-size: 11px; }
 /* A member sits indented under its group's header. */
 .vela-ot-subrow { padding-left: 26px; }
@@ -201,8 +205,10 @@ const CSS = `
 .vela-ot-gap[data-drop] { height: 4px; background: var(--vela-fg-bright); }
 .vela-ot-gap[data-drop]::before { display: none; }
 /* A whole container accepts the drop: merging into a pane, or a pane with no drawings yet.
-   The pane block's transparent border reserves the room for this outline. */
+   The pane block's transparent border reserves the room for this outline; a group unit has no
+   border to color, so it draws the same line as an inset outline (no layout footprint). */
 .vela-ot [data-drop='target'] { border-color: var(--vela-fg-bright); background: var(--vela-hover); }
+.vela-ot-unit[data-drop='target'] { outline: 1px solid var(--vela-fg-bright); outline-offset: -1px; }
 /* Where a reorder would insert. */
 .vela-ot [data-drop='before'] { box-shadow: inset 0 2px 0 var(--vela-fg-bright); }
 .vela-ot [data-drop='after'] { box-shadow: inset 0 -2px 0 var(--vela-fg-bright); }
@@ -337,7 +343,8 @@ class MenuBuilder {
 
 export class ObjectTree extends SidePanel {
     private chart: Vela | null = null;
-    private selectedDrawing: string | null = null;
+    /** What the CHART has selected — every member of a multi-selection, mirrored as rows. */
+    private selectedDrawings = new Set<string>();
     private symbolName = '';
     /** The raw (possibly venue-prefixed) symbol — what icon resolution routes on. */
     private symbolRaw = '';
@@ -406,14 +413,12 @@ export class ObjectTree extends SidePanel {
         // Selection both stores and repaints, in that order: a refresh triggered before the id
         // is recorded would paint the previous selection and never come back to fix it.
         this.unsubs.push(
-            chart.on('drawing:selected', ({ id }) => {
-                this.selectedDrawing = id;
-                // A selection made on the chart takes over the panel's pick. Our own echo does
-                // not, or pushing a multi-pick to the chart would immediately shrink it to one.
-                if (!this.syncingSelection) {
-                    this.picked.clear();
-                    if (id) this.picked.add(id);
-                }
+            chart.on('drawing:selected', ({ ids }) => {
+                this.selectedDrawings = new Set(ids);
+                // A selection made on the chart takes over the panel's pick — all of it, so a
+                // marquee or Ctrl-click selection on the chart lights up every row it covers. Our
+                // own echo does not, or pushing a pick would just replace it with itself mid-render.
+                if (!this.syncingSelection) this.picked = new Set(ids);
                 this.refresh();
             }),
         );
@@ -783,7 +788,7 @@ export class ObjectTree extends SidePanel {
         el.dataset.drag = '1';
         el.title = 'Drag to restack, or onto another pane to move it there';
         if (inGroup) el.classList.add('vela-ot-subrow');
-        if (d.id === this.selectedDrawing) el.dataset.selected = '1';
+        if (this.selectedDrawings.has(d.id)) el.dataset.selected = '1';
         if (this.picked.has(d.id)) el.dataset.picked = '1';
         el.addEventListener('click', (e) => this.onDrawClick(e, d.id));
         return el;

--- a/test/drawings-controller.test.ts
+++ b/test/drawings-controller.test.ts
@@ -329,8 +329,10 @@ describe('DrawingController — editing foundation', () => {
         expect(seen).toContainEqual(['drawing:created', pasted[0]!.id]);
     });
 
-    it('generalized select: additive toggles membership; primary is ids[0]', () => {
-        const { port, ctrl, seen } = setup();
+    it('generalized select: additive toggles membership; primary is ids[0]; the event carries the full list', () => {
+        const { port, ctrl, seen, events } = setup();
+        const payloads: Array<{ id: string | null; ids: string[] }> = [];
+        events.on('drawing:selected', (e) => payloads.push(e));
         port.fire({ kind: 'create', doc: HLINE_DOC });
         port.fire({ kind: 'create', doc: HLINE_DOC });
         const [a, b] = ctrl.all().map((d) => d.id);
@@ -340,6 +342,7 @@ describe('DrawingController — editing foundation', () => {
         port.fire({ kind: 'select', ids: [b!], additive: true });
         expect(port.selectionIds).toEqual([a, b]);
         expect(seen).toContainEqual(['drawing:selected', a]); // primary = first selected
+        expect(payloads[payloads.length - 1]).toEqual({ id: a, ids: [a, b] }); // a host UI can mirror every member
         port.fire({ kind: 'select', ids: [a!], additive: true }); // toggle a back off
         expect(port.selectionIds).toEqual([b]);
     });

--- a/test/drawings-controller.test.ts
+++ b/test/drawings-controller.test.ts
@@ -298,6 +298,24 @@ describe('DrawingController — editing foundation', () => {
         expect(ctrl.all().map((d) => d.id)).toEqual([id]);
     });
 
+    it('clone intent: commits the given (moved) docs as fresh copies, source untouched, one undo step', () => {
+        const { port, ctrl, seen } = setup();
+        port.fire({ kind: 'create', doc: HLINE_DOC });
+        const src = ctrl.all()[0]!;
+        seen.length = 0;
+        // The end of a Ctrl-drag: the renderer hands over the source's twin, already translated.
+        port.fire({ kind: 'clone', docs: [{ ...src, anchors: [{ time: 2000, price: 26000 }] }] });
+        expect(ctrl.all().length).toBe(2);
+        const clone = ctrl.all().find((d) => d.id !== src.id)!;
+        expect(clone.anchors[0]).toEqual({ time: 2000, price: 26000 });
+        expect(clone.zIndex).toBe(src.zIndex); // keeps its source's depth
+        expect(ctrl.all().find((d) => d.id === src.id)!.anchors[0]).toEqual({ time: 1000, price: 25000 }); // source never moved
+        expect(port.selectionIds).toEqual([clone.id]); // the copy becomes the selection
+        expect(seen).toContainEqual(['drawing:created', clone.id]);
+        ctrl.undo();
+        expect(ctrl.all().map((d) => d.id)).toEqual([src.id]);
+    });
+
     it('copy is silent; paste creates fresh drawings', () => {
         const { ctrl, seen } = setup();
         const d = ctrl.add('hline', { anchors: [{ time: 1, price: 1 }] })!;

--- a/test/drawings-interaction.test.ts
+++ b/test/drawings-interaction.test.ts
@@ -310,6 +310,81 @@ describe('DrawingInteraction: selection + claim', () => {
         h.it.up(50, 70);
         expect(h.settings).toHaveLength(0); // shift-click is selection-only
     });
+
+    it('ctrl-click (no move) toggles selection on release, without opening settings', () => {
+        const h = harness(null, [hline()]);
+        h.it.down(50, 70, 'strong', false, true); // Ctrl → strong magnet AND the selection modifier
+        expect(h.intents).toHaveLength(0); // nothing until the release decides click vs drag
+        h.it.up(51, 71); // within the slop → a click
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-1'], additive: true }]);
+        expect(h.settings).toHaveLength(0);
+    });
+});
+
+describe('DrawingInteraction: marquee (Ctrl/Cmd-drag on the empty plot)', () => {
+    // fake projector: x = time, y = 100 − price
+    const inside = () => createDrawing('trendline', { id: 'dw-1', paneId: 'price', anchors: [{ time: 20, price: 80 }, { time: 40, price: 60 }] })!; // px (20,20)→(40,40)
+    const outside = () => createDrawing('trendline', { id: 'dw-2', paneId: 'price', anchors: [{ time: 150, price: 20 }, { time: 180, price: 10 }] })!; // px (150,80)→(180,90)
+    const crossing = () => createDrawing('hline', { id: 'dw-3', paneId: 'price', anchors: [{ time: 0, price: 70 }] })!; // full-width line at y=30
+
+    it('starts only when idle with no tool armed, and claims the gesture', () => {
+        const armed = harness('trendline');
+        expect(armed.it.beginMarquee(5, 5)).toBe(false);
+        const h = harness(null, [inside()]);
+        expect(h.it.claim(100, 90)).toBe(false); // empty space → the host decides (pan vs marquee)
+        expect(h.it.beginMarquee(100, 90)).toBe(true);
+        expect(h.it.claim(100, 90)).toBe(true); // in flight → the drawings layer owns the moves
+        expect(h.it.marqueeRect()).toEqual({ x: 100, y: 90, w: 0, h: 0 });
+    });
+
+    it('release selects every visible drawing whose bounds touch the box (a line crossing it too)', () => {
+        const h = harness(null, [inside(), outside(), crossing()]);
+        h.it.beginMarquee(10, 10);
+        h.it.move(60, 50); // sweep (10,10)→(60,50)
+        expect(h.it.marqueeRect()).toEqual({ x: 10, y: 10, w: 50, h: 40 });
+        h.it.up(60, 50);
+        expect(h.it.marqueeRect()).toBeNull();
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-1', 'dw-3'] }]); // dw-2 sits far right
+    });
+
+    it('a sweep dragged up-left normalizes, and hidden drawings are never picked', () => {
+        const hidden = inside();
+        hidden.visible = false;
+        const h = harness(null, [hidden, crossing()]);
+        h.it.beginMarquee(60, 50);
+        h.it.move(10, 10);
+        h.it.up(10, 10);
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-3'] }]);
+    });
+
+    it('adds to the existing selection (union) and stays silent when nothing new is touched', () => {
+        const h = harness(null, [inside(), outside()]);
+        h.setSelected(['dw-2']);
+        h.it.beginMarquee(10, 10);
+        h.it.move(60, 50);
+        h.it.up(60, 50);
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-2', 'dw-1'] }]); // dw-2 kept, dw-1 added
+        h.intents.length = 0;
+        h.setSelected(['dw-1', 'dw-2']);
+        h.it.beginMarquee(10, 10);
+        h.it.move(60, 50);
+        h.it.up(60, 50); // both already selected → no intent
+        expect(h.intents).toHaveLength(0);
+    });
+
+    it('a box within the slop selects nothing; Escape cancels a sweep', () => {
+        const h = harness(null, [inside()]);
+        h.it.beginMarquee(30, 30);
+        h.it.move(32, 31);
+        h.it.up(32, 31); // a twitch, not a sweep — even though the box touches dw-1
+        expect(h.intents).toHaveLength(0);
+        h.it.beginMarquee(10, 10);
+        h.it.move(60, 50);
+        expect(h.it.cancel()).toBe(true);
+        expect(h.it.marqueeRect()).toBeNull();
+        h.it.up(60, 50);
+        expect(h.intents).toHaveLength(0);
+    });
 });
 
 describe('DrawingInteraction: click-move-click placement (measurement / position)', () => {
@@ -499,6 +574,127 @@ describe('DrawingInteraction: dragging', () => {
         expect(h.it.cancel()).toBe(true);
         expect(d.anchors).toEqual([{ time: 10, price: 10 }, { time: 50, price: 50 }]);
         expect(h.intents.some((i) => i.kind === 'edit')).toBe(false);
+    });
+
+    it('body-dragging a drawing that is part of a multi-selection moves the whole selection (one edit-many)', () => {
+        const a = trend();
+        const b = hline(); // y = 70
+        const locked = createDrawing('hline', { id: 'dw-3', paneId: 'price', anchors: [{ time: 10, price: 80 }] })!;
+        locked.locked = true;
+        const h = harness(null, [a, b, locked]);
+        h.setSelected(['dw-1', 'dw-2', 'dw-3']);
+        h.it.down(20, 80); // press the trend line's body (clear of the hline at y=70)
+        h.it.move(30, 75); // dt=+10, dp=+5
+        expect(b.anchors).toEqual([{ time: 20, price: 35 }]); // the rider follows live
+        expect(locked.anchors).toEqual([{ time: 10, price: 80 }]); // a locked member stays put
+        h.it.up(30, 75);
+        const many = h.intents.find((i) => i.kind === 'edit-many');
+        expect(many?.kind === 'edit-many' && many.docs.map((d) => d.id)).toEqual(['dw-1', 'dw-2']);
+        expect(many?.kind === 'edit-many' && many.docs[0]!.anchors).toEqual([{ time: 20, price: 15 }, { time: 60, price: 55 }]);
+        expect(h.intents.some((i) => i.kind === 'edit')).toBe(false);
+    });
+
+    it('a handle drag of a multi-selected drawing reshapes only that one', () => {
+        const a = trend();
+        const b = hline();
+        const h = harness(null, [a, b]);
+        h.setSelected(['dw-1', 'dw-2']);
+        h.it.down(10, 90); // grab the trend line's p1 handle
+        h.it.move(15, 85);
+        h.it.up(15, 85);
+        expect(b.anchors).toEqual([{ time: 10, price: 30 }]);
+        expect(h.intents.map((i) => i.kind)).toEqual(['edit']);
+    });
+
+    it('Escape during a group drag restores every member', () => {
+        const a = trend();
+        const b = hline();
+        const h = harness(null, [a, b]);
+        h.setSelected(['dw-1', 'dw-2']);
+        h.it.down(20, 80);
+        h.it.move(30, 75);
+        expect(h.it.cancel()).toBe(true);
+        expect(a.anchors).toEqual([{ time: 10, price: 10 }, { time: 50, price: 50 }]);
+        expect(b.anchors).toEqual([{ time: 10, price: 30 }]);
+        expect(h.intents).toHaveLength(0);
+    });
+});
+
+describe('DrawingInteraction: Ctrl/Cmd-drag duplicates', () => {
+    const trend = () =>
+        createDrawing('trendline', { id: 'dw-1', paneId: 'price', anchors: [{ time: 10, price: 10 }, { time: 50, price: 50 }] })!;
+    const hline = () => createDrawing('hline', { id: 'dw-2', paneId: 'price', anchors: [{ time: 10, price: 30 }] })!;
+
+    it('a Ctrl-drag of the body moves a COPY and commits it on release; the source never moves', () => {
+        const d = trend();
+        const h = harness(null, [d]);
+        h.it.down(30, 70, 'strong', false, true); // Ctrl held (strong magnet is its other meaning)
+        expect(h.it.dragClones()).toBeNull(); // nothing is copied until the press becomes a drag
+        h.it.move(40, 65);
+        const clones = h.it.dragClones()!;
+        expect(clones).toHaveLength(1);
+        expect(clones[0]!.anchors).toEqual([{ time: 20, price: 15 }, { time: 60, price: 55 }]); // the copy follows
+        expect(d.anchors).toEqual([{ time: 10, price: 10 }, { time: 50, price: 50 }]); // the source stays
+        h.it.up(40, 65);
+        expect(h.it.dragClones()).toBeNull();
+        expect(h.intents).toHaveLength(1);
+        const clone = h.intents[0]!;
+        expect(clone.kind).toBe('clone');
+        if (clone.kind === 'clone') {
+            expect(clone.docs).toHaveLength(1);
+            expect(clone.docs[0]!.type).toBe('trendline');
+            expect(clone.docs[0]!.anchors).toEqual([{ time: 20, price: 15 }, { time: 60, price: 55 }]);
+        }
+        expect(h.settings).toHaveLength(0);
+    });
+
+    it('Ctrl-dragging a member of a multi-selection copies the whole selection', () => {
+        const a = trend();
+        const b = hline();
+        const h = harness(null, [a, b]);
+        h.setSelected(['dw-1', 'dw-2']);
+        h.it.down(20, 80, 'off', false, true); // the trend line's body, clear of the hline
+        h.it.move(30, 75);
+        h.it.up(30, 75);
+        const clone = h.intents.find((i) => i.kind === 'clone');
+        expect(clone?.kind === 'clone' && clone.docs.map((d) => d.type)).toEqual(['trendline', 'hline']);
+        expect(clone?.kind === 'clone' && clone.docs[1]!.anchors).toEqual([{ time: 20, price: 35 }]);
+        expect(b.anchors).toEqual([{ time: 10, price: 30 }]); // sources untouched
+    });
+
+    it('Ctrl on a HANDLE keeps its resize meaning (no copy)', () => {
+        const d = trend();
+        const h = harness(null, [d]);
+        h.setHovered('dw-1');
+        h.it.down(10, 90, 'off', false, true); // grab p1 with Ctrl held
+        h.it.move(15, 85);
+        expect(h.it.dragClones()).toBeNull();
+        h.it.up(15, 85);
+        expect(h.intents.map((i) => i.kind)).toEqual(['edit']);
+        expect(d.anchors[0]).toEqual({ time: 15, price: 15 });
+    });
+
+    it('Escape during a Ctrl-drag leaves nothing behind and the source untouched', () => {
+        const d = trend();
+        const h = harness(null, [d]);
+        h.it.down(30, 70, 'off', false, true);
+        h.it.move(40, 65);
+        expect(h.it.cancel()).toBe(true);
+        expect(h.it.dragClones()).toBeNull();
+        expect(d.anchors).toEqual([{ time: 10, price: 10 }, { time: 50, price: 50 }]);
+        h.it.up(40, 65);
+        expect(h.intents).toHaveLength(0);
+    });
+
+    it('a locked drawing is never copied by a Ctrl-drag (the press stays a click → toggle)', () => {
+        const d = trend();
+        d.locked = true;
+        const h = harness(null, [d]);
+        h.it.down(30, 70, 'off', false, true);
+        h.it.move(40, 65);
+        expect(h.it.dragClones()).toBeNull();
+        h.it.up(40, 65);
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-1'], additive: true }]);
     });
 });
 

--- a/test/drawings-interaction.test.ts
+++ b/test/drawings-interaction.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { DrawingInteraction } from '../src/renderers/native/drawings/DrawingInteraction';
 import { createProjector } from '../src/renderers/native/drawings/Projector';
+import { deletableSelection, deleteTargets } from '../src/renderers/native/drawings/DrawingHitTester';
 import { effectiveSnapMode } from '../src/renderers/native/core/InputController';
 import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
 import { createDrawing, DEFAULT_DRAWING_COLOR, MAX_PATH_POINTS, type Drawing, type DrawingIntent, type DrawingStyle, type DrawingTypeKey, type Projector } from '../src/core/drawings';
@@ -695,6 +696,45 @@ describe('DrawingInteraction: Ctrl/Cmd-drag duplicates', () => {
         expect(h.it.dragClones()).toBeNull();
         h.it.up(40, 65);
         expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-1'], additive: true }]);
+    });
+});
+
+describe('delete-at-cursor targets (eraser + middle-click)', () => {
+    const line = (id: string, locked = false) => {
+        const d = createDrawing('hline', { id, paneId: 'price', anchors: [{ time: 10, price: 30 }] })!;
+        d.locked = locked;
+        return d;
+    };
+
+    it('a lone unlocked hit goes; a lone locked hit is protected', () => {
+        const a = line('a');
+        const b = line('b', true);
+        expect(deleteTargets(a, new Set(), [a, b], true)).toEqual(['a']);
+        expect(deleteTargets(b, new Set(), [a, b], true)).toEqual([]);
+        expect(deleteTargets(b, new Set(['b']), [a, b], true)).toEqual([]); // selected alone changes nothing
+    });
+
+    it('a middle-click on a LOCKED member of a multi-selection still removes the unlocked members', () => {
+        const a = line('a');
+        const b = line('b', true);
+        const c = line('c');
+        const sel = new Set(['a', 'b', 'c']);
+        expect(deleteTargets(b, sel, [a, b, c], true)).toEqual(['a', 'c']);
+        expect(deleteTargets(a, sel, [a, b, c], true)).toEqual(['a', 'c']); // same result from an unlocked member
+        expect(deletableSelection(sel, [a, b, c])).toEqual(['a', 'c']); // and the same set Delete removes
+    });
+
+    it('an all-locked multi-selection removes nothing', () => {
+        const a = line('a', true);
+        const b = line('b', true);
+        expect(deleteTargets(a, new Set(['a', 'b']), [a, b], true)).toEqual([]);
+    });
+
+    it('the eraser (no withSelection) never widens to the selection', () => {
+        const a = line('a');
+        const b = line('b');
+        expect(deleteTargets(a, new Set(['a', 'b']), [a, b], false)).toEqual(['a']);
+        expect(deleteTargets(line('c', true), new Set(['a', 'b']), [a, b], false)).toEqual([]);
     });
 });
 

--- a/test/drawings-popup-multi.test.ts
+++ b/test/drawings-popup-multi.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { createDrawing } from '../src/core/drawings';
+import { sharedPaths, commonValue, MIXED } from '../src/renderers/native/drawings/DrawingSettingsPopup';
+
+const trend = (id: string, lineColor: string) => createDrawing('trendline', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }], style: { lineColor } })!;
+const box = (id: string) => createDrawing('box', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }] })!;
+const text = (id: string) => createDrawing('text', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }] })!;
+
+describe('multi-selection settings: shared paths', () => {
+    it('same-type drawings share their whole schema', () => {
+        const one = new Set(trend('a', '#f00').schema().fields.map((f) => f.path));
+        expect(sharedPaths([trend('a', '#f00'), trend('b', '#0f0'), trend('c', '#00f')])).toEqual(one);
+    });
+
+    it('mixed types keep only the intersection — type-specific paths drop out', () => {
+        const stroked = sharedPaths([trend('a', '#f00'), box('b')]);
+        expect(stroked.has('style.lineColor')).toBe(true); // both stroke
+        expect(stroked.has('style.fillColor')).toBe(false); // the box's alone
+        const paths = sharedPaths([trend('a', '#f00'), box('b'), text('c')]);
+        expect(paths.has('style.lineColor')).toBe(false); // a text annotation has no stroke
+        for (const p of paths) {
+            expect(trend('a', '#f00').schema().fields.some((f) => f.path === p)).toBe(true);
+            expect(box('b').schema().fields.some((f) => f.path === p)).toBe(true);
+            expect(text('c').schema().fields.some((f) => f.path === p)).toBe(true);
+        }
+    });
+
+    it('a single drawing shares everything with itself; an empty list shares nothing', () => {
+        const b = box('b');
+        expect(sharedPaths([b]).size).toBe(b.schema().fields.length);
+        expect(sharedPaths([]).size).toBe(0);
+    });
+});
+
+describe('multi-selection settings: common value', () => {
+    it('agreeing drawings yield the value; disagreeing ones yield MIXED', () => {
+        const same = [trend('a', '#ff0000'), trend('b', '#ff0000')];
+        expect(commonValue(same, (d) => d.style.lineColor)).toBe('#ff0000');
+        const differ = [trend('a', '#ff0000'), trend('b', '#0000ff')];
+        expect(commonValue(differ, (d) => d.style.lineColor)).toBe(MIXED);
+    });
+
+    it('works for booleans (a lock state) without confusing false with mixed', () => {
+        const a = trend('a', '#f00');
+        const b = trend('b', '#f00');
+        expect(commonValue([a, b], (d) => d.locked)).toBe(false);
+        b.locked = true;
+        expect(commonValue([a, b], (d) => d.locked)).toBe(MIXED);
+        a.locked = true;
+        expect(commonValue([a, b], (d) => d.locked)).toBe(true);
+    });
+});

--- a/test/drawings-popup-multi.test.ts
+++ b/test/drawings-popup-multi.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { createDrawing } from '../src/core/drawings';
 import { sharedPaths, commonValue, MIXED } from '../src/renderers/native/drawings/DrawingSettingsPopup';
 
-const trend = (id: string, lineColor: string) => createDrawing('trendline', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }], style: { lineColor } })!;
+const trend = (id: string, lineColor: string) => createDrawing('trendline', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }], style: { lineColor, lineWidth: 1, lineStyle: 'solid' } })!;
 const box = (id: string) => createDrawing('box', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }] })!;
 const text = (id: string) => createDrawing('text', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }] })!;
 


### PR DESCRIPTION
## Summary

Drawing tools gain cloning, multi-selection and a unified quick-settings popup for a whole selection.

### Duplicate by dragging
- Hold **Ctrl/Cmd** and drag a drawing's body to pull a copy away from it. The original stays in place; the copy follows the cursor and is committed on release (selected, quick-settings popup open) as a single undo step. **Escape** mid-drag leaves nothing behind.
- The quick-settings overflow menu gains a **Duplicate** entry that clones the drawing in place and hands it the selection.

### Multi-selection
- **Ctrl/Cmd+click** toggles a drawing in/out of the selection (same as Shift+click).
- **Ctrl/Cmd+drag on empty space** sweeps a marquee that selects every drawing it touches; successive boxes accumulate, a click on empty space clears.
- Dragging the body of any selected drawing moves the whole selection (locked drawings stay put); Ctrl/Cmd+drag copies the whole selection.
- Delete, arrow keys, copy, duplicate and middle-click act on the full selection, each as one undo step. Deleting a multi-selection removes only unlocked members; locked ones stay in place and remain selected.
- The object tree highlights every selected drawing. `drawing:selected` now carries the full list as `ids` alongside the primary `id`.

### One popup for a whole selection
- Selecting several drawings opens a single quick-settings popup showing only the controls every member supports.
- Controls where the drawings disagree render as mixed (striped swatch, dash in dropdowns, half-lit toggle). Any edit applies to every selected drawing as one undo step; a mixed swatch lists the colors currently in use first.

## Changes
- `DrawingInteraction`, `UserDrawingController`, `InputController`, `NativeRenderer`: Ctrl/Cmd clone-drag, marquee selection, multi-target move/delete/copy/duplicate, lock-aware deletion.
- `DrawingSettingsPopup`: multi-target mode with shared-controls intersection and mixed-state rendering.
- `DrawingPainter`: marquee rectangle painting.
- `DrawingController` / `port.ts` / `events/types.ts`: `ids` in `drawing:selected`, duplicate support.
- `widget/object-tree.ts`: highlight all selected drawings.
- Docs: `drawing-tools.md`, `api-reference.md`, `workspace.md`; `CHANGELOG.md` Unreleased entry.

## Tests
- New: `test/drawings-interaction.test.ts`, `test/drawings-popup-multi.test.ts`.
- Updated: `test/drawings-controller.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large interaction-state changes in native drawing input and selection/popup wiring; behavior is well covered by new tests but regressions in edge cases (popup dismiss, lock rules) are possible.
> 
> **Overview**
> Adds **multi-selection** on the chart: **Ctrl/Cmd+click** toggles like Shift+click, **Ctrl/Cmd+marquee** on empty plot accumulates hits, group **body drags** move everyone (locked stay put), and bulk **delete / nudge / copy / duplicate / middle-click** run as one undo step with **lock-aware** deletes. **Ctrl/Cmd+body drag** duplicates in place (transient copies painted until release) via a new **`clone` intent**; overflow **Duplicate** and **Ctrl/Cmd+D** still clone in place.
> 
> **`drawing:selected`** now includes **`ids`** (full list) plus primary **`id`**; the object tree mirrors every selected row.
> 
> **One quick-settings popup** for multiple drawings: controls are the **intersection** of schemas, **mixed** UI when values disagree, and patches apply to all at once. Empty-plot click **deselects**; popup dismiss logic keeps selection when starting another multi-select or dragging a selected body.
> 
> Input plumbing passes **Ctrl/Cmd (`mod`)** through `InputController` → native drawings layer; marquee is drawn in **`DrawingPainter`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8319fd01a9d30db7aa583d2115cccddd186561c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->