### PR TITLE
Add standard-deviation bands, Quarter/Year periods and full source list to the built-in VWAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Changed
+
+- **The built-in VWAP now carries standard-deviation bands.** Volume Weighted Average
+  Price draws up to three ±k·σ band pairs around the average — a Bands group gives each
+  band its own on/off toggle and multiplier on one row (band 1 is on by default at 1σ;
+  bands 2 and 3 wait at 2σ and 3σ) — with a soft fill between each pair. The reset
+  period gains **Quarter** and **Year** beside Day, Week and Month, and Source now
+  offers the same choices as the moving averages (Close, Open, High, Low, HL2, HLC3,
+  OHLC4, HLCC4). A Style group at the bottom of the settings holds the VWAP color and,
+  per band, its own color (each band starts in a distinct ink) with a Fill switch and the
+  fill's own color — opacity included — beside it. Existing saved VWAP settings keep
+  working: the period, source and line color keys are unchanged.
+
 ## [v0.6.17]
 
 ### Changed

--- a/src/core/native-indicators/classics/overlays.ts
+++ b/src/core/native-indicators/classics/overlays.ts
@@ -1,21 +1,25 @@
 import type { OHLCV } from '../../model/ohlcv';
 import type { MarkerPoint } from '../../model/series';
-import { SERIES_LINE, BULLISH, BEARISH, INFO, WARNING } from '../../palette';
-import type { ClassicIndicatorSpec, ClassicPlot } from './define';
-import { num, str } from './define';
-import { colorInput } from './shared';
+import type { InputSchema } from '../../model/inputs';
+import { SERIES_LINE, BULLISH, BEARISH, INFO, WARNING, CATEGORICAL } from '../../palette';
+import type { ClassicBand, ClassicIndicatorSpec, ClassicPlot } from './define';
+import { bool, num, str } from './define';
+import { sourceValues } from './math';
+import { colorInput, sourceInput, withAlpha } from './shared';
 
 /** Price-anchored specials: stops, anchored averages, levels, pivots, patterns. */
 
 const DAY_MS = 86400000;
 
