### PR TITLE
Status line: adapt the readout to the chart width in steps (v0.6.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Vela, newest first.
 
-## [Unreleased]
+## [v0.6.18]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ All notable changes to Vela, newest first.
 
 ### Changed
 
+- **The status line adapts to the chart's width in steps.** On a wide chart the symbol,
+  venue, timeframe and market status share one line with the full O/H/L/C readout and
+  the bar change. As the chart narrows, the values first move to a second line under the
+  symbol, then drop the open, high and low to keep only the close and the change, and
+  finally keep just the close and its percent change — so the readout stays legible
+  instead of overflowing the plot. Multi-chart cells and phone-width charts follow the
+  same steps; a cell too narrow for even the shortest readout hides it rather than
+  clipping it.
 - **The built-in VWAP now carries standard-deviation bands.** Volume Weighted Average
   Price draws up to three ±k·σ band pairs around the average — a Bands group gives each
   band its own on/off toggle and multiplier on one row (band 1 is on by default at 1σ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/src/widget/format.ts
+++ b/src/widget/format.ts
@@ -21,3 +21,10 @@ export function fmtChange(open: number | null | undefined, close: number | null 
     const sign = diff >= 0 ? '+' : '';
     return `${sign}${fmtPrice(diff, decimalsFor(close))} (${sign}${pct.toFixed(2)}%)`;
 }
+
+/** Signed percent change alone ("+1.23%") from open→close; `''` when unavailable. */
+export function fmtChangePct(open: number | null | undefined, close: number | null | undefined): string {
+    if (open == null || close == null || !Number.isFinite(open) || !Number.isFinite(close) || open === 0) return '';
+    const pct = ((close - open) / open) * 100;
+    return `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`;
+}

--- a/src/widget/statusline-model.ts
+++ b/src/widget/statusline-model.ts
@@ -17,6 +17,47 @@ export function segmentVisibility(parts: Record<StatuslinePart, boolean>, chartH
     return { avatar: parts.logo, symbol: parts.name, meta: parts.name, market: parts.market, ohlc: parts.ohlc && !chartHidden, change: parts.change && !chartHidden, eye: chartHidden };
 }
 
+/** How much of the value readout a width step keeps: every value the price style reads
+ *  out ('full'), just the close and the bar change ('compact'), or the close and the
+ *  percent delta alone ('minimal'). */
+export type StatuslineLevel = 'full' | 'compact' | 'minimal';
+
+/** One rung of the width ladder: whether the value readout sits on its own row under
+ *  the symbol line, and how much of it is kept. */
+export interface StatuslineLayout {
+    stacked: boolean;
+    level: StatuslineLevel;
+}
+
+/** The width ladder the status line walks down until its row fits, widest first: the
+ *  values first move under the symbol line, then shed O/H/L, then the absolute change.
+ *  Every status line — single chart, phone, multi-chart cell — walks the same rungs; in
+ *  fit mode whatever still overflows after the last one is hidden segment by segment
+ *  (see `Statusline.fit`). */
+export const STATUSLINE_LADDER: readonly StatuslineLayout[] = [
+    { stacked: false, level: 'full' },
+    { stacked: true, level: 'full' },
+    { stacked: true, level: 'compact' },
+    { stacked: true, level: 'minimal' },
+];
+
+/** Which of the O/H/L/C cells a level keeps, given the price style's readout shape.
+ *  One-line styles ('value') only ever plot the close, so their readout is the single
+ *  unlabeled value at every level; bar-shaped styles drop O/H/L below 'full' and keep
+ *  the labeled close, whose 'C' the 'minimal' level drops too. */
+export function readoutCells(level: StatuslineLevel, readout: 'ohlc' | 'value'): ReadonlyArray<{ key: 'open' | 'high' | 'low' | 'close'; label: string }> {
+    if (readout === 'value') return [{ key: 'close', label: '' }];
+    if (level === 'full') {
+        return [
+            { key: 'open', label: 'O' },
+            { key: 'high', label: 'H' },
+            { key: 'low', label: 'L' },
+            { key: 'close', label: 'C' },
+        ];
+    }
+    return [{ key: 'close', label: level === 'compact' ? 'C' : '' }];
+}
+
 /** Right-click menu rows: one checkable toggle per part (same labels as the settings
  *  dialog's Status line tab), then the chart itself — the same hide/show of the price
  *  series the object tree's eye drives. */

--- a/src/widget/statusline.ts
+++ b/src/widget/statusline.ts
@@ -7,10 +7,10 @@ import { injectStyles } from '../ui/styles';
 import { Tooltip } from '../ui/components/tooltip';
 import { CalloutBubble } from '../ui/components/callout-bubble';
 import { Menu } from '../ui/components/menu';
-import { segmentVisibility, statuslineMenuItems, type StatuslinePart } from './statusline-model';
+import { segmentVisibility, statuslineMenuItems, STATUSLINE_LADDER, readoutCells, type StatuslinePart, type StatuslineLayout } from './statusline-model';
 import { SESSION_PRE, SESSION_POST, SESSION_OFF } from '../core/palette';
 import { iconAt } from '../core/icons';
-import { fmtPrice, fmtChange, decimalsFor } from './format';
+import { fmtPrice, fmtChange, fmtChangePct, decimalsFor } from './format';
 import { timeframeLabel } from './timeframe';
 import { tickerIconEl } from './symbol-icon';
 import { parseSymbol } from '../data/ProviderRegistry';
@@ -30,6 +30,11 @@ const CSS = `
     display: flex;
     align-items: baseline;
     gap: var(--vela-space-2);
+    /* The chip never grows past the plot: fit() measures overflow against this width to
+     * walk the layout ladder (stack, then shed values), so overflow:hidden only guards
+     * the transient between a resize and the next measure. */
+    max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
+    overflow: hidden;
     color: var(--vela-fg);
     font-size: var(--vela-font-size-md);
     /* Same chip treatment as the indicator legend rows (InputsUI): a translucent wash of
@@ -51,6 +56,31 @@ const CSS = `
 /* Chart hidden (the price series' eye — renderer 'candleVisible'): the line dims to
  * the same 0.5 wash a hidden indicator's legend row wears. */
 .vela-statusline.vela-sl-chart-hidden { opacity: 0.5; }
+/* Two rows inside the chip — the identity (logo / symbol / meta / market badge) and the
+ * value readout (O/H/L/C + change, or the show-chart eye). In the widest layout they sit
+ * side by side on one line; the STACKED layouts (fit() decides, see the ladder in
+ * statusline-model) turn the chip into a column so the values drop under the symbol. */
+.vela-statusline .vela-sl-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--vela-space-2);
+    white-space: nowrap;
+}
+.vela-statusline.vela-sl-stacked {
+    flex-direction: column;
+    align-items: flex-start;
+    /* The same air between the two rows as between the values row and the legend row
+     * that follows the chip (see the stacked legend shift below). */
+    row-gap: var(--vela-space-1);
+}
+/* Stacked, the identity row may shrink (the meta carries the ellipsis) — the values row
+ * never does, so its overflow is what fit() measures to keep descending the ladder. */
+.vela-statusline.vela-sl-stacked .vela-sl-identity { max-width: 100%; }
+.vela-statusline.vela-sl-stacked .vela-sl-meta {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 .vela-statusline .vela-sl-avatar {
     width: 18px;
     height: 18px;
@@ -102,59 +132,13 @@ const CSS = `
  * stylesheet is document-global, so a bare attribute selector here would shift every
  * chart on the page, including statusline-less ones. */
 .vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(26px); }
-/* Mobile: two-line chip — logo / symbol / meta / market status on one aligned row, the
- * bar change on the next. Full O/H/L/C stays hidden (too dense on a phone-width plot).
- * GRID, not a wrapping flexbox: an absolutely positioned wrapping flex container sizes
- * to the one-line sum of ALL segments (max-content), so its background used to stretch
- * far past the market badge; a grid hugs the widest actual row. The meta column may
- * shrink (it carries the ellipsis), the others wrap their content. */
-[data-layout='mobile'] .vela-statusline {
-    display: grid;
-    grid-template-columns: auto auto minmax(0, auto) auto;
-    justify-content: start;
-    align-items: center;
-    row-gap: 1px;
-    max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
-    font-size: var(--vela-font-size-sm);
-}
-[data-layout='mobile'] .vela-statusline .vela-sl-symbol {
-    font-size: var(--vela-font-size-md);
-    line-height: 1;
-}
-[data-layout='mobile'] .vela-statusline .vela-sl-meta {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    line-height: 1;
-}
-[data-layout='mobile'] .vela-statusline .vela-sl-avatar,
-[data-layout='mobile'] .vela-statusline .vela-sl-market { align-self: center; }
-[data-layout='mobile'] .vela-statusline .vela-sl-ohlc { display: none !important; }
-[data-layout='mobile'] .vela-statusline .vela-sl-change {
-    /* Second row, under the text column — the avatar keeps the first column. */
-    grid-column: 2 / -1;
-    font-size: var(--vela-font-size-sm);
-    line-height: 1.2;
-}
-[data-layout='mobile'] .vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(40px); }
-/* FIT mode (multi-chart cells — see setFitMode): the line never wraps; segments that
- * don't fit are HIDDEN by fit() (change first, then meta, then the market badge), so
- * overflow:hidden only guards the transient between a resize and the next measure.
- * Placed after the mobile block on purpose: same specificity, later wins. */
-.vela-statusline.vela-sl-fit {
-    display: flex; /* undo the mobile grid — fit mode is one flex row again */
-    flex-wrap: nowrap;
-    align-items: center;
-    max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
-    overflow: hidden;
-}
-.vela-statusline.vela-sl-fit .vela-sl-change {
-    flex-basis: auto;
-    padding-left: 0;
-}
-/* One row again — the mobile two-line shift doesn't apply in fit mode. */
-[data-layout='mobile'] .vela-sl-fit-host.vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(26px); }
+/* A stacked chip is two lines tall — the legend shifts one more line. fit() flags the
+ * host whenever the ladder lands on a stacked layout. */
+.vela-has-statusline.vela-sl-stacked-host [${LEGEND_AT_TOP_ATTR}] { transform: translateY(40px); }
+/* Mobile: the same ladder at the phone's type scale — the width alone decides how much
+ * of the readout fits, exactly as on a narrow desktop chart. */
+[data-layout='mobile'] .vela-statusline { font-size: var(--vela-font-size-sm); }
+[data-layout='mobile'] .vela-statusline .vela-sl-symbol { font-size: var(--vela-font-size-md); }
 `;
 
 interface BarLike {
@@ -299,6 +283,12 @@ export class Statusline {
     /** Fit mode (multi-chart cells): one row, overflowing segments hidden — see {@link setFitMode}. */
     private fitMode = false;
     private fitRO: ResizeObserver | null = null;
+    /** The identity row (avatar / symbol / meta / market) and the values row (readout /
+     *  eye) — one line side by side, or a two-line column once the ladder stacks them. */
+    private readonly identityRow: HTMLElement;
+    private readonly valuesRow: HTMLElement;
+    /** The ladder rung currently applied — see {@link fit}. */
+    private layout: StatuslineLayout = { stacked: false, level: 'full' };
 
     constructor(
         private readonly host: HTMLElement,
@@ -351,8 +341,19 @@ export class Statusline {
             this.menuHooks?.setChartVisible(true);
             this.setChartHidden(false);
         });
-        this.el.append(this.avatarEl, this.symbolEl, this.metaEl, this.marketEl, this.ohlcEl, this.changeEl, this.eyeEl);
+        this.identityRow = doc.createElement('span');
+        this.identityRow.className = 'vela-sl-row vela-sl-identity';
+        this.identityRow.append(this.avatarEl, this.symbolEl, this.metaEl, this.marketEl);
+        this.valuesRow = doc.createElement('span');
+        this.valuesRow.className = 'vela-sl-row vela-sl-values';
+        this.valuesRow.append(this.ohlcEl, this.changeEl, this.eyeEl);
+        this.el.append(this.identityRow, this.valuesRow);
         host.appendChild(this.el);
+        // The ladder measures against the plot width — re-fit on every host resize.
+        if (typeof ResizeObserver !== 'undefined') {
+            this.fitRO = new ResizeObserver(() => this.fit());
+            this.fitRO.observe(host);
+        }
         // The tooltips portal to the nearest `.vela-ui` ancestor for theme tokens — resolve
         // them AFTER the statusline is in the DOM. The badge's content follows setMarketStatus.
         this.marketTip = new Tooltip(this.marketEl, { content: MARKET_LABELS.open, placement: 'bottom' });
@@ -372,27 +373,15 @@ export class Statusline {
     }
 
     /**
-     * Multi-chart cells: keep the line on ONE row whatever the cell width — never wrap.
-     * Segments that don't fit are hidden outright rather than clipped mid-glyph, least
-     * important first: OHLC, then the bar change, the venue/timeframe meta, and the
-     * market badge; the logo + ticker always stay. Re-fits live on host resizes.
+     * Multi-chart cells: the same width ladder as a single chart, plus a last resort for
+     * cells too narrow for even its bottom rung — whatever still overflows is hidden
+     * outright rather than clipped mid-glyph, least important first: the values, the
+     * venue/timeframe meta, then the market badge; the logo + ticker always stay.
      */
     setFitMode(on: boolean): void {
         if (on === this.fitMode) return;
         this.fitMode = on;
-        this.el.classList.toggle('vela-sl-fit', on);
-        this.host.classList.toggle('vela-sl-fit-host', on);
-        if (on) {
-            if (typeof ResizeObserver !== 'undefined' && !this.fitRO) {
-                this.fitRO = new ResizeObserver(() => this.fit());
-                this.fitRO.observe(this.host);
-            }
-            this.fit();
-        } else {
-            this.fitRO?.disconnect();
-            this.fitRO = null;
-            this.syncParts(); // restore whatever fit() had hidden
-        }
+        this.fit();
     }
 
     /** Project the parts config onto the segments (the baseline fit() prunes from). */
@@ -405,23 +394,48 @@ export class Statusline {
         this.ohlcEl.style.display = seg.ohlc ? '' : 'none';
         this.changeEl.style.display = seg.change ? '' : 'none';
         this.eyeEl.style.display = seg.eye ? 'inline-flex' : 'none';
+        // An empty values row must not hold a gap/padding of its own on the line.
+        this.valuesRow.style.display = seg.ohlc || seg.change || seg.eye ? '' : 'none';
     }
 
-    /** Hide overflowing segments until the row fits its max-width (fit mode only). */
+    /** Apply one ladder rung: the stacked/inline shape and the readout's level. */
+    private applyLayout(layout: StatuslineLayout): void {
+        this.layout = layout;
+        this.el.classList.toggle('vela-sl-stacked', layout.stacked);
+        this.host.classList.toggle('vela-sl-stacked-host', layout.stacked);
+        this.renderValues();
+    }
+
+    /**
+     * Walk the width ladder (see {@link STATUSLINE_LADDER}) until the chip fits its
+     * max-width: the full one-line readout, then the values stacked under the symbol
+     * line, then O/H/L shed, then the absolute change. In fit mode, when the last rung
+     * still overflows, whole segments hide, least important first. Without layout
+     * (detached host, node tests) nothing overflows, so the widest rung stays.
+     */
     private fit(): void {
-        if (!this.fitMode) return;
-        this.syncParts(); // start from the full (parts-allowed) row, then prune
+        this.syncParts(); // start from the full (parts-allowed) row, then descend
         const seg = segmentVisibility(this.parts, this.chartHidden);
+        const overflows = (): boolean => this.el.scrollWidth > this.el.clientWidth;
+        // Only a value readout can stack or shed — with none showing the chip stays one line.
+        const hasValues = seg.ohlc || seg.change;
+        for (const rung of STATUSLINE_LADDER) {
+            this.applyLayout(rung);
+            if (!hasValues || !overflows()) break;
+        }
+        if (!this.fitMode) return;
         const order: Array<[HTMLElement, boolean]> = [
-            [this.ohlcEl, seg.ohlc],
-            [this.changeEl, seg.change],
+            [this.valuesRow, hasValues],
             [this.metaEl, seg.meta],
             [this.marketEl, seg.market],
         ];
         for (const [el, shown] of order) {
-            if (this.el.scrollWidth <= this.el.clientWidth) break;
+            if (!overflows()) break;
             if (shown) el.style.display = 'none';
         }
+        // With the values row gone the chip is one line again — un-stack so the legend
+        // shift drops back to a single line's.
+        if (this.valuesRow.style.display === 'none') this.applyLayout({ ...this.layout, stacked: false });
     }
 
     /** Shape + color the value readout after the active price style: its own up/down
@@ -555,7 +569,7 @@ export class Statusline {
         this.marketTip.destroy();
         this.eyeTip.destroy();
         this.marketBubble.destroy();
-        this.host.classList.remove('vela-has-statusline', 'vela-sl-fit-host'); // the legend shift leaves with the line
+        this.host.classList.remove('vela-has-statusline', 'vela-sl-stacked-host'); // the legend shift leaves with the line
         this.el.remove();
     }
 
@@ -569,6 +583,11 @@ export class Statusline {
         // renderer on every readout refresh (bar ticks, crosshair moves), so a toggle
         // made anywhere (the object tree's eye) reaches the status line.
         if (this.menuHooks) this.setChartHidden(!this.menuHooks.chartVisible());
+        this.fit(); // re-walks the ladder — the readout's width follows the bar
+    }
+
+    /** Write the value readout for the current bar at the current ladder level. */
+    private renderValues(): void {
         const bar = this.hoverBar ?? this.lastBar;
         if (!bar) {
             this.ohlcEl.replaceChildren();
@@ -590,13 +609,14 @@ export class Statusline {
             s.appendChild(b);
             return s;
         };
-        // Bar-shaped styles read out all four values; a one-line style (line/area/baseline)
-        // plots a single series, so its readout is just that value — the close.
-        if (this.readout === 'value') this.ohlcEl.replaceChildren(cell('', bar.close));
-        else this.ohlcEl.replaceChildren(cell('O', bar.open), cell('H', bar.high), cell('L', bar.low), cell('C', bar.close));
-        this.changeEl.textContent = fmtChange(bar.open, bar.close);
+        // Bar-shaped styles read out all four values at the full level and just the close
+        // below it; a one-line style (line/area/baseline) plots a single series, so its
+        // readout is that value — the close — at every level. The minimal level keeps the
+        // percent delta alone.
+        const { level } = this.layout;
+        this.ohlcEl.replaceChildren(...readoutCells(level, this.readout).map((c) => cell(c.label, bar[c.key])));
+        this.changeEl.textContent = level === 'minimal' ? fmtChangePct(bar.open, bar.close) : fmtChange(bar.open, bar.close);
         this.changeEl.dataset.dir = up ? 'up' : 'down';
         this.changeEl.style.color = ink;
-        this.fit(); // the readout's width just changed — cheap no-op outside fit mode
     }
 }

--- a/test/statusline-model.test.ts
+++ b/test/statusline-model.test.ts
@@ -3,7 +3,8 @@
 // meta — and the right-click menu's rows. Pure functions over plain objects, node env;
 // the real overlay and menu are proven in the browser.
 import { describe, it, expect } from 'vitest';
-import { segmentVisibility, statuslineMenuItems, type StatuslinePart } from '../src/widget/statusline-model';
+import { segmentVisibility, statuslineMenuItems, readoutCells, type StatuslinePart } from '../src/widget/statusline-model';
+import { fmtChangePct } from '../src/widget/format';
 
 const allOn: Record<StatuslinePart, boolean> = { logo: true, name: true, market: true, ohlc: true, change: true };
 
@@ -50,6 +51,32 @@ describe('segmentVisibility', () => {
         expect(seg.change).toBe(true);
         expect(seg.eye).toBe(false);
         expect(segmentVisibility({ ...allOn, ohlc: false }, false).ohlc).toBe(false);
+    });
+});
+
+describe('readoutCells', () => {
+    it('bar-shaped styles read out all four values at the full level', () => {
+        expect(readoutCells('full', 'ohlc').map((c) => c.label)).toEqual(['O', 'H', 'L', 'C']);
+    });
+
+    it('compact keeps the labeled close; minimal drops the label too', () => {
+        expect(readoutCells('compact', 'ohlc')).toEqual([{ key: 'close', label: 'C' }]);
+        expect(readoutCells('minimal', 'ohlc')).toEqual([{ key: 'close', label: '' }]);
+    });
+
+    it('one-line styles only ever read out the unlabeled close', () => {
+        for (const level of ['full', 'compact', 'minimal'] as const) {
+            expect(readoutCells(level, 'value')).toEqual([{ key: 'close', label: '' }]);
+        }
+    });
+});
+
+describe('fmtChangePct', () => {
+    it('formats the signed percent delta alone', () => {
+        expect(fmtChangePct(100, 101.5)).toBe('+1.50%');
+        expect(fmtChangePct(100, 98)).toBe('-2.00%');
+        expect(fmtChangePct(0, 98)).toBe('');
+        expect(fmtChangePct(null, 98)).toBe('');
     });
 });
 


### PR DESCRIPTION
## Summary

The status line adapts to the chart's width in steps instead of overflowing the plot, and this cuts **v0.6.18**.

**Width ladder** (widest first; every status line — single chart, phone layout, multi-chart cell — takes the same steps):

1. One line: symbol · venue · timeframe · market status · `O H L C` · change
2. Values move to a second line under the symbol line (full `O H L C` + change)
3. Second line keeps only `C` + change
4. Second line keeps only the close and its percent change

Multi-chart cells too narrow for even step 4 hide the readout, then the venue/timeframe, then the market badge, rather than clipping mid-glyph (the logo + ticker always stay).

## Details

- `statusline-model.ts`: `STATUSLINE_LADDER` (the rungs) and `readoutCells(level, readout)` (which cells each level keeps) — pure, tested.
- `statusline.ts`: segments grouped into an identity row and a values row; `fit()` applies each rung and measures overflow against the chip's `max-width` (plot minus the renderer's gutters), stepping down until it fits. The chip re-fits on host resizes and on every readout refresh.
- The stacked chip spaces its rows with the same gap as between the values row and the indicator legend below; the legend shifts down one more line while the chip is stacked and returns when it isn't.
- `format.ts`: `fmtChangePct` for the last rung.
- The old mobile-only grid CSS (which always hid OHLC) is replaced by the shared ladder at the mobile type scale.

## Verification

- Gate: typecheck · lint · test (1575) · build — all green.
- Playground (HMR from `src/`), swept 1800 → 240 px and back in 20 px steps with frame-synced reads: every rung appears in order in both directions, no overflow at any step. Single chart: inline ≥ ~1000 → stacked OHLC → stacked `C` (780) → close + % (240). 2×2 workspace: inline (877 px cell) → stacked OHLC (677) → stacked `C` (457) → close + % (239) → values + meta hidden, un-stacked (209).
- Legend shift measured at 26 px (one line) / 40 px (stacked); row gaps measured on text boxes at 5.2 px / 5.4 px.

## Release

Second commit renames `[Unreleased]` to `[v0.6.18]` and bumps `package.json` / lockfile, the same shape as the previous release commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only status line layout and formatting; behavior is well-covered by unit tests with no auth, data, or security impact.
> 
> **Overview**
> **v0.6.18** release bump plus a responsive in-chart **status line** that steps down layout as the plot narrows instead of overflowing.
> 
> The chip is split into **identity** (logo, symbol, meta, market) and **values** (OHLC, change, eye) rows. A shared **`STATUSLINE_LADDER`** walks four rungs: one-line full readout → stacked full OHLC → stacked close + change → stacked close + **percent-only** change via new **`fmtChangePct`**. **`fit()`** measures overflow against a plot **`max-width`**, applies each rung, and re-runs on **`ResizeObserver`** and readout updates. **Multi-chart fit mode** still hides whole segments (values, meta, market) when the ladder is exhausted; mobile-specific grid CSS that always hid OHLC is removed in favor of the same ladder at smaller type.
> 
> Pure model helpers **`readoutCells`** / ladder types live in **`statusline-model.ts`** with tests; stacked chips shift the top legend an extra line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d1c7e3a69f8e80ebac15ea9bbb5854ec2f39a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->