### PR TITLE
Sync main for the v0.6.20 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.6.20]
+
+### Added
+
+- **Native indicator settings and visibility persist.** The workspace ledger's native
+  entries carry input DELTAS and a `hidden` flag (manifest entries carry `hidden` too),
+  the legend eye marks the state dirty, and `ctx.addIndicator` accepts `hidden` so
+  plugin restores can apply it. Restores converge kept indicators to the document's
+  values; legacy bare-string ledgers still restore unchanged. (#146, #149)
+
+### Fixed
+
+- Classic native indicators no longer compute against unloaded bars when a restore
+  applies stored inputs before the first data lands (a pre-start guard in
+  `ClassicIndicator`; the orchestrator replays the values at `start`). (#149)
+
 ## [v0.6.19]
 
 ## [v0.6.18]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.19",
+      "version": "0.6.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/src/core/native-indicators/classics/define.ts
+++ b/src/core/native-indicators/classics/define.ts
@@ -99,7 +99,8 @@ function toPoints(bars: readonly OHLCV[], values: readonly number[], colors?: Re
 }
 
 class ClassicIndicator implements NativeIndicator {
-    private ctx!: NativeIndicatorContext;
+    /** Null until start() — a pre-start setInputs must record without computing. */
+    private ctx: NativeIndicatorContext | null = null;
     private inputs: Record<string, InputValue> = {};
 
     constructor(private readonly spec: ClassicIndicatorSpec) {}
@@ -118,6 +119,10 @@ class ClassicIndicator implements NativeIndicator {
 
     setInputs(inputs: Record<string, InputValue>): void {
         this.inputs = inputs;
+        // Pre-start edits (a workspace restore applies stored inputs the moment the
+        // handle exists) just record: `ctx` lands at start(), which recomputes with
+        // the orchestrator's replayed values — computing here would read no bars.
+        if (!this.ctx) return;
         this.recompute();
     }
 
@@ -131,6 +136,7 @@ class ClassicIndicator implements NativeIndicator {
     stop(): void {}
 
     private recompute(): void {
+        if (!this.ctx) return;
         const bars = this.ctx.bars();
         const out = this.spec.compute(bars, this.inputs);
         const instanceId = this.spec.type;

--- a/src/widget/contributions.ts
+++ b/src/widget/contributions.ts
@@ -63,6 +63,10 @@ export interface ExternalIndicatorEntry {
     inputs?: Record<string, InputValue>;
     /** Declaration-prop overrides applied at add time. */
     props?: Record<string, InputValue>;
+    /** Restore hidden: the indicator is suspended right after the add (legend row
+     *  stays, marked hidden) — a persistence handler carrying a hidden flag applies
+     *  it here so the engine never spends anything on a tucked-away indicator. */
+    hidden?: boolean;
 }
 
 /** Where an action is projected. */

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -1095,7 +1095,7 @@ export class ChartCell {
     addExternalIndicator(entry: ExternalIndicatorEntry): void {
         this.addManifestInstance(
             { ...entry, enabled: true },
-            { external: true, ...(entry.inputs ? { inputs: entry.inputs } : {}), ...(entry.props ? { props: entry.props } : {}) },
+            { external: true, ...(entry.inputs ? { inputs: entry.inputs } : {}), ...(entry.props ? { props: entry.props } : {}), ...(entry.hidden ? { hidden: true } : {}) },
         );
     }
 


### PR DESCRIPTION
Brings main up to dev for the v0.6.20 publish: the indicator settings/visibility persistence (#146, #149) and the version bump (#150), plus the handful of dev commits main was behind. After merge: npm publish and push the v0.6.20 tag (the workflow mirrors it to GitHub Packages on the tag).