-type Anchor = 'Day' | 'Week' | 'Month';
+type Anchor = 'Day' | 'Week' | 'Month' | 'Quarter' | 'Year';
 
 /** UTC period key for an anchor (epoch day 0 was a Thursday; weeks start Monday). */
 function periodKey(anchor: Anchor, time: number): number {
     if (anchor === 'Week') return Math.floor((Math.floor(time / DAY_MS) + 3) / 7);
-    if (anchor === 'Month') {
+    if (anchor === 'Month' || anchor === 'Quarter' || anchor === 'Year') {
         const d = new Date(time);
+        if (anchor === 'Year') return d.getUTCFullYear();
+        if (anchor === 'Quarter') return d.getUTCFullYear() * 4 + Math.floor(d.getUTCMonth() / 3);
         return d.getUTCFullYear() * 12 + d.getUTCMonth();
     }
     return Math.floor(time / DAY_MS);
@@ -70,40 +74,89 @@ const parabolicSar: ClassicIndicatorSpec = {
     },
 };
 
+const VWAP_BANDS_GROUP = 'Bands';
+const VWAP_STYLE = 'Style';
+/** The three ±k·σ band pairs. Each band has its own ink so the pairs read apart at a glance. */
+const VWAP_BANDS = [
+    { on: 'band1', mult: 'band1Mult', color: 'band1Color', fill: 'band1Fill', fillColor: 'band1FillColor', defMult: 1, defOn: true, defColor: BULLISH },
+    { on: 'band2', mult: 'band2Mult', color: 'band2Color', fill: 'band2Fill', fillColor: 'band2FillColor', defMult: 2, defOn: false, defColor: WARNING },
+    { on: 'band3', mult: 'band3Mult', color: 'band3Color', fill: 'band3Fill', fillColor: 'band3FillColor', defMult: 3, defOn: false, defColor: CATEGORICAL[4]! },
+] as const;
+
 const vwap: ClassicIndicatorSpec = {
     type: 'vwap',
     title: 'Volume Weighted Average Price',
     shortTitle: 'VWAP',
     overlay: true,
     inputs: [
-        { key: 'anchor', title: 'Anchor', type: 'string', defval: 'Day', options: ['Day', 'Week', 'Month'], tooltip: 'Where the accumulation resets (UTC periods)' },
-        { key: 'source', title: 'Source', type: 'string', defval: 'HLC3', options: ['HLC3', 'OHLC4', 'Close'] },
-        colorInput(INFO),
+        { key: 'anchor', title: 'Period', type: 'string', defval: 'Day', options: ['Day', 'Week', 'Month', 'Quarter', 'Year'], tooltip: 'Where the accumulation resets (UTC periods)' },
+        sourceInput('HLC3'),
+        // Each band is one row: its toggle leads, the multiplier follows unlabeled.
+        ...VWAP_BANDS.flatMap((b, i): InputSchema[] => [
+            { key: b.on, title: `Band ${i + 1} multiplier`, type: 'bool', defval: b.defOn, inline: b.on, group: VWAP_BANDS_GROUP },
+            { key: b.mult, title: '', type: 'float', defval: b.defMult, min: 0.1, max: 10, step: 0.1, inline: b.on, group: VWAP_BANDS_GROUP },
+        ]),
+        { ...colorInput(INFO, 'VWAP color'), group: VWAP_STYLE },
+        // One row per band: its ink, then the fill toggle with the fill's own (translucent) color.
+        ...VWAP_BANDS.flatMap((b, i): InputSchema[] => [
+            { ...colorInput(b.defColor, `Band ${i + 1} color`, b.color), inline: b.color, group: VWAP_STYLE },
+            { key: b.fill, title: 'Fill', type: 'bool', defval: true, inline: b.color, group: VWAP_STYLE },
+            { ...colorInput(withAlpha(b.defColor), '', b.fillColor), inline: b.color, group: VWAP_STYLE },
+        ]),
     ],
     compute: (bars, inputs) => {
         const anchor = str(inputs, 'anchor', 'Day') as Anchor;
-        const source = str(inputs, 'source', 'HLC3');
-        const values = new Array<number>(bars.length).fill(Number.NaN);
+        const src = sourceValues(bars, str(inputs, 'source', 'HLC3'));
+        const n = bars.length;
+        const values = new Array<number>(n).fill(Number.NaN);
+        const bands = VWAP_BANDS.filter((b) => bool(inputs, b.on, b.defOn)).map((b) => ({
+            mult: Math.max(0, num(inputs, b.mult, b.defMult)),
+            color: str(inputs, b.color, b.defColor),
+            fill: bool(inputs, b.fill, true),
+            fillColor: str(inputs, b.fillColor, withAlpha(b.defColor)),
+            up: new Array<number>(n).fill(Number.NaN),
+            down: new Array<number>(n).fill(Number.NaN),
+        }));
         let period = Number.NaN;
         let cumPV = 0;
+        let cumPV2 = 0;
         let cumV = 0;
-        for (let i = 0; i < bars.length; i++) {
+        for (let i = 0; i < n; i++) {
             const b = bars[i]!;
             const key = periodKey(anchor, b.time);
             if (key !== period) {
                 period = key;
                 cumPV = 0;
+                cumPV2 = 0;
                 cumV = 0;
             }
             const v = b.volume;
             if (v != null && Number.isFinite(v) && v > 0) {
-                const tp = source === 'Close' ? b.close : source === 'OHLC4' ? (b.open + b.high + b.low + b.close) / 4 : (b.high + b.low + b.close) / 3;
+                const tp = src[i]!;
                 cumPV += tp * v;
+                cumPV2 += tp * tp * v;
                 cumV += v;
             }
-            if (cumV > 0) values[i] = cumPV / cumV;
+            if (cumV <= 0) continue;
+            const mean = cumPV / cumV;
+            // Variance clamped at 0 — IEEE drift can dip `E[x²] − mean²` a hair under.
+            const sd = Math.sqrt(Math.max(0, cumPV2 / cumV - mean * mean));
+            values[i] = mean;
+            for (const band of bands) {
+                band.up[i] = mean + band.mult * sd;
+                band.down[i] = mean - band.mult * sd;
+            }
         }
-        return { plots: [{ key: 'vwap', title: 'VWAP', values, color: str(inputs, 'color', INFO), width: 2 }] };
+        const plots: ClassicPlot[] = [{ key: 'vwap', title: 'VWAP', values, color: str(inputs, 'color', INFO), width: 2 }];
+        const fills: ClassicBand[] = [];
+        bands.forEach((band, i) => {
+            plots.push(
+                { key: `up${i}`, title: `Upper ${band.mult}σ`, values: band.up, color: band.color },
+                { key: `down${i}`, title: `Lower ${band.mult}σ`, values: band.down, color: band.color },
+            );
+            if (band.fill) fills.push({ key: `band${i}`, from: `up${i}`, to: `down${i}`, color: band.fillColor });
+        });
+        return { plots, bands: fills };
     },
 };
 

--- a/test/classic-indicators.test.ts
+++ b/test/classic-indicators.test.ts
@@ -351,4 +351,90 @@ describe('classic descriptor adapter', () => {
         expect(points[1]!.value).toBeCloseTo(15, 10);
         expect(points[2]!.value).toBeCloseTo(30, 10); // reset at the new day
     });
+
+    it('resets VWAP on UTC quarter and year boundaries', () => {
+        const spec = classicSpecs.find((s) => s.type === 'vwap')!;
+        const flat = (iso: string, price: number): OHLCV => ({ time: Date.parse(iso), open: price, high: price, low: price, close: price, volume: 1 });
+        const bars = [flat('2024-02-10T00:00:00Z', 10), flat('2024-03-31T23:00:00Z', 20), flat('2024-04-01T00:00:00Z', 30), flat('2025-01-01T00:00:00Z', 40)];
+        const quarter = pointsOf(runOnce(spec, bars, { anchor: 'Quarter', source: 'Close' }).series![0]);
+        expect(quarter.map((p) => p.value)).toEqual([10, 15, 30, 40]);
+        const year = pointsOf(runOnce(spec, bars, { anchor: 'Year', source: 'Close' }).series![0]);
+        expect(year.map((p) => p.value)).toEqual([10, 15, 20, 40]);
+    });
+
+    it('draws VWAP σ bands per enabled pair, each in its own color, fills optional', () => {
+        const spec = classicSpecs.find((s) => s.type === 'vwap')!;
+        // Flat bars make every source = price: vwap of (100×1, 106×2) = 104, σ = √8.
+        const bars: OHLCV[] = [
+            { time: 0, open: 100, high: 100, low: 100, close: 100, volume: 1 },
+            { time: 60000, open: 106, high: 106, low: 106, close: 106, volume: 2 },
+        ];
+        const out = runOnce(spec, bars, { band1: true, band1Mult: 1, band2: false, band3: true, band3Mult: 2.5, band1Color: '#ff0000', band3Color: '#00ff00', band1FillColor: '#ff000014', band3FillColor: '#00ff0014' });
+        expect(out.series!.map((s) => s.title)).toEqual(['VWAP', 'Upper 1σ', 'Lower 1σ', 'Upper 2.5σ', 'Lower 2.5σ']);
+        const sd = Math.sqrt(8);
+        expect(pointsOf(out.series![1])[1]!.value).toBeCloseTo(104 + sd, 10);
+        expect(pointsOf(out.series![4])[1]!.value).toBeCloseTo(104 - 2.5 * sd, 10);
+        const inkOf = (s: SeriesSpec): string | undefined => (isLineLikeSeries(s) ? s.style.color : undefined);
+        expect(inkOf(out.series![1]!)).toBe('#ff0000');
+        expect(inkOf(out.series![3]!)).toBe('#00ff00');
+        expect(out.fills!.map((f) => f.color)).toEqual(['#ff000014', '#00ff0014']);
+
+        // Fills are per band: band 1 keeps its fill, band 2's is off.
+        const partial = runOnce(spec, bars, { band2: true, band2Fill: false });
+        expect(partial.series).toHaveLength(5);
+        expect(partial.fills!.map((f) => f.fromSeriesId)).toEqual([partial.series![1]!.id]);
+
+        // Only band 1 is on by default. Inks differ per band, and each fill defaults to its
+        // band's ink at 8% alpha.
+        expect(runOnce(spec, bars).series).toHaveLength(3);
+        const all = runOnce(spec, bars, { band2: true, band3: true });
+        const inks = [1, 3, 5].map((i) => (isLineLikeSeries(all.series![i]!) ? all.series![i]!.style.color : ''));
+        expect(new Set(inks).size).toBe(3);
+        expect(all.fills!.map((f) => f.color)).toEqual(inks.map((c) => `${c}14`));
+
+        // The fill color is its own input.
+        const custom = runOnce(spec, bars, { band1FillColor: '#12345680' });
+        expect(custom.fills![0]!.color).toBe('#12345680');
+    });
+
+    it('reads VWAP source through the shared source vocabulary', () => {
+        const spec = classicSpecs.find((s) => s.type === 'vwap')!;
+        const source = spec.inputs.find((i) => i.key === 'source')!;
+        expect(source.options).toEqual(['Close', 'Open', 'High', 'Low', 'HL2', 'HLC3', 'OHLC4', 'HLCC4']);
+        const bars: OHLCV[] = [{ time: 0, open: 1, high: 9, low: 3, close: 5, volume: 1 }];
+        expect(pointsOf(runOnce(spec, bars, { source: 'High' }).series![0])[0]!.value).toBe(9);
+        expect(pointsOf(runOnce(spec, bars, { source: 'HL2' }).series![0])[0]!.value).toBe(6);
+    });
+
+    it('lays out VWAP bands in a Bands group and inks + fills in a trailing Style group', () => {
+        const spec = classicSpecs.find((s) => s.type === 'vwap')!;
+        const anchor = spec.inputs.find((i) => i.key === 'anchor')!;
+        expect(anchor.options).toEqual(['Day', 'Week', 'Month', 'Quarter', 'Year']);
+        for (const n of [1, 2, 3]) {
+            const on = spec.inputs.find((i) => i.key === `band${n}`)!;
+            const mult = spec.inputs.find((i) => i.key === `band${n}Mult`)!;
+            expect(on.type).toBe('bool');
+            expect(on.group).toBe('Bands');
+            expect(mult.title).toBe(''); // the toggle carries the row's label
+            expect(mult.inline).toBe(on.inline);
+            expect(mult.group).toBe('Bands');
+            const color = spec.inputs.find((i) => i.key === `band${n}Color`)!;
+            const fill = spec.inputs.find((i) => i.key === `band${n}Fill`)!;
+            expect(color.group).toBe('Style');
+            expect(fill.type).toBe('bool');
+            expect(fill.inline).toBe(color.inline); // fill toggle sits beside its band's swatch
+            const fillColor = spec.inputs.find((i) => i.key === `band${n}FillColor`)!;
+            expect(fillColor.type).toBe('color');
+            expect(fillColor.title).toBe(''); // unlabeled — the Fill toggle names it
+            expect(fillColor.inline).toBe(color.inline);
+        }
+        const styled = spec.inputs.filter((i) => i.group === 'Style').map((i) => i.key);
+        expect(styled).toEqual([
+            'color',
+            'band1Color', 'band1Fill', 'band1FillColor',
+            'band2Color', 'band2Fill', 'band2FillColor',
+            'band3Color', 'band3Fill', 'band3FillColor',
+        ]);
+        expect(spec.inputs.slice(-styled.length).map((i) => i.key)).toEqual(styled);
+    });
 });


