### PR TITLE
Persist native indicator settings and indicator visibility in the workspace state

### DIFF
--- a/src/state/document.ts
+++ b/src/state/document.ts
@@ -82,10 +82,11 @@ export interface CellState {
     rendererConfig?: unknown;
     /** The user-drawings document (`drawings.toJSON()`). */
     drawings?: unknown;
-    /** The indicator ledger: manifest entries + present native types. A manifest entry
-     *  is the bare NAME when every value sits on its declaration default, else the
-     *  name plus the input/prop DELTAS (defaults are never frozen into documents). */
-    indicators?: { manifest: PersistedManifestEntry[]; natives: string[] };
+    /** The indicator ledger: manifest entries + native entries. Either side persists
+     *  the bare NAME/TYPE when every value sits on its declaration default and the
+     *  indicator is visible, else the name/type plus the input(/prop) DELTAS and a
+     *  `hidden` flag (defaults are never frozen into documents). */
+    indicators?: { manifest: PersistedManifestEntry[]; natives: PersistedNativeEntry[] };
     /** Third-party per-chart state, by namespaced key (`'vendor.feature'`) — written and
      *  read by registered state-persistence handlers (`registerStatePersistence`, scope
      *  `'cell'`). Values are OPAQUE here: the codec preserves entries verbatim — a key
@@ -95,7 +96,12 @@ export interface CellState {
 }
 
 /** One persisted manifest-instance entry (see `CellState.indicators`). */
-export type PersistedManifestEntry = string | { name: string; inputs?: Record<string, unknown>; props?: Record<string, unknown> };
+export type PersistedManifestEntry = string | { name: string; inputs?: Record<string, unknown>; props?: Record<string, unknown>; hidden?: boolean };
+
+/** One persisted native-indicator entry (see `CellState.indicators`). The bare TYPE is
+ *  the historical shape and still the common case; the object form carries the input
+ *  DELTAS and/or the hidden flag so native settings and visibility survive a reload. */
+export type PersistedNativeEntry = string | { type: string; inputs?: Record<string, unknown>; hidden?: boolean };
 
 /** One entry of the document's `charts` array: a chart's state plus its cell IDENTITY. */
 export interface ChartState extends CellState {
@@ -232,20 +238,34 @@ function sanitizeCell(raw: unknown): CellState | null {
     if (ind != null && typeof ind === 'object') {
         // Bare names pass as-is; object entries keep only a string name and plain-object
         // value bags (the add path validates individual values against the schema).
+        const bag = (v: unknown): Record<string, unknown> | undefined => (v != null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined);
         const manifest: PersistedManifestEntry[] = Array.isArray(ind.manifest)
             ? ind.manifest.flatMap((n): PersistedManifestEntry[] => {
                   if (typeof n === 'string') return [n];
                   if (n != null && typeof n === 'object' && typeof (n as { name?: unknown }).name === 'string') {
-                      const e = n as { name: string; inputs?: unknown; props?: unknown };
-                      const bag = (v: unknown): Record<string, unknown> | undefined => (v != null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined);
+                      const e = n as { name: string; inputs?: unknown; props?: unknown; hidden?: unknown };
                       const inputs = bag(e.inputs);
                       const props = bag(e.props);
-                      return [inputs || props ? { name: e.name, ...(inputs ? { inputs } : {}), ...(props ? { props } : {}) } : e.name];
+                      const hidden = e.hidden === true;
+                      return [inputs || props || hidden ? { name: e.name, ...(inputs ? { inputs } : {}), ...(props ? { props } : {}), ...(hidden ? { hidden } : {}) } : e.name];
                   }
                   return [];
               })
             : [];
-        const natives = Array.isArray(ind.natives) ? ind.natives.filter((n): n is string => typeof n === 'string') : [];
+        // Native entries mirror the manifest shape: bare types pass as-is; object entries
+        // keep only a string type, a plain-object input bag, and a true hidden flag.
+        const natives: PersistedNativeEntry[] = Array.isArray(ind.natives)
+            ? ind.natives.flatMap((n): PersistedNativeEntry[] => {
+                  if (typeof n === 'string') return [n];
+                  if (n != null && typeof n === 'object' && typeof (n as { type?: unknown }).type === 'string') {
+                      const e = n as { type: string; inputs?: unknown; hidden?: unknown };
+                      const inputs = bag(e.inputs);
+                      const hidden = e.hidden === true;
+                      return [inputs || hidden ? { type: e.type, ...(inputs ? { inputs } : {}), ...(hidden ? { hidden } : {}) } : e.type];
+                  }
+                  return [];
+              })
+            : [];
         out.indicators = { manifest, natives };
     }
     const ext = sanitizeExt(c.ext);

--- a/src/widget/indicators.ts
+++ b/src/widget/indicators.ts
@@ -94,15 +94,27 @@ export async function resolveIndicators(
  * declaration default, else the name plus the DELTAS (see `inputDeltas`) — a default
  * that later changes in the script must never stay frozen in saved documents.
  */
-export type LedgerManifestEntry = string | { name: string; inputs?: Record<string, InputValue>; props?: Record<string, InputValue> };
+export type LedgerManifestEntry = string | { name: string; inputs?: Record<string, InputValue>; props?: Record<string, InputValue>; hidden?: boolean };
 
 /** The entry's manifest NAME, whichever shape it travels as. */
 export const ledgerEntryName = (e: LedgerManifestEntry): string => (typeof e === 'string' ? e : e.name);
 
+/**
+ * One persisted native-indicator entry: the bare TYPE when every input sits on its
+ * declaration default and the indicator is visible, else the type plus the input
+ * DELTAS and/or the `hidden` flag — same rule as {@link LedgerManifestEntry}, so
+ * native settings and visibility survive a state round-trip too.
+ */
+export type LedgerNativeEntry = string | { type: string; inputs?: Record<string, InputValue>; hidden?: boolean };
+
+/** The entry's native TYPE, whichever shape it travels as. */
+export const ledgerNativeType = (e: LedgerNativeEntry): string => (typeof e === 'string' ? e : e.type);
+
 /** Everything {@link indicatorLedger} needs to decide what a state snapshot reports. */
 export interface LedgerInputs {
-    /** Native types present on the chart RIGHT NOW (`chart.presentNativeIndicators()` — sync). */
-    present: readonly string[];
+    /** Native entries present on the chart RIGHT NOW (live handles: type + input
+     *  deltas + hidden, falling back to bare types from the sync registry). */
+    present: readonly LedgerNativeEntry[];
     /** The live manifest instances (the shell's own synchronous array), values included. */
     instanceEntries: readonly LedgerManifestEntry[];
     /** A restored ledger's manifest half, until it materializes (null once consumed). */
@@ -130,9 +142,9 @@ export interface LedgerInputs {
  * never be repainted as "empty because nothing loaded yet" — that resurrection was the
  * bug this helper exists to pin down.
  */
-export function indicatorLedger(i: LedgerInputs): { manifest: LedgerManifestEntry[]; natives: string[] } {
+export function indicatorLedger(i: LedgerInputs): { manifest: LedgerManifestEntry[]; natives: LedgerNativeEntry[] } {
     const natives = [...i.present];
-    if (i.volumePending && !natives.includes('volume')) natives.push('volume');
+    if (i.volumePending && !natives.some((e) => ledgerNativeType(e) === 'volume')) natives.push('volume');
     return {
         manifest: i.manifestSettled ? [...i.instanceEntries] : [...(i.pendingManifest ?? i.instanceEntries)],
         natives,

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -24,7 +24,7 @@ import { CellControls } from '../widget/cell-controls';
 import { ChartContextMenu } from '../widget/context-menu';
 import { WidgetHistory } from '../widget/history';
 import type { RangePreset } from '../widget/bottombar';
-import { indicatorLedger, ledgerEntryName, type LedgerManifestEntry, type ResolvedIndicator } from '../widget/indicators';
+import { indicatorLedger, ledgerEntryName, ledgerNativeType, type LedgerManifestEntry, type LedgerNativeEntry, type ResolvedIndicator } from '../widget/indicators';
 import { inputDeltas, type InputValue } from '../core/model/inputs';
 import {
     legendActionsProviderFor,
@@ -189,6 +189,13 @@ interface CellInstance {
     handle: IndicatorHandle | null;
     external?: boolean;
     values?: { inputs?: Record<string, InputValue>; props?: Record<string, InputValue> };
+}
+
+/** A native handle's ledger entry: the bare type, or type + input deltas + hidden flag. */
+function nativeLedgerEntry(handle: IndicatorHandle): LedgerNativeEntry {
+    const inputs = inputDeltas(handle.inputs, handle.inputValues());
+    const hidden = !handle.visible;
+    return inputs || hidden ? { type: handle.nativeType!, ...(inputs ? { inputs } : {}), ...(hidden ? { hidden: true } : {}) } : handle.nativeType!;
 }
 
 /** The handle's current input/prop DELTAS against declaration defaults (see `inputDeltas`). */
@@ -368,10 +375,13 @@ export class ChartCell {
         // resolving) and stay reported by `dehydrate` until then, so an early snapshot
         // (persist flush racing the resolution) never wipes them.
         if (seed.indicators) {
-            for (const type of seed.indicators.natives) this.inner.addNativeIndicator(type);
+            for (const entry of seed.indicators.natives as LedgerNativeEntry[]) {
+                const handle = this.inner.addNativeIndicator(ledgerNativeType(entry));
+                this.applyNativeLedgerEntry(handle, entry);
+            }
             this.pendingManifestNames = [...seed.indicators.manifest] as LedgerManifestEntry[];
         }
-        this.volumeIntent = seed.indicators ? seed.indicators.natives.includes('volume') : deps.volume;
+        this.volumeIntent = seed.indicators ? seed.indicators.natives.some((e) => ledgerNativeType(e as LedgerNativeEntry) === 'volume') : deps.volume;
         // Third-party state rides in verbatim; the workspace triggers the handlers'
         // `restore` AFTER wiring the cell (restorePersistedExt) — a restore that adds
         // indicators must not call back into a workspace that doesn't know the cell yet.
@@ -458,6 +468,9 @@ export class ChartCell {
             this.refreshNativeCatalog();
         });
         this.inner.on('indicator:inputs', () => this.deps.onStateDirty());
+        // A legend-eye toggle is a persistable choice like an input edit — without this
+        // a hidden indicator came back visible on reload (nothing marked the doc dirty).
+        this.inner.on('indicator:visibility', () => this.deps.onStateDirty());
         this.inner.on('indicator:removed', ({ id }) => {
             if (this.destroyed) return;
             // Out-of-band removals (legend ✕, object tree, middle-click, handle.remove())
@@ -965,7 +978,7 @@ export class ChartCell {
             if (list.length === 0) return; // the manifest hasn't resolved yet — keep waiting
             for (const led of this.pendingManifestNames) {
                 const entry = list.find((e) => e.name === ledgerEntryName(led));
-                if (entry) this.addManifestInstance(entry, { record: false, ...(typeof led === 'object' ? { inputs: led.inputs, props: led.props } : {}) });
+                if (entry) this.addManifestInstance(entry, { record: false, ...(typeof led === 'object' ? { inputs: led.inputs, props: led.props, hidden: led.hidden } : {}) });
             }
             this.pendingManifestNames = null;
             return;
@@ -982,29 +995,42 @@ export class ChartCell {
      * resolves. Convergence is state application, not user edits — nothing enters the
      * undo timeline.
      */
-    private applyIndicatorLedger(led: { manifest: LedgerManifestEntry[]; natives: string[] }): void {
+    private applyIndicatorLedger(led: { manifest: LedgerManifestEntry[]; natives: LedgerNativeEntry[] }): void {
         const chart = this.inner;
         if (!chart) return;
-        this.volumeIntent = led.natives.includes('volume');
+        this.volumeIntent = led.natives.some((e) => ledgerNativeType(e) === 'volume');
         this.history.silently(() => {
             // Converge as a MULTISET: a multi-instance type is listed once per instance.
-            // Existing instances are kept while the ledger still owes their type; the
-            // surplus goes, the shortfall is added.
-            const owed = new Map<string, number>();
-            for (const type of led.natives) owed.set(type, (owed.get(type) ?? 0) + 1);
+            // Existing instances are kept while the ledger still owes their type — each
+            // consumes one owed ENTRY and converges to its values/visibility — the
+            // surplus goes, the shortfall is added with the entry's values.
+            const owed = new Map<string, LedgerNativeEntry[]>();
+            for (const e of led.natives) {
+                const type = ledgerNativeType(e);
+                const queue = owed.get(type);
+                if (queue) queue.push(e);
+                else owed.set(type, [e]);
+            }
             for (const h of this.nativeHandles()) {
-                const type = h.nativeType!;
-                const n = owed.get(type) ?? 0;
-                if (n > 0) owed.set(type, n - 1);
+                const entry = owed.get(h.nativeType!)?.shift();
+                if (entry !== undefined) this.applyNativeLedgerEntry(h, entry);
                 else h.remove();
             }
-            for (const [type, n] of owed) for (let i = 0; i < n; i++) chart.addNativeIndicator(type);
+            for (const queue of owed.values()) {
+                for (const e of queue) {
+                    const h = chart.addNativeIndicator(ledgerNativeType(e));
+                    this.applyNativeLedgerEntry(h, e);
+                }
+            }
             for (const it of [...this.instances]) this.dropInstance(it);
             if (this.manifest.length > 0) {
                 for (const item of led.manifest) {
                     const entry = this.manifest.find((e) => e.name === ledgerEntryName(item));
                     if (entry)
-                        this.addManifestInstance(entry, { record: false, ...(typeof item === 'object' ? { inputs: item.inputs, props: item.props } : {}) });
+                        this.addManifestInstance(entry, {
+                            record: false,
+                            ...(typeof item === 'object' ? { inputs: item.inputs, props: item.props, hidden: item.hidden } : {}),
+                        });
                 }
                 this.pendingManifestNames = null;
             } else if (!this.deps.manifestSettled()) {
@@ -1076,11 +1102,15 @@ export class ChartCell {
     /** Add ONE instance of a manifest entry (repeatable — duplicates are legitimate). */
     addManifestInstance(
         entry: ResolvedIndicator,
-        opts: { record?: boolean; external?: boolean; inputs?: Record<string, InputValue>; props?: Record<string, InputValue> } = {},
+        opts: { record?: boolean; external?: boolean; inputs?: Record<string, InputValue>; props?: Record<string, InputValue>; hidden?: boolean } = {},
     ): void {
         if (this.destroyed) return;
         const values = opts.inputs || opts.props ? { inputs: opts.inputs, props: opts.props } : undefined;
         const it: CellInstance = { entry, handle: this.addToChart(entry, values), ...(opts.external ? { external: true } : {}), ...(values ? { values } : {}) };
+        // A restored `hidden` applies right after the add — the handle is usable
+        // synchronously, and hiding suspends the engine session before it spends
+        // anything on an indicator the user had tucked away.
+        if (opts.hidden) it.handle?.setVisible(false);
         this.instances.push(it);
         this.deps.onIndicatorsChanged(this.id);
         if (opts.record === false) return;
@@ -1130,6 +1160,31 @@ export class ChartCell {
     /** Add a native indicator. A multi-instance type gets a fresh instance every time; a
      *  single-instance type already on the chart hands back its existing one — nothing
      *  changed, so nothing enters the undo timeline. */
+    /**
+     * Converge one native handle to a restored ledger entry: every schema key gets the
+     * entry's value or its declaration default (the DOCUMENT is the truth — a live
+     * tweak must not survive a restore that says otherwise), and visibility follows
+     * the `hidden` flag. Skips the input write when nothing differs — `setInputs`
+     * re-runs the indicator, and a no-op restore must not flicker every native.
+     */
+    private applyNativeLedgerEntry(handle: IndicatorHandle, entry: LedgerNativeEntry): void {
+        const wanted = typeof entry === 'string' ? undefined : entry.inputs;
+        if (handle.inputs.length > 0) {
+            const current = handle.inputValues();
+            const next: Record<string, InputValue> = {};
+            for (const schema of handle.inputs) {
+                const target = wanted?.[schema.key] ?? schema.defval;
+                if (JSON.stringify(current[schema.key]) !== JSON.stringify(target)) next[schema.key] = target;
+            }
+            if (Object.keys(next).length > 0) handle.setInputs(next);
+        } else if (wanted) {
+            // Schema not exposed (nothing to diff against) — apply the stored values verbatim.
+            handle.setInputs(wanted);
+        }
+        const visible = !(typeof entry === 'object' && entry.hidden);
+        if (handle.visible !== visible) handle.setVisible(visible);
+    }
+
     addNative(type: string): void {
         const chart = this.inner;
         if (!chart) return;
@@ -1266,7 +1321,7 @@ export class ChartCell {
         // Cosmetics + drawings round-trip (both validate untrusted input).
         if (cs.rendererConfig != null) this.inner.renderer.applyConfig(cs.rendererConfig);
         if (cs.drawings != null) this.inner.drawings.fromJSON(cs.drawings);
-        if (cs.indicators) this.applyIndicatorLedger(cs.indicators as { manifest: LedgerManifestEntry[]; natives: string[] });
+        if (cs.indicators) this.applyIndicatorLedger(cs.indicators as { manifest: LedgerManifestEntry[]; natives: LedgerNativeEntry[] });
         // Third-party state converges to the document too: the restored bag REPLACES
         // the baseline (absent in the document = the document carries none), then the
         // registered handlers re-apply. After the ledger — a handler re-adding external
@@ -1316,14 +1371,17 @@ export class ChartCell {
             // (`ctx.addIndicator`) stay out: their names would never resolve against the
             // manifest — their plugin persists them via the `ext` seam instead.
             indicators: indicatorLedger({
-                present: this.inner ? this.inner.presentNativeIndicators() : [],
+                // Live handles carry what the registry read cannot: the input DELTAS and
+                // the hidden flag, so native settings/visibility survive the round-trip.
+                present: this.inner ? this.nativeHandles().map((h) => nativeLedgerEntry(h)) : [],
                 instanceEntries: this.instances
                     .filter((it) => !it.external)
                     .map((it) => {
                         // LIVE deltas from the handle; a handle-less instance (add failed)
                         // keeps whatever values it was restored with.
                         const d = it.handle ? instanceDeltas(it.handle) : it.values;
-                        return d ? { name: it.entry.name, ...d } : it.entry.name;
+                        const hidden = it.handle ? !it.handle.visible : false;
+                        return d || hidden ? { name: it.entry.name, ...(d ?? {}), ...(hidden ? { hidden: true } : {}) } : it.entry.name;
                     }),
                 pendingManifest: this.pendingManifestNames,
                 manifestSettled: this.deps.manifestSettled(),

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -288,8 +288,18 @@ describe('indicatorLedger', () => {
     it('reports the volume INTENT until the auto-add had its chance, never duplicating', () => {
         expect(indicatorLedger({ ...base, volumePending: true })).toEqual({ manifest: [], natives: ['volume'] });
         expect(indicatorLedger({ ...base, volumePending: true, present: ['volume'] })).toEqual({ manifest: [], natives: ['volume'] });
+        // ...including when the present volume travels as a VALUE-carrying entry.
+        expect(indicatorLedger({ ...base, volumePending: true, present: [{ type: 'volume', hidden: true }] })).toEqual({
+            manifest: [],
+            natives: [{ type: 'volume', hidden: true }],
+        });
         // After the first load the registry is the whole truth: no intent padding.
         expect(indicatorLedger({ ...base, volumePending: false, present: ['vpvr'] })).toEqual({ manifest: [], natives: ['vpvr'] });
+    });
+
+    it('native entries carry input deltas and hidden flags verbatim', () => {
+        const present = ['volume', { type: 'aroon', inputs: { length: 50 } }, { type: 'vpvr', hidden: true }];
+        expect(indicatorLedger({ ...base, present }).natives).toEqual(present);
     });
 });
 

--- a/test/workspace-persist.test.ts
+++ b/test/workspace-persist.test.ts
@@ -98,6 +98,43 @@ describe('sanitizeState (the applyState gate)', () => {
         });
     });
 
+    it('native entries carry input deltas and the hidden flag; manifest entries carry hidden', () => {
+        const doc = sanitizeState({
+            version: 1,
+            layout: '1',
+            charts: [
+                {
+                    id: 'c1',
+                    indicators: {
+                        // Object natives: type required, inputs must be a plain bag, hidden must be TRUE.
+                        // A delta-less visible object collapses to the bare type; typeless entries vanish.
+                        natives: [
+                            'volume',
+                            { type: 'aroon', inputs: { length: 50 } },
+                            { type: 'vpvr', hidden: true },
+                            { type: 'sma', inputs: [9], hidden: false },
+                            { inputs: { length: 3 } },
+                        ],
+                        manifest: [{ name: 'RSI', hidden: true }, { name: 'MACD', hidden: 'yes' }],
+                    },
+                },
+            ],
+        });
+        expect(doc).toEqual({
+            version: 1,
+            layout: '1',
+            charts: [
+                {
+                    id: 'c1',
+                    indicators: {
+                        natives: ['volume', { type: 'aroon', inputs: { length: 50 } }, { type: 'vpvr', hidden: true }, 'sma'],
+                        manifest: [{ name: 'RSI', hidden: true }, 'MACD'],
+                    },
+                },
+            ],
+        });
+    });
+
     it('keeps a valid session value and drops anything else', () => {
         const doc = sanitizeState({
             version: 1,


### PR DESCRIPTION
Fixes #138 (reported via LuxAlgo/app#420: change Aroon's length from 14 to 50, switch workspaces, switch back, it resets to 14; same for hiding an indicator).

Two gaps closed:

**1. Native indicator settings.** The ledger persisted natives as bare type strings, so `rehydrate` re-added them with declaration defaults. Natives now dehydrate from their LIVE handles like manifest instances do: the bare type stays the common case, and an object entry `{ type, inputs?, hidden? }` carries the input DELTAS (defaults are never frozen into documents, same rule as manifest entries). The multiset convergence in `applyIndicatorLedger` now converges each kept/added handle to its entry: every schema key gets the entry's value or its declaration default (the document is the truth), skipping the write when nothing differs so a no-op restore never re-runs an indicator.

**2. Indicator visibility.** The legend-eye state was not captured anywhere and toggling it never marked the state dirty. Both ledger sides now carry `hidden?: true` (natives and manifest entries), `indicator:visibility` marks the cell state dirty like `indicator:inputs` does, and restore applies `setVisible(false)` right after the add, so a hidden indicator's engine session never spends anything before it is suspended.

Back-compat both directions: bare strings remain valid entries (old documents restore unchanged), and delta-less visible indicators still persist as bare strings (new documents only grow objects where there is something to carry). `sanitizeState` validates the new object forms the same way it validates manifest value bags.

Tests: sanitizer coverage for the new native/manifest shapes (malformed objects dropped, delta-less objects collapse to bare types), and ledger coverage for value-carrying native entries including the volume-intent dedup. Full suite green (1576), tsc and lint clean.