### PR TITLE
Release v0.6.18

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,0 +1,116 @@
+name: Report a bug
+description: Something in Vela renders, behaves, or types incorrectly.
+title: '[Bug]: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Charts are visual and runtime-heavy, so the fastest path to a fix is a reproduction a maintainer can *see*: exact steps in the playground, a minimal page, or a failing test. A screenshot or a short recording of the wrong rendering is worth a lot.
+
+        Please search the existing issues first. If you have a question or an idea rather than a defect, use the **Feature request** or **Community feedback** template.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where does it happen?
+      description: Pick the entry point you use. It tells us which layer to look at first.
+      options:
+        - Headless chart (`new Vela(...)` from `@luxalgo/vela`)
+        - Workspace / widget (`@luxalgo/vela/workspace`)
+        - Drawing tools
+        - Built-in (native) indicators
+        - Scripting engine integration (`ScriptingEngine` port, `@luxalgo/vela-pinets` addon)
+        - Data provider (Binance, Coinbase, Hyperliquid, or a custom provider)
+        - Plugin SDK (`@luxalgo/vela/plugin`: chart types, renderer layers, widget actions)
+        - UI kit (`@luxalgo/vela/ui`)
+        - Browser bundle (`dist/vela.global.js`)
+        - TypeScript types / package exports
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the actual behavior, and what you expected to see instead. Attach a screenshot or recording if the problem is visual.
+      placeholder: |
+        Actual: the crosshair price label is cut off at the right edge of the pane when ...
+        Expected: the label stays fully visible inside the price axis.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: The minimal sequence that triggers the bug. Steps in the playground (`npm run playground`, `/widget.html` or `/workspace.html`) are ideal because they run against `src/`. Otherwise share a minimal page, a StackBlitz or CodeSandbox link, or a failing vitest test.
+      placeholder: |
+        1. Open /widget.html with symbol BTCUSDT, timeframe 60
+        2. Zoom in until fewer than 20 bars are visible
+        3. Move the pointer over the last bar
+        4. See ...
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: code
+    attributes:
+      label: Code
+      description: The options you pass to `Vela` / `VelaWorkspace`, the provider or engine you register, and any plugin SDK registrations involved. A `chart.inspect()` snapshot is helpful for rendering bugs.
+      render: ts
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console output
+      description: Errors or warnings from the browser console, if any. Paste them as text, not as a screenshot.
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Vela version
+      description: The `@luxalgo/vela` version (`npm ls @luxalgo/vela`). Add the addon version if a scripting engine is involved.
+      placeholder: '@luxalgo/vela 0.6.18, @luxalgo/vela-pinets 0.2.7'
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+      placeholder: 'Chrome 128 on Windows 11 · Safari 18 on iOS 18 · Firefox 130 on Ubuntu 24.04'
+    validations:
+      required: true
+  - type: dropdown
+    id: renderer
+    attributes:
+      label: Renderer backend
+      description: Vela draws with WebGL2 and falls back to canvas2d when WebGL2 is unavailable. If you are not sure, leave "Unknown".
+      options:
+        - Unknown
+        - WebGL2
+        - canvas2d fallback
+        - Both (reproduces on either)
+    validations:
+      required: false
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Is this a regression?
+      description: Did this work in an earlier version of Vela?
+      options:
+        - Not sure
+        - Yes, it worked in an earlier version (say which one in the description)
+        - No, it never worked
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched the existing issues and this bug has not been reported yet
+          required: true
+        - label: I agree to follow this project's [code of conduct](https://github.com/LuxAlgo/Vela/blob/main/CONTRIBUTING.md#code-of-conduct)
+          required: true

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yml
@@ -1,0 +1,101 @@
+name: Feature request
+description: Propose a new capability or a change to how Vela behaves.
+title: '[Feature]: '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping shape Vela. Start with the problem you are trying to solve, not only the solution you have in mind — that is what lets us find the right seam for it.
+
+        Vela is designed to be extended without forking: chart types, renderer layers, native indicators, widget actions, and settings sections all register through the public [plugin SDK](https://github.com/LuxAlgo/Vela/blob/main/docs/contributing/plugin-sdk.md), and data providers and scripting engines plug in behind ports. Before proposing a change to the library itself, check whether the SDK already lets you build what you need. If the feature is Pine Script specific, it belongs in the [engine addon](https://github.com/LuxAlgo/Vela-pinets) instead.
+
+        A feature request that changes a public option, type, port, or SDK registry is reviewed as a design first (see [Design-first changes](https://github.com/LuxAlgo/Vela/blob/main/CONTRIBUTING.md#design-first-changes) in the contributing guide). Opening the issue before writing code saves you from building something that cannot be merged.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and what stops you today? Describe the use case from the point of view of the person using the chart or the developer integrating it.
+      placeholder: |
+        As a developer embedding the workspace, I want users to ... but today ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should it work? Sketch the behavior, and the option, method, or SDK surface you imagine if you have one in mind. Pseudo-code is welcome.
+      placeholder: |
+        Add a `foo` option to `VelaWorkspace` that ... / A new drawing tool that ... / A renderer layer placement that ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which part of Vela does this touch?
+      description: Your best guess is fine; maintainers will confirm.
+      options:
+        - Headless core (data model, options, chart API)
+        - Workspace / widget (topbar, pickers, layouts, keyboard, persistence)
+        - Drawing tools
+        - Built-in (native) indicators
+        - Renderer (native WebGL2 / canvas2d, layers, axes, crosshair)
+        - Data providers (a new provider, or provider capabilities)
+        - Scripting engine integration (`ScriptingEngine` port)
+        - Plugin SDK (a new registry or extension point)
+        - UI kit
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: public-api
+    attributes:
+      label: Does it change a public interface?
+      description: A new or changed option, exported type, method, port, or plugin SDK registry is visible to every Vela consumer and has semver consequences.
+      options:
+        - Not sure
+        - No, it is internal or purely additive UI behavior
+        - Yes, it adds a new public option, method, type, or SDK surface
+        - Yes, it changes or removes an existing public behavior (potentially breaking)
+    validations:
+      required: true
+  - type: textarea
+    id: sdk-check
+    attributes:
+      label: Can it be built with the existing plugin SDK?
+      description: If you tried to build it outside the core (a chart type, a renderer layer, a widget action, a custom provider) and hit a wall, describe exactly what was missing. That gap is often the real feature.
+      placeholder: |
+        I tried registering a renderer layer with `placement: 'above-data'`, but the layer has no access to ...
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to solve the problem, and why they fall short.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, screenshots, links to related issues, or examples of the behavior in other software described by what it does (please do not name other charting products).
+    validations:
+      required: false
+  - type: checkboxes
+    id: implementation
+    attributes:
+      label: Implementation
+      options:
+        - label: I would like to implement this myself once the design is agreed
+          required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched the existing issues and this feature has not been requested yet
+          required: true
+        - label: I agree to follow this project's [code of conduct](https://github.com/LuxAlgo/Vela/blob/main/CONTRIBUTING.md#code-of-conduct)
+          required: true

--- a/.github/ISSUE_TEMPLATE/3.community_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/3.community_feedback.yml
@@ -1,0 +1,51 @@
+name: Community feedback
+description: Feedback on the docs, the contribution process, or the project as a whole.
+title: '[Feedback]: '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for feedback that is not a defect and not a feature of the library: a docs page that led you astray, a contributing step that was unclear, an issue or pull request template that asked the wrong questions, or an idea that would make Vela easier to adopt or contribute to.
+
+        For a rendering or behavior problem, use **Report a bug**. For a new capability, use **Feature request**.
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      options:
+        - Documentation (guides, API reference, examples)
+        - Contribution process (templates, review, CLA, workflow)
+        - Playground and developer experience
+        - Release notes / changelog
+        - Project direction
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    attributes:
+      label: What happened, or what would you change?
+      description: Tell us what you ran into, or what you would like the project to do differently.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Where?
+      description: Links to the docs page, issue, pull request, or template you are referring to.
+    validations:
+      required: false
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change
+      description: If you have a concrete proposal, describe the outcome you would like to see.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I agree to follow this project's [code of conduct](https://github.com/LuxAlgo/Vela/blob/main/CONTRIBUTING.md#code-of-conduct)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Read the documentation
+    url: https://github.com/LuxAlgo/Vela/blob/main/docs/index.md
+    about: User guides, options, the API reference, and the plugin SDK. Many questions are answered there.
+  - name: Contributing guide
+    url: https://github.com/LuxAlgo/Vela/blob/main/CONTRIBUTING.md
+    about: How to set up the project, what a good pull request looks like, and how issues are handled.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+<!--
+Thank you for contributing to Vela.
+
+Please read the contributing guide before submitting:
+https://github.com/LuxAlgo/Vela/blob/main/CONTRIBUTING.md
+
+The most important rule: ONE pull request does ONE thing — one bug fix, one feature,
+one refactor, or one documentation update. If your title needs the word "and", split
+the PR. Focused PRs are reviewed faster and merge sooner.
+
+Open the PR against the `dev` branch.
+-->
+
+## Background
+
+<!--
+Why is this change necessary? Link the issue or discussion that motivated it.
+-->
+
+## Summary
+
+<!-- What did you change? Keep it to the one thing this PR does. -->
+
+## End-to-end verification
+
+<!--
+For features and bug fixes. Remove the section for docs-only changes.
+Explain how you verified the change works end to end: what you exercised in the
+playground (`npm run playground`), in which browser, and what you saw.
+Do not list unit tests or lint here — they are covered by the checklist.
+-->
+
+## Checklist
+
+<!--
+Do not edit this list. Leave items unchecked that do not apply.
+-->
+
+- [ ] This PR does one thing (one fix, one feature, one refactor, or one docs change)
+- [ ] `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` all pass
+- [ ] Tests have been added / updated (for bug fixes / features)
+- [ ] Documentation in `docs/` has been added / updated (for public interface or feature changes)
+- [ ] `CHANGELOG.md` has an entry under `[Unreleased]` (for user-visible changes)
+- [ ] I have signed the CLA (the bot asks in this PR)
+- [ ] I have reviewed this pull request myself (self-review)
+
+## Contributor credit
+
+<!--
+List issue authors, reviewers, or community members whose report, reproduction,
+test case, or context should be credited. Remove the section if not needed.
+-->
+
+## Future work
+
+<!--
+Things not covered by this PR that could be done in follow-up PRs.
+Remove the section if not needed.
+-->
+
+## Related issues
+
+<!--
+List related issues, e.g. "Fixes #123". Remove the section if not needed.
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **The symbol menu and the timeframe menu no longer lose keystrokes when you type
+  fast.** Typing straight onto the chart opens the symbol menu (letters) or the
+  timeframe menu (digits) seeded with what you typed. The second key used to vanish
+  when it arrived before the menu's field had taken focus, leaving only the first
+  character; every key now reaches the menu.
+
 ## [v0.6.16]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ All notable changes to Vela, newest first.
   cursor passes over). Dragging the body of any selected drawing then moves the whole
   selection together (locked drawings stay put), Ctrl/Cmd+dragging it copies the whole
   selection, and Delete, the arrow keys, copy, duplicate and a middle-click on a selected
-  drawing act on all of them, each as a single undo step.
+  drawing act on all of them, each as a single undo step. A lock protects a drawing inside
+  a group: deleting a multi-selection removes only its unlocked members and leaves the
+  locked ones in place, still selected. The object tree highlights every selected drawing,
+  not just the first, and the `drawing:selected` event now carries the full list as `ids`
+  alongside the primary `id`.
 - **One settings popup for a whole selection.** Selecting several drawings opens a single
   quick-settings popup for all of them, showing only the controls every one of them
   supports — three trend lines get the full trend-line bar; a trend line, a box and a text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Duplicate drawings by dragging, and select several at once.** Hold **Ctrl/Cmd** and
+  drag a drawing's body to pull a copy away from it: the original stays where it is, the
+  copy follows the cursor and is committed when you release — selected, with its
+  quick-settings popup open — as one undo step; press **Escape** mid-drag and nothing is
+  left behind. The quick-settings popup's overflow
+  menu gains a **Duplicate** entry that clones the drawing in place and hands it the
+  selection, ready to drag. Selection also grows beyond one drawing: **Ctrl/Cmd+click**
+  adds a drawing to (or removes it from) the selection, just as Shift+click does, and
+  **Ctrl/Cmd+drag on an empty spot** sweeps a selection box that picks up every drawing
+  it touches — successive boxes accumulate, and a click on an empty spot clears the
+  selection (while Ctrl/Cmd is held, handles mark only what is selected, not what the
+  cursor passes over). Dragging the body of any selected drawing then moves the whole
+  selection together (locked drawings stay put), Ctrl/Cmd+dragging it copies the whole
+  selection, and Delete, the arrow keys, copy, duplicate and a middle-click on a selected
+  drawing act on all of them, each as a single undo step.
+- **One settings popup for a whole selection.** Selecting several drawings opens a single
+  quick-settings popup for all of them, showing only the controls every one of them
+  supports — three trend lines get the full trend-line bar; a trend line, a box and a text
+  annotation share just their common ground, and anything a member lacks disappears rather
+  than showing disabled. Where the drawings agree a control reads normally; where they
+  differ it reads as mixed — a swatch striped with every color in use, a dash in a
+  dropdown, a half-lit toggle. Any edit applies to every selected drawing as one undo step,
+  and opening a mixed swatch lists the colors currently in use first, so unifying onto one
+  of them is a single click.
+
 ## [v0.6.17]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Vela, newest first.
 
-## [Unreleased]
+## [v0.6.18]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to Vela, newest first.
   per band, its own color (each band starts in a distinct ink) with a Fill switch and the
   fill's own color — opacity included — beside it. Existing saved VWAP settings keep
   working: the period, source and line color keys are unchanged.
+- **The object tree names indicators by their compact title.** An indicator that
+  declares a short title now shows it on its row in the object tree, so the row reads
+  the same as its legend chip. Indicators without a short title keep their full name,
+  and a study pane's heading still carries the full name of the indicator that owns it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ All notable changes to Vela, newest first.
   drag a drawing's body to pull a copy away from it: the original stays where it is, the
   copy follows the cursor and is committed when you release — selected, with its
   quick-settings popup open — as one undo step; press **Escape** mid-drag and nothing is
-  left behind. The quick-settings popup's overflow
-  menu gains a **Duplicate** entry that clones the drawing in place and hands it the
-  selection, ready to drag. Selection also grows beyond one drawing: **Ctrl/Cmd+click**
+  left behind. The quick-settings popup's overflow menu gains a **Duplicate** entry that
+  clones the drawing in place and hands it the selection, ready to drag. Selection also
+  grows beyond one drawing: **Ctrl/Cmd+click**
   adds a drawing to (or removes it from) the selection, just as Shift+click does, and
   **Ctrl/Cmd+drag on an empty spot** sweeps a selection box that picks up every drawing
   it touches — successive boxes accumulate, and a click on an empty spot clears the
@@ -34,7 +34,7 @@ All notable changes to Vela, newest first.
   dropdown, a half-lit toggle. Any edit applies to every selected drawing as one undo step,
   and opening a mixed swatch lists the colors currently in use first, so unifying onto one
   of them is a single click.
-  
+
 ### Changed
 
 - **The built-in VWAP now carries standard-deviation bands.** Volume Weighted Average

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Changed
+
+- **The built-in VWAP now carries standard-deviation bands.** Volume Weighted Average
+  Price draws up to three ±k·σ band pairs around the average — a Bands group gives each
+  band its own on/off toggle and multiplier on one row (band 1 is on by default at 1σ;
+  bands 2 and 3 wait at 2σ and 3σ) — with a soft fill between each pair. The reset
+  period gains **Quarter** and **Year** beside Day, Week and Month, and Source now
+  offers the same choices as the moving averages (Close, Open, High, Low, HL2, HLC3,
+  OHLC4, HLCC4). A Style group at the bottom of the settings holds the VWAP color and,
+  per band, its own color (each band starts in a distinct ink) with a Fill switch and the
+  fill's own color — opacity included — beside it. Existing saved VWAP settings keep
+  working: the period, source and line color keys are unchanged.
+
 ## [v0.6.17]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ All notable changes to Vela, newest first.
 
 ### Changed
 
+- **The status line adapts to the chart's width in steps.** On a wide chart the symbol,
+  venue, timeframe and market status share one line with the full O/H/L/C readout and
+  the bar change. As the chart narrows, the values first move to a second line under the
+  symbol, then drop the open, high and low to keep only the close and the change, and
+  finally keep just the close and its percent change — so the readout stays legible
+  instead of overflowing the plot. Multi-chart cells and phone-width charts follow the
+  same steps; a cell too narrow for even the shortest readout hides it rather than
+  clipping it.
 - **The built-in VWAP now carries standard-deviation bands.** Volume Weighted Average
   Price draws up to three ±k·σ band pairs around the average — a Bands group gives each
   band its own on/off toggle and multiplier on one row (band 1 is on by default at 1σ;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,276 @@
+# Contributing to Vela™
+
+Thank you for considering a contribution to Vela™. Whether you fix a bug, add a drawing
+tool, improve a provider, or clarify the docs, your help is appreciated.
+
+This page tells you how to contribute so your work lands quickly. The most important
+rule is also the shortest one: **one pull request does one thing.**
+
+## Table of contents
+
+- [Code of conduct](#code-of-conduct)
+- [How can I contribute?](#how-can-i-contribute)
+- [Pull request guidelines](#pull-request-guidelines)
+- [Development workflow](#development-workflow)
+- [Testing requirements](#testing-requirements)
+- [Code style](#code-style)
+- [Changelog](#changelog)
+- [License and CLA](#license-and-cla)
+- [Getting help](#getting-help)
+
+---
+
+## Code of conduct
+
+Be respectful and constructive. Assume good faith, critique the code rather than the
+person, and keep the discussion focused on making the library better. Maintainers may
+close or lock threads that do not follow this rule.
+
+---
+
+## How can I contribute?
+
+### Report a bug
+
+Open an issue with the **Report a bug** template. Before you do,
+search the existing issues to avoid duplicates. A useful report includes:
+
+- what you expected and what happened instead
+- reproduction steps: a list of steps to reproduce issues. StackBlitz / CodeSandbox link, images or videos are welcome to illustrate the issue
+- your environment: `@luxalgo/vela` version, the scripting-engine addon and its version
+  if one is involved, browser and OS, and whether the chart runs on WebGL2 or the
+  canvas2d fallback.
+
+Consider opening an issue first for bugs instead of making a PR.
+
+### Request a feature
+
+Open an issue with the **Feature request** template. For
+anything beyond a small addition, open the issue **before** you write code, see
+[Design-first changes](#design-first-changes) below. Agreeing on the shape up front keeps
+you from building something that cannot be merged.
+
+### Share feedback
+
+Use the **Community feedback** issue template for feedback about the project itself:
+the contribution process, the templates, the documentation experience, or the community.
+
+---
+
+## Pull request guidelines
+
+### One PR, one feature
+
+A pull request should contain exactly one logical change: one bug fix, one feature, 
+one refactor, or one documentation update.
+
+Focused PRs are reviewed faster, bisect cleanly when something regresses, produce an
+honest changelog entry, and can be reverted on their own. Large or mixed PRs stall:
+reviewers cannot hold them in their head, one contested part blocks the rest, and a
+revert takes unrelated work down with it.
+
+A simple test: **if the PR title needs the word "and", split it.**
+
+#### Good PRs
+
+- **One bug fix.** "Fix crosshair price label clipping at the right edge of the pane."
+- **One feature.** "Add a Fibonacci wedge drawing tool." / "Add `listSymbols` filtering
+  to the Coinbase provider."
+- **One refactor, on its own.** "Extract shared axis-label formatting into a helper", 
+  with no behavior change, so the diff can be checked mechanically.
+- **One documentation update.** "Document the `persist` option in the workspace guide."
+
+#### PRs that will be sent back to split
+
+- A bug fix plus a new feature plus a drive-by refactor in one diff.
+- A new drawing tool bundled with a redesign of the drawing toolbar.
+- A change that touches a data provider, the renderer, and the widget for unrelated
+  reasons.
+- A "various fixes" PR with several independent fixes. Open one PR per fix, even if each
+  is only a few lines.
+- A "feature dump" of many new indicators or tools in one PR. Land them one at a time.
+
+#### When a feature needs groundwork first
+
+If the feature you want needs a refactor of existing code before it fits, **land the
+refactor as its own PR first**, gate it, and then open the feature PR on top. The
+refactor is reviewed for "same behavior, better shape"; the feature is reviewed for
+"new behavior, correct". Mixing the two makes both reviews harder.
+
+Stacked PRs are welcome, mention the dependency in the description ("Builds on #123").
+
+#### Size
+
+There is no hard line limit, but a PR a reviewer can read in one sitting merges in one
+round. If your change is large because the feature is large, say so in the description
+and explain how the diff is organized. If it is large because it does several things,
+split it.
+
+### Design-first changes
+
+Some changes need agreement on the design before code. **Open an issue first** when your
+change:
+
+- adds or changes a **public option, method, or type**, every Vela consumer sees it,
+  and it has semver consequences;
+- adds or reshapes a **port** (`DataProvider` / `MarketDataFeed`, `ScriptingEngine`,
+  `IChartRenderer`) or a **plugin SDK** registry;
+- **crosses an architecture boundary**, the lint import rules are the architecture,
+  and a boundary failure is a design question, not a style nit;
+- adds a **runtime dependency**;
+- adds a new **renderer backend** or a new **scripting engine** to this repo (engines
+  live in separate packages; see [License and CLA](#license-and-cla)).
+
+Describe the use case, the seam you intend to use, and what stays out of the core.
+Prefer extending Vela through its **public seams**, chart types, renderer layers,
+native indicators, widget actions, settings sections, over adding a new hole in a
+layer. If you believe a new seam is needed, propose it as a neutral, general-purpose
+surface, not one shaped for a single feature.
+
+### PR checklist
+
+Before you mark the PR ready for review, make sure that:
+
+- [ ] the PR does **one thing**, and the title says what it is;
+- [ ] the **four gate checks** pass together: `npm run typecheck`, `npm run lint`,
+      `npm test`, `npm run build`;
+- [ ] **tests** cover the new behavior, and a bug fix includes a test that failed
+      before the fix;
+- [ ] anything visual or interactive was **verified in the playground** in a real
+      browser, and the description says how;
+- [ ] **documentation** in `docs/` is updated when a public interface or a feature
+      changes;
+- [ ] **`CHANGELOG.md`** has an entry under `[Unreleased]` for user-visible work
+      (see [Changelog](#changelog));
+- [ ] the **CLA** is signed (the bot asks in the PR; see [License and CLA](#license-and-cla));
+- [ ] you have **reviewed your own diff** for leftovers: debug output, unrelated
+      formatting changes, files that do not belong.
+
+### PR process
+
+1. **Fork** the repository and create a branch from `dev`. Use a prefix that says what
+   the branch is:
+
+   ```bash
+   git checkout -b fix/crosshair-label-clipping
+   # or
+   git checkout -b feat/fib-wedge-drawing
+   # or
+   git checkout -b docs/workspace-persist-option
+   ```
+
+2. **Make your change** following the guidelines on this page.
+
+3. **Run the gate** and verify in the browser:
+
+   ```bash
+   npm run typecheck && npm run lint && npm test && npm run build
+   npm run playground   # http://localhost:5190
+   ```
+
+4. **Commit** with clear, English, user-readable messages that describe the change.
+
+5. **Push** and open a pull request **against `dev`** (releases are cut from `dev` to
+   `main`). Fill in the PR template.
+
+6. **Respond to review.** Push follow-up commits rather than force-pushing while the
+   review is in progress, so reviewers can see what changed.
+
+---
+
+## Testing requirements
+
+Every behavior change comes with a test. Vela is tested in two tiers; see
+[docs/contributing/testing.md](docs/contributing/testing.md).
+
+- **Unit tests (vitest, Node).** Pure logic and the port contracts. The
+  dependency-injection seams let you drive the core with fake renderers, fake feeds and
+  fake engines, use them instead of mocking internals.
+- **Browser verification (playground).** Anything you need to *see*: a renderer change,
+  a new drawing tool, an interaction. Exercise it in the playground and describe what
+  you checked in the PR.
+
+Three rules:
+
+- **A bug fix starts with a failing test.** Reproduce first; the fix is done when that
+  test passes and the rest of the suite stays green.
+- **A green suite proves nothing about a new feature.** Add a test that would fail if
+  the feature were absent.
+- **Regenerate fixtures deliberately; never hand-edit them.** Captured JSON fixtures are
+  trusted runs. When behavior legitimately changes, regenerate and review the diff.
+
+---
+
+## Code style
+
+- **TypeScript**, typed signatures, no `any` where a real type exists.
+- **Formatting** follows `.prettierrc.json` (4-space indent, single quotes, trailing
+  commas, 160-column width). Run `npx prettier --write <files>` on what you touched.
+- **Lint is architecture.** `npm run lint` enforces the import boundaries: the core
+  imports no concrete backend, the UI kit never imports engine internals, the core never
+  imports the kit, and only the composition root wires defaults. Do not work around a
+  boundary failure, it means the change is in the wrong place.
+- **The core is headless.** No `window`, `document`, `history`, or `location`
+  assumptions outside the renderer and widget layers.
+- **Comments state constraints the code cannot show.** Explain *why*, not *what*; no
+  narration of the next line.
+- **Everything is written in English**, code, comments, commit messages, docs.
+- **Never name other charting products** in code, comments, commit messages, or docs.
+  Describe a feature by its own behavior.
+- **Match the surrounding code**: naming, comment density, file layout. New UI-kit
+  components follow the `controller.ts` + `view.ts` + `styles.css` + `index.ts`
+  skeleton in [docs/contributing/adding-a-ui-component.md](docs/contributing/adding-a-ui-component.md).
+
+---
+
+## Changelog
+
+`CHANGELOG.md` is written for the person **using** Vela, not for the developer reading
+the diff. When your PR changes something a user can notice, add the entry in the same
+PR:
+
+- Put it under a `## [Unreleased]` heading at the top (create it if missing). Never edit
+  a section for a version that has already shipped.
+- Use `### Added` / `### Changed` / `### Fixed`, in that order, only when non-empty.
+  Flag breaking changes inline: `_(Breaking: what changed and what to do instead.)_`
+- Write one entry per feature: `- **Bold, feature-first lead.** ` followed by a short,
+  concrete sentence or two about what the user can now do.
+- Keep it high level. Public names the user types are fine; module paths, internal
+  identifiers and architecture vocabulary are not.
+- Skip internal refactors, tests, CI, and playground-only tweaks.
+
+Read a few existing entries before writing yours and match their tone.
+
+---
+
+## License and CLA
+
+Vela™ is licensed under the **Apache License 2.0** (see [LICENSE](LICENSE)) with a
+**NOTICE-based attribution requirement** (see [NOTICE](NOTICE)): every chart renders a
+small attribution mark by default, and any example or documentation that disables it
+must mention the equivalent-notice obligation. Do not weaken either side.
+
+**Contributor License Agreement.** Contributions to LuxAlgo repositories require a
+signed [CLA](https://github.com/LuxAlgo/cla-signatures/blob/main/CLA.md). You sign it
+once, for all LuxAlgo repositories, from inside your first pull request: a bot comments
+with instructions and the PR status stays pending until the signature is recorded.
+
+**Keep the license boundary intact.** Vela ships no scripting engine and must not
+import one. Pine Script support lives in the separate, AGPL-3.0
+[`@luxalgo/vela-pinets`](https://github.com/LuxAlgo/Vela-pinets) addon; importing it
+(or the PineTS runtime) into this package would pull that license onto Vela, and the
+lint rules reject it. Contributions to the engine belong in that repository.
+
+---
+
+## Getting help
+
+- **Bug reports and feature requests:** [GitHub Issues](https://github.com/LuxAlgo/Vela/issues)
+- **Documentation:** [docs/index.md](docs/index.md), user guides, architecture,
+  and contributor guides
+- **API reference:** [docs/user/api-reference.md](docs/user/api-reference.md)
+- **Plugin SDK:** [docs/contributing/plugin-sdk.md](docs/contributing/plugin-sdk.md)
+
+---
+
+Thank you for contributing to Vela™.

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -367,7 +367,8 @@ can't paint drawings — `chart.drawings.supported` reports this), while the **m
 | `getConfig()` / `applyConfig(doc)` | no | Aliases of `toJSON` / `fromJSON`, mirroring `chart.renderer`. |
 
 Drawing lifecycle is also surfaced as chart events (`drawing:created` / `drawing:edited` /
-`drawing:removed` / `drawing:selected` / `drawing:settings`), and the tool/mode state as
+`drawing:removed` / `drawing:selected` / `drawing:settings` — `drawing:selected` carries the
+primary `id` plus `ids`, every member of a multi-selection), and the tool/mode state as
 `drawing:tool` / `drawing:snap` / `drawing:stay` / `drawing:mode` — the seam an external toolbar mirrors. See
 [Drawing tools](./drawing-tools.md) for the tool catalogue, toolbar UX, and keyboard shortcuts.
 

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -70,8 +70,10 @@ the magnet so the locked angle is kept exactly.
 Select a drawing (click it) to show its **handles** and a compact **quick-settings popup** floating
 beside it. The popup is built from each tool's own schema, so it shows only the controls that tool
 supports — line color/width/style, fill, text, and (for Fibonacci tools) a **gear** panel to
-enable/recolor/label each level. The popup also locks, reorders (bring-to-front /
-send-to-back), and deletes the drawing.
+enable/recolor/label each level. The popup also locks and deletes the drawing, and its overflow
+menu (the `⋮` button) duplicates it in place, reorders it (bring-to-front / send-to-back), or
+resets its settings. A duplicate lands exactly on its source and becomes the selection, ready to
+drag away.
 
 **Text is typed on the chart.** Placing a text annotation opens a blinking caret at the click point
 next to an `Enter Text` placeholder, framed by a thin gray box that marks the text as being edited,
@@ -93,6 +95,41 @@ field behind the popup's **Text** button, next to the text they format. On shape
 label (a trend line, a box), all four controls stay in that panel with the label field.
 
 Drag a handle to reshape; drag the body to move the whole drawing.
+
+### Selecting several drawings
+
+- **Shift+click** or **Ctrl/Cmd+click** a drawing to add it to (or remove it from) the selection.
+- **Ctrl/Cmd+drag on an empty spot** sweeps a selection box: every drawing it touches joins the
+  selection. Successive boxes accumulate.
+- While Ctrl/Cmd is held, handles mark only what is selected — hovering a drawing no longer shows
+  them — so the selection you are building is what you see.
+- Dragging the body of a selected drawing then moves the **whole selection** together, as one
+  undo step; a handle drag still reshapes just that one drawing. Locked members stay where they
+  are. Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on
+  the whole selection too.
+- Click an empty spot to clear the selection (a drag to pan keeps it).
+
+### One popup for several drawings
+
+Selecting several drawings opens a **single quick-settings popup** for all of them, floating
+above their combined extent. It shows only the controls every selected drawing supports: three
+trend lines get the full trend-line bar, while a trend line, a box and a text annotation share
+just their common ground (text styling, lock, delete, the overflow menu) — controls a member
+lacks disappear rather than showing disabled. Where the drawings agree the control reads
+normally; where they differ it reads as **mixed**: a color swatch striped with every color in
+use, a dash in a dropdown, a half-lit toggle. Any edit applies to every selected drawing as one
+undo step, so picking blue from a mixed swatch turns them all blue. Opening a mixed swatch lists
+the colors currently in use first, so unifying onto one of them is a single click. The per-drawing
+panels — Fibonacci levels, position sizing, volume-profile rows, the text field — stay with a
+single selection.
+
+### Duplicating by dragging
+
+**Ctrl/Cmd+drag** a drawing's body to drag a **copy** away from it — the original stays put, the
+copy follows the cursor and is committed when you release, with its quick-settings popup open
+(one undo step; **Escape** mid-drag leaves nothing behind). With several drawings selected, the
+whole selection is copied at once and stays selected as a group.
+Ctrl/Cmd on a **handle** keeps its usual meaning — a strong magnet snap while reshaping.
 
 ### Keyboard shortcuts
 
@@ -366,7 +403,8 @@ the next load.
   snapshot history. A multi-target action (multi-drag, multi-delete, duplicate, paste) is one
   undo step.
 - **Clipboard.** `copyToClipboard(ids)` + `paste()`, or `duplicate(ids)` / `clone(id)`, mint fresh
-  copies (new ids) and select them — an in-memory, per-chart clipboard.
+  copies (new ids) and select them — an in-memory, per-chart clipboard. On the chart, the
+  popup's overflow menu, **Ctrl/Cmd+D**, and a **Ctrl/Cmd+drag** of the body do the same.
 
 ---
 

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -105,7 +105,9 @@ Drag a handle to reshape; drag the body to move the whole drawing.
   them — so the selection you are building is what you see.
 - Dragging the body of a selected drawing then moves the **whole selection** together, as one
   undo step; a handle drag still reshapes just that one drawing. Locked members stay where they
-  are. Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on
+  are. The selection survives the drag, and its popup comes back over the moved drawings.
+- A **lock protects a drawing inside a group**: deleting a multi-selection — Delete, middle-click,
+  or the popup's trash — removes only its unlocked members; the locked ones stay, still selected. Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on
   the whole selection too.
 - Click an empty spot to clear the selection (a drag to pan keeps it).
 

--- a/docs/user/drawing-tools.md
+++ b/docs/user/drawing-tools.md
@@ -106,9 +106,10 @@ Drag a handle to reshape; drag the body to move the whole drawing.
 - Dragging the body of a selected drawing then moves the **whole selection** together, as one
   undo step; a handle drag still reshapes just that one drawing. Locked members stay where they
   are. The selection survives the drag, and its popup comes back over the moved drawings.
+- Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on the
+  whole selection too, each as one undo step.
 - A **lock protects a drawing inside a group**: deleting a multi-selection — Delete, middle-click,
-  or the popup's trash — removes only its unlocked members; the locked ones stay, still selected. Delete, nudge, copy, duplicate — and a **middle-click** on any selected drawing — act on
-  the whole selection too.
+  or the popup's trash — removes only its unlocked members; the locked ones stay, still selected.
 - Click an empty spot to clear the selection (a drag to pan keeps it).
 
 ### One popup for several drawings

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -438,7 +438,8 @@ they work from the very first keystroke, before any click.
   the stack together. Drawings can be multi-selected
   (Ctrl/Cmd-click) and bundled into a named group that hides, locks, deletes and drags as one
   block; groups live for as long as the chart and are not persisted. Kept in sync with the
-  chart's events.
+  chart's events — a selection made on the chart (Ctrl/Cmd-click, a marquee) lights up every
+  row it covers, and a pick made in the panel selects the same drawings on the chart.
 - **Data window** — the other docked panel: the date and time of the bar under the crosshair,
   its OHLCV tinted with the bar's direction, then one section per indicator showing each plot's
   value in its own color. It follows the crosshair and falls back to the latest bar when the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/src/core/drawings/DrawingController.ts
+++ b/src/core/drawings/DrawingController.ts
@@ -385,16 +385,20 @@ export class DrawingController {
             next = [...ids];
         }
         this.selectedIds = next.filter((id) => this.store.has(id));
+        this.announceSelection();
+    }
+
+    /** Push the selection to the renderer and announce it (primary + the full list). */
+    private announceSelection(): void {
         this.port?.setSelection(this.selectedIds);
-        this.events.emit('drawing:selected', { id: this.selectedIds[0] ?? null });
+        this.events.emit('drawing:selected', { id: this.selectedIds[0] ?? null, ids: [...this.selectedIds] });
     }
 
     /** Restore a history snapshot, reconciling selection against what survived. */
     private restoreSnapshot(doc: DrawingsDocument): void {
         this.store.load(doc); // fires onChange → sync() + autoscale
         this.selectedIds = this.selectedIds.filter((id) => this.store.has(id));
-        this.port?.setSelection(this.selectedIds);
-        this.events.emit('drawing:selected', { id: this.selectedIds[0] ?? null });
+        this.announceSelection();
     }
 
     /** Delete drawings as one undo step; prune them from the selection. */

--- a/src/core/drawings/DrawingController.ts
+++ b/src/core/drawings/DrawingController.ts
@@ -544,6 +544,9 @@ export class DrawingController {
             case 'duplicate':
                 this.duplicate(i.ids);
                 break;
+            case 'clone':
+                if (this.enabled && i.docs.length) this.insertClones(i.docs);
+                break;
             case 'copy':
                 this.copy(i.ids);
                 break;

--- a/src/core/drawings/port.ts
+++ b/src/core/drawings/port.ts
@@ -47,6 +47,11 @@ export type DrawingIntent =
     | { kind: 'undo' }
     | { kind: 'redo' }
     | { kind: 'duplicate'; ids: string[] } // clone in place + select the clones
+    /** Commit COPIES carrying the geometry given (the end of a drag-to-duplicate: the
+     *  sources never moved, the docs are their serialized twins already translated).
+     *  Ids are reassigned; the copies keep their sources' depth and become the selection.
+     *  One undo step. */
+    | { kind: 'clone'; docs: SerializedDrawing[] }
     | { kind: 'copy'; ids: string[] }
     | { kind: 'paste' };
 

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1695,7 +1695,12 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             if (!model) continue;
             const paneId = model.paneId ?? 'price';
             if (!byPane.has(paneId)) byPane.set(paneId, []);
-            byPane.get(paneId)!.push({ id: r.id, title: model.title || r.title, ownScale: model.ownScale === true });
+            byPane.get(paneId)!.push({
+                id: r.id,
+                title: model.title || r.title,
+                ...(model.shorttitle ? { shorttitle: model.shorttitle } : {}),
+                ownScale: model.ownScale === true,
+            });
         }
         const panes: PaneInfo[] = [];
         for (const paneId of this.paneOrder) {

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -70,8 +70,9 @@ export interface VelaEventMap extends Record<string, unknown> {
   "drawing:draft": { doc: SerializedDrawing | null };
   /** A user drawing's anchors/style/text changed. */
   "drawing:edited": { id: string };
-  /** Selection changed (`id` is null when nothing is selected). */
-  "drawing:selected": { id: string | null };
+  /** Selection changed. `ids` is every selected drawing in selection order; `id` is the
+   *  primary (`ids[0]`, the one a settings popup edits), null when nothing is selected. */
+  "drawing:selected": { id: string | null; ids: string[] };
   /** The favorite-tool set changed (star toggles or a bulk restore). */
   "drawing:favorites": { favorites: string[] };
   /** The armed drawing tool changed — toolbar click, one-shot tool finishing (back to

--- a/src/core/model/indicator.ts
+++ b/src/core/model/indicator.ts
@@ -35,11 +35,11 @@ export type PaneAxis = 'none' | { bands: PaneAxisBand[] };
 export interface IndicatorModel {
     /** Per-instance id (stable). */
     id: string;
-    /** Full display name (settings dialog, object tree, inspect). */
+    /** Full display name (picker, inspect, and every surface with no {@link shorttitle}). */
     title: string;
     /**
-     * Compact label the legend chip and the settings dialog show instead of the full
-     * {@link title}. Absent ⇒ both use {@link title}. Mirrors Pine
+     * Compact label the legend chip, the settings dialog and the object tree's rows show
+     * instead of the full {@link title}. Absent ⇒ all use {@link title}. Mirrors Pine
      * `indicator(..., shorttitle=)`.
      */
     shorttitle?: string;

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -91,7 +91,8 @@ export interface NativeIndicatorDescriptor {
     /** Full display name (picker, settings header, handle title). */
     readonly title: string;
     /**
-     * Compact name for the on-chart legend chip and the settings-dialog header.
+     * Compact name for the on-chart legend chip, the settings-dialog header and the
+     * object tree's indicator rows.
      * Absent ⇒ {@link title}. The picker keeps the full title either way.
      */
     readonly shortTitle?: string;

--- a/src/core/native-indicators/classics/overlays.ts
+++ b/src/core/native-indicators/classics/overlays.ts
@@ -1,21 +1,25 @@
 import type { OHLCV } from '../../model/ohlcv';
 import type { MarkerPoint } from '../../model/series';
-import { SERIES_LINE, BULLISH, BEARISH, INFO, WARNING } from '../../palette';
-import type { ClassicIndicatorSpec, ClassicPlot } from './define';
-import { num, str } from './define';
-import { colorInput } from './shared';
+import type { InputSchema } from '../../model/inputs';
+import { SERIES_LINE, BULLISH, BEARISH, INFO, WARNING, CATEGORICAL } from '../../palette';
+import type { ClassicBand, ClassicIndicatorSpec, ClassicPlot } from './define';
+import { bool, num, str } from './define';
+import { sourceValues } from './math';
+import { colorInput, sourceInput, withAlpha } from './shared';
 
 /** Price-anchored specials: stops, anchored averages, levels, pivots, patterns. */
 
 const DAY_MS = 86400000;
 
-type Anchor = 'Day' | 'Week' | 'Month';
+type Anchor = 'Day' | 'Week' | 'Month' | 'Quarter' | 'Year';
 
 /** UTC period key for an anchor (epoch day 0 was a Thursday; weeks start Monday). */
 function periodKey(anchor: Anchor, time: number): number {
     if (anchor === 'Week') return Math.floor((Math.floor(time / DAY_MS) + 3) / 7);
-    if (anchor === 'Month') {
+    if (anchor === 'Month' || anchor === 'Quarter' || anchor === 'Year') {
         const d = new Date(time);
+        if (anchor === 'Year') return d.getUTCFullYear();
+        if (anchor === 'Quarter') return d.getUTCFullYear() * 4 + Math.floor(d.getUTCMonth() / 3);
         return d.getUTCFullYear() * 12 + d.getUTCMonth();
     }
     return Math.floor(time / DAY_MS);
@@ -70,40 +74,89 @@ const parabolicSar: ClassicIndicatorSpec = {
     },
 };
 
+const VWAP_BANDS_GROUP = 'Bands';
+const VWAP_STYLE = 'Style';
+/** The three ±k·σ band pairs. Each band has its own ink so the pairs read apart at a glance. */
+const VWAP_BANDS = [
+    { on: 'band1', mult: 'band1Mult', color: 'band1Color', fill: 'band1Fill', fillColor: 'band1FillColor', defMult: 1, defOn: true, defColor: BULLISH },
+    { on: 'band2', mult: 'band2Mult', color: 'band2Color', fill: 'band2Fill', fillColor: 'band2FillColor', defMult: 2, defOn: false, defColor: WARNING },
+    { on: 'band3', mult: 'band3Mult', color: 'band3Color', fill: 'band3Fill', fillColor: 'band3FillColor', defMult: 3, defOn: false, defColor: CATEGORICAL[4]! },
+] as const;
+
 const vwap: ClassicIndicatorSpec = {
     type: 'vwap',
     title: 'Volume Weighted Average Price',
     shortTitle: 'VWAP',
     overlay: true,
     inputs: [
-        { key: 'anchor', title: 'Anchor', type: 'string', defval: 'Day', options: ['Day', 'Week', 'Month'], tooltip: 'Where the accumulation resets (UTC periods)' },
-        { key: 'source', title: 'Source', type: 'string', defval: 'HLC3', options: ['HLC3', 'OHLC4', 'Close'] },
-        colorInput(INFO),
+        { key: 'anchor', title: 'Period', type: 'string', defval: 'Day', options: ['Day', 'Week', 'Month', 'Quarter', 'Year'], tooltip: 'Where the accumulation resets (UTC periods)' },
+        sourceInput('HLC3'),
+        // Each band is one row: its toggle leads, the multiplier follows unlabeled.
+        ...VWAP_BANDS.flatMap((b, i): InputSchema[] => [
+            { key: b.on, title: `Band ${i + 1} multiplier`, type: 'bool', defval: b.defOn, inline: b.on, group: VWAP_BANDS_GROUP },
+            { key: b.mult, title: '', type: 'float', defval: b.defMult, min: 0.1, max: 10, step: 0.1, inline: b.on, group: VWAP_BANDS_GROUP },
+        ]),
+        { ...colorInput(INFO, 'VWAP color'), group: VWAP_STYLE },
+        // One row per band: its ink, then the fill toggle with the fill's own (translucent) color.
+        ...VWAP_BANDS.flatMap((b, i): InputSchema[] => [
+            { ...colorInput(b.defColor, `Band ${i + 1} color`, b.color), inline: b.color, group: VWAP_STYLE },
+            { key: b.fill, title: 'Fill', type: 'bool', defval: true, inline: b.color, group: VWAP_STYLE },
+            { ...colorInput(withAlpha(b.defColor), '', b.fillColor), inline: b.color, group: VWAP_STYLE },
+        ]),
     ],
     compute: (bars, inputs) => {
         const anchor = str(inputs, 'anchor', 'Day') as Anchor;
-        const source = str(inputs, 'source', 'HLC3');
-        const values = new Array<number>(bars.length).fill(Number.NaN);
+        const src = sourceValues(bars, str(inputs, 'source', 'HLC3'));
+        const n = bars.length;
+        const values = new Array<number>(n).fill(Number.NaN);
+        const bands = VWAP_BANDS.filter((b) => bool(inputs, b.on, b.defOn)).map((b) => ({
+            mult: Math.max(0, num(inputs, b.mult, b.defMult)),
+            color: str(inputs, b.color, b.defColor),
+            fill: bool(inputs, b.fill, true),
+            fillColor: str(inputs, b.fillColor, withAlpha(b.defColor)),
+            up: new Array<number>(n).fill(Number.NaN),
+            down: new Array<number>(n).fill(Number.NaN),
+        }));
         let period = Number.NaN;
         let cumPV = 0;
+        let cumPV2 = 0;
         let cumV = 0;
-        for (let i = 0; i < bars.length; i++) {
+        for (let i = 0; i < n; i++) {
             const b = bars[i]!;
             const key = periodKey(anchor, b.time);
             if (key !== period) {
                 period = key;
                 cumPV = 0;
+                cumPV2 = 0;
                 cumV = 0;
             }
             const v = b.volume;
             if (v != null && Number.isFinite(v) && v > 0) {
-                const tp = source === 'Close' ? b.close : source === 'OHLC4' ? (b.open + b.high + b.low + b.close) / 4 : (b.high + b.low + b.close) / 3;
+                const tp = src[i]!;
                 cumPV += tp * v;
+                cumPV2 += tp * tp * v;
                 cumV += v;
             }
-            if (cumV > 0) values[i] = cumPV / cumV;
+            if (cumV <= 0) continue;
+            const mean = cumPV / cumV;
+            // Variance clamped at 0 — IEEE drift can dip `E[x²] − mean²` a hair under.
+            const sd = Math.sqrt(Math.max(0, cumPV2 / cumV - mean * mean));
+            values[i] = mean;
+            for (const band of bands) {
+                band.up[i] = mean + band.mult * sd;
+                band.down[i] = mean - band.mult * sd;
+            }
         }
-        return { plots: [{ key: 'vwap', title: 'VWAP', values, color: str(inputs, 'color', INFO), width: 2 }] };
+        const plots: ClassicPlot[] = [{ key: 'vwap', title: 'VWAP', values, color: str(inputs, 'color', INFO), width: 2 }];
+        const fills: ClassicBand[] = [];
+        bands.forEach((band, i) => {
+            plots.push(
+                { key: `up${i}`, title: `Upper ${band.mult}σ`, values: band.up, color: band.color },
+                { key: `down${i}`, title: `Lower ${band.mult}σ`, values: band.down, color: band.color },
+            );
+            if (band.fill) fills.push({ key: `band${i}`, from: `up${i}`, to: `down${i}`, color: band.fillColor });
+        });
+        return { plots, bands: fills };
     },
 };
 

--- a/src/core/native-indicators/classics/trend.ts
+++ b/src/core/native-indicators/classics/trend.ts
@@ -20,10 +20,6 @@ const aroon: ClassicIndicatorSpec = {
                 { key: 'up', title: 'Aroon up', values: up, color: BULLISH, width: 2 },
                 { key: 'down', title: 'Aroon down', values: down, color: BEARISH, width: 2 },
             ],
-            levels: [
-                { key: 'upper', price: 100, color: NEUTRAL, lineStyle: 'dotted' },
-                { key: 'lower', price: 0, color: NEUTRAL, lineStyle: 'dotted' },
-            ],
         };
     },
 };

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -243,7 +243,12 @@ export interface PaneInfo {
     order: number;
     collapsed: boolean;
     maximized: boolean;
-    indicators: Array<{ id: string; title: string; ownScale: boolean }>;
+    indicators: Array<{
+        id: string;
+        title: string;
+        shorttitle?: string;
+        ownScale: boolean;
+    }>;
 }
 
 /** Options for `chart.addIndicator(source, options?)`. */

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1362,7 +1362,10 @@ export class NativeRenderer implements IChartRenderer {
             zoomTo: (target, anchorLogical, anchorX) => this.zoomTo(target, anchorLogical, anchorX),
             fling: (v) => this.fling(v),
             onPointerMove: (x, y) => this.handlePointerMove(x, y),
-            onClick: (x) => this.handleClick(x),
+            onClick: (x) => {
+                this.userDrawings?.deselect(); // a click on the empty plot ends a (multi-)selection
+                this.handleClick(x);
+            },
             onAxisLongPress: (axis, x, y) => {
                 for (const cb of this.axisLongPressCbs) cb({ axis, x, y });
             },
@@ -1380,11 +1383,12 @@ export class NativeRenderer implements IChartRenderer {
             // User drawings claim a gesture before pan when armed / over a drawing.
             drawingsClaim: (x, y) => this.userDrawings?.claim(x, y) ?? false,
             drawingsMeasureStart: (x, y, snap) => this.userDrawings?.beginMeasureAt(x, y, snap) ?? false,
-            drawingsDeleteAt: (x, y) => this.userDrawings?.deleteAt(x, y) ?? false,
+            drawingsMarqueeStart: (x, y) => this.userDrawings?.beginMarqueeAt(x, y) ?? false,
+            drawingsDeleteAt: (x, y) => this.userDrawings?.deleteAt(x, y, true) ?? false, // middle-click: a selected hit takes the whole selection
             drawingsCancelPlacement: () => this.userDrawings?.cancelPlacement() ?? false,
             drawingsSnapMode: () => this.snapMode,
-            drawingsPointerDown: (x, y, snap, shift) => this.userDrawings?.pointerDown(x, y, snap, shift),
-            drawingsPointerMove: (x, y, snap, shift) => this.userDrawings?.pointerMove(x, y, snap, shift),
+            drawingsPointerDown: (x, y, snap, shift, mod) => this.userDrawings?.pointerDown(x, y, snap, shift, mod),
+            drawingsPointerMove: (x, y, snap, shift, mod) => this.userDrawings?.pointerMove(x, y, snap, shift, mod),
             drawingsPointerUp: (x, y, snap) => this.userDrawings?.pointerUp(x, y, snap),
             drawingsCursor: (x, y) => this.userDrawings?.cursorAt(x, y) ?? null,
             drawingsDblClick: (x, y) => this.userDrawings?.dblClick(x, y) ?? false,

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -1997,8 +1997,8 @@ export class NativeRenderer implements IChartRenderer {
         // say so or the recorded order (object tree, seriesOrder reads) starts out a lie.
         if (model.native && this.extLayers.some((l) => l.def.id === model.native!.type)) this.scene.assignIndicatorZTop(model.id);
         else this.scene.assignIndicatorZ(model.id);
-        // The legend chip and the settings dialog both show the compact shorttitle when
-        // declared; the full title stays on the picker, object tree and inspect().
+        // The legend chip, the settings dialog and the object tree's rows all show the compact
+        // shorttitle when declared; the full title stays on the picker and inspect().
         this.inputsUI.upsert(model.id, model.shorttitle ?? model.title, model.inputs, model.inputValues, model.paneId, {
             native: !!model.native,
             ...(model.props ? { props: model.props, propValues: model.propValues ?? {} } : {}),

--- a/src/renderers/native/core/InputController.ts
+++ b/src/renderers/native/core/InputController.ts
@@ -52,6 +52,9 @@ export interface InputControllerDeps {
      *  the effective magnet. True when it started (the drawings layer then owns the rest
      *  of the gesture). */
     drawingsMeasureStart?(x: number, y: number, snap: SnapMode): boolean;
+    /** Ctrl/Cmd+press on empty plot: start sweeping a selection box at (x,y). True when it
+     *  started (the drawings layer then owns the rest of the gesture). */
+    drawingsMarqueeStart?(x: number, y: number): boolean;
     /** Middle-click: delete the drawing under the cursor. True when one was removed. */
     drawingsDeleteAt?(x: number, y: number): boolean;
     /** Right-click: cancel/disarm whatever non-persistent tool is active — an in-progress
@@ -59,11 +62,13 @@ export interface InputControllerDeps {
      *  revert to the pointer. True when consumed — the companion contextmenu is then
      *  suppressed. */
     drawingsCancelPlacement?(): boolean;
-    /** A claimed press began. `snap` = effective magnet mode; `shift` = additive (multi-) select. */
-    drawingsPointerDown?(x: number, y: number, snap: SnapMode, shift: boolean): void;
+    /** A claimed press began. `snap` = effective magnet mode; `shift` = additive (multi-) select;
+     *  `mod` = Ctrl/Cmd held (a click toggles the selection, a body drag duplicates). */
+    drawingsPointerDown?(x: number, y: number, snap: SnapMode, shift: boolean, mod: boolean): void;
     /** Pointer moved (forwarded for the placing ghost / drag preview). `snap` = effective magnet
-     *  mode; `shift` = lock a line tool's segment angle to 45° steps. */
-    drawingsPointerMove?(x: number, y: number, snap: SnapMode, shift: boolean): void;
+     *  mode; `shift` = lock a line tool's segment angle to 45° steps; `mod` = Ctrl/Cmd held
+     *  (the cursor is picking a selection — no hover handles). */
+    drawingsPointerMove?(x: number, y: number, snap: SnapMode, shift: boolean, mod: boolean): void;
     /** Cursor to show while hovering the drawings layer (e.g. `'pointer'` over a drawing), or null. */
     drawingsCursor?(x: number, y: number): string | null;
     /** The sticky magnet mode set on the toolbar (off/weak/strong) — Ctrl/Cmd overrides it to strong. */
@@ -322,7 +327,7 @@ export class InputController {
         if (e.repeat || (e.key !== 'Shift' && e.key !== 'Control' && e.key !== 'Meta')) return;
         if (Number.isNaN(this.cursorX)) return; // pointer is not over the chart
         if (this.dragging && this.region !== 'drawing') return; // mid pan/axis gesture — nothing to re-shape
-        this.deps.drawingsPointerMove?.(this.cursorX, this.cursorY, this.snapMode(e), e.shiftKey);
+        this.deps.drawingsPointerMove?.(this.cursorX, this.cursorY, this.snapMode(e), e.shiftKey, e.ctrlKey || e.metaKey);
     };
 
     private local(e: PointerEvent | WheelEvent | MouseEvent): { x: number; y: number } {
@@ -390,13 +395,19 @@ export class InputController {
         // over a drawing/handle it claims the WHOLE gesture (no pan/fling), atomically.
         if (this.deps.drawingsClaim?.(x, y)) {
             this.region = 'drawing';
-            this.deps.drawingsPointerDown?.(x, y, this.snapMode(e), e.shiftKey);
+            this.deps.drawingsPointerDown?.(x, y, this.snapMode(e), e.shiftKey, e.ctrlKey || e.metaKey);
             this.capture(e.pointerId);
             return;
         }
         // Shift+press on the empty plot starts the measure ruler in one gesture (a press
         // over a drawing keeps the additive-select meaning of shift, via the claim above).
         if (e.shiftKey && this.regionAt(x, y) === 'data' && this.deps.drawingsMeasureStart?.(x, y, this.snapMode(e))) {
+            this.region = 'drawing';
+            this.capture(e.pointerId);
+            return;
+        }
+        // Ctrl/Cmd+press on the empty plot sweeps a selection box over the drawings.
+        if ((e.ctrlKey || e.metaKey) && this.regionAt(x, y) === 'data' && this.deps.drawingsMarqueeStart?.(x, y)) {
             this.region = 'drawing';
             this.capture(e.pointerId);
             return;
@@ -533,7 +544,7 @@ export class InputController {
                 this.deps.apply({ barSpacing, rightOffset: this.startRightOffset });
             } else if (this.region === 'drawing') {
                 if (Math.abs(x - this.startX) > slop || Math.abs(y - this.startY) > slop) this.moved = true;
-                this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey);
+                this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey, e.ctrlKey || e.metaKey);
             } else {
                 const coords = this.deps.getCoords();
                 const vp = coords.getViewport();
@@ -563,7 +574,7 @@ export class InputController {
             this.el.style.cursor = drawCursor ?? (r === 'price' ? 'ns-resize' : r === 'time' ? 'ew-resize' : r === 'separator' ? 'row-resize' : '');
             // Forward hover moves so the drawings layer can advance a placing ghost
             // (placing is click-based, so the cursor follow happens with no button down).
-            this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey);
+            this.deps.drawingsPointerMove?.(x, y, this.snapMode(e), e.shiftKey, e.ctrlKey || e.metaKey);
         }
         // Hover crosshair is a MOUSE affordance. A touch never hovers: its crosshair
         // comes only from the long-press inspect path (region 'crosshair' above) —

--- a/src/renderers/native/drawings/DrawingHitTester.ts
+++ b/src/renderers/native/drawings/DrawingHitTester.ts
@@ -26,3 +26,24 @@ export function topDrawingAt(
     }
     return null;
 }
+
+/**
+ * What a selection-wide delete removes: a lone selected drawing goes regardless, but inside a
+ * multi-selection a LOCKED drawing is protected — the others go and it stays (selected).
+ */
+export function deletableSelection(selected: Iterable<string>, drawings: readonly Drawing[]): string[] {
+    const ids = [...selected];
+    if (ids.length < 2) return ids;
+    return ids.filter((id) => !drawings.find((d) => d.id === id)?.locked);
+}
+
+/**
+ * What a delete-at-cursor press removes when `hit` is the drawing under it. A hit on a member of
+ * a multi-selection (with `withSelection`) takes the selection's deletable members — even when
+ * the hit itself is locked, so a middle-click on the locked one still clears the rest of the
+ * group. Any other locked hit is protected and nothing is removed.
+ */
+export function deleteTargets(hit: Drawing, selected: ReadonlySet<string>, drawings: readonly Drawing[], withSelection: boolean): string[] {
+    if (withSelection && selected.size >= 2 && selected.has(hit.id)) return deletableSelection(selected, drawings);
+    return hit.locked ? [] : [hit.id];
+}

--- a/src/renderers/native/drawings/DrawingInteraction.ts
+++ b/src/renderers/native/drawings/DrawingInteraction.ts
@@ -197,6 +197,11 @@ export class DrawingInteraction {
         return this.state.kind === 'pressed' && this.state.moved ? this.state.id : null;
     }
 
+    /** The drawing under a press that has not been released yet (drag or click undecided), or null. */
+    pressedId(): string | null {
+        return this.state.kind === 'pressed' ? this.state.id : null;
+    }
+
     /** The copies a Ctrl-drag is moving (transient — not yet in the store), or null. */
     dragClones(): readonly Drawing[] | null {
         return this.state.kind === 'pressed' && this.state.moved && this.state.clones ? this.state.clones.map((c) => c.d) : null;

--- a/src/renderers/native/drawings/DrawingInteraction.ts
+++ b/src/renderers/native/drawings/DrawingInteraction.ts
@@ -1,5 +1,5 @@
 import type { Drawing, DrawingIntent, DrawingPoint, DrawingStyle, DrawingTypeKey, FreeAxis, Projector, SnapMode } from '../../../core/drawings';
-import { createDrawing } from '../../../core/drawings';
+import { createDrawing, deserializeDrawing } from '../../../core/drawings';
 import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
 
 /** Pixels of motion before a press counts as a drag (vs a click → open settings). */
@@ -35,16 +35,59 @@ export interface InteractionDeps {
     lastStyle(): DrawingStyle | undefined;
 }
 
+/** A drawing riding along with a body drag, with its anchors as they were at the press. */
+interface Rider {
+    id: string;
+    orig: DrawingPoint[];
+}
+
+/** A drawing a body drag moves (a source or its transient copy), with the anchors to translate from. */
+interface DragTarget {
+    d: Drawing;
+    orig: DrawingPoint[];
+}
+
+/** An axis-aligned pixel rectangle. */
+export interface PxRect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
 type State =
     | { kind: 'idle' }
     | { kind: 'placing'; draft: Drawing; need: number; cursor: DrawingPoint | null }
-    | { kind: 'pressed'; id: string; handle: number; grab: DrawingPoint; orig: DrawingPoint[]; px: number; py: number; moved: boolean };
+    | {
+          kind: 'pressed';
+          id: string;
+          handle: number;
+          orig: DrawingPoint[];
+          px: number;
+          py: number;
+          moved: boolean;
+          /** The OTHER selected drawings a body drag carries along (a multi-selection moves as one). */
+          riders: Rider[];
+          /** Ctrl/Cmd was held at the press: a click toggles the selection, a body drag moves copies. */
+          mod: boolean;
+          /** The transient copies a Ctrl-drag moves (built at drag start); the sources stay put. */
+          clones: DragTarget[] | null;
+      }
+    /** Ctrl/Cmd-drag on the empty plot: a rubber-band box from the press to the cursor. */
+    | { kind: 'marquee'; x0: number; y0: number; x1: number; y1: number };
 
 /**
  * The single user-drawing interaction state machine: arm → place (click anchors,
  * live ghost) → press a drawing → release-without-moving opens its settings, or
  * drag (whole body / a handle) to move/resize. Built with a deps closure so it is
  * unit-testable without a canvas. `locked` drawings open settings but never drag.
+ *
+ * Modifiers at the press: Shift or Ctrl/Cmd over a drawing make the click a selection
+ * toggle (multi-select); Ctrl/Cmd plus a body drag DUPLICATES — the copies follow the
+ * cursor and are committed on release (`clone` intent), so the drag is one undo step and
+ * cancelling it leaves nothing behind. Ctrl/Cmd-drag on the empty plot sweeps a marquee
+ * that adds the drawings it touches to the selection. A body drag of a drawing that is
+ * part of a multi-selection moves (or copies) the whole selection.
  */
 export class DrawingInteraction {
     private state: State = { kind: 'idle' };
@@ -154,10 +197,31 @@ export class DrawingInteraction {
         return this.state.kind === 'pressed' && this.state.moved ? this.state.id : null;
     }
 
+    /** The copies a Ctrl-drag is moving (transient — not yet in the store), or null. */
+    dragClones(): readonly Drawing[] | null {
+        return this.state.kind === 'pressed' && this.state.moved && this.state.clones ? this.state.clones.map((c) => c.d) : null;
+    }
+
+    /** The marquee box being swept, normalized (or null when none is in progress). */
+    marqueeRect(): PxRect | null {
+        if (this.state.kind !== 'marquee') return null;
+        const { x0, y0, x1, y1 } = this.state;
+        return { x: Math.min(x0, x1), y: Math.min(y0, y1), w: Math.abs(x1 - x0), h: Math.abs(y1 - y0) };
+    }
+
+    /** Ctrl/Cmd-press on the empty plot: start sweeping a selection box. False when a tool is
+     *  armed or a gesture is in flight (that path owns the press). */
+    beginMarquee(x: number, y: number): boolean {
+        if (this.state.kind !== 'idle' || this.deps.activeTool() != null) return false;
+        this.state = { kind: 'marquee', x0: x, y0: y, x1: x, y1: y };
+        return true;
+    }
+
     /** A press: place the next anchor, or grab a drawing/handle (resolved as click or drag on release).
      *  `shift` over a drawing toggles it in/out of the selection (multi-select) instead of dragging;
-     *  while placing a line tool it locks the segment angle to 45° steps. */
-    down(x: number, y: number, mode: SnapMode = 'off', shift = false): void {
+     *  while placing a line tool it locks the segment angle to 45° steps. `mod` (Ctrl/Cmd) over a
+     *  drawing also toggles on a click, but a body drag then moves a COPY. */
+    down(x: number, y: number, mode: SnapMode = 'off', shift = false, mod = false): void {
         const proj = this.deps.projector();
         if (this.state.kind === 'placing') {
             if (this.state.draft.placementMode() !== 'click') return; // drag/freehand finalize on release, not extra clicks
@@ -190,9 +254,57 @@ export class DrawingInteraction {
                 return;
             }
             const handle = hit.hitHandle(x, y, proj, HIT_TOLERANCE); // -1 = body, ≥0 = a handle
-            this.state = { kind: 'pressed', id: hit.id, handle, grab: proj.pxToPoint(x, y, hit.paneId), orig: cloneAnchors(hit), px: x, py: y, moved: false };
+            // A body drag of a SELECTED drawing carries the rest of the selection along; a handle
+            // drag reshapes just the one, and an unselected drawing drags alone.
+            const riders: Rider[] = [];
+            if (handle < 0 && this.deps.selectedIds().has(hit.id)) {
+                for (const id of this.deps.selectedIds()) {
+                    const d = id === hit.id ? null : this.byId(id);
+                    if (d && !d.locked && d.visible) riders.push({ id, orig: cloneAnchors(d) });
+                }
+            }
+            this.state = { kind: 'pressed', id: hit.id, handle, orig: cloneAnchors(hit), px: x, py: y, moved: false, riders, mod, clones: null };
         }
         // empty space → nothing here: the popup self-dismisses + hover already cleared handles.
+    }
+
+    /** The data-space delta a body drag from the press to (x, y) means on `paneId` — resolved per
+     *  pane so drawings riding along on another pane move by the same PIXELS, not the same price. */
+    private bodyDelta(paneId: string, x: number, y: number): { dt: number; dp: number } {
+        if (this.state.kind !== 'pressed') return { dt: 0, dp: 0 };
+        const proj = this.deps.projector();
+        const from = proj.pxToPoint(this.state.px, this.state.py, paneId);
+        const to = proj.pxToPoint(x, y, paneId);
+        return { dt: to.time - from.time, dp: to.price - from.price };
+    }
+
+    /** The pressed drawing and its riders, each with its anchors at the press. */
+    private dragSources(d: Drawing): DragTarget[] {
+        if (this.state.kind !== 'pressed') return [];
+        const out: DragTarget[] = [{ d, orig: this.state.orig }];
+        for (const r of this.state.riders) {
+            const rd = this.byId(r.id);
+            if (rd) out.push({ d: rd, orig: r.orig });
+        }
+        return out;
+    }
+
+    /** Move the pressed drawing's body (and its riders) — or, on a Ctrl-drag, their copies — to the
+     *  cursor. The copies are built on the first move (so a Ctrl-click never creates anything), from
+     *  sources that have not moved yet, so their own anchors are the origin to translate from. */
+    private dragBody(d: Drawing, x: number, y: number): void {
+        if (this.state.kind !== 'pressed') return;
+        this.snapAt = null; // whole-body moves stay smooth (no snap)
+        if (this.state.mod && !this.state.clones) {
+            this.state.clones = this.dragSources(d).flatMap((s) => {
+                const c = deserializeDrawing(s.d.serialize());
+                return c ? [{ d: c, orig: cloneAnchors(c) }] : [];
+            });
+        }
+        for (const t of this.state.clones ?? this.dragSources(d)) {
+            const { dt, dp } = this.bodyDelta(t.d.paneId, x, y);
+            t.d.anchors = t.d.translateBody(dt, dp, t.orig); // a callout pins its tip + moves only the box
+        }
     }
 
     /** Pointer move: advance the placing ghost, or live-preview a drag once past the slop.
@@ -219,12 +331,20 @@ export class DrawingInteraction {
             this.deps.changed();
             return;
         }
+        if (this.state.kind === 'marquee') {
+            this.state.x1 = x;
+            this.state.y1 = y;
+            this.deps.changed();
+            return;
+        }
         if (this.state.kind !== 'pressed') return;
         const d = this.byId(this.state.id);
         if (!d || d.locked) return; // locked → never drags (stays a click)
         if (!this.state.moved && Math.abs(x - this.state.px) <= DRAG_SLOP && Math.abs(y - this.state.py) <= DRAG_SLOP) return;
         this.state.moved = true;
-        if (this.state.handle >= 0) {
+        if (this.state.handle < 0) {
+            this.dragBody(d, x, y);
+        } else {
             const a = d.anchors[this.state.handle]; // a handle snaps to the candle
             if (a) {
                 // Shift on a two-point line re-locks the dragged endpoint's angle around the other one.
@@ -233,12 +353,6 @@ export class DrawingInteraction {
                 applyFree(a, point, d.anchorSchema().slots[this.state.handle]?.free ?? 'both');
             }
             d.constrainHandleDrag(this.state.handle); // e.g. a position flips its reward/stop to stay opposed
-        } else {
-            const pt = this.deps.projector().pxToPoint(x, y, d.paneId); // whole-body move stays smooth (no snap)
-            this.snapAt = null;
-            const dt = pt.time - this.state.grab.time;
-            const dp = pt.price - this.state.grab.price;
-            d.anchors = d.translateBody(dt, dp, this.state.orig); // a callout pins its tip + moves only the box
         }
         this.deps.changed();
     }
@@ -260,16 +374,48 @@ export class DrawingInteraction {
             }
             return; // click placement: releasing a click adds nothing (the press already placed the anchor)
         }
+        if (this.state.kind === 'marquee') {
+            const rect = this.marqueeRect()!;
+            this.state = { kind: 'idle' };
+            if (rect.w > DRAG_SLOP || rect.h > DRAG_SLOP) this.selectWithin(rect);
+            this.deps.changed();
+            return;
+        }
         if (this.state.kind !== 'pressed') return;
-        const { id, moved } = this.state;
+        const { id, moved, riders, mod, clones } = this.state;
         this.state = { kind: 'idle' };
         const d = this.byId(id);
-        if (moved) {
-            if (d) this.deps.emit({ kind: 'edit', doc: d.serialize() });
-            this.deps.changed();
-        } else {
-            this.deps.openSettings(id, x, y); // a click opens the settings popup
+        if (!moved) {
+            // A click: Ctrl/Cmd toggles the drawing in/out of the selection; plain opens its settings.
+            if (mod) this.deps.emit({ kind: 'select', ids: [id], additive: true });
+            else this.deps.openSettings(id, x, y);
+            return;
         }
+        if (clones) {
+            this.deps.emit({ kind: 'clone', docs: clones.map((c) => c.d.serialize()) });
+        } else if (d) {
+            const docs = [d.serialize()];
+            for (const r of riders) {
+                const rd = this.byId(r.id);
+                if (rd) docs.push(rd.serialize());
+            }
+            if (docs.length > 1) this.deps.emit({ kind: 'edit-many', docs });
+            else this.deps.emit({ kind: 'edit', doc: docs[0]! });
+        }
+        this.deps.changed();
+    }
+
+    /** Add every visible drawing whose on-screen bounds touch `rect` to the selection (a union,
+     *  so successive sweeps accumulate). No change when the box touches nothing new. */
+    private selectWithin(rect: PxRect): void {
+        const proj = this.deps.projector();
+        const ids = [...this.deps.selectedIds()];
+        for (const d of this.deps.drawings()) {
+            if (!d.visible || ids.includes(d.id)) continue;
+            const b = d.bounds(proj);
+            if (b && rectsIntersect(rect, b)) ids.push(d.id);
+        }
+        if (ids.length > this.deps.selectedIds().size) this.deps.emit({ kind: 'select', ids });
     }
 
     /** Cancel an in-progress placement or drag (Escape). Returns whether anything was cancelled. */
@@ -283,8 +429,16 @@ export class DrawingInteraction {
             return true;
         }
         if (this.state.kind === 'pressed') {
-            const d = this.byId(this.state.id);
-            if (d && this.state.moved) d.anchors = this.state.orig.map((o) => ({ time: o.time, price: o.price }));
+            // A Ctrl-drag moved copies only — dropping them is the whole rollback.
+            if (this.state.moved && !this.state.clones) {
+                const d = this.byId(this.state.id);
+                if (d) for (const s of this.dragSources(d)) s.d.anchors = s.orig.map((o) => ({ time: o.time, price: o.price }));
+            }
+            this.state = { kind: 'idle' };
+            this.deps.changed();
+            return true;
+        }
+        if (this.state.kind === 'marquee') {
             this.state = { kind: 'idle' };
             this.deps.changed();
             return true;
@@ -413,6 +567,11 @@ export class DrawingInteraction {
 
 function cloneAnchors(d: Drawing): DrawingPoint[] {
     return d.anchors.map((a) => ({ time: a.time, price: a.price }));
+}
+
+/** Closed-interval overlap, so a zero-thickness bound (a horizontal line's) still counts. */
+function rectsIntersect(a: PxRect, b: PxRect): boolean {
+    return a.x <= b.x + b.w && b.x <= a.x + a.w && a.y <= b.y + b.h && b.y <= a.y + a.h;
 }
 
 /** Move an anchor toward `pt`, honoring which axes its handle is free to move along. */

--- a/src/renderers/native/drawings/DrawingPainter.ts
+++ b/src/renderers/native/drawings/DrawingPainter.ts
@@ -168,6 +168,19 @@ export class DrawingPainter {
         this.paintHandles(ctx, pts);
     }
 
+    /** The selection box a Ctrl/Cmd-drag on the empty plot sweeps: a faint fill in the handle
+     *  accent under a thin dashed outline. */
+    paintMarquee(ctx: CanvasRenderingContext2D, rect: { x: number; y: number; w: number; h: number }): void {
+        ctx.save();
+        ctx.fillStyle = withAlpha(HANDLE_BORDER, 0.08);
+        ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+        ctx.strokeStyle = HANDLE_BORDER;
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 3]);
+        ctx.strokeRect(rect.x + 0.5, rect.y + 0.5, rect.w, rect.h);
+        ctx.restore();
+    }
+
     /** A hollow ring marking the candle point the magnet (Ctrl) will snap the next anchor to. */
     paintSnapRing(ctx: CanvasRenderingContext2D, x: number, y: number, theme: VelaTheme): void {
         ctx.setLineDash([]);

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -29,17 +29,47 @@ import { DrawingSettingsDialog } from './DrawingSettingsDialog';
 /** A `{ path: value }` patch emitted as the user edits a control. */
 export type SettingsPatch = Record<string, unknown>;
 
-/** The actions a settings popup can invoke (wired by the controller to intents). */
+/** The actions a settings popup can invoke (wired by the controller to intents). With several
+ *  drawings selected every action applies to all of them. */
 export interface SettingsActions {
-    /** The current live instance (sync rebuilds instances, so panels re-read through this). */
+    /** The current live PRIMARY instance (sync rebuilds instances, so panels re-read through this). */
     resolve(): Drawing | null;
     patch(p: SettingsPatch): void;
     setLocked(v: boolean): void;
     reorder(to: 'front' | 'back'): void;
+    /** Clone the drawing(s) in place (the copies become the selection). */
+    duplicate(): void;
     resetSettings(): void;
     remove(): void;
     /** Restore a serialized snapshot (Cancel in the settings dialog). */
     restore?(doc: SerializedDrawing): void;
+}
+
+/** The value of a control whose drawings disagree — the bar shows it as "mixed" and the first
+ *  edit unifies them. */
+export const MIXED: unique symbol = Symbol('mixed');
+export type Mixed = typeof MIXED;
+
+/** The settings paths every one of `drawings` supports — what a multi-selection bar can edit. */
+export function sharedPaths(drawings: readonly Drawing[]): Set<string> {
+    const [first, ...rest] = drawings;
+    const paths = new Set(first?.schema().fields.map((f) => f.path) ?? []);
+    for (const d of rest) {
+        const own = new Set(d.schema().fields.map((f) => f.path));
+        for (const p of paths) if (!own.has(p)) paths.delete(p);
+    }
+    return paths;
+}
+
+/** One value read off every drawing: the shared value when they all agree, else {@link MIXED}. */
+export function commonValue<T>(drawings: readonly Drawing[], read: (d: Drawing) => T): T | Mixed {
+    const first = read(drawings[0]!);
+    return drawings.every((d) => read(d) === first) ? first : MIXED;
+}
+
+/** The distinct values a mixed control spans (first-seen order) — the "in use" shortcuts. */
+function distinctValues<T>(drawings: readonly Drawing[], read: (d: Drawing) => T): T[] {
+    return [...new Set(drawings.map(read))];
 }
 
 /** The drawing's pixel bounding box, so the toolbar floats clear of it (not over it). */
@@ -53,7 +83,7 @@ export interface PopupAnchor {
 const BTN = 30; // icon-button side (px)
 const ICON = 21; // icon glyph side (px)
 const STYLE_ID = 'vela-drawing-popup-styles';
-const STYLE_REV = '3';
+const STYLE_REV = '4';
 
 /** Inject the scoped styles that inline cssText can't reach (`:focus`, scrollbar
  *  pseudo-elements). Idempotent — one shared sheet for all popups. */
@@ -68,6 +98,8 @@ function ensureStyles(): void {
 .vela-dpop-btn{background:transparent;color:var(--vela-fg-muted);transition:background var(--vela-dur-fast) ease,color var(--vela-dur-fast) ease;}
 .vela-dpop-btn:hover{background:var(--vela-hover-strong);color:var(--vela-fg-bright);}
 .vela-dpop-btn[data-active='1']{background:var(--vela-active);color:var(--vela-fg-bright);}
+/* Mixed (a multi-selection disagrees): the active fill at half strength behind a dashed ring. */
+.vela-dpop-btn[data-active='mixed']{background:var(--vela-hover-strong);color:var(--vela-fg-bright);outline:1px dashed var(--vela-fg-muted);outline-offset:-2px;}
 .vela-dpop-item{background:transparent;transition:background var(--vela-dur-fast) ease;}
 .vela-dpop-item:hover{background:var(--vela-hover-strong);}
 .vela-dpop-item[data-active='1']{background:var(--vela-active);}
@@ -96,7 +128,7 @@ export class DrawingSettingsPopup {
     private menuPop: Popover | null = null;
     private menuOwner: HTMLElement | null = null;
     private theme: VelaTheme;
-    private onClose: (() => void) | null = null;
+    private onClose: ((e?: PointerEvent) => void) | null = null;
 
     constructor(
         private readonly host: HTMLElement,
@@ -132,18 +164,32 @@ export class DrawingSettingsPopup {
         return node != null && (this.isOwnChrome(node) || this.settingsDialog.contains(node));
     }
 
-    /** Open the quick toolbar for `drawing`, floating clear of its `anchor` box.
-     *  `onClose` fires on an outside-click dismissal (not a programmatic close). */
-    open(drawing: Drawing, anchor: PopupAnchor | null, actions: SettingsActions, onClose?: () => void): void {
+    /** Open the quick toolbar for `drawings` (one, or a whole multi-selection), floating clear of
+     *  their `anchor` box. With several drawings the bar shows only the controls they ALL support,
+     *  a control whose values differ reads as mixed, and every edit applies to all of them —
+     *  per-drawing panels (levels, position sizing, the text field) stay single-drawing only.
+     *  `onClose` fires on a dismissal (an outside press, or Escape in the text field — not a
+     *  programmatic close), with the dismissing press when there is one, so the caller can tell a
+     *  modifier press (multi-select) from a plain one. */
+    open(drawings: readonly Drawing[], anchor: PopupAnchor | null, actions: SettingsActions, onClose?: (e?: PointerEvent) => void): void {
         this.close();
+        const drawing = drawings[0];
+        if (!drawing) return;
         ensureStyles();
         this.onClose = onClose ?? null;
         const t = this.theme;
+        const multi = drawings.length > 1;
         const schema = drawing.schema();
-        const paths = new Set(schema.fields.map((f) => f.path));
+        const paths = sharedPaths(drawings);
+        const common = <T>(read: (d: Drawing) => T): T | Mixed => commonValue(drawings, read);
+        const every = (pred: (d: Drawing) => boolean): boolean => drawings.every(pred);
+        /** A color swatch over the drawings: shared color, or striped with the colors in use. */
+        const swatch = (tip: string, glyph: string, read: (d: Drawing) => string, path: string, iconSize?: number): HTMLButtonElement =>
+            this.colorButton(tip, glyph, common(read), (v) => actions.patch({ [path]: v }), iconSize, distinctValues(drawings, read));
         // Text-first annotations (and computed labels) wear their text controls on the bar; on a
-        // shape that merely CAN carry a label they stay beside the label field.
-        const textOnBar = schema.textIsContent === true || !paths.has('text.value');
+        // shape that merely CAN carry a label they stay beside the label field — and a
+        // multi-selection has no label field, so its text styling always sits on the bar.
+        const textOnBar = multi || schema.textIsContent === true || !paths.has('text.value');
 
         const el = document.createElement('div');
         el.className = 'vela-dpop';
@@ -166,92 +212,96 @@ export class DrawingSettingsPopup {
         bar.appendChild(this.dragHandle());
 
         if (paths.has('glyph')) {
-            const cur = (drawing as unknown as { glyph?: string }).glyph ?? GLYPH_OPTIONS[0];
+            const cur = common((d) => (d as unknown as { glyph?: string }).glyph ?? GLYPH_OPTIONS[0]!);
             bar.appendChild(this.dropdown('Icon', GLYPH_OPTIONS, cur, (g) => glyphIcon(g), (v) => actions.patch({ glyph: v })));
         }
         if (paths.has('size')) {
-            const sz = (drawing as unknown as { size?: string }).size ?? 'normal';
+            const sz = common((d) => (d as unknown as { size?: string }).size ?? 'normal');
             bar.appendChild(this.dropdown('Icon size', STAMP_SIZE_OPTIONS, sz, (s) => stampSizeIcon(s), (v) => actions.patch({ size: v }), { label: sizeLabel }));
         }
         // Magnifier: the lower-timeframe pick is the tool's one behavior control — it leads the
         // bar (text-only: the label IS the glyph); the inset candles' up/down colors ride along.
         // Only timeframes strictly below the chart's are offered; unset colors show the theme's
         // series colors (the inset follows the chart series until the user recolors it).
-        if (paths.has('magnifier.timeframe') && drawing instanceof Magnifier) {
+        if (paths.has('magnifier.timeframe') && every((d) => d instanceof Magnifier)) {
+            const mag = (d: Drawing): Magnifier => d as Magnifier;
             const options = this.lowerTimeframeOptions();
             if (options.length > 0) {
                 bar.appendChild(
-                    this.dropdown('Lower timeframe', options.map((o) => o.value), drawing.magnifier.timeframe, () => '', (v) => actions.patch({ 'magnifier.timeframe': v }), {
+                    this.dropdown('Lower timeframe', options.map((o) => o.value), common((d) => mag(d).magnifier.timeframe), () => '', (v) => actions.patch({ 'magnifier.timeframe': v }), {
                         label: (v) => magnifierTimeframeLabel(String(v)),
                         labelInTrigger: true,
                     }),
                 );
             }
-            bar.appendChild(this.colorButton('Up candles', BUCKET_ICON, drawing.magnifier.upColor || t.upColor, (v) => actions.patch({ 'magnifier.upColor': v })));
-            bar.appendChild(this.colorButton('Down candles', BUCKET_ICON, drawing.magnifier.downColor || t.downColor, (v) => actions.patch({ 'magnifier.downColor': v })));
+            bar.appendChild(swatch('Up candles', BUCKET_ICON, (d) => mag(d).magnifier.upColor || t.upColor, 'magnifier.upColor'));
+            bar.appendChild(swatch('Down candles', BUCKET_ICON, (d) => mag(d).magnifier.downColor || t.downColor, 'magnifier.downColor'));
         }
         // The magnifier's unset border means the theme's contrast ink — the swatch shows that
         // effective color (same idea as effectiveFillColor below), not the generic blue default.
-        if (paths.has('style.lineColor')) bar.appendChild(this.colorButton('Line color', BRUSH_ICON, drawing.style.lineColor || (drawing instanceof Magnifier ? contrastColor(this.theme.background) : DEFAULT_DRAWING_COLOR), (v) => actions.patch({ 'style.lineColor': v })));
+        if (paths.has('style.lineColor')) bar.appendChild(swatch('Line color', BRUSH_ICON, (d) => d.style.lineColor || (d instanceof Magnifier ? contrastColor(this.theme.background) : DEFAULT_DRAWING_COLOR), 'style.lineColor'));
         if (paths.has('style.lineWidth')) {
             // A marker-width field (floor above the hairline ladder, e.g. the
             // highlighter's 4–60) can't live in the 1–4 dropdown — a free numeric
             // input honoring the schema's declared range replaces it.
             const wf = schema.fields.find((f) => f.path === 'style.lineWidth');
+            const width = common((d) => d.style.lineWidth);
             if (wf?.kind === 'number' && (wf.min ?? 1) > 1) {
-                bar.appendChild(this.widthInput('Line width', drawing.style.lineWidth, wf.min ?? 1, wf.max ?? 60, wf.step ?? 1, (v) => actions.patch({ 'style.lineWidth': v })));
+                bar.appendChild(this.widthInput('Line width', width, wf.min ?? 1, wf.max ?? 60, wf.step ?? 1, (v) => actions.patch({ 'style.lineWidth': v })));
             } else {
-                bar.appendChild(this.dropdown('Line width', [1, 2, 3, 4], drawing.style.lineWidth, (w) => lineIcon(w, 'solid'), (v) => actions.patch({ 'style.lineWidth': v }), { label: (v) => `${v}px`, labelInTrigger: true }));
+                bar.appendChild(this.dropdown('Line width', [1, 2, 3, 4], width, (w) => lineIcon(w, 'solid'), (v) => actions.patch({ 'style.lineWidth': v }), { label: (v) => `${v}px`, labelInTrigger: true }));
             }
         }
-        if (paths.has('style.lineStyle')) bar.appendChild(this.dropdown('Line style', LINE_STYLE_OPTIONS.map((o) => o.value), drawing.style.lineStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'style.lineStyle': v }), { label: styleLabel }));
+        if (paths.has('style.lineStyle')) bar.appendChild(this.dropdown('Line style', LINE_STYLE_OPTIONS.map((o) => o.value), common((d) => d.style.lineStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'style.lineStyle': v }), { label: styleLabel }));
         // initialize the Fill swatch to the color actually painted (validity tint / line-color wash /
         // background fallback), not a stale default — same source the renderer fills with.
-        if (paths.has('style.fillColor')) bar.appendChild(this.colorButton('Fill', BUCKET_ICON, effectiveFillColor(drawing, this.theme) ?? drawing.style.fillColor ?? DEFAULT_DRAWING_COLOR, (v) => actions.patch({ 'style.fillColor': v })));
+        if (paths.has('style.fillColor')) bar.appendChild(swatch('Fill', BUCKET_ICON, (d) => effectiveFillColor(d, this.theme) ?? d.style.fillColor ?? DEFAULT_DRAWING_COLOR, 'style.fillColor'));
         // Fixed-range VP: all settings live in the gear panel (nothing inline on the quick bar).
         const isFrvp = paths.has('frvp.rows') && drawing instanceof FixedRangeVolumeProfile;
         // Position tool: zone colors sit on the bar; risk/reward numbers + display toggles live
         // in the gear panel (they drive the loss/size labels).
-        const isPosition = paths.has('riskPercent') && drawing instanceof PositionTool;
+        const isPosition = paths.has('riskPercent') && every((d) => d instanceof PositionTool);
         if (isPosition) {
-            const pos = drawing as PositionTool;
-            bar.appendChild(this.colorButton('Profit zone', BUCKET_ICON, pos.profitColor, (v) => actions.patch({ profitColor: v })));
-            bar.appendChild(this.colorButton('Loss zone', BUCKET_ICON, pos.lossColor, (v) => actions.patch({ lossColor: v })));
+            const pos = (d: Drawing): PositionTool => d as PositionTool;
+            bar.appendChild(swatch('Profit zone', BUCKET_ICON, (d) => pos(d).profitColor, 'profitColor'));
+            bar.appendChild(swatch('Loss zone', BUCKET_ICON, (d) => pos(d).lossColor, 'lossColor'));
         }
         // Regression channel: per-line color + style, the two area fills, and the R² toggle.
-        const reg = (drawing as unknown as { reg?: RegressionStyle }).reg;
-        if (paths.has('reg.midColor') && reg) {
+        const regOf = (d: Drawing): RegressionStyle | undefined => (d as unknown as { reg?: RegressionStyle }).reg;
+        if (paths.has('reg.midColor') && every((d) => regOf(d) != null)) {
+            const reg = (d: Drawing): RegressionStyle => regOf(d)!;
             const styles = LINE_STYLE_OPTIONS.map((o) => o.value);
-            bar.appendChild(this.colorButton('Midline color', BRUSH_ICON, reg.midColor, (v) => actions.patch({ 'reg.midColor': v })));
-            bar.appendChild(this.dropdown('Midline style', styles, reg.midStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.midStyle': v }), { label: styleLabel }));
-            bar.appendChild(this.colorButton('Upper line color', BRUSH_ICON, reg.upperColor, (v) => actions.patch({ 'reg.upperColor': v })));
-            bar.appendChild(this.dropdown('Upper line style', styles, reg.upperStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.upperStyle': v }), { label: styleLabel }));
-            bar.appendChild(this.colorButton('Lower line color', BRUSH_ICON, reg.lowerColor, (v) => actions.patch({ 'reg.lowerColor': v })));
-            bar.appendChild(this.dropdown('Lower line style', styles, reg.lowerStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.lowerStyle': v }), { label: styleLabel }));
-            bar.appendChild(this.colorButton('Upper fill', BUCKET_ICON, reg.upperFill, (v) => actions.patch({ 'reg.upperFill': v })));
-            bar.appendChild(this.colorButton('Lower fill', BUCKET_ICON, reg.lowerFill, (v) => actions.patch({ 'reg.lowerFill': v })));
-            bar.appendChild(this.toggle('Show R²', R2_ICON, reg.showR2, (v) => actions.patch({ 'reg.showR2': v })));
+            bar.appendChild(swatch('Midline color', BRUSH_ICON, (d) => reg(d).midColor, 'reg.midColor'));
+            bar.appendChild(this.dropdown('Midline style', styles, common((d) => reg(d).midStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.midStyle': v }), { label: styleLabel }));
+            bar.appendChild(swatch('Upper line color', BRUSH_ICON, (d) => reg(d).upperColor, 'reg.upperColor'));
+            bar.appendChild(this.dropdown('Upper line style', styles, common((d) => reg(d).upperStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.upperStyle': v }), { label: styleLabel }));
+            bar.appendChild(swatch('Lower line color', BRUSH_ICON, (d) => reg(d).lowerColor, 'reg.lowerColor'));
+            bar.appendChild(this.dropdown('Lower line style', styles, common((d) => reg(d).lowerStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'reg.lowerStyle': v }), { label: styleLabel }));
+            bar.appendChild(swatch('Upper fill', BUCKET_ICON, (d) => reg(d).upperFill, 'reg.upperFill'));
+            bar.appendChild(swatch('Lower fill', BUCKET_ICON, (d) => reg(d).lowerFill, 'reg.lowerFill'));
+            bar.appendChild(this.toggle('Show R²', R2_ICON, common((d) => reg(d).showR2), (v) => actions.patch({ 'reg.showR2': v })));
         }
         // Anchored VWAP: midline color + style, band σ-multiplier, the two band-line colors, and the fill.
-        const vwap = (drawing as unknown as { vwap?: VwapStyle }).vwap;
-        if (paths.has('vwap.midColor') && vwap) {
+        const vwapOf = (d: Drawing): VwapStyle | undefined => (d as unknown as { vwap?: VwapStyle }).vwap;
+        if (paths.has('vwap.midColor') && every((d) => vwapOf(d) != null)) {
+            const vwap = (d: Drawing): VwapStyle => vwapOf(d)!;
             const styles = LINE_STYLE_OPTIONS.map((o) => o.value);
             const MULTS = [0.5, 1, 1.5, 2, 2.5, 3, 4, 5];
-            bar.appendChild(this.colorButton('VWAP color', BRUSH_ICON, vwap.midColor, (v) => actions.patch({ 'vwap.midColor': v })));
-            bar.appendChild(this.dropdown('VWAP style', styles, vwap.midStyle, (s) => lineIcon(2, s), (v) => actions.patch({ 'vwap.midStyle': v }), { label: styleLabel }));
+            bar.appendChild(swatch('VWAP color', BRUSH_ICON, (d) => vwap(d).midColor, 'vwap.midColor'));
+            bar.appendChild(this.dropdown('VWAP style', styles, common((d) => vwap(d).midStyle), (s) => lineIcon(2, s), (v) => actions.patch({ 'vwap.midStyle': v }), { label: styleLabel }));
             bar.appendChild(
-                this.dropdown('Band multiplier', MULTS, vwap.multiplier, () => BANDS_ICON, (v) => actions.patch({ 'vwap.multiplier': v }), {
+                this.dropdown('Band multiplier', MULTS, common((d) => vwap(d).multiplier), () => BANDS_ICON, (v) => actions.patch({ 'vwap.multiplier': v }), {
                     label: (v) => `${v}σ`,
                     labelInTrigger: true,
                 }),
             );
-            bar.appendChild(this.colorButton('Upper band color', BRUSH_ICON, vwap.upperColor, (v) => actions.patch({ 'vwap.upperColor': v })));
-            bar.appendChild(this.colorButton('Lower band color', BRUSH_ICON, vwap.lowerColor, (v) => actions.patch({ 'vwap.lowerColor': v })));
-            bar.appendChild(this.colorButton('Band fill', BUCKET_ICON, vwap.bandFill, (v) => actions.patch({ 'vwap.bandFill': v })));
+            bar.appendChild(swatch('Upper band color', BRUSH_ICON, (d) => vwap(d).upperColor, 'vwap.upperColor'));
+            bar.appendChild(swatch('Lower band color', BRUSH_ICON, (d) => vwap(d).lowerColor, 'vwap.lowerColor'));
+            bar.appendChild(swatch('Band fill', BUCKET_ICON, (d) => vwap(d).bandFill, 'vwap.bandFill'));
         }
         // Dedekind tessellation: max circle curvature (tessellation density).
         if (paths.has('maxCurvature')) {
-            const cur = (drawing as unknown as { maxCurvature?: number }).maxCurvature ?? 24;
+            const cur = common((d) => (d as unknown as { maxCurvature?: number }).maxCurvature ?? 24);
             bar.appendChild(
                 this.dropdown('Max curvature', DEDEKIND_CURVATURE_OPTIONS, cur, () => DEDEKIND_ICON, (v) => actions.patch({ maxCurvature: v }), {
                     label: (v) => `n=${v}`,
@@ -261,7 +311,7 @@ export class DrawingSettingsPopup {
         }
         // Mach figures: wave count + (supersonic) Mach number.
         if (paths.has('mach')) {
-            const cur = (drawing as unknown as { mach?: number }).mach ?? 2;
+            const cur = common((d) => (d as unknown as { mach?: number }).mach ?? 2);
             bar.appendChild(
                 this.dropdown('Mach number', MACH_NUMBER_OPTIONS, cur, () => SUPERSONIC_ICON, (v) => actions.patch({ mach: v }), {
                     label: (v) => `M=${v}`,
@@ -270,7 +320,7 @@ export class DrawingSettingsPopup {
             );
         }
         if (paths.has('waveCount')) {
-            const cur = (drawing as unknown as { waveCount?: number }).waveCount ?? 6;
+            const cur = common((d) => (d as unknown as { waveCount?: number }).waveCount ?? 6);
             bar.appendChild(
                 this.dropdown('Waves', MACH_WAVE_COUNT_OPTIONS, cur, () => SONIC_ICON, (v) => actions.patch({ waveCount: v }), {
                     label: (v) => `${v}`,
@@ -279,30 +329,33 @@ export class DrawingSettingsPopup {
             );
         }
         // Range toggles + computed-label text styling (drawings whose label is computed, not typed).
-        const toggles = drawing as unknown as { showPrice?: boolean; showDate?: boolean };
-        if (paths.has('showPrice')) bar.appendChild(this.toggle('Show price', PRICE_DELTA_ICON, toggles.showPrice !== false, (v) => actions.patch({ showPrice: v })));
-        if (paths.has('showDate')) bar.appendChild(this.toggle('Show date', DATE_DELTA_ICON, toggles.showDate !== false, (v) => actions.patch({ showDate: v })));
-        if (paths.has('text.color') && textOnBar) bar.appendChild(this.colorButton('Text color', TYPE_ICON, drawing.text?.color || t.textColor, (v) => actions.patch({ 'text.color': v })));
-        if (paths.has('text.size') && textOnBar) bar.appendChild(this.dropdown('Text size', TEXT_SIZE_OPTIONS.map((o) => o.value), drawing.text?.size ?? 'normal', (s) => labelSizeIcon(s), (v) => actions.patch({ 'text.size': v }), { label: sizeLabel }));
-        // Bold/italic live under the text field; a computed label has no field, so they go on the bar.
-        if (paths.has('text.bold') && !paths.has('text.value')) bar.appendChild(this.toggle('Bold', BOLD_ICON, !!drawing.text?.bold, (v) => actions.patch({ 'text.bold': v })));
-        if (paths.has('text.italic') && !paths.has('text.value')) bar.appendChild(this.toggle('Italic', ITALIC_ICON, !!drawing.text?.italic, (v) => actions.patch({ 'text.italic': v })));
-        if (paths.has('text.value')) bar.appendChild(this.iconBtn('Text', TYPE_ICON, () => this.toggleTextPanel(drawing, actions, !textOnBar)));
+        const flags = (d: Drawing): { showPrice?: boolean; showDate?: boolean } => d as unknown as { showPrice?: boolean; showDate?: boolean };
+        if (paths.has('showPrice')) bar.appendChild(this.toggle('Show price', PRICE_DELTA_ICON, common((d) => flags(d).showPrice !== false), (v) => actions.patch({ showPrice: v })));
+        if (paths.has('showDate')) bar.appendChild(this.toggle('Show date', DATE_DELTA_ICON, common((d) => flags(d).showDate !== false), (v) => actions.patch({ showDate: v })));
+        if (paths.has('text.color') && textOnBar) bar.appendChild(swatch('Text color', TYPE_ICON, (d) => d.text?.color || t.textColor, 'text.color'));
+        if (paths.has('text.size') && textOnBar) bar.appendChild(this.dropdown('Text size', TEXT_SIZE_OPTIONS.map((o) => o.value), common((d) => d.text?.size ?? 'normal'), (s) => labelSizeIcon(s), (v) => actions.patch({ 'text.size': v }), { label: sizeLabel }));
+        // Bold/italic live under the text field; a computed label has no field (nor does a
+        // multi-selection), so they go on the bar.
+        const textField = !multi && paths.has('text.value');
+        if (paths.has('text.bold') && !textField) bar.appendChild(this.toggle('Bold', BOLD_ICON, common((d) => !!d.text?.bold), (v) => actions.patch({ 'text.bold': v })));
+        if (paths.has('text.italic') && !textField) bar.appendChild(this.toggle('Italic', ITALIC_ICON, common((d) => !!d.text?.italic), (v) => actions.patch({ 'text.italic': v })));
+        if (textField) bar.appendChild(this.iconBtn('Text', TYPE_ICON, () => this.toggleTextPanel(drawing, actions, !textOnBar)));
         const editableLevels = drawing.editableLevels();
-        if (editableLevels && !(drawing instanceof MachFigure)) {
-            const fib = drawing as unknown as { numbersSize?: string; labelsSize?: string };
+        if (editableLevels && every((d) => d.editableLevels() != null && !(d instanceof MachFigure))) {
+            const fib = (d: Drawing): { numbersSize?: string; labelsSize?: string } => d as unknown as { numbersSize?: string; labelsSize?: string };
             const sizes = TEXT_SIZE_OPTIONS.map((o) => o.value);
-            bar.appendChild(this.dropdown('Numbers size', sizes, fib.numbersSize ?? 'small', (s) => numbersSizeIcon(s), (v) => actions.patch({ numbersSize: v }), { label: sizeLabel }));
-            bar.appendChild(this.dropdown('Label size', sizes, fib.labelsSize ?? 'normal', (s) => labelSizeIcon(s), (v) => actions.patch({ labelsSize: v }), { label: sizeLabel }));
+            bar.appendChild(this.dropdown('Numbers size', sizes, common((d) => fib(d).numbersSize ?? 'small'), (s) => numbersSizeIcon(s), (v) => actions.patch({ numbersSize: v }), { label: sizeLabel }));
+            bar.appendChild(this.dropdown('Label size', sizes, common((d) => fib(d).labelsSize ?? 'normal'), (s) => labelSizeIcon(s), (v) => actions.patch({ labelsSize: v }), { label: sizeLabel }));
         }
 
         // Trailing group: settings wheel (when the tool has one) sits just left of the lock,
-        // and a kebab overflow (z-order + reset) sits just right of delete.
+        // and a kebab overflow (z-order + reset) sits just right of delete. The gear panels edit
+        // one drawing's own data (levels, sizing, profile rows) — they stay off a multi-selection.
         bar.appendChild(this.divider());
-        if (isFrvp) bar.appendChild(this.iconBtn('Settings', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'frvp')));
-        if (isPosition) bar.appendChild(this.iconBtn('Position size', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'position')));
-        if (editableLevels) bar.appendChild(this.iconBtn('Levels', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'levels')));
-        bar.appendChild(this.toggle('Lock', LOCK_ICON, drawing.locked, (v) => actions.setLocked(v)));
+        if (!multi && isFrvp) bar.appendChild(this.iconBtn('Settings', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'frvp')));
+        if (!multi && isPosition) bar.appendChild(this.iconBtn('Position size', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'position')));
+        if (!multi && editableLevels) bar.appendChild(this.iconBtn('Levels', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'levels')));
+        bar.appendChild(this.toggle('Lock', LOCK_ICON, common((d) => d.locked), (v) => actions.setLocked(v)));
         const del = this.iconBtn('Delete', TRASH_ICON, () => actions.remove());
         del.style.color = 'var(--vela-danger)';
         bar.appendChild(del);
@@ -350,7 +403,7 @@ export class DrawingSettingsPopup {
         if (this.isOwnChrome(node)) return;
         const cb = this.onClose;
         this.close();
-        cb?.();
+        cb?.(e as PointerEvent);
     };
 
     /** Bar, host-floated shells, and kit popovers (select list / color chip) portaled into `host`. */
@@ -526,7 +579,7 @@ export class DrawingSettingsPopup {
         return b;
     }
 
-    /** The trailing kebab overflow — z-order actions + reset settings. */
+    /** The trailing kebab overflow — duplicate, z-order actions, reset settings. */
     private kebabButton(actions: SettingsActions): HTMLButtonElement {
         const b = this.base('More');
         b.innerHTML = sized(KEBAB_ICON);
@@ -540,6 +593,7 @@ export class DrawingSettingsPopup {
                 return;
             }
             this.openActionMenu(b, [
+                { icon: CLONE_ICON, label: 'Duplicate', onClick: () => actions.duplicate() },
                 { icon: FRONT_ICON, label: 'Bring to front', onClick: () => actions.reorder('front') },
                 { icon: BACK_ICON, label: 'Send to back', onClick: () => actions.reorder('back') },
                 { icon: RESET_ICON, label: 'Reset settings', onClick: () => actions.resetSettings() },
@@ -699,17 +753,19 @@ export class DrawingSettingsPopup {
         this.tipEl = null;
     }
 
-    private toggle(tip: string, icon: string, active: boolean, onChange: (v: boolean) => void): HTMLButtonElement {
+    /** An on/off button. A mixed state (the selected drawings disagree) reads as half-lit and
+     *  the first click turns it ON for all of them. */
+    private toggle(tip: string, icon: string, active: boolean | Mixed, onChange: (v: boolean) => void): HTMLButtonElement {
         const b = this.base(tip);
         b.innerHTML = sized(icon);
-        // `data-active` alone drives the fill — the stylesheet owns idle/hover/active.
-        const set = (on: boolean): void => {
-            b.dataset.active = on ? '1' : '0';
+        // `data-active` alone drives the fill — the stylesheet owns idle/hover/active/mixed.
+        const set = (on: boolean | Mixed): void => {
+            b.dataset.active = on === MIXED ? 'mixed' : on ? '1' : '0';
         };
         set(active);
         let on = active;
         b.addEventListener('click', () => {
-            on = !on;
+            on = on === MIXED ? true : !on;
             set(on);
             onChange(on);
         });
@@ -717,10 +773,11 @@ export class DrawingSettingsPopup {
     }
 
     /** An inline numeric width field for tools whose stroke range outgrows the 1–4px
-     *  ladder — the value is clamped to the schema's declared min/max on commit. */
-    private widthInput(tip: string, value: number, min: number, max: number, step: number, onChange: (v: number) => void): HTMLElement {
+     *  ladder — the value is clamped to the schema's declared min/max on commit. A mixed
+     *  value shows an empty field with a dash until a number is typed for all. */
+    private widthInput(tip: string, value: number | Mixed, min: number, max: number, step: number, onChange: (v: number) => void): HTMLElement {
         const ni = new NumberInput({
-            value,
+            value: value === MIXED ? min : value,
             min,
             max,
             step,
@@ -732,6 +789,10 @@ export class DrawingSettingsPopup {
             title: tip,
             onChange,
         });
+        if (value === MIXED) {
+            ni.input.value = '';
+            ni.input.placeholder = '—';
+        }
         ni.el.dataset.tip = tip;
         trapChartKeys(ni.el);
         return ni.el;
@@ -739,11 +800,12 @@ export class DrawingSettingsPopup {
 
     /** A pick-one dropdown: the trigger shows the current value's glyph (plus an optional inline
      *  text label — e.g. `2px` — for controls that would otherwise look alike), and clicking it
-     *  opens a floating list of every option so a value is one click away (no cycling through). */
+     *  opens a floating list of every option so a value is one click away (no cycling through).
+     *  A mixed value shows a dash in the trigger and highlights no row. */
     private dropdown(
         tip: string,
         values: readonly (string | number)[],
-        current: string | number,
+        current: string | number | Mixed,
         render: (v: string | number) => string,
         onChange: (v: string | number) => void,
         opts: { label?: (v: string | number) => string; labelInTrigger?: boolean } = {},
@@ -754,9 +816,15 @@ export class DrawingSettingsPopup {
         b.style.padding = '0 4px';
         b.style.gap = '2px';
         let cur = current;
-        const paint = (v: string | number): void => {
+        const paint = (v: string | number | Mixed): void => {
             b.replaceChildren();
-            const glyph = render(v);
+            if (v === MIXED) {
+                const dash = document.createElement('span');
+                dash.textContent = '—';
+                dash.style.cssText = 'min-width:18px;text-align:center;opacity:0.85;';
+                b.appendChild(dash);
+            }
+            const glyph = v === MIXED ? '' : render(v);
             if (glyph) {
                 // An empty glyph means a text-only control (e.g. the magnifier's timeframe) —
                 // the trigger then shows just the label + chevron.
@@ -765,7 +833,7 @@ export class DrawingSettingsPopup {
                 ic.innerHTML = sized(glyph);
                 b.appendChild(ic);
             }
-            if (opts.label && opts.labelInTrigger) {
+            if (opts.label && opts.labelInTrigger && v !== MIXED) {
                 const tx = document.createElement('span');
                 tx.textContent = opts.label(v);
                 tx.style.cssText = 'font-size:11px;opacity:0.85;font-variant-numeric:tabular-nums;';
@@ -800,7 +868,7 @@ export class DrawingSettingsPopup {
     private openMenu(
         anchor: HTMLElement,
         values: readonly (string | number)[],
-        current: string | number,
+        current: string | number | Mixed,
         render: (v: string | number) => string,
         label: ((v: string | number) => string) | undefined,
         onPick: (v: string | number) => void,
@@ -847,8 +915,10 @@ export class DrawingSettingsPopup {
 
     /** A color control: an `icon` over a thin **colored underline** showing the current
      *  value (the common idiom), with an invisible native picker overlaid to edit it.
-     *  `iconSize` shrinks it for the floating text controls. */
-    private colorButton(tip: string, icon: string, color: string, onChange: (v: string) => void, iconSize = 17): HTMLButtonElement {
+     *  `iconSize` shrinks it for the floating text controls. A mixed color paints the
+     *  underline striped with the colors `used` across the selection, and the picker then
+     *  leads with those colors so unifying onto one of them is a single click. */
+    private colorButton(tip: string, icon: string, color: string | Mixed, onChange: (v: string) => void, iconSize = 17, used: readonly string[] = []): HTMLButtonElement {
         const b = document.createElement('button');
         b.type = 'button';
         b.dataset.tip = tip;
@@ -858,7 +928,7 @@ export class DrawingSettingsPopup {
         ic.style.cssText = 'display:flex;';
         ic.innerHTML = sized(icon, iconSize);
         const bar = document.createElement('span');
-        bar.style.cssText = `display:block;height:3px;width:${Math.round(iconSize * 0.85)}px;border-radius:2px;background:${color};`;
+        bar.style.cssText = `display:block;height:3px;width:${Math.round(iconSize * 0.85)}px;border-radius:2px;background:${color === MIXED ? stripes(used) : color};`;
         b.append(ic, bar);
         let cur = color;
         // Stop the swatch's own pointerdown from reaching `el` (which would pre-close the popover),
@@ -866,7 +936,9 @@ export class DrawingSettingsPopup {
         b.addEventListener('pointerdown', (e) => e.stopPropagation());
         b.addEventListener('click', (e) => {
             e.stopPropagation();
-            this.toggleColorPopover(b, cur, (v) => {
+            // A mixed picker starts from the first color in use — some real value must seed the sliders.
+            const seed = cur === MIXED ? used[0] ?? DEFAULT_DRAWING_COLOR : cur;
+            this.toggleColorPopover(b, seed, cur === MIXED ? used : [], (v) => {
                 cur = v;
                 bar.style.background = v;
                 onChange(v);
@@ -876,21 +948,45 @@ export class DrawingSettingsPopup {
     }
 
     /** Open the color popover for `anchor`, or close it if it's already this anchor's (toggle). */
-    private toggleColorPopover(anchor: HTMLElement, color: string, onChange: (v: string) => void): void {
+    private toggleColorPopover(anchor: HTMLElement, color: string, used: readonly string[], onChange: (v: string) => void): void {
         if (this.colorOwner === anchor) {
             this.closeColorPopover();
             return;
         }
-        this.openColorPopover(anchor, color, onChange);
+        this.openColorPopover(anchor, color, used, onChange);
     }
 
-    /** A floating RGB picker + opacity slider anchored to a color swatch — emits `#RRGGBB(AA)`. */
-    private openColorPopover(anchor: HTMLElement, color: string, onChange: (v: string) => void): void {
+    /** A floating RGB picker + opacity slider anchored to a color swatch — emits `#RRGGBB(AA)`.
+     *  `used` (a mixed swatch's colors) leads the picker as one-click unify shortcuts. */
+    private openColorPopover(anchor: HTMLElement, color: string, used: readonly string[], onChange: (v: string) => void): void {
         const t = this.theme;
         this.colorPop = this.hostFloat(anchor, {
             zIndex: 25,
             padding: '10px',
-            fill: (el) => { el.appendChild(buildColorPicker(color, t, onChange)); },
+            fill: (el, pop) => {
+                if (used.length > 1) {
+                    const row = document.createElement('div');
+                    row.style.cssText = 'display:flex;align-items:center;gap:6px;padding-bottom:9px;border-bottom:1px solid var(--vela-border);';
+                    const lbl = document.createElement('span');
+                    lbl.textContent = 'In use';
+                    lbl.style.cssText = 'font:var(--vela-font-size-sm) inherit;opacity:0.7;margin-right:2px;';
+                    row.appendChild(lbl);
+                    for (const c of used) {
+                        const sw = document.createElement('button');
+                        sw.type = 'button';
+                        sw.dataset.tip = c;
+                        sw.style.cssText = `width:18px;height:18px;border-radius:4px;border:1px solid var(--vela-border-strong);cursor:pointer;background:${c};padding:0;`;
+                        sw.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            pop.hide();
+                            onChange(c);
+                        });
+                        row.appendChild(sw);
+                    }
+                    el.appendChild(row);
+                }
+                el.appendChild(buildColorPicker(color, t, onChange));
+            },
         });
         this.colorOwner = anchor;
     }
@@ -922,6 +1018,7 @@ const BOLD_ICON = icon('bold');
 const ITALIC_ICON = icon('italic');
 const GRIP_ICON = icon('grip');
 const KEBAB_ICON = icon('kebab');
+const CLONE_ICON = icon('clone');
 const RESET_ICON = icon('reset');
 const GEAR_ICON = icon('gear');
 const CHEVRON_ICON = icon('chevron-down');
@@ -930,6 +1027,15 @@ const BANDS_ICON = icon('bands');
 const DEDEKIND_ICON = icon('dedekind');
 const SONIC_ICON = icon('sonic');
 const SUPERSONIC_ICON = icon('supersonic');
+
+/** A striped underline for a mixed color swatch: equal bands of every color in use (a neutral
+ *  gray pair when nothing concrete is known), so the mix itself is visible without opening it. */
+function stripes(colors: readonly string[]): string {
+    const bands = colors.length > 1 ? colors : ['var(--vela-fg-faint)', 'var(--vela-fg-muted)'];
+    const step = 100 / bands.length;
+    const stops = bands.map((c, i) => `${c} ${i * step}% ${(i + 1) * step}%`).join(',');
+    return `linear-gradient(90deg,${stops})`;
+}
 
 /** A line glyph at a given width + style (for the width/style dropdown glyphs). The stroke IS
  *  the value being previewed, so it overrides the tier's weight. */

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -243,10 +243,17 @@ export class DrawingSettingsPopup {
         if (paths.has('style.lineWidth')) {
             // A marker-width field (floor above the hairline ladder, e.g. the
             // highlighter's 4–60) can't live in the 1–4 dropdown — a free numeric
-            // input honoring the schema's declared range replaces it.
-            const wf = schema.fields.find((f) => f.path === 'style.lineWidth');
+            // input honoring the schema's declared range replaces it. Only when EVERY
+            // selected drawing is a marker, though: mixed with a hairline tool the
+            // ladder is the range they all accept.
+            const widthField = (d: Drawing) => d.schema().fields.find((f) => f.path === 'style.lineWidth');
+            const wf = widthField(drawing);
             const width = common((d) => d.style.lineWidth);
-            if (wf?.kind === 'number' && (wf.min ?? 1) > 1) {
+            const markers = every((d) => {
+                const f = widthField(d);
+                return f?.kind === 'number' && (f.min ?? 1) > 1;
+            });
+            if (markers && wf?.kind === 'number') {
                 bar.appendChild(this.widthInput('Line width', width, wf.min ?? 1, wf.max ?? 60, wf.step ?? 1, (v) => actions.patch({ 'style.lineWidth': v })));
             } else {
                 bar.appendChild(this.dropdown('Line width', [1, 2, 3, 4], width, (w) => lineIcon(w, 'solid'), (v) => actions.patch({ 'style.lineWidth': v }), { label: (v) => `${v}px`, labelInTrigger: true }));

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -184,8 +184,8 @@ export class DrawingSettingsPopup {
         const common = <T>(read: (d: Drawing) => T): T | Mixed => commonValue(drawings, read);
         const every = (pred: (d: Drawing) => boolean): boolean => drawings.every(pred);
         /** A color swatch over the drawings: shared color, or striped with the colors in use. */
-        const swatch = (tip: string, glyph: string, read: (d: Drawing) => string, path: string, iconSize?: number): HTMLButtonElement =>
-            this.colorButton(tip, glyph, common(read), (v) => actions.patch({ [path]: v }), iconSize, distinctValues(drawings, read));
+        const swatch = (tip: string, glyph: string, read: (d: Drawing) => string, path: string): HTMLButtonElement =>
+            this.colorButton(tip, glyph, common(read), (v) => actions.patch({ [path]: v }), undefined, distinctValues(drawings, read));
         // Text-first annotations (and computed labels) wear their text controls on the bar; on a
         // shape that merely CAN carry a label they stay beside the label field — and a
         // multi-selection has no label field, so its text styling always sits on the bar.

--- a/src/renderers/native/drawings/DrawingSettingsPopup.ts
+++ b/src/renderers/native/drawings/DrawingSettingsPopup.ts
@@ -362,7 +362,7 @@ export class DrawingSettingsPopup {
         if (!multi && isFrvp) bar.appendChild(this.iconBtn('Settings', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'frvp')));
         if (!multi && isPosition) bar.appendChild(this.iconBtn('Position size', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'position')));
         if (!multi && editableLevels) bar.appendChild(this.iconBtn('Levels', GEAR_ICON, () => this.settingsDialog.open(drawing, actions, 'levels')));
-        bar.appendChild(this.toggle('Lock', LOCK_ICON, common((d) => d.locked), (v) => actions.setLocked(v)));
+        bar.appendChild(this.toggle('Lock', LOCK_ICON, common((d) => d.locked), (v) => actions.setLocked(v), UNLOCK_ICON));
         const del = this.iconBtn('Delete', TRASH_ICON, () => actions.remove());
         del.style.color = 'var(--vela-danger)';
         bar.appendChild(del);
@@ -761,13 +761,14 @@ export class DrawingSettingsPopup {
     }
 
     /** An on/off button. A mixed state (the selected drawings disagree) reads as half-lit and
-     *  the first click turns it ON for all of them. */
-    private toggle(tip: string, icon: string, active: boolean | Mixed, onChange: (v: boolean) => void): HTMLButtonElement {
+     *  the first click turns it ON for all of them. `off` swaps in a distinct glyph while the
+     *  toggle is off (a lock reads as an open padlock until it is engaged); mixed shows `icon`. */
+    private toggle(tip: string, icon: string, active: boolean | Mixed, onChange: (v: boolean) => void, off?: string): HTMLButtonElement {
         const b = this.base(tip);
-        b.innerHTML = sized(icon);
         // `data-active` alone drives the fill — the stylesheet owns idle/hover/active/mixed.
         const set = (on: boolean | Mixed): void => {
             b.dataset.active = on === MIXED ? 'mixed' : on ? '1' : '0';
+            b.innerHTML = sized(off && on === false ? off : icon);
         };
         set(active);
         let on = active;
@@ -1018,6 +1019,7 @@ const TYPE_ICON = icon('type');
 const PRICE_DELTA_ICON = icon('price-delta');
 const DATE_DELTA_ICON = icon('date-delta');
 const LOCK_ICON = icon('lock');
+const UNLOCK_ICON = icon('unlock');
 const FRONT_ICON = icon('bring-front');
 const BACK_ICON = icon('send-back');
 const TRASH_ICON = icon('trash');

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -19,7 +19,7 @@ import { withAlpha } from '../core/chartConfig';
 import { blendOver, splitColor } from '../../../ui/components/color-picker';
 import { DrawingPainter, handleIdsFor, type PaintTargets } from './DrawingPainter';
 import { DrawingInteraction } from './DrawingInteraction';
-import { DrawingSettingsPopup } from './DrawingSettingsPopup';
+import { DrawingSettingsPopup, type PopupAnchor } from './DrawingSettingsPopup';
 import { DrawingToolbar, TOOLBAR_WIDTH, TOOLBAR_COLLAPSED_WIDTH } from './DrawingToolbar';
 import { MeasureOverlay } from './MeasureOverlay';
 import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
@@ -136,6 +136,9 @@ export class UserDrawingController implements IDrawingsRendererPort {
     private readonly painter = new DrawingPainter();
     private readonly interaction: DrawingInteraction;
     private readonly popup: DrawingSettingsPopup;
+    /** The open popup is the multi-selection bar (vs one drawing's own) — decides what a
+     *  shrinking selection does with it. */
+    private popupMulti = false;
     private readonly toolbar: DrawingToolbar;
 
     constructor(
@@ -343,6 +346,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     setSelection(ids: readonly string[]): void {
         this.selectedIds = new Set(ids);
+        // A multi-selection gets ONE bar for all of its drawings; when it shrinks back to a single
+        // drawing that drawing's own bar takes over, and an emptied selection takes the bar away.
+        if (ids.length >= 2) this.openSettingsForSelection(ids);
+        else if (this.popupMulti) {
+            this.popupMulti = false;
+            this.popup.close();
+            if (ids.length === 1) this.openSettingsById(ids[0]!, 0, 0);
+        }
         this.render();
     }
 
@@ -394,12 +405,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
     }
 
     /** Delete the (unlocked) drawing under the cursor. True when one was removed.
-     *  Shared by the eraser (click + drag) and the middle-click shortcut. */
-    deleteAt(x: number, y: number): boolean {
+     *  Shared by the eraser (click + drag) and the middle-click shortcut; the latter passes
+     *  `withSelection` so a hit on a SELECTED drawing removes the whole selection with it. */
+    deleteAt(x: number, y: number, withSelection = false): boolean {
         const hit = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE);
         if (!hit || hit.locked) return false;
         this.popup.close();
-        this.emit({ kind: 'delete', ids: [hit.id] });
+        const ids = withSelection && this.selectedIds.has(hit.id) ? this.selectionIds() : [hit.id];
+        this.emit({ kind: 'delete', ids });
         return true;
     }
 
@@ -428,7 +441,15 @@ export class UserDrawingController implements IDrawingsRendererPort {
         }
     }
 
-    pointerDown(x: number, y: number, snap: SnapMode = 'off', shift = false): void {
+    /** Ctrl/Cmd+press on the empty plot: sweep a selection box (adds the drawings it touches to
+     *  the selection). Returns false when a mode/tool is active (the normal press path owns it). */
+    beginMarqueeAt(x: number, y: number): boolean {
+        if (this.measureMode || this.eraserMode || !this.interaction.beginMarquee(x, y)) return false;
+        this.render();
+        return true;
+    }
+
+    pointerDown(x: number, y: number, snap: SnapMode = 'off', shift = false, mod = false): void {
         if (this.eraserMode) {
             this.erasing = true; // hold to drag-erase across multiple drawings
             this.deleteAt(x, y);
@@ -451,10 +472,10 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 return;
             }
         }
-        this.interaction.down(x, y, snap, shift); // the popup self-dismisses on any outside press
+        this.interaction.down(x, y, snap, shift, mod); // the popup self-dismisses on any outside press
     }
 
-    pointerMove(x: number, y: number, snap: SnapMode = 'off', shift = false): void {
+    pointerMove(x: number, y: number, snap: SnapMode = 'off', shift = false, mod = false): void {
         if (this.eraserMode) {
             if (this.erasing) this.deleteAt(x, y); // erase only while the button is held (not on hover)
             return;
@@ -466,13 +487,15 @@ export class UserDrawingController implements IDrawingsRendererPort {
             return;
         }
         this.interaction.move(x, y, snap, shift);
-        this.updateHover(x, y); // show handles for the drawing under the cursor
+        this.updateHover(x, y, mod); // show handles for the drawing under the cursor
     }
 
-    /** Track which drawing is hovered so its handles appear on hover (and only then). */
-    private updateHover(x: number, y: number): void {
+    /** Track which drawing is hovered so its handles appear on hover (and only then). While
+     *  Ctrl/Cmd is held the cursor is picking a selection — handles then mark only what IS
+     *  selected, so a hovered candidate doesn't already read as selected. */
+    private updateHover(x: number, y: number, mod = false): void {
         let id: string | null = null;
-        if (this.activeTool == null && !this.interaction.isPlacing() && !this.interaction.isDragging()) {
+        if (!mod && this.activeTool == null && !this.interaction.isPlacing() && !this.interaction.isDragging()) {
             id = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE)?.id ?? null;
         }
         if (id !== this.hoveredId) {
@@ -936,6 +959,10 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.painter.seriesLook = this.deps.seriesLook();
         this.painter.paintAll(ctx, this.drawings.filter((d) => !this.isInterleaved(d)), proj, this.deps.theme(), targets);
         this.painter.paintHighlights(ctx, this.drawings.filter((d) => this.isInterleaved(d)), proj, handleIdsFor(targets));
+        // A Ctrl-drag moves COPIES that are not in the store yet: paint them here, in full and with
+        // handles, so they read as the real drawings they are about to become.
+        const clones = this.interaction.dragClones();
+        if (clones) this.painter.paintAll(ctx, clones, proj, this.deps.theme(), { selected: new Set(clones.map((c) => c.id)) });
         this.layoutTextEditor();
         const ghost = this.interaction.ghost();
         if (ghost) this.painter.paintGhost(ctx, ghost, proj, this.deps.theme());
@@ -960,6 +987,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
         if (m && my != null) this.painter.paintSnapRing(ctx, proj.xOf(m.point.time), my, this.deps.theme());
         // The transient ruler paints on top of everything (until cleared on the next press/pan/zoom).
         if (this.measure.isActive()) this.measure.paint(ctx, proj, this.deps.theme());
+        const marquee = this.interaction.marqueeRect();
+        if (marquee) this.painter.paintMarquee(ctx, marquee);
     }
 
     destroy(): void {
@@ -980,15 +1009,87 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.render();
     }
 
+    /** Dismiss-on-outside-press also clears the selection — except when the press carries a
+     *  multi-select modifier (Shift / Ctrl / Cmd): that press is about to ADD to the selection
+     *  (or sweep a marquee onto it), so the drawings whose bar just closed must stay selected. */
+    private readonly onPopupDismissed = (e?: PointerEvent): void => {
+        if (!(e && (e.shiftKey || e.ctrlKey || e.metaKey))) this.clearSelection();
+    };
+
+    /** Report the live drawings' current state as one edit (one undo step, however many). */
+    private emitEdits(drawings: readonly Drawing[]): void {
+        const docs = drawings.map((d) => d.serialize());
+        if (docs.length === 1) this.emit({ kind: 'edit', doc: docs[0]! });
+        else if (docs.length > 1) this.emit({ kind: 'edit-many', docs });
+    }
+
+    /** The one bar for a multi-selection: it shows the controls all of its drawings share and
+     *  every action applies to all of them. Floats clear of their combined bounds. */
+    private openSettingsForSelection(ids: readonly string[]): void {
+        const live = (): Drawing[] => ids.map((id) => this.drawings.find((d) => d.id === id)).filter((d): d is Drawing => d != null);
+        const drawings = live();
+        if (drawings.length < 2) return;
+        const proj = this.deps.projector();
+        let anchor: PopupAnchor | null = null;
+        for (const d of drawings) {
+            const b = d.bounds(proj);
+            if (!b) continue;
+            if (!anchor) anchor = { ...b };
+            else {
+                const right = Math.max(anchor.x + anchor.w, b.x + b.w);
+                const bottom = Math.max(anchor.y + anchor.h, b.y + b.h);
+                anchor.x = Math.min(anchor.x, b.x);
+                anchor.y = Math.min(anchor.y, b.y);
+                anchor.w = right - anchor.x;
+                anchor.h = bottom - anchor.y;
+            }
+        }
+        this.popupMulti = true;
+        this.emit({ kind: 'settings', id: drawings[0]!.id });
+        this.popup.open(drawings, anchor, {
+            resolve: () => live()[0] ?? null,
+            patch: (p) => {
+                const ds = live();
+                for (const d of ds) d.applySettings(p);
+                this.render();
+                this.emitEdits(ds);
+            },
+            setLocked: (v) => {
+                const ds = live();
+                for (const d of ds) d.locked = v;
+                this.emitEdits(ds);
+            },
+            reorder: (to) => {
+                for (const d of live()) this.emit({ kind: 'reorder', id: d.id, to });
+            },
+            duplicate: () => {
+                this.popup.close();
+                this.emit({ kind: 'duplicate', ids: live().map((d) => d.id) });
+            },
+            resetSettings: () => {
+                const ds = live();
+                for (const d of ds) resetDrawingSettings(d);
+                this.render();
+                this.emitEdits(ds);
+                this.openSettingsForSelection(ids); // rebuild so the controls reflect the restored defaults
+            },
+            remove: () => {
+                this.popup.close();
+                this.emit({ kind: 'delete', ids: live().map((d) => d.id) });
+            },
+        }, this.onPopupDismissed);
+    }
+
     /** A click on a drawing opens its settings toolbar (text labels edit text here too). */
     private openSettingsById(id: string, _x: number, _y: number): void {
         const drawing = this.drawings.find((d) => d.id === id);
         if (!drawing) return;
         const live = (): Drawing | undefined => this.drawings.find((d) => d.id === id);
+        this.popupMulti = false;
         this.emit({ kind: 'select', ids: [id] }); // editing this drawing → it stays highlighted while the popup is open
         this.emit({ kind: 'settings', id });
         const anchor = drawing.bounds(this.deps.projector()); // float the toolbar clear of the drawing
-        this.popup.open(drawing, anchor, {
+        this.popup.open([drawing], anchor, {
             // Sync rebuilds instances, so a panel that reads values back after a patch (e.g. the
             // position tool's price fields, where one edit can flip another level) resolves fresh.
             resolve: () => live() ?? null,
@@ -1006,6 +1107,13 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.emit({ kind: 'edit', doc: d.serialize() });
             },
             reorder: (to) => this.emit({ kind: 'reorder', id, to }),
+            duplicate: () => {
+                // The copy lands on its source and becomes the selection (same as Ctrl/Cmd+D) —
+                // ready to drag away; the source's popup would otherwise outlive its selection.
+                this.finishTextEditor(true); // typed text is part of what gets copied
+                this.popup.close();
+                this.emit({ kind: 'duplicate', ids: [id] });
+            },
             resetSettings: () => {
                 const d = live();
                 if (!d) return;
@@ -1029,7 +1137,13 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.popup.close();
                 this.emit({ kind: 'delete', ids: [id] });
             },
-        }, () => this.clearSelection()); // dismiss-on-outside-click also clears the selection/highlight
+        }, this.onPopupDismissed);
+    }
+
+    /** A plain click on the empty plot: drop the selection (the multi-select twin of the popup's
+     *  dismiss-on-outside-press, which only covers the single-drawing case). */
+    deselect(): void {
+        this.clearSelection();
     }
 
     /** Report placement progress upstream (`draft` intent) so the drawings sync can
@@ -1067,6 +1181,15 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.openSettingsById(fresh.id, 0, 0);
                 if (isInlineEditable(fresh)) this.editTextInline(fresh.id); // focus lands in the editor, not the bar
             }, 0);
+            return;
+        }
+        if (i.kind === 'clone') {
+            // A drag-to-duplicate ends like a click on the copy: its settings bar opens so it can be
+            // restyled right away. Several copies stay a plain multi-selection (one bar edits one drawing).
+            const before = new Set(this.drawings.map((d) => d.id));
+            this.intentCb?.(i);
+            const fresh = this.drawings.filter((d) => !before.has(d.id));
+            if (fresh.length === 1) this.openSettingsById(fresh[0]!.id, 0, 0);
             return;
         }
         this.intentCb?.(i);

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -406,12 +406,13 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     /** Delete the (unlocked) drawing under the cursor. True when one was removed.
      *  Shared by the eraser (click + drag) and the middle-click shortcut; the latter passes
-     *  `withSelection` so a hit on a SELECTED drawing removes the whole selection with it. */
+     *  `withSelection` so a hit on a SELECTED drawing removes the selection with it (its
+     *  locked members excepted). */
     deleteAt(x: number, y: number, withSelection = false): boolean {
         const hit = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE);
         if (!hit || hit.locked) return false;
         this.popup.close();
-        const ids = withSelection && this.selectedIds.has(hit.id) ? this.selectionIds() : [hit.id];
+        const ids = withSelection && this.selectedIds.has(hit.id) ? this.deletableSelection() : [hit.id];
         this.emit({ kind: 'delete', ids });
         return true;
     }
@@ -516,7 +517,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
             this.render();
             return;
         }
+        // A drag of a SELECTED drawing dismissed its bar on the press (but kept the selection —
+        // see onPopupDismissed); once the drag lands, bring the bar back over the moved drawings.
+        const dragged = this.interaction.isDragging() ? this.interaction.pressedId() : null;
         this.interaction.up(x, y); // commit a drag, or open settings on a no-move click
+        if (dragged && this.selectedIds.has(dragged) && !this.popup.isOpen()) {
+            if (this.selectedIds.size >= 2) this.openSettingsForSelection(this.selectionIds());
+            else this.openSettingsById(dragged, x, y);
+        }
     }
 
     /** Toggle the transient ruler. Arming it clears any drawing tool + selection. */
@@ -822,7 +830,7 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.emit({ kind: 'duplicate', ids: this.selectionIds() });
                 break;
             case 'delete': {
-                const ids = this.selectedIds.size ? this.selectionIds() : this.hoveredId ? [this.hoveredId] : [];
+                const ids = this.selectedIds.size ? this.deletableSelection() : this.hoveredId ? [this.hoveredId] : [];
                 if (ids.length) {
                     this.popup.close();
                     this.emit({ kind: 'delete', ids });
@@ -838,6 +846,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     private selectionIds(): string[] {
         return [...this.selectedIds];
+    }
+
+    /** What a selection-wide delete removes: a lone selected drawing goes regardless, but inside
+     *  a multi-selection a LOCKED drawing is protected — the others go and it stays (selected). */
+    private deletableSelection(): string[] {
+        const ids = this.selectionIds();
+        if (ids.length < 2) return ids;
+        return ids.filter((id) => !this.drawings.find((d) => d.id === id)?.locked);
     }
 
     /** Move every selected (unlocked) drawing by a pixel delta — one edit/edit-many → one undo step. */
@@ -1009,11 +1025,16 @@ export class UserDrawingController implements IDrawingsRendererPort {
         this.render();
     }
 
-    /** Dismiss-on-outside-press also clears the selection — except when the press carries a
-     *  multi-select modifier (Shift / Ctrl / Cmd): that press is about to ADD to the selection
-     *  (or sweep a marquee onto it), so the drawings whose bar just closed must stay selected. */
+    /** Dismiss-on-outside-press also clears the selection — except when the press is ABOUT the
+     *  selection: it carries a multi-select modifier (Shift / Ctrl / Cmd — it will add to the
+     *  selection or sweep a marquee onto it), or it landed on a drawing that is already selected
+     *  (the canvas handler ran first and is holding it for a drag or a click), so the drawings
+     *  whose bar just closed must stay selected. */
     private readonly onPopupDismissed = (e?: PointerEvent): void => {
-        if (!(e && (e.shiftKey || e.ctrlKey || e.metaKey))) this.clearSelection();
+        if (e && (e.shiftKey || e.ctrlKey || e.metaKey)) return;
+        const pressed = this.interaction.pressedId();
+        if (pressed && this.selectedIds.has(pressed)) return;
+        this.clearSelection();
     };
 
     /** Report the live drawings' current state as one edit (one undo step, however many). */
@@ -1074,8 +1095,11 @@ export class UserDrawingController implements IDrawingsRendererPort {
                 this.openSettingsForSelection(ids); // rebuild so the controls reflect the restored defaults
             },
             remove: () => {
+                // Locked members are protected: they stay behind (still selected) while the rest go.
+                const ids = live().filter((d) => !d.locked).map((d) => d.id);
+                if (ids.length === 0) return;
                 this.popup.close();
-                this.emit({ kind: 'delete', ids: live().map((d) => d.id) });
+                this.emit({ kind: 'delete', ids });
             },
         }, this.onPopupDismissed);
     }

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -22,7 +22,7 @@ import { DrawingInteraction } from './DrawingInteraction';
 import { DrawingSettingsPopup, type PopupAnchor } from './DrawingSettingsPopup';
 import { DrawingToolbar, TOOLBAR_WIDTH, TOOLBAR_COLLAPSED_WIDTH } from './DrawingToolbar';
 import { MeasureOverlay } from './MeasureOverlay';
-import { topDrawingAt, HIT_TOLERANCE } from './DrawingHitTester';
+import { topDrawingAt, deletableSelection, deleteTargets, HIT_TOLERANCE } from './DrawingHitTester';
 import { keyToDrawingAction, isEditingText } from './DrawingKeys';
 import type { DrawingSlice } from '../core/SceneGraph';
 
@@ -406,13 +406,14 @@ export class UserDrawingController implements IDrawingsRendererPort {
 
     /** Delete the (unlocked) drawing under the cursor. True when one was removed.
      *  Shared by the eraser (click + drag) and the middle-click shortcut; the latter passes
-     *  `withSelection` so a hit on a SELECTED drawing removes the selection with it (its
-     *  locked members excepted). */
+     *  `withSelection` so a hit on a member of a multi-selection removes the selection's
+     *  unlocked members — whichever member was hit, locked or not. */
     deleteAt(x: number, y: number, withSelection = false): boolean {
         const hit = topDrawingAt(this.drawings, x, y, this.deps.projector(), HIT_TOLERANCE);
-        if (!hit || hit.locked) return false;
+        if (!hit) return false;
+        const ids = deleteTargets(hit, this.selectedIds, this.drawings, withSelection);
+        if (ids.length === 0) return false;
         this.popup.close();
-        const ids = withSelection && this.selectedIds.has(hit.id) ? this.deletableSelection() : [hit.id];
         this.emit({ kind: 'delete', ids });
         return true;
     }
@@ -848,12 +849,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
         return [...this.selectedIds];
     }
 
-    /** What a selection-wide delete removes: a lone selected drawing goes regardless, but inside
-     *  a multi-selection a LOCKED drawing is protected — the others go and it stays (selected). */
     private deletableSelection(): string[] {
-        const ids = this.selectionIds();
-        if (ids.length < 2) return ids;
-        return ids.filter((id) => !this.drawings.find((d) => d.id === id)?.locked);
+        return deletableSelection(this.selectedIds, this.drawings);
     }
 
     /** Move every selected (unlocked) drawing by a pixel delta — one edit/edit-many → one undo step. */

--- a/src/renderers/native/drawings/UserDrawingController.ts
+++ b/src/renderers/native/drawings/UserDrawingController.ts
@@ -1161,8 +1161,9 @@ export class UserDrawingController implements IDrawingsRendererPort {
         }, this.onPopupDismissed);
     }
 
-    /** A plain click on the empty plot: drop the selection (the multi-select twin of the popup's
-     *  dismiss-on-outside-press, which only covers the single-drawing case). */
+    /** A plain click on the empty plot: drop the selection. The popup's dismiss-on-outside-press
+     *  does the same, but a selection can exist with no bar open (a lone Ctrl-click pick, a
+     *  selection whose bar was dismissed by a modifier press) — this covers those. */
     deselect(): void {
         this.clearSelection();
     }
@@ -1206,7 +1207,8 @@ export class UserDrawingController implements IDrawingsRendererPort {
         }
         if (i.kind === 'clone') {
             // A drag-to-duplicate ends like a click on the copy: its settings bar opens so it can be
-            // restyled right away. Several copies stay a plain multi-selection (one bar edits one drawing).
+            // restyled right away. Several copies need nothing here — the selection they become
+            // brings up the multi-selection bar on its own (see setSelection).
             const before = new Set(this.drawings.map((d) => d.id));
             this.intentCb?.(i);
             const fresh = this.drawings.filter((d) => !before.has(d.id));

--- a/src/widget/format.ts
+++ b/src/widget/format.ts
@@ -21,3 +21,10 @@ export function fmtChange(open: number | null | undefined, close: number | null 
     const sign = diff >= 0 ? '+' : '';
     return `${sign}${fmtPrice(diff, decimalsFor(close))} (${sign}${pct.toFixed(2)}%)`;
 }
+
+/** Signed percent change alone ("+1.23%") from open→close; `''` when unavailable. */
+export function fmtChangePct(open: number | null | undefined, close: number | null | undefined): string {
+    if (open == null || close == null || !Number.isFinite(open) || !Number.isFinite(close) || open === 0) return '';
+    const pct = ((close - open) / open) * 100;
+    return `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`;
+}

--- a/src/widget/object-tree-model.ts
+++ b/src/widget/object-tree-model.ts
@@ -109,9 +109,15 @@ export function paneLabel(pane: PaneInfo, fallbackTitle: (id: string) => string 
     return `Pane ${pane.order + 1}`;
 }
 
-/** An indicator's display name. */
+/** An indicator's full display name. */
 function indicatorLabel(i: PaneInfo['indicators'][number], fallbackTitle: (id: string) => string | undefined): string {
     return i.title || fallbackTitle(i.id) || i.id;
+}
+
+/** An indicator row's label: the compact name it declares — matching its legend chip — or
+ *  else its full name. */
+function indicatorRowLabel(i: PaneInfo['indicators'][number], fallbackTitle: (id: string) => string | undefined): string {
+    return i.shorttitle || indicatorLabel(i, fallbackTitle);
 }
 
 /** The pane's series rows, extracted from its stack in rendered (front-first) order. */
@@ -330,7 +336,7 @@ function paneItems(snap: TreeSnapshot, pane: PaneInfo, units: DrawUnit[]): TreeI
     const indicatorRow = (i: PaneInfo['indicators'][number]): IndicatorRow => ({
         kind: 'indicator',
         id: i.id,
-        label: indicatorLabel(i, snap.handleTitle),
+        label: indicatorRowLabel(i, snap.handleTitle),
         visible: snap.indicatorVisible(i.id),
         ownScale: i.ownScale,
     });

--- a/src/widget/object-tree.ts
+++ b/src/widget/object-tree.ts
@@ -142,9 +142,13 @@ const CSS = `
 .vela-ot-empty { padding: 20px 10px; text-align: center; color: var(--vela-fg-muted); font-size: 12px; }
 
 /* ── drawing groups ── */
-/* One top-level entry in a pane's drawing list: a lone drawing, or a whole group block. The
-   transparent border reserves the outline used when a drawing is dropped into the group. */
-.vela-ot-unit { border: 1px solid transparent; border-radius: 6px; }
+/* One top-level entry in a pane's drawing list: a lone drawing, or a whole group block. No
+   border of its own — units stack flush, so consecutive highlighted rows read as one block; the
+   drop-into-group outline is drawn inside the box instead (see the drag-and-drop rules). */
+.vela-ot-unit { border-radius: 6px; }
+/* Adjacent picked rows merge into one contiguous highlight: the shared edge loses its rounding. */
+.vela-ot-unit:has(> .vela-ot-row[data-picked]) + .vela-ot-unit > .vela-ot-row[data-picked] { border-top-left-radius: 0; border-top-right-radius: 0; }
+.vela-ot-unit:has(+ .vela-ot-unit > .vela-ot-row[data-picked]) > .vela-ot-row[data-picked] { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
 .vela-ot-row[data-row-kind='group'] > .vela-icon { width: 12px; font-size: 11px; }
 /* A member sits indented under its group's header. */
 .vela-ot-subrow { padding-left: 26px; }
@@ -201,8 +205,10 @@ const CSS = `
 .vela-ot-gap[data-drop] { height: 4px; background: var(--vela-fg-bright); }
 .vela-ot-gap[data-drop]::before { display: none; }
 /* A whole container accepts the drop: merging into a pane, or a pane with no drawings yet.
-   The pane block's transparent border reserves the room for this outline. */
+   The pane block's transparent border reserves the room for this outline; a group unit has no
+   border to color, so it draws the same line as an inset outline (no layout footprint). */
 .vela-ot [data-drop='target'] { border-color: var(--vela-fg-bright); background: var(--vela-hover); }
+.vela-ot-unit[data-drop='target'] { outline: 1px solid var(--vela-fg-bright); outline-offset: -1px; }
 /* Where a reorder would insert. */
 .vela-ot [data-drop='before'] { box-shadow: inset 0 2px 0 var(--vela-fg-bright); }
 .vela-ot [data-drop='after'] { box-shadow: inset 0 -2px 0 var(--vela-fg-bright); }
@@ -337,7 +343,8 @@ class MenuBuilder {
 
 export class ObjectTree extends SidePanel {
     private chart: Vela | null = null;
-    private selectedDrawing: string | null = null;
+    /** What the CHART has selected — every member of a multi-selection, mirrored as rows. */
+    private selectedDrawings = new Set<string>();
     private symbolName = '';
     /** The raw (possibly venue-prefixed) symbol — what icon resolution routes on. */
     private symbolRaw = '';
@@ -406,14 +413,12 @@ export class ObjectTree extends SidePanel {
         // Selection both stores and repaints, in that order: a refresh triggered before the id
         // is recorded would paint the previous selection and never come back to fix it.
         this.unsubs.push(
-            chart.on('drawing:selected', ({ id }) => {
-                this.selectedDrawing = id;
-                // A selection made on the chart takes over the panel's pick. Our own echo does
-                // not, or pushing a multi-pick to the chart would immediately shrink it to one.
-                if (!this.syncingSelection) {
-                    this.picked.clear();
-                    if (id) this.picked.add(id);
-                }
+            chart.on('drawing:selected', ({ ids }) => {
+                this.selectedDrawings = new Set(ids);
+                // A selection made on the chart takes over the panel's pick — all of it, so a
+                // marquee or Ctrl-click selection on the chart lights up every row it covers. Our
+                // own echo does not, or pushing a pick would just replace it with itself mid-render.
+                if (!this.syncingSelection) this.picked = new Set(ids);
                 this.refresh();
             }),
         );
@@ -783,7 +788,7 @@ export class ObjectTree extends SidePanel {
         el.dataset.drag = '1';
         el.title = 'Drag to restack, or onto another pane to move it there';
         if (inGroup) el.classList.add('vela-ot-subrow');
-        if (d.id === this.selectedDrawing) el.dataset.selected = '1';
+        if (this.selectedDrawings.has(d.id)) el.dataset.selected = '1';
         if (this.picked.has(d.id)) el.dataset.picked = '1';
         el.addEventListener('click', (e) => this.onDrawClick(e, d.id));
         return el;

--- a/src/widget/statusline-model.ts
+++ b/src/widget/statusline-model.ts
@@ -17,6 +17,47 @@ export function segmentVisibility(parts: Record<StatuslinePart, boolean>, chartH
     return { avatar: parts.logo, symbol: parts.name, meta: parts.name, market: parts.market, ohlc: parts.ohlc && !chartHidden, change: parts.change && !chartHidden, eye: chartHidden };
 }
 
+/** How much of the value readout a width step keeps: every value the price style reads
+ *  out ('full'), just the close and the bar change ('compact'), or the close and the
+ *  percent delta alone ('minimal'). */
+export type StatuslineLevel = 'full' | 'compact' | 'minimal';
+
+/** One rung of the width ladder: whether the value readout sits on its own row under
+ *  the symbol line, and how much of it is kept. */
+export interface StatuslineLayout {
+    stacked: boolean;
+    level: StatuslineLevel;
+}
+
+/** The width ladder the status line walks down until its row fits, widest first: the
+ *  values first move under the symbol line, then shed O/H/L, then the absolute change.
+ *  Every status line — single chart, phone, multi-chart cell — walks the same rungs; in
+ *  fit mode whatever still overflows after the last one is hidden segment by segment
+ *  (see `Statusline.fit`). */
+export const STATUSLINE_LADDER: readonly StatuslineLayout[] = [
+    { stacked: false, level: 'full' },
+    { stacked: true, level: 'full' },
+    { stacked: true, level: 'compact' },
+    { stacked: true, level: 'minimal' },
+];
+
+/** Which of the O/H/L/C cells a level keeps, given the price style's readout shape.
+ *  One-line styles ('value') only ever plot the close, so their readout is the single
+ *  unlabeled value at every level; bar-shaped styles drop O/H/L below 'full' and keep
+ *  the labeled close, whose 'C' the 'minimal' level drops too. */
+export function readoutCells(level: StatuslineLevel, readout: 'ohlc' | 'value'): ReadonlyArray<{ key: 'open' | 'high' | 'low' | 'close'; label: string }> {
+    if (readout === 'value') return [{ key: 'close', label: '' }];
+    if (level === 'full') {
+        return [
+            { key: 'open', label: 'O' },
+            { key: 'high', label: 'H' },
+            { key: 'low', label: 'L' },
+            { key: 'close', label: 'C' },
+        ];
+    }
+    return [{ key: 'close', label: level === 'compact' ? 'C' : '' }];
+}
+
 /** Right-click menu rows: one checkable toggle per part (same labels as the settings
  *  dialog's Status line tab), then the chart itself — the same hide/show of the price
  *  series the object tree's eye drives. */

--- a/src/widget/statusline.ts
+++ b/src/widget/statusline.ts
@@ -7,10 +7,10 @@ import { injectStyles } from '../ui/styles';
 import { Tooltip } from '../ui/components/tooltip';
 import { CalloutBubble } from '../ui/components/callout-bubble';
 import { Menu } from '../ui/components/menu';
-import { segmentVisibility, statuslineMenuItems, type StatuslinePart } from './statusline-model';
+import { segmentVisibility, statuslineMenuItems, STATUSLINE_LADDER, readoutCells, type StatuslinePart, type StatuslineLayout } from './statusline-model';
 import { SESSION_PRE, SESSION_POST, SESSION_OFF } from '../core/palette';
 import { iconAt } from '../core/icons';
-import { fmtPrice, fmtChange, decimalsFor } from './format';
+import { fmtPrice, fmtChange, fmtChangePct, decimalsFor } from './format';
 import { timeframeLabel } from './timeframe';
 import { tickerIconEl } from './symbol-icon';
 import { parseSymbol } from '../data/ProviderRegistry';
@@ -30,6 +30,11 @@ const CSS = `
     display: flex;
     align-items: baseline;
     gap: var(--vela-space-2);
+    /* The chip never grows past the plot: fit() measures overflow against this width to
+     * walk the layout ladder (stack, then shed values), so overflow:hidden only guards
+     * the transient between a resize and the next measure. */
+    max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
+    overflow: hidden;
     color: var(--vela-fg);
     font-size: var(--vela-font-size-md);
     /* Same chip treatment as the indicator legend rows (InputsUI): a translucent wash of
@@ -51,6 +56,31 @@ const CSS = `
 /* Chart hidden (the price series' eye — renderer 'candleVisible'): the line dims to
  * the same 0.5 wash a hidden indicator's legend row wears. */
 .vela-statusline.vela-sl-chart-hidden { opacity: 0.5; }
+/* Two rows inside the chip — the identity (logo / symbol / meta / market badge) and the
+ * value readout (O/H/L/C + change, or the show-chart eye). In the widest layout they sit
+ * side by side on one line; the STACKED layouts (fit() decides, see the ladder in
+ * statusline-model) turn the chip into a column so the values drop under the symbol. */
+.vela-statusline .vela-sl-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--vela-space-2);
+    white-space: nowrap;
+}
+.vela-statusline.vela-sl-stacked {
+    flex-direction: column;
+    align-items: flex-start;
+    /* The same air between the two rows as between the values row and the legend row
+     * that follows the chip (see the stacked legend shift below). */
+    row-gap: var(--vela-space-1);
+}
+/* Stacked, the identity row may shrink (the meta carries the ellipsis) — the values row
+ * never does, so its overflow is what fit() measures to keep descending the ladder. */
+.vela-statusline.vela-sl-stacked .vela-sl-identity { max-width: 100%; }
+.vela-statusline.vela-sl-stacked .vela-sl-meta {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 .vela-statusline .vela-sl-avatar {
     width: 18px;
     height: 18px;
@@ -102,59 +132,13 @@ const CSS = `
  * stylesheet is document-global, so a bare attribute selector here would shift every
  * chart on the page, including statusline-less ones. */
 .vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(26px); }
-/* Mobile: two-line chip — logo / symbol / meta / market status on one aligned row, the
- * bar change on the next. Full O/H/L/C stays hidden (too dense on a phone-width plot).
- * GRID, not a wrapping flexbox: an absolutely positioned wrapping flex container sizes
- * to the one-line sum of ALL segments (max-content), so its background used to stretch
- * far past the market badge; a grid hugs the widest actual row. The meta column may
- * shrink (it carries the ellipsis), the others wrap their content. */
-[data-layout='mobile'] .vela-statusline {
-    display: grid;
-    grid-template-columns: auto auto minmax(0, auto) auto;
-    justify-content: start;
-    align-items: center;
-    row-gap: 1px;
-    max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
-    font-size: var(--vela-font-size-sm);
-}
-[data-layout='mobile'] .vela-statusline .vela-sl-symbol {
-    font-size: var(--vela-font-size-md);
-    line-height: 1;
-}
-[data-layout='mobile'] .vela-statusline .vela-sl-meta {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    line-height: 1;
-}
-[data-layout='mobile'] .vela-statusline .vela-sl-avatar,
-[data-layout='mobile'] .vela-statusline .vela-sl-market { align-self: center; }
-[data-layout='mobile'] .vela-statusline .vela-sl-ohlc { display: none !important; }
-[data-layout='mobile'] .vela-statusline .vela-sl-change {
-    /* Second row, under the text column — the avatar keeps the first column. */
-    grid-column: 2 / -1;
-    font-size: var(--vela-font-size-sm);
-    line-height: 1.2;
-}
-[data-layout='mobile'] .vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(40px); }
-/* FIT mode (multi-chart cells — see setFitMode): the line never wraps; segments that
- * don't fit are HIDDEN by fit() (change first, then meta, then the market badge), so
- * overflow:hidden only guards the transient between a resize and the next measure.
- * Placed after the mobile block on purpose: same specificity, later wins. */
-.vela-statusline.vela-sl-fit {
-    display: flex; /* undo the mobile grid — fit mode is one flex row again */
-    flex-wrap: nowrap;
-    align-items: center;
-    max-width: calc(100% - var(--vela-toolbar-gutter, 0px) - var(--vela-scale-gutter, 0px) - 24px);
-    overflow: hidden;
-}
-.vela-statusline.vela-sl-fit .vela-sl-change {
-    flex-basis: auto;
-    padding-left: 0;
-}
-/* One row again — the mobile two-line shift doesn't apply in fit mode. */
-[data-layout='mobile'] .vela-sl-fit-host.vela-has-statusline [${LEGEND_AT_TOP_ATTR}] { transform: translateY(26px); }
+/* A stacked chip is two lines tall — the legend shifts one more line. fit() flags the
+ * host whenever the ladder lands on a stacked layout. */
+.vela-has-statusline.vela-sl-stacked-host [${LEGEND_AT_TOP_ATTR}] { transform: translateY(40px); }
+/* Mobile: the same ladder at the phone's type scale — the width alone decides how much
+ * of the readout fits, exactly as on a narrow desktop chart. */
+[data-layout='mobile'] .vela-statusline { font-size: var(--vela-font-size-sm); }
+[data-layout='mobile'] .vela-statusline .vela-sl-symbol { font-size: var(--vela-font-size-md); }
 `;
 
 interface BarLike {
@@ -299,6 +283,12 @@ export class Statusline {
     /** Fit mode (multi-chart cells): one row, overflowing segments hidden — see {@link setFitMode}. */
     private fitMode = false;
     private fitRO: ResizeObserver | null = null;
+    /** The identity row (avatar / symbol / meta / market) and the values row (readout /
+     *  eye) — one line side by side, or a two-line column once the ladder stacks them. */
+    private readonly identityRow: HTMLElement;
+    private readonly valuesRow: HTMLElement;
+    /** The ladder rung currently applied — see {@link fit}. */
+    private layout: StatuslineLayout = { stacked: false, level: 'full' };
 
     constructor(
         private readonly host: HTMLElement,
@@ -351,8 +341,19 @@ export class Statusline {
             this.menuHooks?.setChartVisible(true);
             this.setChartHidden(false);
         });
-        this.el.append(this.avatarEl, this.symbolEl, this.metaEl, this.marketEl, this.ohlcEl, this.changeEl, this.eyeEl);
+        this.identityRow = doc.createElement('span');
+        this.identityRow.className = 'vela-sl-row vela-sl-identity';
+        this.identityRow.append(this.avatarEl, this.symbolEl, this.metaEl, this.marketEl);
+        this.valuesRow = doc.createElement('span');
+        this.valuesRow.className = 'vela-sl-row vela-sl-values';
+        this.valuesRow.append(this.ohlcEl, this.changeEl, this.eyeEl);
+        this.el.append(this.identityRow, this.valuesRow);
         host.appendChild(this.el);
+        // The ladder measures against the plot width — re-fit on every host resize.
+        if (typeof ResizeObserver !== 'undefined') {
+            this.fitRO = new ResizeObserver(() => this.fit());
+            this.fitRO.observe(host);
+        }
         // The tooltips portal to the nearest `.vela-ui` ancestor for theme tokens — resolve
         // them AFTER the statusline is in the DOM. The badge's content follows setMarketStatus.
         this.marketTip = new Tooltip(this.marketEl, { content: MARKET_LABELS.open, placement: 'bottom' });
@@ -372,27 +373,15 @@ export class Statusline {
     }
 
     /**
-     * Multi-chart cells: keep the line on ONE row whatever the cell width — never wrap.
-     * Segments that don't fit are hidden outright rather than clipped mid-glyph, least
-     * important first: OHLC, then the bar change, the venue/timeframe meta, and the
-     * market badge; the logo + ticker always stay. Re-fits live on host resizes.
+     * Multi-chart cells: the same width ladder as a single chart, plus a last resort for
+     * cells too narrow for even its bottom rung — whatever still overflows is hidden
+     * outright rather than clipped mid-glyph, least important first: the values, the
+     * venue/timeframe meta, then the market badge; the logo + ticker always stay.
      */
     setFitMode(on: boolean): void {
         if (on === this.fitMode) return;
         this.fitMode = on;
-        this.el.classList.toggle('vela-sl-fit', on);
-        this.host.classList.toggle('vela-sl-fit-host', on);
-        if (on) {
-            if (typeof ResizeObserver !== 'undefined' && !this.fitRO) {
-                this.fitRO = new ResizeObserver(() => this.fit());
-                this.fitRO.observe(this.host);
-            }
-            this.fit();
-        } else {
-            this.fitRO?.disconnect();
-            this.fitRO = null;
-            this.syncParts(); // restore whatever fit() had hidden
-        }
+        this.fit();
     }
 
     /** Project the parts config onto the segments (the baseline fit() prunes from). */
@@ -405,23 +394,48 @@ export class Statusline {
         this.ohlcEl.style.display = seg.ohlc ? '' : 'none';
         this.changeEl.style.display = seg.change ? '' : 'none';
         this.eyeEl.style.display = seg.eye ? 'inline-flex' : 'none';
+        // An empty values row must not hold a gap/padding of its own on the line.
+        this.valuesRow.style.display = seg.ohlc || seg.change || seg.eye ? '' : 'none';
     }
 
-    /** Hide overflowing segments until the row fits its max-width (fit mode only). */
+    /** Apply one ladder rung: the stacked/inline shape and the readout's level. */
+    private applyLayout(layout: StatuslineLayout): void {
+        this.layout = layout;
+        this.el.classList.toggle('vela-sl-stacked', layout.stacked);
+        this.host.classList.toggle('vela-sl-stacked-host', layout.stacked);
+        this.renderValues();
+    }
+
+    /**
+     * Walk the width ladder (see {@link STATUSLINE_LADDER}) until the chip fits its
+     * max-width: the full one-line readout, then the values stacked under the symbol
+     * line, then O/H/L shed, then the absolute change. In fit mode, when the last rung
+     * still overflows, whole segments hide, least important first. Without layout
+     * (detached host, node tests) nothing overflows, so the widest rung stays.
+     */
     private fit(): void {
-        if (!this.fitMode) return;
-        this.syncParts(); // start from the full (parts-allowed) row, then prune
+        this.syncParts(); // start from the full (parts-allowed) row, then descend
         const seg = segmentVisibility(this.parts, this.chartHidden);
+        const overflows = (): boolean => this.el.scrollWidth > this.el.clientWidth;
+        // Only a value readout can stack or shed — with none showing the chip stays one line.
+        const hasValues = seg.ohlc || seg.change;
+        for (const rung of STATUSLINE_LADDER) {
+            this.applyLayout(rung);
+            if (!hasValues || !overflows()) break;
+        }
+        if (!this.fitMode) return;
         const order: Array<[HTMLElement, boolean]> = [
-            [this.ohlcEl, seg.ohlc],
-            [this.changeEl, seg.change],
+            [this.valuesRow, hasValues],
             [this.metaEl, seg.meta],
             [this.marketEl, seg.market],
         ];
         for (const [el, shown] of order) {
-            if (this.el.scrollWidth <= this.el.clientWidth) break;
+            if (!overflows()) break;
             if (shown) el.style.display = 'none';
         }
+        // With the values row gone the chip is one line again — un-stack so the legend
+        // shift drops back to a single line's.
+        if (this.valuesRow.style.display === 'none') this.applyLayout({ ...this.layout, stacked: false });
     }
 
     /** Shape + color the value readout after the active price style: its own up/down
@@ -555,7 +569,7 @@ export class Statusline {
         this.marketTip.destroy();
         this.eyeTip.destroy();
         this.marketBubble.destroy();
-        this.host.classList.remove('vela-has-statusline', 'vela-sl-fit-host'); // the legend shift leaves with the line
+        this.host.classList.remove('vela-has-statusline', 'vela-sl-stacked-host'); // the legend shift leaves with the line
         this.el.remove();
     }
 
@@ -569,6 +583,11 @@ export class Statusline {
         // renderer on every readout refresh (bar ticks, crosshair moves), so a toggle
         // made anywhere (the object tree's eye) reaches the status line.
         if (this.menuHooks) this.setChartHidden(!this.menuHooks.chartVisible());
+        this.fit(); // re-walks the ladder — the readout's width follows the bar
+    }
+
+    /** Write the value readout for the current bar at the current ladder level. */
+    private renderValues(): void {
         const bar = this.hoverBar ?? this.lastBar;
         if (!bar) {
             this.ohlcEl.replaceChildren();
@@ -590,13 +609,14 @@ export class Statusline {
             s.appendChild(b);
             return s;
         };
-        // Bar-shaped styles read out all four values; a one-line style (line/area/baseline)
-        // plots a single series, so its readout is just that value — the close.
-        if (this.readout === 'value') this.ohlcEl.replaceChildren(cell('', bar.close));
-        else this.ohlcEl.replaceChildren(cell('O', bar.open), cell('H', bar.high), cell('L', bar.low), cell('C', bar.close));
-        this.changeEl.textContent = fmtChange(bar.open, bar.close);
+        // Bar-shaped styles read out all four values at the full level and just the close
+        // below it; a one-line style (line/area/baseline) plots a single series, so its
+        // readout is that value — the close — at every level. The minimal level keeps the
+        // percent delta alone.
+        const { level } = this.layout;
+        this.ohlcEl.replaceChildren(...readoutCells(level, this.readout).map((c) => cell(c.label, bar[c.key])));
+        this.changeEl.textContent = level === 'minimal' ? fmtChangePct(bar.open, bar.close) : fmtChange(bar.open, bar.close);
         this.changeEl.dataset.dir = up ? 'up' : 'down';
         this.changeEl.style.color = ink;
-        this.fit(); // the readout's width just changed — cheap no-op outside fit mode
     }
 }

--- a/src/widget/symbol-picker.ts
+++ b/src/widget/symbol-picker.ts
@@ -384,6 +384,22 @@ export class SymbolPicker {
         this.dialog.show();
     }
 
+    get isOpen(): boolean {
+        return this.dialog.open;
+    }
+
+    /** Text typed at the picker that never reached its field: closed, it opens seeded
+     *  with the text; open (the field takes focus a tick after the dialog does, and a
+     *  fast typist's next key lands in that tick), it extends the query. */
+    type(text: string): void {
+        if (!this.isOpen) {
+            this.open(text);
+            return;
+        }
+        this.input.value = (this.input.value + text).toUpperCase();
+        this.refresh();
+    }
+
     close(): void {
         this.dialog.hide(); // onOpenChange(false) blurs the field (iOS focus-zoom)
     }

--- a/src/widget/timeframe-quick.ts
+++ b/src/widget/timeframe-quick.ts
@@ -75,6 +75,22 @@ export class TimeframeQuick {
         }, 0);
     }
 
+    get isOpen(): boolean {
+        return this.dialog.open;
+    }
+
+    /** Text typed at the entry that never reached its field: closed, it opens seeded
+     *  with the text; open (the field takes focus a tick after the dialog does, and a
+     *  fast typist's next key lands in that tick), it extends the entry. */
+    type(text: string): void {
+        if (!this.isOpen) {
+            this.open(text);
+            return;
+        }
+        this.input.value += text;
+        this.renderHint();
+    }
+
     close(): void {
         this.dialog.hide();
     }

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -222,6 +222,32 @@ export function nextAutoCellId(taken: ReadonlySet<string>): string {
     }
 }
 
+/** Which dialogs are up when a bare keystroke reaches the workspace root. */
+export interface TypingState {
+    dialogs: number;
+    symbolSearch: boolean;
+    timeframeEntry: boolean;
+}
+
+/**
+ * What a bare keystroke on the workspace root does. Nothing open: a letter seeds symbol
+ * search, a digit the timeframe entry. An ENTRY dialog open: its field takes focus a
+ * tick after the dialog reports open, so the next key of a fast typist (`NQ`, `15`)
+ * still lands on the root — it is handed to that dialog as more typed text instead of
+ * dropped. Any other open dialog swallows bare typing. Pure — unit-tested.
+ */
+export function resolveTyping(key: string, open: TypingState): { target: 'symbol' | 'timeframe'; text: string } | null {
+    if (open.dialogs > 0) {
+        if (key.length !== 1) return null; // a printable character, not a control key
+        if (open.symbolSearch) return { target: 'symbol', text: key.toUpperCase() };
+        if (open.timeframeEntry) return { target: 'timeframe', text: key };
+        return null;
+    }
+    if (/^[a-zA-Z]$/.test(key)) return { target: 'symbol', text: key.toUpperCase() };
+    if (/^[0-9]$/.test(key)) return { target: 'timeframe', text: key };
+    return null;
+}
+
 export class VelaWorkspace {
     readonly root: HTMLElement;
     /** The shortcut system — one manager for the whole workspace, routed to the active cell. */
@@ -2199,17 +2225,14 @@ export class VelaWorkspace {
 
     /** Bare-typing router: letters → symbol search (seeded), digits → timeframe entry. */
     private routeTyping(ev: KeyboardEvent): void {
-        if (this.destroyed || this.openDialogs > 0) return;
+        if (this.destroyed) return;
         if (ev.ctrlKey || ev.metaKey || ev.altKey) return;
         if (isEditableTarget(ev)) return; // never hijack a keystroke someone is TYPING
-        const key = ev.key;
-        if (/^[a-zA-Z]$/.test(key)) {
-            ev.preventDefault();
-            this.symbolPicker.open(key.toUpperCase());
-        } else if (/^[0-9]$/.test(key)) {
-            ev.preventDefault();
-            this.tfQuick.open(key);
-        }
+        const hit = resolveTyping(ev.key, { dialogs: this.openDialogs, symbolSearch: this.symbolPicker.isOpen, timeframeEntry: this.tfQuick.isOpen });
+        if (!hit) return;
+        ev.preventDefault();
+        if (hit.target === 'symbol') this.symbolPicker.type(hit.text);
+        else this.tfQuick.type(hit.text);
     }
 
     private trackDialog(open: boolean): void {

--- a/test/classic-indicators.test.ts
+++ b/test/classic-indicators.test.ts
@@ -351,4 +351,90 @@ describe('classic descriptor adapter', () => {
         expect(points[1]!.value).toBeCloseTo(15, 10);
         expect(points[2]!.value).toBeCloseTo(30, 10); // reset at the new day
     });
+
+    it('resets VWAP on UTC quarter and year boundaries', () => {
+        const spec = classicSpecs.find((s) => s.type === 'vwap')!;
+        const flat = (iso: string, price: number): OHLCV => ({ time: Date.parse(iso), open: price, high: price, low: price, close: price, volume: 1 });
+        const bars = [flat('2024-02-10T00:00:00Z', 10), flat('2024-03-31T23:00:00Z', 20), flat('2024-04-01T00:00:00Z', 30), flat('2025-01-01T00:00:00Z', 40)];
+        const quarter = pointsOf(runOnce(spec, bars, { anchor: 'Quarter', source: 'Close' }).series![0]);
+        expect(quarter.map((p) => p.value)).toEqual([10, 15, 30, 40]);
+        const year = pointsOf(runOnce(spec, bars, { anchor: 'Year', source: 'Close' }).series![0]);
+        expect(year.map((p) => p.value)).toEqual([10, 15, 20, 40]);
+    });
+
+    it('draws VWAP σ bands per enabled pair, each in its own color, fills optional', () => {
+        const spec = classicSpecs.find((s) => s.type === 'vwap')!;
+        // Flat bars make every source = price: vwap of (100×1, 106×2) = 104, σ = √8.
+        const bars: OHLCV[] = [
+            { time: 0, open: 100, high: 100, low: 100, close: 100, volume: 1 },
+            { time: 60000, open: 106, high: 106, low: 106, close: 106, volume: 2 },
+        ];
+        const out = runOnce(spec, bars, { band1: true, band1Mult: 1, band2: false, band3: true, band3Mult: 2.5, band1Color: '#ff0000', band3Color: '#00ff00', band1FillColor: '#ff000014', band3FillColor: '#00ff0014' });
+        expect(out.series!.map((s) => s.title)).toEqual(['VWAP', 'Upper 1σ', 'Lower 1σ', 'Upper 2.5σ', 'Lower 2.5σ']);
+        const sd = Math.sqrt(8);
+        expect(pointsOf(out.series![1])[1]!.value).toBeCloseTo(104 + sd, 10);
+        expect(pointsOf(out.series![4])[1]!.value).toBeCloseTo(104 - 2.5 * sd, 10);
+        const inkOf = (s: SeriesSpec): string | undefined => (isLineLikeSeries(s) ? s.style.color : undefined);
+        expect(inkOf(out.series![1]!)).toBe('#ff0000');
+        expect(inkOf(out.series![3]!)).toBe('#00ff00');
+        expect(out.fills!.map((f) => f.color)).toEqual(['#ff000014', '#00ff0014']);
+
+        // Fills are per band: band 1 keeps its fill, band 2's is off.
+        const partial = runOnce(spec, bars, { band2: true, band2Fill: false });
+        expect(partial.series).toHaveLength(5);
+        expect(partial.fills!.map((f) => f.fromSeriesId)).toEqual([partial.series![1]!.id]);
+
+        // Only band 1 is on by default. Inks differ per band, and each fill defaults to its
+        // band's ink at 8% alpha.
+        expect(runOnce(spec, bars).series).toHaveLength(3);
+        const all = runOnce(spec, bars, { band2: true, band3: true });
+        const inks = [1, 3, 5].map((i) => (isLineLikeSeries(all.series![i]!) ? all.series![i]!.style.color : ''));
+        expect(new Set(inks).size).toBe(3);
+        expect(all.fills!.map((f) => f.color)).toEqual(inks.map((c) => `${c}14`));
+
+        // The fill color is its own input.
+        const custom = runOnce(spec, bars, { band1FillColor: '#12345680' });
+        expect(custom.fills![0]!.color).toBe('#12345680');
+    });
+
+    it('reads VWAP source through the shared source vocabulary', () => {
+        const spec = classicSpecs.find((s) => s.type === 'vwap')!;
+        const source = spec.inputs.find((i) => i.key === 'source')!;
+        expect(source.options).toEqual(['Close', 'Open', 'High', 'Low', 'HL2', 'HLC3', 'OHLC4', 'HLCC4']);
+        const bars: OHLCV[] = [{ time: 0, open: 1, high: 9, low: 3, close: 5, volume: 1 }];
+        expect(pointsOf(runOnce(spec, bars, { source: 'High' }).series![0])[0]!.value).toBe(9);
+        expect(pointsOf(runOnce(spec, bars, { source: 'HL2' }).series![0])[0]!.value).toBe(6);
+    });
+
+    it('lays out VWAP bands in a Bands group and inks + fills in a trailing Style group', () => {
+        const spec = classicSpecs.find((s) => s.type === 'vwap')!;
+        const anchor = spec.inputs.find((i) => i.key === 'anchor')!;
+        expect(anchor.options).toEqual(['Day', 'Week', 'Month', 'Quarter', 'Year']);
+        for (const n of [1, 2, 3]) {
+            const on = spec.inputs.find((i) => i.key === `band${n}`)!;
+            const mult = spec.inputs.find((i) => i.key === `band${n}Mult`)!;
+            expect(on.type).toBe('bool');
+            expect(on.group).toBe('Bands');
+            expect(mult.title).toBe(''); // the toggle carries the row's label
+            expect(mult.inline).toBe(on.inline);
+            expect(mult.group).toBe('Bands');
+            const color = spec.inputs.find((i) => i.key === `band${n}Color`)!;
+            const fill = spec.inputs.find((i) => i.key === `band${n}Fill`)!;
+            expect(color.group).toBe('Style');
+            expect(fill.type).toBe('bool');
+            expect(fill.inline).toBe(color.inline); // fill toggle sits beside its band's swatch
+            const fillColor = spec.inputs.find((i) => i.key === `band${n}FillColor`)!;
+            expect(fillColor.type).toBe('color');
+            expect(fillColor.title).toBe(''); // unlabeled — the Fill toggle names it
+            expect(fillColor.inline).toBe(color.inline);
+        }
+        const styled = spec.inputs.filter((i) => i.group === 'Style').map((i) => i.key);
+        expect(styled).toEqual([
+            'color',
+            'band1Color', 'band1Fill', 'band1FillColor',
+            'band2Color', 'band2Fill', 'band2FillColor',
+            'band3Color', 'band3Fill', 'band3FillColor',
+        ]);
+        expect(spec.inputs.slice(-styled.length).map((i) => i.key)).toEqual(styled);
+    });
 });

--- a/test/drawings-controller.test.ts
+++ b/test/drawings-controller.test.ts
@@ -329,8 +329,10 @@ describe('DrawingController — editing foundation', () => {
         expect(seen).toContainEqual(['drawing:created', pasted[0]!.id]);
     });
 
-    it('generalized select: additive toggles membership; primary is ids[0]', () => {
-        const { port, ctrl, seen } = setup();
+    it('generalized select: additive toggles membership; primary is ids[0]; the event carries the full list', () => {
+        const { port, ctrl, seen, events } = setup();
+        const payloads: Array<{ id: string | null; ids: string[] }> = [];
+        events.on('drawing:selected', (e) => payloads.push(e));
         port.fire({ kind: 'create', doc: HLINE_DOC });
         port.fire({ kind: 'create', doc: HLINE_DOC });
         const [a, b] = ctrl.all().map((d) => d.id);
@@ -340,6 +342,7 @@ describe('DrawingController — editing foundation', () => {
         port.fire({ kind: 'select', ids: [b!], additive: true });
         expect(port.selectionIds).toEqual([a, b]);
         expect(seen).toContainEqual(['drawing:selected', a]); // primary = first selected
+        expect(payloads[payloads.length - 1]).toEqual({ id: a, ids: [a, b] }); // a host UI can mirror every member
         port.fire({ kind: 'select', ids: [a!], additive: true }); // toggle a back off
         expect(port.selectionIds).toEqual([b]);
     });

--- a/test/drawings-controller.test.ts
+++ b/test/drawings-controller.test.ts
@@ -298,6 +298,24 @@ describe('DrawingController — editing foundation', () => {
         expect(ctrl.all().map((d) => d.id)).toEqual([id]);
     });
 
+    it('clone intent: commits the given (moved) docs as fresh copies, source untouched, one undo step', () => {
+        const { port, ctrl, seen } = setup();
+        port.fire({ kind: 'create', doc: HLINE_DOC });
+        const src = ctrl.all()[0]!;
+        seen.length = 0;
+        // The end of a Ctrl-drag: the renderer hands over the source's twin, already translated.
+        port.fire({ kind: 'clone', docs: [{ ...src, anchors: [{ time: 2000, price: 26000 }] }] });
+        expect(ctrl.all().length).toBe(2);
+        const clone = ctrl.all().find((d) => d.id !== src.id)!;
+        expect(clone.anchors[0]).toEqual({ time: 2000, price: 26000 });
+        expect(clone.zIndex).toBe(src.zIndex); // keeps its source's depth
+        expect(ctrl.all().find((d) => d.id === src.id)!.anchors[0]).toEqual({ time: 1000, price: 25000 }); // source never moved
+        expect(port.selectionIds).toEqual([clone.id]); // the copy becomes the selection
+        expect(seen).toContainEqual(['drawing:created', clone.id]);
+        ctrl.undo();
+        expect(ctrl.all().map((d) => d.id)).toEqual([src.id]);
+    });
+
     it('copy is silent; paste creates fresh drawings', () => {
         const { ctrl, seen } = setup();
         const d = ctrl.add('hline', { anchors: [{ time: 1, price: 1 }] })!;

--- a/test/drawings-interaction.test.ts
+++ b/test/drawings-interaction.test.ts
@@ -310,6 +310,81 @@ describe('DrawingInteraction: selection + claim', () => {
         h.it.up(50, 70);
         expect(h.settings).toHaveLength(0); // shift-click is selection-only
     });
+
+    it('ctrl-click (no move) toggles selection on release, without opening settings', () => {
+        const h = harness(null, [hline()]);
+        h.it.down(50, 70, 'strong', false, true); // Ctrl → strong magnet AND the selection modifier
+        expect(h.intents).toHaveLength(0); // nothing until the release decides click vs drag
+        h.it.up(51, 71); // within the slop → a click
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-1'], additive: true }]);
+        expect(h.settings).toHaveLength(0);
+    });
+});
+
+describe('DrawingInteraction: marquee (Ctrl/Cmd-drag on the empty plot)', () => {
+    // fake projector: x = time, y = 100 − price
+    const inside = () => createDrawing('trendline', { id: 'dw-1', paneId: 'price', anchors: [{ time: 20, price: 80 }, { time: 40, price: 60 }] })!; // px (20,20)→(40,40)
+    const outside = () => createDrawing('trendline', { id: 'dw-2', paneId: 'price', anchors: [{ time: 150, price: 20 }, { time: 180, price: 10 }] })!; // px (150,80)→(180,90)
+    const crossing = () => createDrawing('hline', { id: 'dw-3', paneId: 'price', anchors: [{ time: 0, price: 70 }] })!; // full-width line at y=30
+
+    it('starts only when idle with no tool armed, and claims the gesture', () => {
+        const armed = harness('trendline');
+        expect(armed.it.beginMarquee(5, 5)).toBe(false);
+        const h = harness(null, [inside()]);
+        expect(h.it.claim(100, 90)).toBe(false); // empty space → the host decides (pan vs marquee)
+        expect(h.it.beginMarquee(100, 90)).toBe(true);
+        expect(h.it.claim(100, 90)).toBe(true); // in flight → the drawings layer owns the moves
+        expect(h.it.marqueeRect()).toEqual({ x: 100, y: 90, w: 0, h: 0 });
+    });
+
+    it('release selects every visible drawing whose bounds touch the box (a line crossing it too)', () => {
+        const h = harness(null, [inside(), outside(), crossing()]);
+        h.it.beginMarquee(10, 10);
+        h.it.move(60, 50); // sweep (10,10)→(60,50)
+        expect(h.it.marqueeRect()).toEqual({ x: 10, y: 10, w: 50, h: 40 });
+        h.it.up(60, 50);
+        expect(h.it.marqueeRect()).toBeNull();
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-1', 'dw-3'] }]); // dw-2 sits far right
+    });
+
+    it('a sweep dragged up-left normalizes, and hidden drawings are never picked', () => {
+        const hidden = inside();
+        hidden.visible = false;
+        const h = harness(null, [hidden, crossing()]);
+        h.it.beginMarquee(60, 50);
+        h.it.move(10, 10);
+        h.it.up(10, 10);
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-3'] }]);
+    });
+
+    it('adds to the existing selection (union) and stays silent when nothing new is touched', () => {
+        const h = harness(null, [inside(), outside()]);
+        h.setSelected(['dw-2']);
+        h.it.beginMarquee(10, 10);
+        h.it.move(60, 50);
+        h.it.up(60, 50);
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-2', 'dw-1'] }]); // dw-2 kept, dw-1 added
+        h.intents.length = 0;
+        h.setSelected(['dw-1', 'dw-2']);
+        h.it.beginMarquee(10, 10);
+        h.it.move(60, 50);
+        h.it.up(60, 50); // both already selected → no intent
+        expect(h.intents).toHaveLength(0);
+    });
+
+    it('a box within the slop selects nothing; Escape cancels a sweep', () => {
+        const h = harness(null, [inside()]);
+        h.it.beginMarquee(30, 30);
+        h.it.move(32, 31);
+        h.it.up(32, 31); // a twitch, not a sweep — even though the box touches dw-1
+        expect(h.intents).toHaveLength(0);
+        h.it.beginMarquee(10, 10);
+        h.it.move(60, 50);
+        expect(h.it.cancel()).toBe(true);
+        expect(h.it.marqueeRect()).toBeNull();
+        h.it.up(60, 50);
+        expect(h.intents).toHaveLength(0);
+    });
 });
 
 describe('DrawingInteraction: click-move-click placement (measurement / position)', () => {
@@ -499,6 +574,127 @@ describe('DrawingInteraction: dragging', () => {
         expect(h.it.cancel()).toBe(true);
         expect(d.anchors).toEqual([{ time: 10, price: 10 }, { time: 50, price: 50 }]);
         expect(h.intents.some((i) => i.kind === 'edit')).toBe(false);
+    });
+
+    it('body-dragging a drawing that is part of a multi-selection moves the whole selection (one edit-many)', () => {
+        const a = trend();
+        const b = hline(); // y = 70
+        const locked = createDrawing('hline', { id: 'dw-3', paneId: 'price', anchors: [{ time: 10, price: 80 }] })!;
+        locked.locked = true;
+        const h = harness(null, [a, b, locked]);
+        h.setSelected(['dw-1', 'dw-2', 'dw-3']);
+        h.it.down(20, 80); // press the trend line's body (clear of the hline at y=70)
+        h.it.move(30, 75); // dt=+10, dp=+5
+        expect(b.anchors).toEqual([{ time: 20, price: 35 }]); // the rider follows live
+        expect(locked.anchors).toEqual([{ time: 10, price: 80 }]); // a locked member stays put
+        h.it.up(30, 75);
+        const many = h.intents.find((i) => i.kind === 'edit-many');
+        expect(many?.kind === 'edit-many' && many.docs.map((d) => d.id)).toEqual(['dw-1', 'dw-2']);
+        expect(many?.kind === 'edit-many' && many.docs[0]!.anchors).toEqual([{ time: 20, price: 15 }, { time: 60, price: 55 }]);
+        expect(h.intents.some((i) => i.kind === 'edit')).toBe(false);
+    });
+
+    it('a handle drag of a multi-selected drawing reshapes only that one', () => {
+        const a = trend();
+        const b = hline();
+        const h = harness(null, [a, b]);
+        h.setSelected(['dw-1', 'dw-2']);
+        h.it.down(10, 90); // grab the trend line's p1 handle
+        h.it.move(15, 85);
+        h.it.up(15, 85);
+        expect(b.anchors).toEqual([{ time: 10, price: 30 }]);
+        expect(h.intents.map((i) => i.kind)).toEqual(['edit']);
+    });
+
+    it('Escape during a group drag restores every member', () => {
+        const a = trend();
+        const b = hline();
+        const h = harness(null, [a, b]);
+        h.setSelected(['dw-1', 'dw-2']);
+        h.it.down(20, 80);
+        h.it.move(30, 75);
+        expect(h.it.cancel()).toBe(true);
+        expect(a.anchors).toEqual([{ time: 10, price: 10 }, { time: 50, price: 50 }]);
+        expect(b.anchors).toEqual([{ time: 10, price: 30 }]);
+        expect(h.intents).toHaveLength(0);
+    });
+});
+
+describe('DrawingInteraction: Ctrl/Cmd-drag duplicates', () => {
+    const trend = () =>
+        createDrawing('trendline', { id: 'dw-1', paneId: 'price', anchors: [{ time: 10, price: 10 }, { time: 50, price: 50 }] })!;
+    const hline = () => createDrawing('hline', { id: 'dw-2', paneId: 'price', anchors: [{ time: 10, price: 30 }] })!;
+
+    it('a Ctrl-drag of the body moves a COPY and commits it on release; the source never moves', () => {
+        const d = trend();
+        const h = harness(null, [d]);
+        h.it.down(30, 70, 'strong', false, true); // Ctrl held (strong magnet is its other meaning)
+        expect(h.it.dragClones()).toBeNull(); // nothing is copied until the press becomes a drag
+        h.it.move(40, 65);
+        const clones = h.it.dragClones()!;
+        expect(clones).toHaveLength(1);
+        expect(clones[0]!.anchors).toEqual([{ time: 20, price: 15 }, { time: 60, price: 55 }]); // the copy follows
+        expect(d.anchors).toEqual([{ time: 10, price: 10 }, { time: 50, price: 50 }]); // the source stays
+        h.it.up(40, 65);
+        expect(h.it.dragClones()).toBeNull();
+        expect(h.intents).toHaveLength(1);
+        const clone = h.intents[0]!;
+        expect(clone.kind).toBe('clone');
+        if (clone.kind === 'clone') {
+            expect(clone.docs).toHaveLength(1);
+            expect(clone.docs[0]!.type).toBe('trendline');
+            expect(clone.docs[0]!.anchors).toEqual([{ time: 20, price: 15 }, { time: 60, price: 55 }]);
+        }
+        expect(h.settings).toHaveLength(0);
+    });
+
+    it('Ctrl-dragging a member of a multi-selection copies the whole selection', () => {
+        const a = trend();
+        const b = hline();
+        const h = harness(null, [a, b]);
+        h.setSelected(['dw-1', 'dw-2']);
+        h.it.down(20, 80, 'off', false, true); // the trend line's body, clear of the hline
+        h.it.move(30, 75);
+        h.it.up(30, 75);
+        const clone = h.intents.find((i) => i.kind === 'clone');
+        expect(clone?.kind === 'clone' && clone.docs.map((d) => d.type)).toEqual(['trendline', 'hline']);
+        expect(clone?.kind === 'clone' && clone.docs[1]!.anchors).toEqual([{ time: 20, price: 35 }]);
+        expect(b.anchors).toEqual([{ time: 10, price: 30 }]); // sources untouched
+    });
+
+    it('Ctrl on a HANDLE keeps its resize meaning (no copy)', () => {
+        const d = trend();
+        const h = harness(null, [d]);
+        h.setHovered('dw-1');
+        h.it.down(10, 90, 'off', false, true); // grab p1 with Ctrl held
+        h.it.move(15, 85);
+        expect(h.it.dragClones()).toBeNull();
+        h.it.up(15, 85);
+        expect(h.intents.map((i) => i.kind)).toEqual(['edit']);
+        expect(d.anchors[0]).toEqual({ time: 15, price: 15 });
+    });
+
+    it('Escape during a Ctrl-drag leaves nothing behind and the source untouched', () => {
+        const d = trend();
+        const h = harness(null, [d]);
+        h.it.down(30, 70, 'off', false, true);
+        h.it.move(40, 65);
+        expect(h.it.cancel()).toBe(true);
+        expect(h.it.dragClones()).toBeNull();
+        expect(d.anchors).toEqual([{ time: 10, price: 10 }, { time: 50, price: 50 }]);
+        h.it.up(40, 65);
+        expect(h.intents).toHaveLength(0);
+    });
+
+    it('a locked drawing is never copied by a Ctrl-drag (the press stays a click → toggle)', () => {
+        const d = trend();
+        d.locked = true;
+        const h = harness(null, [d]);
+        h.it.down(30, 70, 'off', false, true);
+        h.it.move(40, 65);
+        expect(h.it.dragClones()).toBeNull();
+        h.it.up(40, 65);
+        expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-1'], additive: true }]);
     });
 });
 

--- a/test/drawings-interaction.test.ts
+++ b/test/drawings-interaction.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { DrawingInteraction } from '../src/renderers/native/drawings/DrawingInteraction';
 import { createProjector } from '../src/renderers/native/drawings/Projector';
+import { deletableSelection, deleteTargets } from '../src/renderers/native/drawings/DrawingHitTester';
 import { effectiveSnapMode } from '../src/renderers/native/core/InputController';
 import { CoordinateSystem } from '../src/renderers/native/core/CoordinateSystem';
 import { createDrawing, DEFAULT_DRAWING_COLOR, MAX_PATH_POINTS, type Drawing, type DrawingIntent, type DrawingStyle, type DrawingTypeKey, type Projector } from '../src/core/drawings';
@@ -695,6 +696,45 @@ describe('DrawingInteraction: Ctrl/Cmd-drag duplicates', () => {
         expect(h.it.dragClones()).toBeNull();
         h.it.up(40, 65);
         expect(h.intents).toEqual([{ kind: 'select', ids: ['dw-1'], additive: true }]);
+    });
+});
+
+describe('delete-at-cursor targets (eraser + middle-click)', () => {
+    const line = (id: string, locked = false) => {
+        const d = createDrawing('hline', { id, paneId: 'price', anchors: [{ time: 10, price: 30 }] })!;
+        d.locked = locked;
+        return d;
+    };
+
+    it('a lone unlocked hit goes; a lone locked hit is protected', () => {
+        const a = line('a');
+        const b = line('b', true);
+        expect(deleteTargets(a, new Set(), [a, b], true)).toEqual(['a']);
+        expect(deleteTargets(b, new Set(), [a, b], true)).toEqual([]);
+        expect(deleteTargets(b, new Set(['b']), [a, b], true)).toEqual([]); // selected alone changes nothing
+    });
+
+    it('a middle-click on a LOCKED member of a multi-selection still removes the unlocked members', () => {
+        const a = line('a');
+        const b = line('b', true);
+        const c = line('c');
+        const sel = new Set(['a', 'b', 'c']);
+        expect(deleteTargets(b, sel, [a, b, c], true)).toEqual(['a', 'c']);
+        expect(deleteTargets(a, sel, [a, b, c], true)).toEqual(['a', 'c']); // same result from an unlocked member
+        expect(deletableSelection(sel, [a, b, c])).toEqual(['a', 'c']); // and the same set Delete removes
+    });
+
+    it('an all-locked multi-selection removes nothing', () => {
+        const a = line('a', true);
+        const b = line('b', true);
+        expect(deleteTargets(a, new Set(['a', 'b']), [a, b], true)).toEqual([]);
+    });
+
+    it('the eraser (no withSelection) never widens to the selection', () => {
+        const a = line('a');
+        const b = line('b');
+        expect(deleteTargets(a, new Set(['a', 'b']), [a, b], false)).toEqual(['a']);
+        expect(deleteTargets(line('c', true), new Set(['a', 'b']), [a, b], false)).toEqual([]);
     });
 });
 

--- a/test/drawings-popup-multi.test.ts
+++ b/test/drawings-popup-multi.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { createDrawing } from '../src/core/drawings';
+import { sharedPaths, commonValue, MIXED } from '../src/renderers/native/drawings/DrawingSettingsPopup';
+
+const trend = (id: string, lineColor: string) => createDrawing('trendline', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }], style: { lineColor } })!;
+const box = (id: string) => createDrawing('box', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }] })!;
+const text = (id: string) => createDrawing('text', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }] })!;
+
+describe('multi-selection settings: shared paths', () => {
+    it('same-type drawings share their whole schema', () => {
+        const one = new Set(trend('a', '#f00').schema().fields.map((f) => f.path));
+        expect(sharedPaths([trend('a', '#f00'), trend('b', '#0f0'), trend('c', '#00f')])).toEqual(one);
+    });
+
+    it('mixed types keep only the intersection — type-specific paths drop out', () => {
+        const stroked = sharedPaths([trend('a', '#f00'), box('b')]);
+        expect(stroked.has('style.lineColor')).toBe(true); // both stroke
+        expect(stroked.has('style.fillColor')).toBe(false); // the box's alone
+        const paths = sharedPaths([trend('a', '#f00'), box('b'), text('c')]);
+        expect(paths.has('style.lineColor')).toBe(false); // a text annotation has no stroke
+        for (const p of paths) {
+            expect(trend('a', '#f00').schema().fields.some((f) => f.path === p)).toBe(true);
+            expect(box('b').schema().fields.some((f) => f.path === p)).toBe(true);
+            expect(text('c').schema().fields.some((f) => f.path === p)).toBe(true);
+        }
+    });
+
+    it('a single drawing shares everything with itself; an empty list shares nothing', () => {
+        const b = box('b');
+        expect(sharedPaths([b]).size).toBe(b.schema().fields.length);
+        expect(sharedPaths([]).size).toBe(0);
+    });
+});
+
+describe('multi-selection settings: common value', () => {
+    it('agreeing drawings yield the value; disagreeing ones yield MIXED', () => {
+        const same = [trend('a', '#ff0000'), trend('b', '#ff0000')];
+        expect(commonValue(same, (d) => d.style.lineColor)).toBe('#ff0000');
+        const differ = [trend('a', '#ff0000'), trend('b', '#0000ff')];
+        expect(commonValue(differ, (d) => d.style.lineColor)).toBe(MIXED);
+    });
+
+    it('works for booleans (a lock state) without confusing false with mixed', () => {
+        const a = trend('a', '#f00');
+        const b = trend('b', '#f00');
+        expect(commonValue([a, b], (d) => d.locked)).toBe(false);
+        b.locked = true;
+        expect(commonValue([a, b], (d) => d.locked)).toBe(MIXED);
+        a.locked = true;
+        expect(commonValue([a, b], (d) => d.locked)).toBe(true);
+    });
+});

--- a/test/drawings-popup-multi.test.ts
+++ b/test/drawings-popup-multi.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { createDrawing } from '../src/core/drawings';
 import { sharedPaths, commonValue, MIXED } from '../src/renderers/native/drawings/DrawingSettingsPopup';
 
-const trend = (id: string, lineColor: string) => createDrawing('trendline', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }], style: { lineColor } })!;
+const trend = (id: string, lineColor: string) => createDrawing('trendline', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }], style: { lineColor, lineWidth: 1, lineStyle: 'solid' } })!;
 const box = (id: string) => createDrawing('box', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 10, price: 10 }] })!;
 const text = (id: string) => createDrawing('text', { id, paneId: 'price', anchors: [{ time: 0, price: 0 }] })!;
 

--- a/test/object-tree-model.test.ts
+++ b/test/object-tree-model.test.ts
@@ -36,14 +36,14 @@ import {
 import type { PaneInfo } from '../src/core/options';
 import type { SerializedDrawing } from '../src/core/drawings/Drawing';
 
-function pane(id: string, kind: 'price' | 'study', order: number, indicators: Array<{ id: string; title?: string; ownScale?: boolean }> = []): PaneInfo {
+function pane(id: string, kind: 'price' | 'study', order: number, indicators: Array<{ id: string; title?: string; shorttitle?: string; ownScale?: boolean }> = []): PaneInfo {
     return {
         id,
         kind,
         order,
         collapsed: false,
         maximized: false,
-        indicators: indicators.map((i) => ({ id: i.id, title: i.title ?? i.id, ownScale: i.ownScale === true })),
+        indicators: indicators.map((i) => ({ id: i.id, title: i.title ?? i.id, ...(i.shorttitle ? { shorttitle: i.shorttitle } : {}), ownScale: i.ownScale === true })),
     };
 }
 
@@ -138,6 +138,14 @@ describe('buildTree — the unified stack', () => {
         const tree = buildTree(snap({ panes: [p], indicatorVisible: (id) => id !== 'a', handleTitle: () => 'Indicator' }));
         const a = paneRows(tree[0]!).find((r) => r.kind === 'indicator');
         expect(a).toMatchObject({ label: 'SMA 20', visible: false, ownScale: true });
+    });
+
+    it('labels an indicator row with its compact name when it declares one — the pane keeps the full title', () => {
+        const panes = [pane('price', 'price', 0), pane('p1', 'study', 1, [{ id: 'rsi', title: 'Relative Strength Index', shorttitle: 'RSI' }])];
+        const tree = buildTree(snap({ panes, zOrder: [{ id: 'rsi', z: 0 }] }));
+        const row = paneRows(tree[1]!).find((r) => r.kind === 'indicator');
+        expect(row?.label).toBe('RSI');
+        expect(tree[1]!.label).toBe('Relative Strength Index');
     });
 
     it('falls back to the handle title, then the id, when the pane model has no title', () => {

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1321,6 +1321,11 @@ describe('EngineOrchestrator — loading placeholder + legend status', () => {
         expect(last?.id).toBe(ind.id);
         expect(last?.title).toBe('Mock');
         expect(last?.shorttitle).toBe('MK');
+
+        // The pane listing carries the compact name alongside the full title, so the object
+        // tree can label the row the way the legend chip does.
+        const entry = chart.panes.list().flatMap((p) => p.indicators).find((i) => i.id === ind.id);
+        expect(entry).toMatchObject({ title: 'Mock', shorttitle: 'MK' });
     });
 
     it('re-routes to the right pane when the computed overlay differs from the prepare-time guess', async () => {

--- a/test/statusline-model.test.ts
+++ b/test/statusline-model.test.ts
@@ -3,7 +3,8 @@
 // meta — and the right-click menu's rows. Pure functions over plain objects, node env;
 // the real overlay and menu are proven in the browser.
 import { describe, it, expect } from 'vitest';
-import { segmentVisibility, statuslineMenuItems, type StatuslinePart } from '../src/widget/statusline-model';
+import { segmentVisibility, statuslineMenuItems, readoutCells, type StatuslinePart } from '../src/widget/statusline-model';
+import { fmtChangePct } from '../src/widget/format';
 
 const allOn: Record<StatuslinePart, boolean> = { logo: true, name: true, market: true, ohlc: true, change: true };
 
@@ -50,6 +51,32 @@ describe('segmentVisibility', () => {
         expect(seg.change).toBe(true);
         expect(seg.eye).toBe(false);
         expect(segmentVisibility({ ...allOn, ohlc: false }, false).ohlc).toBe(false);
+    });
+});
+
+describe('readoutCells', () => {
+    it('bar-shaped styles read out all four values at the full level', () => {
+        expect(readoutCells('full', 'ohlc').map((c) => c.label)).toEqual(['O', 'H', 'L', 'C']);
+    });
+
+    it('compact keeps the labeled close; minimal drops the label too', () => {
+        expect(readoutCells('compact', 'ohlc')).toEqual([{ key: 'close', label: 'C' }]);
+        expect(readoutCells('minimal', 'ohlc')).toEqual([{ key: 'close', label: '' }]);
+    });
+
+    it('one-line styles only ever read out the unlabeled close', () => {
+        for (const level of ['full', 'compact', 'minimal'] as const) {
+            expect(readoutCells(level, 'value')).toEqual([{ key: 'close', label: '' }]);
+        }
+    });
+});
+
+describe('fmtChangePct', () => {
+    it('formats the signed percent delta alone', () => {
+        expect(fmtChangePct(100, 101.5)).toBe('+1.50%');
+        expect(fmtChangePct(100, 98)).toBe('-2.00%');
+        expect(fmtChangePct(0, 98)).toBe('');
+        expect(fmtChangePct(null, 98)).toBe('');
     });
 });
 

--- a/test/workspace-core.test.ts
+++ b/test/workspace-core.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../src/workspace/layouts';
 import { evenTracks, resizeTracks, trackOffsets, seamSegments, segmentSpanPx } from '../src/workspace/splitters';
 import { seedDefaults, cellChartDefaults, cellDrawings } from '../src/workspace/ChartCell';
-import { declaredOrder, nextAutoCellId } from '../src/workspace/VelaWorkspace';
+import { declaredOrder, nextAutoCellId, resolveTyping } from '../src/workspace/VelaWorkspace';
 import { parseSymbol } from '../src/data/ProviderRegistry';
 
 registerBuiltinLayouts();
@@ -401,6 +401,33 @@ describe('cell identity ↔ slot position (declaredOrder / nextAutoCellId)', () 
         expect(nextAutoCellId(new Set())).toBe('c1');
         expect(nextAutoCellId(new Set(['c1', 'c2']))).toBe('c3');
         expect(nextAutoCellId(new Set(['btc', 'c1', 'c3']))).toBe('c2'); // holes fill first
+    });
+});
+
+describe('resolveTyping — bare keystrokes on the workspace root', () => {
+    const idle = { dialogs: 0, symbolSearch: false, timeframeEntry: false };
+
+    it('with nothing open: a letter seeds symbol search, a digit the timeframe entry', () => {
+        expect(resolveTyping('n', idle)).toEqual({ target: 'symbol', text: 'N' });
+        expect(resolveTyping('Q', idle)).toEqual({ target: 'symbol', text: 'Q' });
+        expect(resolveTyping('1', idle)).toEqual({ target: 'timeframe', text: '1' });
+        expect(resolveTyping('Escape', idle)).toBeNull();
+        expect(resolveTyping(' ', idle)).toBeNull();
+    });
+
+    it('hands the next keystroke to the entry dialog that just opened (fast typing `NQ`, `15`)', () => {
+        // The dialog reports open before its field takes focus; the second key lands
+        // on the root in that gap and must extend the query, not vanish.
+        expect(resolveTyping('q', { dialogs: 1, symbolSearch: true, timeframeEntry: false })).toEqual({ target: 'symbol', text: 'Q' });
+        expect(resolveTyping('2', { dialogs: 1, symbolSearch: true, timeframeEntry: false })).toEqual({ target: 'symbol', text: '2' });
+        expect(resolveTyping('5', { dialogs: 1, symbolSearch: false, timeframeEntry: true })).toEqual({ target: 'timeframe', text: '5' });
+        expect(resolveTyping('m', { dialogs: 1, symbolSearch: false, timeframeEntry: true })).toEqual({ target: 'timeframe', text: 'm' });
+        expect(resolveTyping('Enter', { dialogs: 1, symbolSearch: true, timeframeEntry: false })).toBeNull();
+    });
+
+    it('any other open dialog swallows bare typing', () => {
+        expect(resolveTyping('n', { dialogs: 1, symbolSearch: false, timeframeEntry: false })).toBeNull();
+        expect(resolveTyping('1', { dialogs: 2, symbolSearch: false, timeframeEntry: false })).toBeNull();
     });
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large interaction changes in the native renderer drawing stack plus a backward-compatible extension to `drawing:selected`; regressions in selection, undo, or popup dismissal are the main review focus.
> 
> **Overview**
> **Release v0.6.18** bumps `@luxalgo/vela` to **0.6.18** and documents the ship in `CHANGELOG.md`. It also adds contributor-facing GitHub workflow: structured issue templates (bug / feature / community feedback), a PR template, `CONTRIBUTING.md`, and `blank_issues_enabled: false` with doc links.
> 
> **Drawing tools** get the bulk of the product changes: **multi-select** (Shift/Cmd+click, marquee, group move/copy/delete with single undo steps, locked drawings protected in multi-delete), **duplicate by Cmd/Ctrl+drag** and overflow-menu duplicate, and a **shared quick-settings bar** for multi-selection with mixed-value UI. The public **`drawing:selected` event** now includes **`ids`** (full selection) alongside primary `id`; core adds a **`clone`** drawing intent for drag-to-duplicate. Object tree and workspace docs sync to chart multi-selection.
> 
> **Widget / indicators:** Status line uses a **width ladder** (stack OHLC, then compact/minimal readouts). Native **VWAP** gains **±σ bands**, Quarter/Year reset, and broader source inputs. Object tree shows indicator **`shorttitle`** when set. **`PaneInfo`** indicators can expose optional **`shorttitle`**.
> 
> **Fix (per changelog):** symbol/timeframe type-ahead menus no longer drop the second keystroke when focus lags.
> 
> User docs (`drawing-tools.md`, `api-reference.md`, `workspace.md`) are updated for the new drawing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee161b35aecb41742d12ca87f10a338e7e11cee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->