### PR TITLE
Release version 0.6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.6.19]
+
 ## [v0.6.18]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",


### PR DESCRIPTION
Bumps the package version from 0.6.18 to 0.6.19 and adds the matching \## [v0.6.19]\ heading to \CHANGELOG.md\. No other changes.

Made with [Cursor](https://cursor.com)