### PR TITLE
146 follow-up: pre-start guard for classic natives and the hidden seam on ctx.addIndicator

### DIFF
--- a/src/core/native-indicators/classics/define.ts
+++ b/src/core/native-indicators/classics/define.ts
@@ -99,7 +99,8 @@ function toPoints(bars: readonly OHLCV[], values: readonly number[], colors?: Re
 }
 
 class ClassicIndicator implements NativeIndicator {
-    private ctx!: NativeIndicatorContext;
+    /** Null until start() — a pre-start setInputs must record without computing. */
+    private ctx: NativeIndicatorContext | null = null;
     private inputs: Record<string, InputValue> = {};
 
     constructor(private readonly spec: ClassicIndicatorSpec) {}
@@ -118,6 +119,10 @@ class ClassicIndicator implements NativeIndicator {
 
     setInputs(inputs: Record<string, InputValue>): void {
         this.inputs = inputs;
+        // Pre-start edits (a workspace restore applies stored inputs the moment the
+        // handle exists) just record: `ctx` lands at start(), which recomputes with
+        // the orchestrator's replayed values — computing here would read no bars.
+        if (!this.ctx) return;
         this.recompute();
     }
 
@@ -131,6 +136,7 @@ class ClassicIndicator implements NativeIndicator {
     stop(): void {}
 
     private recompute(): void {
+        if (!this.ctx) return;
         const bars = this.ctx.bars();
         const out = this.spec.compute(bars, this.inputs);
         const instanceId = this.spec.type;

--- a/src/widget/contributions.ts
+++ b/src/widget/contributions.ts
@@ -63,6 +63,10 @@ export interface ExternalIndicatorEntry {
     inputs?: Record<string, InputValue>;
     /** Declaration-prop overrides applied at add time. */
     props?: Record<string, InputValue>;
+    /** Restore hidden: the indicator is suspended right after the add (legend row
+     *  stays, marked hidden) — a persistence handler carrying a hidden flag applies
+     *  it here so the engine never spends anything on a tucked-away indicator. */
+    hidden?: boolean;
 }
 
 /** Where an action is projected. */

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -1095,7 +1095,7 @@ export class ChartCell {
     addExternalIndicator(entry: ExternalIndicatorEntry): void {
         this.addManifestInstance(
             { ...entry, enabled: true },
-            { external: true, ...(entry.inputs ? { inputs: entry.inputs } : {}), ...(entry.props ? { props: entry.props } : {}) },
+            { external: true, ...(entry.inputs ? { inputs: entry.inputs } : {}), ...(entry.props ? { props: entry.props } : {}), ...(entry.hidden ? { hidden: true } : {}) },
         );
     }
 


### PR DESCRIPTION
The #146 merge snapshot predates the branch's last two commits, so dev (and the 0.6.19 release) is missing them:

1. **ClassicIndicator pre-start guard.** Without it, restoring a workspace whose document carries stored native inputs calls setInputs before start() and recompute reads bars off a null context, crashing workspace boot and rehydrate (reproduced in the app: switching workspaces with a saved Aroon length crashes applyState). The orchestrator stores inputValues and replays them at start(), so the early return loses nothing.

2. **ExternalIndicatorEntry.hidden on ctx.addIndicator.** Vela-pro#80 (merged) restores library indicator visibility through this seam; without it the hidden flag is silently dropped on restore.

Both were playground-verified as part of the #146 work (full round trip: settings and hidden state survive reload, drifted charts converge, legacy docs reset clean). Suite 1577 green.

**0.6.19 should not be published without this** (or publish it as 0.6.20 immediately after).