### PR DESCRIPTION
## Summary

The built-in Volume Weighted Average Price overlay replaces its single line with the fuller VWAP that previously lived in Vela-pro's order-flow roster, and extends it.

- **Standard-deviation bands.** Up to three ±k·σ band pairs around the average. A **Bands** group gives each band one inline row — `[x] Band N multiplier ( )` — with band 1 on by default at 1σ and bands 2/3 waiting at 2σ and 3σ.
- **Period** gains **Quarter** and **Year** beside Day, Week and Month (UTC resets).
- **Source** now uses the shared source vocabulary of the moving averages: Close, Open, High, Low, HL2, HLC3, OHLC4, HLCC4.
- **Style group** (bottom of the settings): VWAP color, then one row per band — its line color (distinct default ink per band), a **Fill** switch, and the fill's own translucent color (opacity slider included).
- Saved settings keep working: the `anchor`, `source` and `color` keys are unchanged.

Companion change: LuxAlgo/Vela-pro removes its `vwap-bands` native so the two catalogs stop overlapping.

## Verification

- `npm run typecheck` · `npm run lint` · `npm run test` (1546) · `npm run build` — green, after merging `dev` into this branch.
- New unit tests: Quarter/Year resets, per-band values/colors/fills, source resolution, and the Bands/Style layout.
- Playground (live Binance data): the dialog renders Bands and Style groups as designed; toggling a band, a fill, its fill color, the period and the source all repaint the model (`chart.inspect()` series/fill counts change accordingly).

