### PR TITLE
Let a native indicator opt out of the legend with legend: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Native indicators can opt out of the legend.** A native indicator registered with
+  `legend: false` paints its output with no in-chart chrome: no legend row (no title
+  chip, no eye/gear/✕, not counted by the fold chip) and no entry in `panes.list()`, so
+  the object tree shows nothing either. It is for host-owned overlays — journal trade
+  markers, event flags — whose on/off switch lives in the host's own UI; the host keeps
+  controlling the indicator through its handle. Hidden indicators are unchanged: they
+  keep their row so the user can unhide them.
+
 ## [v0.6.22]
 
 ### Fixed

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -156,6 +156,15 @@ carry several instances (a study users stack at different settings); every add t
 creates a fresh instance. A type that pushes a bespoke layer payload through `pushData`
 must stay single-instance — the renderer's native layer is keyed by type.
 
+A native that is really **host-owned chrome** — trade markers from a journal, event flags,
+anything whose on/off switch lives in the host's own UI — can opt out of in-chart chrome with
+`legend: false` on the descriptor. Its output still computes and paints, but the chart mounts
+no legend row for it (no title chip, no eye/gear/✕, not counted by the fold chip) and
+`panes.list()` does not report it, so the object tree shows nothing either. The host controls
+it through the `IndicatorHandle` it got from `addNativeIndicator` (`remove()`, `setVisible()`).
+This is different from hiding: a hidden indicator keeps its row so the user can unhide it; a
+legend-less one has no row to begin with.
+
 A native whose visuals come entirely from a bespoke renderer layer (its `type` equals a
 registered layer id) can override the axis of the pane it OWNS by emitting **`paneAxis`**
 on its output: such content is not value-mapped (the layer paints in pixel bands), so a

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1612,6 +1612,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             overlay: d.overlay,
             paneHint: d.paneHint,
             native: { type: record.native!.type },
+            ...(d.legend === false ? { legend: false } : {}),
             ...(out.paneAxis != null ? { paneAxis: out.paneAxis } : {}),
             series: out.series ?? [],
             fills: out.fills ?? [],
