### PR TITLE
Remove fixed 0/100 levels from Aroon

### DIFF
--- a/src/core/native-indicators/classics/trend.ts
+++ b/src/core/native-indicators/classics/trend.ts
@@ -20,10 +20,6 @@ const aroon: ClassicIndicatorSpec = {
                 { key: 'up', title: 'Aroon up', values: up, color: BULLISH, width: 2 },
                 { key: 'down', title: 'Aroon down', values: down, color: BEARISH, width: 2 },
             ],
-            levels: [
-                { key: 'upper', price: 100, color: NEUTRAL, lineStyle: 'dotted' },
-                { key: 'lower', price: 0, color: NEUTRAL, lineStyle: 'dotted' },
-            ],
         };
     },
 };


### PR DESCRIPTION
Drops the two dotted horizontal levels the Aroon indicator emitted at 0 and 100. Plots are unchanged.

Made with [Cursor](https://cursor.com)