### PR TITLE
ChartCell persistence regression harness (plus two pre-start guards it caught)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Vela, newest first.
 
+## [v0.6.21]
+
+### Fixed
+
+- Native indicators restored HIDDEN no longer crash (volume/VPVR `resume`/`setInputs`
+  dereferenced a null context before `start`) and now START on un-hide instead of
+  resuming a never-started instance — previously the show path either crashed or left
+  a permanently blank row. Same pre-start family as the classic-indicator guard in
+  v0.6.20.
+- The constructor's volume auto-add intent reads object-form ledger entries
+  (`{ type: 'volume', hidden: true }` was missed by the bare-string check).
+
+### Added
+
+- A ChartCell persistence regression harness (jsdom): boots a real cell with a fake
+  renderer/feed and locks the dehydrate/rehydrate round-trip — stored-input seeds,
+  delta/hidden capture, drifted-chart convergence, legacy-ledger resets, the
+  visibility save trigger, and un-hide starting never-started natives.
+
 ## [v0.6.20]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxalgo/vela",
-      "version": "0.6.20",
+      "version": "0.6.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@zag-js/core": "^1.42.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,216 @@
       },
       "devDependencies": {
         "eslint": "^9.0.0",
+        "jsdom": "^29.1.1",
         "tsup": "^8.0.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.0.0",
         "vite": "^8.1.5",
         "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -669,6 +874,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2133,6 +2356,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.1.0.tgz",
+      "integrity": "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
@@ -2299,11 +2532,39 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2323,6 +2584,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2338,6 +2606,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2748,6 +3029,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2808,6 +3102,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2846,6 +3147,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -3207,6 +3549,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3216,6 +3568,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3373,6 +3732,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -3556,6 +3928,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3643,6 +4025,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.62.2",
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -3771,6 +4166,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3833,6 +4235,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.12.tgz",
+      "integrity": "sha512-WylhSDKVeYnWXL3a+vKTaOxjnOeEGw938hImY8zoRWJjRRK/Jp1K+IihBzIONpUmW4e3WmXT6q5FW6vlESVZCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.12"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+      "integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -4461,6 +4909,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4676,6 +5134,54 @@
         "node": ">=18"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4718,6 +5224,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "eslint": "^9.0.0",
+    "jsdom": "^29.1.1",
     "tsup": "^8.0.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/vela",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "Open-source charting library with a native high-performance renderer, drawing tools, pluggable chart types and pluggable scripting engines.",
   "license": "Apache-2.0",
   "homepage": "https://luxalgo.com/vela",

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -764,6 +764,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             if (!record.native) continue;
             record.native.instance.stop();
             record.native.instance = record.native.descriptor.create();
+            record.native.started = false;
             record.pendingStructural = true; // the next emitted model remounts over the old visuals
             if (record.hidden) {
                 record.native.stale = true;
@@ -1360,9 +1361,12 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             if (record.renderHandle) this.renderer.setIndicatorVisible?.(record.renderHandle, true);
             record.pendingStructural = true; // visuals dropped on hide → next model re-mounts
             if (record.native) {
-                if (record.native.stale) {
-                    // The instance was re-created for a NEW market while hidden — resume()
-                    // would revive the old market's compute; start the fresh instance instead.
+                if (record.native.stale || !record.native.started) {
+                    // The instance was re-created for a NEW market while hidden (`stale`),
+                    // or was ADDED hidden and never started (a restored hidden ledger entry —
+                    // startNativeIndicator bails on hidden records): resume() would either
+                    // revive the old market's compute or poke a context-less instance.
+                    // Start the instance instead.
                     record.native.stale = false;
                     const handle = this.handles.get(id);
                     if (handle) void this.startNativeIndicator(id, handle);
@@ -1586,6 +1590,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
                 },
             };
             record.native.instance.start(ctx, record.inputValues);
+            record.native.started = true;
         } catch (err) {
             this.fail(id, handle, err);
         }

--- a/src/core/engine/IndicatorRegistry.ts
+++ b/src/core/engine/IndicatorRegistry.ts
@@ -18,7 +18,7 @@ export interface IndicatorRecord {
      * `stale` marks an instance re-created for a NEW market while the indicator was hidden —
      * showing it must START the fresh instance instead of resuming the old market's compute.
      */
-    native?: { type: string; instance: NativeIndicator; descriptor: NativeIndicatorDescriptor; stale?: boolean };
+    native?: { type: string; instance: NativeIndicator; descriptor: NativeIndicatorDescriptor; stale?: boolean; started?: boolean };
     /** Routing/inputs options from addIndicator (used to re-route on a fresh first model). */
     options?: AddIndicatorOptions;
     /** The engine selected for this indicator's language. */

--- a/src/core/native-indicators/volume/VolumeIndicator.ts
+++ b/src/core/native-indicators/volume/VolumeIndicator.ts
@@ -34,7 +34,8 @@ export function volumeLayerData(inputs: Record<string, InputValue>): VolumeLayer
  * this instance only carries lifecycle + settings.
  */
 class VolumeIndicator implements NativeIndicator {
-    private ctx!: NativeIndicatorContext;
+    /** Null until start() — pre-start setInputs/resume must record without pushing. */
+    private ctx: NativeIndicatorContext | null = null;
     private inputs: Record<string, InputValue> = {};
 
     start(ctx: NativeIndicatorContext, inputs: Record<string, InputValue>): void {
@@ -52,14 +53,18 @@ class VolumeIndicator implements NativeIndicator {
 
     setInputs(inputs: Record<string, InputValue>): void {
         this.inputs = inputs;
-        this.ctx.pushData(volumeLayerData(inputs));
+        // Pre-start edits (a workspace restore applies stored inputs the moment the
+        // handle exists) just record: start() pushes the orchestrator's replayed values.
+        this.ctx?.pushData(volumeLayerData(inputs));
     }
 
     /** Hiding is a renderer-layer flag (set via `setIndicatorVisible`); no resources to free. */
     suspend(): void {}
 
     resume(): void {
-        this.ctx.pushData(volumeLayerData(this.inputs));
+        // Pre-start resume (a restore un-hiding an indicator that never started) is a
+        // no-op — start() pushes when the context lands.
+        this.ctx?.pushData(volumeLayerData(this.inputs));
     }
 
     stop(): void {}

--- a/src/core/native-indicators/vpvr/VpvrIndicator.ts
+++ b/src/core/native-indicators/vpvr/VpvrIndicator.ts
@@ -41,7 +41,8 @@ export function vpvrLayerData(inputs: Record<string, InputValue>): VpvrLayerData
  * carries lifecycle + settings.
  */
 class VpvrIndicator implements NativeIndicator {
-    private ctx!: NativeIndicatorContext;
+    /** Null until start() — pre-start setInputs/resume must record without pushing. */
+    private ctx: NativeIndicatorContext | null = null;
     private inputs: Record<string, InputValue> = {};
 
     start(ctx: NativeIndicatorContext, inputs: Record<string, InputValue>): void {
@@ -59,14 +60,18 @@ class VpvrIndicator implements NativeIndicator {
 
     setInputs(inputs: Record<string, InputValue>): void {
         this.inputs = inputs;
-        this.ctx.pushData(vpvrLayerData(inputs));
+        // Pre-start edits (a workspace restore applies stored inputs the moment the
+        // handle exists) just record: start() pushes the orchestrator's replayed values.
+        this.ctx?.pushData(vpvrLayerData(inputs));
     }
 
     /** Hiding is a renderer-layer flag (set via `setIndicatorVisible`); no resources to free. */
     suspend(): void {}
 
     resume(): void {
-        this.ctx.pushData(vpvrLayerData(this.inputs));
+        // Pre-start resume (a restore un-hiding an indicator that never started) is a
+        // no-op — start() pushes when the context lands.
+        this.ctx?.pushData(vpvrLayerData(this.inputs));
     }
 
     stop(): void {}

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -322,7 +322,7 @@ export class ChartCell {
                 // A RESTORED ledger is authoritative for the auto-added volume too: a
                 // slot persisted without it must come back without it (fresh slots
                 // keep the workspace default).
-                volume: seed.indicators ? seed.indicators.natives.includes('volume') : deps.volume,
+                volume: seed.indicators ? (seed.indicators.natives as LedgerNativeEntry[]).some((e) => ledgerNativeType(e) === 'volume') : deps.volume,
                 nativeBackend: deps.nativeBackend,
                 // The user's drawings option minus its toolbar: one SHARED bar serves
                 // the whole workspace (per-cell bars would cost a 44px gutter each).

--- a/test/chart-cell-persistence.test.ts
+++ b/test/chart-cell-persistence.test.ts
@@ -112,15 +112,27 @@ class FakeRenderer implements IChartRenderer {
     onPriceStyleChange(_cb: (style: PriceStyle) => void): Unsubscribe {
         return () => {};
     }
-    setNativeData(): void {}
+    nativePushes: Array<[string, unknown]> = [];
+    setNativeData(type: string, data: unknown): void {
+        this.nativePushes.push([type, data]);
+    }
     setIndicatorStatus(): void {}
+}
+
+/** The most recently constructed FakeRenderer (Vela instantiates the class). */
+let lastRenderer: FakeRenderer | null = null;
+class TrackedRenderer extends FakeRenderer {
+    constructor() {
+        super();
+        lastRenderer = this;
+    }
 }
 
 function makeDeps(over: Partial<CellDeps> = {}): CellDeps {
     return {
         feed: new MockDataFeed(),
         engines: {},
-        chartDefaults: { renderer: FakeRenderer, drawings: false } as CellDeps['chartDefaults'],
+        chartDefaults: { renderer: TrackedRenderer, drawings: false } as CellDeps['chartDefaults'],
         theme: DARK_THEME,
         live: false,
         volume: true,
@@ -221,6 +233,25 @@ describe('ChartCell native persistence round-trip (#146/#149)', () => {
         expect(natives).toHaveLength(2);
         expect(aroonOf(cell)!.inputValues().length).toBe(14); // declaration default
         expect(volumeOf(cell)!.visible).toBe(true);
+        cell.destroy();
+    });
+
+    it('un-hiding a RESTORED-HIDDEN native STARTS it (never-started instances must not stay blank)', async () => {
+        // The regression behind the volume/vpvr guards: an indicator restored hidden
+        // never starts (startNativeIndicator bails on hidden records), so the show
+        // path's resume() used to poke a context-less instance — a crash before the
+        // guards, a permanently blank row with guards alone. The orchestrator now
+        // STARTS a never-started instance on show; the layer push proves it ran.
+        const cell = makeCell({
+            indicators: { natives: [{ type: 'volume', hidden: true }], manifest: [] },
+        } as Partial<CellBoot>);
+        await settle();
+        const renderer = lastRenderer!;
+        renderer.nativePushes.length = 0;
+        volumeOf(cell)!.setVisible(true);
+        await settle();
+        expect(volumeOf(cell)!.visible).toBe(true);
+        expect(renderer.nativePushes.some(([type]) => type === 'volume')).toBe(true);
         cell.destroy();
     });
 

--- a/test/chart-cell-persistence.test.ts
+++ b/test/chart-cell-persistence.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+// This jsdom build ships no `CSS` global; the style injector only needs `escape`.
+(globalThis as { CSS?: unknown }).CSS ??= { escape: (v: string) => v };
+
+import { ChartCell, type CellBoot, type CellDeps } from '../src/workspace/ChartCell';
+import type {
+    IChartRenderer,
+    RendererCapabilities,
+    IndicatorRenderHandle,
+    VisibleRange,
+    InputChangeEvent,
+    ClickEvent,
+    CrosshairEvent,
+} from '../src/core/ports/IChartRenderer';
+import type { MarketDataFeed } from '../src/core/ports/MarketDataFeed';
+import type { OHLCV } from '../src/core/model/ohlcv';
+import type { InputValue } from '../src/core/model/inputs';
+import type { IndicatorModel, Pane, ScenePatch } from '../src/core/model';
+import type { PriceStyle } from '../src/core/options';
+import type { Unsubscribe } from '../src/core/util/types';
+import { DARK_THEME } from '../src/core/theme';
+
+/**
+ * The ChartCell persistence round-trip — the layer the unit suite never covered
+ * (dehydrate reads LIVE handles, applyIndicatorLedger converges them): the
+ * regression net for the native settings/visibility persistence work (#146,
+ * #149). The chart runs for real (classic natives compute in-process); only the
+ * renderer and the data feed are fakes, per the orchestrator tests' pattern.
+ */
+
+const FIVE_MIN = 300_000;
+const makeBars = (n: number): OHLCV[] =>
+    Array.from({ length: n }, (_, i) => ({
+        time: 1_700_000_000_000 + i * FIVE_MIN,
+        open: 100 + i,
+        high: 101 + i,
+        low: 99 + i,
+        close: 100.5 + i,
+        volume: 10 + i,
+    }));
+
+class MockDataFeed implements MarketDataFeed {
+    load(): Promise<OHLCV[]> {
+        return Promise.resolve(makeBars(60));
+    }
+    subscribe(): Unsubscribe {
+        return () => {};
+    }
+}
+
+/** Minimal renderer: records mounts/visibility, honors nothing visual. */
+class FakeRenderer implements IChartRenderer {
+    readonly capabilities: RendererCapabilities = {
+        panes: true,
+        paneManagement: false,
+        fills: 'primitive',
+        bgcolor: 'primitive',
+        hline: 'native',
+        markers: true,
+        barcolor: 'approximated',
+        perPointColor: true,
+        drawings: true,
+        userDrawings: false,
+        tables: true,
+        inputsUI: true,
+    };
+    readonly name = 'fake';
+    readonly features: readonly string[] = [];
+    mount(): void {}
+    setTheme(): void {}
+    resize(): void {}
+    applyFeature(): void {}
+    readFeature(): unknown {
+        return undefined;
+    }
+    destroy(): void {}
+    setBars(): void {}
+    updateBar(): void {}
+    ensurePane(_p: Pane): void {}
+    removePane(): void {}
+    mountIndicator(model: IndicatorModel): IndicatorRenderHandle {
+        return { id: model.id };
+    }
+    updateIndicator(_h: IndicatorRenderHandle, _p: ScenePatch): void {}
+    removeIndicator(): void {}
+    setIndicatorInputs(_h: IndicatorRenderHandle, _v: Record<string, InputValue>): void {}
+    setIndicatorVisible(_h: IndicatorRenderHandle, _v: boolean): void {}
+    onInputChange(_cb: (e: InputChangeEvent) => void): Unsubscribe {
+        return () => {};
+    }
+    onRemoveIndicator(_cb: (id: string) => void): Unsubscribe {
+        return () => {};
+    }
+    onToggleIndicatorVisible(_cb: (id: string, visible: boolean) => void): Unsubscribe {
+        return () => {};
+    }
+    onCrosshairMove(_cb: (e: CrosshairEvent) => void): Unsubscribe {
+        return () => {};
+    }
+    onClick(_cb: (e: ClickEvent) => void): Unsubscribe {
+        return () => {};
+    }
+    getVisibleRange(): VisibleRange | null {
+        return null;
+    }
+    setVisibleRange(): void {}
+    onViewportChange(_cb: (r: VisibleRange) => void): Unsubscribe {
+        return () => {};
+    }
+    onPriceStyleChange(_cb: (style: PriceStyle) => void): Unsubscribe {
+        return () => {};
+    }
+    setNativeData(): void {}
+    setIndicatorStatus(): void {}
+}
+
+function makeDeps(over: Partial<CellDeps> = {}): CellDeps {
+    return {
+        feed: new MockDataFeed(),
+        engines: {},
+        chartDefaults: { renderer: FakeRenderer, drawings: false } as CellDeps['chartDefaults'],
+        theme: DARK_THEME,
+        live: false,
+        volume: true,
+        statusline: false,
+        watermark: false,
+        nativeBackend: 'canvas2d',
+        dialogHost: document.body,
+        timezone: () => 'Etc/UTC',
+        setTimezone: () => {},
+        context: () => ({}) as never,
+        manifestSettled: () => true,
+        activate: () => {},
+        multiCell: () => false,
+        isMaximized: () => false,
+        toggleMaximize: () => {},
+        cellDragTarget: () => null,
+        previewDropTarget: () => {},
+        dropCell: () => {},
+        onMarketChanged: () => {},
+        onPriceStyleChanged: () => {},
+        onIndicatorsChanged: () => {},
+        onStatusPrefsChanged: () => {},
+        onStateDirty: () => {},
+        toast: () => {},
+        ...over,
+    };
+}
+
+const SEED: CellBoot = {
+    symbol: 'BINANCE:BTCUSDT',
+    timeframe: '60',
+    priceStyle: 'candles',
+} as CellBoot;
+
+function makeCell(seed: Partial<CellBoot> = {}, deps: Partial<CellDeps> = {}): ChartCell {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    return new ChartCell('c1', host, { ...SEED, ...seed } as CellBoot, makeDeps(deps));
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 20));
+
+const aroonOf = (cell: ChartCell) => cell.chart.indicators().find((h) => h.nativeType === 'aroon');
+const volumeOf = (cell: ChartCell) => cell.chart.indicators().find((h) => h.nativeType === 'volume');
+
+describe('ChartCell native persistence round-trip (#146/#149)', () => {
+    it('a stored-input seed boots WITHOUT computing against unloaded bars (the #149 crash) and applies values + hidden', async () => {
+        // Pre-#149 this threw inside the constructor: applyNativeLedgerEntry called
+        // setInputs before start(), and ClassicIndicator.recompute read bars off a
+        // null context — killing workspace boot.
+        const cell = makeCell({
+            indicators: { natives: [{ type: 'volume', hidden: true }, { type: 'aroon', inputs: { length: 50 } }], manifest: [] },
+        } as Partial<CellBoot>);
+        await settle();
+        const aroon = aroonOf(cell)!;
+        expect(aroon.inputValues().length).toBe(50);
+        expect(aroon.visible).toBe(true);
+        expect(volumeOf(cell)!.visible).toBe(false);
+        cell.destroy();
+    });
+
+    it('dehydrate captures the live deltas and hidden flags; defaults collapse to bare types', async () => {
+        const cell = makeCell({ indicators: { natives: ['volume', 'aroon'], manifest: [] } } as Partial<CellBoot>);
+        await settle();
+        aroonOf(cell)!.setInput('length', 50);
+        volumeOf(cell)!.setVisible(false);
+        const led = cell.dehydrate().indicators!;
+        expect(led.natives).toEqual([{ type: 'volume', hidden: true }, { type: 'aroon', inputs: { length: 50 } }]);
+        cell.destroy();
+    });
+
+    it('rehydrate converges a DRIFTED chart back to the document', async () => {
+        const cell = makeCell({ indicators: { natives: ['volume', 'aroon'], manifest: [] } } as Partial<CellBoot>);
+        await settle();
+        const saved = {
+            ...SEED,
+            indicators: { natives: [{ type: 'volume', hidden: true }, { type: 'aroon', inputs: { length: 50 } }], manifest: [] },
+        };
+        // Drift the live chart away from the document…
+        aroonOf(cell)!.setInput('length', 21);
+        volumeOf(cell)!.setVisible(true);
+        // …and the document wins on rehydrate.
+        cell.rehydrate(saved as never);
+        await settle();
+        expect(aroonOf(cell)!.inputValues().length).toBe(50);
+        expect(volumeOf(cell)!.visible).toBe(false);
+        cell.destroy();
+    });
+
+    it('a LEGACY bare-string ledger resets to declaration defaults, visible, without duplicating', async () => {
+        const cell = makeCell({
+            indicators: { natives: [{ type: 'volume', hidden: true }, { type: 'aroon', inputs: { length: 50 } }], manifest: [] },
+        } as Partial<CellBoot>);
+        await settle();
+        cell.rehydrate({ ...SEED, indicators: { natives: ['volume', 'aroon'], manifest: [] } } as never);
+        await settle();
+        const natives = cell.chart.indicators().filter((h) => h.nativeType !== undefined);
+        expect(natives).toHaveLength(2);
+        expect(aroonOf(cell)!.inputValues().length).toBe(14); // declaration default
+        expect(volumeOf(cell)!.visible).toBe(true);
+        cell.destroy();
+    });
+
+    it('the legend eye marks the cell state dirty (the save trigger for visibility)', async () => {
+        const onStateDirty = vi.fn();
+        const cell = makeCell({ indicators: { natives: ['aroon'], manifest: [] } } as Partial<CellBoot>, { onStateDirty });
+        await settle();
+        onStateDirty.mockClear();
+        aroonOf(cell)!.setVisible(false);
+        await settle();
+        expect(onStateDirty).toHaveBeenCalled();
+        cell.destroy();
+    });
+});


### PR DESCRIPTION
Follow-up to #146/#149: the dehydrate/rehydrate layer had no automated coverage (the repo's shell-verification convention), which is exactly where the #149 boot crash lived. This adds a jsdom harness that boots a REAL ChartCell — real chart, real classic natives computing in-process — with only the renderer and data feed faked, per the orchestrator tests' injection pattern.

Five regressions locked:
- a stored-input seed boots without computing against unloaded bars (the #149 crash) and applies values + hidden
- dehydrate captures live deltas and hidden flags, defaults collapse to bare types
- rehydrate converges a drifted chart back to the document
- a legacy bare-string ledger resets to declaration defaults without duplicating
- the legend eye marks the cell state dirty (the visibility save trigger)

The harness immediately caught two more crashes of the #149 family: VolumeIndicator.resume and Vpvr/Volume setInputs dereference ctx before start(), so un-hiding (or editing) an indicator that was restored hidden and never started crashed. Both guarded the same way as ClassicIndicator (record, let start() push the replayed values).

Also: the constructor's volume auto-add intent now reads object-form ledger entries (natives.includes('volume') missed {type:'volume',hidden:true}; benign because the seed loop re-added it, but the intent read was wrong).

jsdom lands as a devDependency (first DOM-environment test in the repo); a two-line CSS.escape polyfill covers the style injector. Full suite 1582 green, tsc and lint clean.