## Notes

- Band multipliers are part of the band series titles (`Upper 2σ`), as in the previous Pro implementation.
- Changelog entry added under `[Unreleased]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VWAP compute and adds many new persisted inputs, but legacy keys are preserved and behavior is covered by new tests; risk is mainly visual/settings regression on a widely used overlay.
> 
> **Overview**
> The built-in **VWAP** overlay grows from a single line into a fuller study: up to three optional **±k·σ band pairs** around the volume-weighted mean, with soft fills between each enabled upper/lower line.
> 
> **Period** (renamed from Anchor in the UI) now includes **Quarter** and **Year** UTC reset boundaries alongside Day, Week, and Month. **Source** switches to the same shared price-source list as the moving averages (Close through HLCC4) via `sourceValues`.
> 
> Settings are reorganized into a **Bands** group (per-band on/off + multiplier on one row; band 1 defaults on at 1σ) and a trailing **Style** group (VWAP line color, then per-band line color, fill toggle, and fill color with default translucent inks). Compute tracks `cumPV2` for volume-weighted variance (clamped at zero) and emits extra plot series plus `ClassicBand` fills. Existing saves that only set `anchor`, `source`, and `color` keep working.
> 
> Changelog documents the change; unit tests cover quarter/year resets, band math/colors/fills, source resolution, and input layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bd5ba04b31ea9a0ce154c4f29eaf483eaa0090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->