@@ -1739,6 +1740,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         for (const r of this.registry.all()) {
             const model = r.model;
             if (!model) continue;
+            if (model.legend === false) continue; // host-owned chrome: no row anywhere, the handle is the control
             const paneId = model.paneId ?? 'price';
             if (!byPane.has(paneId)) byPane.set(paneId, []);
             byPane.get(paneId)!.push({

--- a/src/core/model/indicator.ts
+++ b/src/core/model/indicator.ts
@@ -51,6 +51,8 @@ export interface IndicatorModel {
      * (distinct title color) + list ordering (native indicators pin to the top).
      */
     native?: { type: string };
+    /** `false` ⇒ no legend row and no pane listing for this indicator (host-owned chrome); absent ⇒ a row. */
+    legend?: boolean;
     /**
      * Value-axis override for the pane this indicator OWNS — declared by content that is
      * not value-mapped (e.g. a bespoke renderer layer painting in pixel bands), where a

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -103,6 +103,15 @@ export interface NativeIndicatorDescriptor {
     /** Marks the type as beta — surfaced in the catalog so a host "add indicator" UI can badge it. */
     readonly beta?: boolean;
     /**
+     * Whether instances get in-chart chrome. Absent ⇒ a legend row like any indicator.
+     * `false` ⇒ the output paints, but there is NO legend row (no title chip, no eye/gear/✕,
+     * uncounted by the fold chip) and `panes.list()` does not report it — for host-owned
+     * overlays (trade markers, event flags) whose on/off lives in the host's own UI. Distinct
+     * from hidden: a legend-less indicator still computes and paints; the host controls it
+     * through its handle.
+     */
+    readonly legend?: boolean;
+    /**
      * Allow several instances of this type on one chart — every add creates a new one (a study
      * like a moving average is typically stacked at different lengths). Absent ⇒ SINGLE instance
      * per type: a second add returns the existing handle. A type that pushes a bespoke layer

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -2019,11 +2019,14 @@ export class NativeRenderer implements IChartRenderer {
         if (model.native && this.extLayers.some((l) => l.def.id === model.native!.type)) this.scene.assignIndicatorZTop(model.id);
         else this.scene.assignIndicatorZ(model.id);
         // The legend chip, the settings dialog and the object tree's rows all show the compact
-        // shorttitle when declared; the full title stays on the picker and inspect().
-        this.inputsUI.upsert(model.id, model.shorttitle ?? model.title, model.inputs, model.inputValues, model.paneId, {
-            native: !!model.native,
-            ...(model.props ? { props: model.props, propValues: model.propValues ?? {} } : {}),
-        });
+        // shorttitle when declared; the full title stays on the picker and inspect(). A
+        // `legend: false` native gets none of it — the scene model still mounts and paints.
+        if (model.legend !== false) {
+            this.inputsUI.upsert(model.id, model.shorttitle ?? model.title, model.inputs, model.inputValues, model.paneId, {
+                native: !!model.native,
+                ...(model.props ? { props: model.props, propValues: model.propValues ?? {} } : {}),
+            });
+        }
         if (model.native?.type === 'volume') {
             this.volumeActive = true; // the volume layer follows the indicator's presence
             this.volumeHidden = false;
@@ -3710,7 +3713,8 @@ export class NativeRenderer implements IChartRenderer {
         const map = new Map<string, string | null>();
         for (const pane of this.scene.panes.values()) {
             if (!pane.collapsed) continue;
-            const models = this.scene.orderedIndicatorsForPane(pane.id);
+            // Only models with a legend row can front a collapsed strip.
+            const models = this.scene.orderedIndicatorsForPane(pane.id).filter((m) => m.legend !== false);
             const merged = new Set(this.scene.ownScaleIndicatorsForPane(pane.id).map((m) => m.id));
             const master = models.find((m) => !merged.has(m.id)) ?? models[0];
             map.set(pane.id, master?.id ?? null);

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -2447,3 +2447,60 @@ describe('EngineOrchestrator — force_overlay routing', () => {
         chart.destroy();
     });
 });
+
+describe('native indicators — legend: false (host-owned chrome)', () => {
+    const legendless: NativeIndicatorDescriptor = {
+        ...testNativeDescriptor,
+        type: 'test-native-legendless',
+        title: 'Host markers',
+        legend: false,
+        create: () => new TestNativeIndicator(),
+    };
+    afterEach(() => unregisterNativeIndicator(legendless.type));
+
+    async function makeChart(): Promise<{ chart: Vela; renderer: FakeRenderer }> {
+        registerNativeIndicator(legendless);
+        const renderer = new FakeRenderer();
+        const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [], dataFeed: new MockDataFeed() });
+        await chart.ready();
+        await flush();
+        return { chart, renderer };
+    }
+
+    it('paints its output but mounts with no legend row and no pane listing', async () => {
+        const { chart, renderer } = await makeChart();
+        const handle = chart.addNativeIndicator(legendless.type);
+        await flush();
+        const model = renderer.mountedModels.find((m) => m.id === handle.id);
+        expect(model).toBeDefined();
+        expect(model!.legend).toBe(false); // the renderer skips the legend row on this flag
+        expect(model!.series).toHaveLength(1); // the output still reaches the scene
+        expect(chart.panes.list().flatMap((p) => p.indicators.map((i) => i.id))).not.toContain(handle.id);
+    });
+
+    it('the host still controls it through its handle', async () => {
+        const { chart, renderer } = await makeChart();
+        const handle = chart.addNativeIndicator(legendless.type);
+        await flush();
+        handle.setVisible(false);
+        await flush();
+        expect(renderer.indicatorVisible.get(handle.id)).toBe(false);
+        handle.remove();
+        await flush();
+        expect(renderer.removed).toContain(handle.id);
+        expect(chart.inspect().indicators.some((s) => s.id === handle.id)).toBe(false);
+    });
+
+    it('an ordinary native keeps its legend row and pane listing', async () => {
+        const { chart, renderer } = await makeChart();
+        registerNativeIndicator(testNativeDescriptor);
+        try {
+            const handle = chart.addNativeIndicator(testNativeDescriptor.type);
+            await flush();
+            expect(renderer.mountedModels.find((m) => m.id === handle.id)!.legend).toBeUndefined();
+            expect(chart.panes.list().flatMap((p) => p.indicators.map((i) => i.id))).toContain(handle.id);
+        } finally {
+            unregisterNativeIndicator(testNativeDescriptor.type);
+        }
+    });
+});


### PR DESCRIPTION
## What

A native indicator registered with `legend: false` paints its output with no in-chart chrome: no legend row (no title chip, no eye/gear/✕, not counted by the fold chip) and no entry in `panes.list()`, so the object tree shows nothing either. It is for host-owned overlays such as journal trade markers and event flags, whose on/off switch lives in the host's own UI; the host keeps controlling the indicator through its `IndicatorHandle`.

## How

- `NativeIndicatorDescriptor.legend?: boolean`, projected onto `IndicatorModel.legend` in `buildNativeModel`, so both the live emit path and the hidden-row path carry it.
- `NativeRenderer.mountIndicator` skips the legend `upsert` on the flag; the scene model still mounts and paints. Remove, visibility, and pane moves are already no-ops for an unknown legend row.
- `EngineOrchestrator.listPanes` leaves it out, and a legend-less model can never front a collapsed pane strip.
- Hidden semantics are unchanged: a hidden indicator keeps its row so the user can unhide it; a legend-less one never had a row.

Design call worth a look: hiding it from `panes.list()` (and so the object tree) rather than listing it with a gear that opens nothing.

## Verification

- Gate: typecheck, lint, test (1597), build.
- Tests: a `legend: false` native mounts with output and no pane listing; the host still controls it through its handle; an ordinary native keeps its row and listing.
- Playground: a `legend: false` probe painted its line with no legend text and no pane listing, while a control native beside it got its row; both still appear in `inspect()`.

## Docs

Native indicators section of `docs/contributing/plugin-sdk.md`; changelog under Unreleased.