### PR TITLE
Object tree: label indicator rows with their short title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to Vela, newest first.
   per band, its own color (each band starts in a distinct ink) with a Fill switch and the
   fill's own color — opacity included — beside it. Existing saved VWAP settings keep
   working: the period, source and line color keys are unchanged.
+- **The object tree names indicators by their compact title.** An indicator that
+  declares a short title now shows it on its row in the object tree, so the row reads
+  the same as its legend chip. Indicators without a short title keep their full name,
+  and a study pane's heading still carries the full name of the indicator that owns it.
 
 ### Fixed
 

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1695,7 +1695,12 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             if (!model) continue;
             const paneId = model.paneId ?? 'price';
             if (!byPane.has(paneId)) byPane.set(paneId, []);
-            byPane.get(paneId)!.push({ id: r.id, title: model.title || r.title, ownScale: model.ownScale === true });
+            byPane.get(paneId)!.push({
+                id: r.id,
+                title: model.title || r.title,
+                ...(model.shorttitle ? { shorttitle: model.shorttitle } : {}),
+                ownScale: model.ownScale === true,
+            });
         }
         const panes: PaneInfo[] = [];
         for (const paneId of this.paneOrder) {

--- a/src/core/model/indicator.ts
+++ b/src/core/model/indicator.ts
@@ -35,11 +35,11 @@ export type PaneAxis = 'none' | { bands: PaneAxisBand[] };
 export interface IndicatorModel {
     /** Per-instance id (stable). */
     id: string;
-    /** Full display name (settings dialog, object tree, inspect). */
+    /** Full display name (picker, inspect, and every surface with no {@link shorttitle}). */
     title: string;
     /**
-     * Compact label the legend chip and the settings dialog show instead of the full
-     * {@link title}. Absent ⇒ both use {@link title}. Mirrors Pine
+     * Compact label the legend chip, the settings dialog and the object tree's rows show
+     * instead of the full {@link title}. Absent ⇒ all use {@link title}. Mirrors Pine
      * `indicator(..., shorttitle=)`.
      */
     shorttitle?: string;

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -91,7 +91,8 @@ export interface NativeIndicatorDescriptor {
     /** Full display name (picker, settings header, handle title). */
     readonly title: string;
     /**
-     * Compact name for the on-chart legend chip and the settings-dialog header.
+     * Compact name for the on-chart legend chip, the settings-dialog header and the
+     * object tree's indicator rows.
      * Absent ⇒ {@link title}. The picker keeps the full title either way.
      */
     readonly shortTitle?: string;

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -243,7 +243,12 @@ export interface PaneInfo {
     order: number;
     collapsed: boolean;
     maximized: boolean;
-    indicators: Array<{ id: string; title: string; ownScale: boolean }>;
+    indicators: Array<{
+        id: string;
+        title: string;
+        shorttitle?: string;
+        ownScale: boolean;
+    }>;
 }
 
 /** Options for `chart.addIndicator(source, options?)`. */

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1997,8 +1997,8 @@ export class NativeRenderer implements IChartRenderer {
         // say so or the recorded order (object tree, seriesOrder reads) starts out a lie.
         if (model.native && this.extLayers.some((l) => l.def.id === model.native!.type)) this.scene.assignIndicatorZTop(model.id);
         else this.scene.assignIndicatorZ(model.id);
-        // The legend chip and the settings dialog both show the compact shorttitle when
-        // declared; the full title stays on the picker, object tree and inspect().
+        // The legend chip, the settings dialog and the object tree's rows all show the compact
+        // shorttitle when declared; the full title stays on the picker and inspect().
         this.inputsUI.upsert(model.id, model.shorttitle ?? model.title, model.inputs, model.inputValues, model.paneId, {
             native: !!model.native,
             ...(model.props ? { props: model.props, propValues: model.propValues ?? {} } : {}),

--- a/src/widget/object-tree-model.ts
+++ b/src/widget/object-tree-model.ts
@@ -109,9 +109,15 @@ export function paneLabel(pane: PaneInfo, fallbackTitle: (id: string) => string 
     return `Pane ${pane.order + 1}`;
 }
 
-/** An indicator's display name. */
+/** An indicator's full display name. */
 function indicatorLabel(i: PaneInfo['indicators'][number], fallbackTitle: (id: string) => string | undefined): string {
     return i.title || fallbackTitle(i.id) || i.id;
+}
+
+/** An indicator row's label: the compact name it declares — matching its legend chip — or
+ *  else its full name. */
+function indicatorRowLabel(i: PaneInfo['indicators'][number], fallbackTitle: (id: string) => string | undefined): string {
+    return i.shorttitle || indicatorLabel(i, fallbackTitle);
 }
 
 /** The pane's series rows, extracted from its stack in rendered (front-first) order. */
@@ -330,7 +336,7 @@ function paneItems(snap: TreeSnapshot, pane: PaneInfo, units: DrawUnit[]): TreeI
     const indicatorRow = (i: PaneInfo['indicators'][number]): IndicatorRow => ({
         kind: 'indicator',
         id: i.id,
-        label: indicatorLabel(i, snap.handleTitle),
+        label: indicatorRowLabel(i, snap.handleTitle),
         visible: snap.indicatorVisible(i.id),
         ownScale: i.ownScale,
     });

--- a/test/object-tree-model.test.ts
+++ b/test/object-tree-model.test.ts
@@ -36,14 +36,14 @@ import {
 import type { PaneInfo } from '../src/core/options';
 import type { SerializedDrawing } from '../src/core/drawings/Drawing';
 
-function pane(id: string, kind: 'price' | 'study', order: number, indicators: Array<{ id: string; title?: string; ownScale?: boolean }> = []): PaneInfo {
+function pane(id: string, kind: 'price' | 'study', order: number, indicators: Array<{ id: string; title?: string; shorttitle?: string; ownScale?: boolean }> = []): PaneInfo {
     return {
         id,
         kind,
         order,
         collapsed: false,
         maximized: false,
-        indicators: indicators.map((i) => ({ id: i.id, title: i.title ?? i.id, ownScale: i.ownScale === true })),
+        indicators: indicators.map((i) => ({ id: i.id, title: i.title ?? i.id, ...(i.shorttitle ? { shorttitle: i.shorttitle } : {}), ownScale: i.ownScale === true })),
     };
 }
 
@@ -138,6 +138,14 @@ describe('buildTree — the unified stack', () => {
         const tree = buildTree(snap({ panes: [p], indicatorVisible: (id) => id !== 'a', handleTitle: () => 'Indicator' }));
         const a = paneRows(tree[0]!).find((r) => r.kind === 'indicator');
         expect(a).toMatchObject({ label: 'SMA 20', visible: false, ownScale: true });
+    });
+
+    it('labels an indicator row with its compact name when it declares one — the pane keeps the full title', () => {
+        const panes = [pane('price', 'price', 0), pane('p1', 'study', 1, [{ id: 'rsi', title: 'Relative Strength Index', shorttitle: 'RSI' }])];
+        const tree = buildTree(snap({ panes, zOrder: [{ id: 'rsi', z: 0 }] }));
+        const row = paneRows(tree[1]!).find((r) => r.kind === 'indicator');
+        expect(row?.label).toBe('RSI');
+        expect(tree[1]!.label).toBe('Relative Strength Index');
     });
 
     it('falls back to the handle title, then the id, when the pane model has no title', () => {

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1321,6 +1321,11 @@ describe('EngineOrchestrator — loading placeholder + legend status', () => {
         expect(last?.id).toBe(ind.id);
         expect(last?.title).toBe('Mock');
         expect(last?.shorttitle).toBe('MK');
+
+        // The pane listing carries the compact name alongside the full title, so the object
+        // tree can label the row the way the legend chip does.
+        const entry = chart.panes.list().flatMap((p) => p.indicators).find((i) => i.id === ind.id);
+        expect(entry).toMatchObject({ title: 'Mock', shorttitle: 'MK' });
     });
 
     it('re-routes to the right pane when the computed overlay differs from the prepare-time guess', async () => {


### PR DESCRIPTION
## Summary

The object tree labels each indicator row with its compact short title (Pine `shorttitle`, native `shortTitle`) when one is declared, so the row reads the same as its legend chip. Indicators without a short title keep their full name. Study pane headings still carry the full title of the indicator that owns the pane.

## Changes

- `PaneInfo.indicators[]` gains an optional `shorttitle` (additive, non-breaking), populated by `chart.panes.list()`.
- The object tree model labels indicator rows as `shorttitle || title || handle title || id`.
- Doc comments that claimed the object tree shows the full title are updated.
- Changelog entry under `[Unreleased] › Changed`.

## Tests

- New tree-model case: the row reads `RSI` while the pane heading stays `Relative Strength Index`.
- The orchestrator short-title test also asserts `panes.list()` carries the short title.

## Verification

- Gate: typecheck, lint, tests (1547 passed), build — all green.
- Playground probe (live data): added OBV and Parabolic SAR, opened the object tree, read the rendered row text with non-empty bounding rects. Rows: `BTCUSDT`, `Volume`, `MA`, `VWAP`, `SAR`, `OBV`; pane headings: `Main chart`, `On Balance Volume`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public type field and display-only labeling in the object tree; behavior is covered by new unit tests.
> 
> **Overview**
> **Object tree indicator rows now match legend chips when a compact title exists.** If an indicator declares `shorttitle` (Pine) or `shortTitle` (native), its row in the object tree shows that label instead of the full name; indicators without one behave as before.
> 
> `chart.panes.list()` adds an optional `shorttitle` on each entry in `PaneInfo.indicators[]` (additive, non-breaking), filled from the mounted model in `EngineOrchestrator.listPanes()`. The object tree model picks row labels via `shorttitle || title` while **study pane headings** still use the full title through `paneLabel`. Related doc comments are updated to reflect that the object tree no longer always shows the full title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7703953e76fd8d17bf92fb5948bff220cb62767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->