### PR TITLE
Release version 0.6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.6.20]
+
+### Added
+
+- **Native indicator settings and visibility persist.** The workspace ledger's native
+  entries carry input DELTAS and a `hidden` flag (manifest entries carry `hidden` too),
+  the legend eye marks the state dirty, and `ctx.addIndicator` accepts `hidden` so
+  plugin restores can apply it. Restores converge kept indicators to the document's
+  values; legacy bare-string ledgers still restore unchanged. (#146, #149)
+
+### Fixed
+
+- Classic native indicators no longer compute against unloaded bars when a restore
+  applies stored inputs before the first data lands (a pre-start guard in
+  `ClassicIndicator`; the orchestrator replays the values at `start`). (#149)
+
 ## [v0.6.19]
 
 ## [v0.6.18]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.19",
+      "version": "0.6.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",


### PR DESCRIPTION
Version bump with the changelog entry for the indicator settings/visibility persistence work (#146 plus the #149 follow-up the 146 merge snapshot missed). 0.6.19 was never published and predates #149, so 0.6.20 is the first publishable version carrying the complete feature.

Verified end to end against the LuxAlgo app with a local build of this exact content: native settings and visibility survive workspace switches and reloads, no crash on applyState, legacy documents restore unchanged. Full suite green (1577).