### PR TITLE
Add timeline marks — host events pinned to bars, with a popup and an Events settings tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Added
+
+- **Timeline marks — events on the chart.** `chart.marks` pins host events (dividends,
+  splits, earnings, news, releases…) to the bar they belong to and shows them as small
+  outlined tokens — a letter or an icon in the event's color — on a lane just above the
+  time axis. A token swells briefly under the pointer and fills with its color while its
+  popup is open. Clicking one opens a popup centered on the token, with a short fade,
+  showing the event's title and details: plain text, formatted HTML (sanitized), or a
+  panel of fields and buttons — and the details can load on demand. Several events of
+  one kind on the same bar fold into one slightly larger token that lists them all;
+  events of different kinds on one bar stack into a small deck that fans out on hover
+  (or a tap) so each can be opened. Marks follow the bars: switch timeframes and they
+  re-snap and regroup. Every kind of event gets its own checkbox on a new **Events** tab
+  of the chart settings, and the choice is saved with the chart. Hosts hear every click
+  through the new `mark:click` event, and the playground pages carry a sample set.
+- **Popovers can center on their trigger and fade.** The UI kit's `Popover` accepts
+  `align: 'center'` and a `fadeMs` duration for a short fade in and out — what the
+  timeline-mark popup uses.
+
 ## [v0.6.22]
 
 ### Fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Each layer ships with a **bundled default backend** that you can replace. One nu
 
 The documentation is grouped by what you are trying to do.
 
-- **User** — get a chart rendering and drive it from your app: [Quickstart](user/quickstart.md), [The workspace](user/workspace.md) (single chart or a multi-chart grid), [Options](user/options.md), [API reference](user/api-reference.md), [Drawing tools](user/drawing-tools.md), [Renderer features](user/renderer-features.md), [Data providers](user/data-providers.md), [Scripting engines](user/scripting-engines.md), [Examples](user/examples.md), [FAQ](user/faq.md).
+- **User** — get a chart rendering and drive it from your app: [Quickstart](user/quickstart.md), [The workspace](user/workspace.md) (single chart or a multi-chart grid), [Options](user/options.md), [API reference](user/api-reference.md), [Drawing tools](user/drawing-tools.md), [Timeline marks](user/timeline-marks.md), [Renderer features](user/renderer-features.md), [Data providers](user/data-providers.md), [Scripting engines](user/scripting-engines.md), [Examples](user/examples.md), [FAQ](user/faq.md).
 - **Architecture** — understand the core, the three layers, the neutral model, and how data flows: [Overview](architecture/overview.md), [Data flow](architecture/data-flow.md), and the [decision records](architecture/adr/README.md).
 - **Contributing** — set up the project and extend Vela™: the [plugin SDK](contributing/plugin-sdk.md) (chart types, renderer layers, widget actions — no fork needed), or extend a layer behind its port in-repo: add a [renderer](contributing/adding-a-renderer.md), an [engine](contributing/adding-an-engine.md), a [data provider](contributing/adding-a-data-provider.md), a [drawing tool](contributing/adding-a-drawing-tool.md), or a [UI-kit component](contributing/adding-a-ui-component.md).
 
@@ -53,6 +53,7 @@ Pick the path that matches your goal.
 - **"I want to render a headless chart fast"** → [User quickstart](user/quickstart.md)
 - **"I want to run Pine Script indicators"** → [Scripting engines](user/scripting-engines.md)
 - **"I want to draw on the chart"** → [Drawing tools](user/drawing-tools.md)
+- **"I want to pin events — dividends, news, releases — to the chart"** → [Timeline marks](user/timeline-marks.md)
 - **"I want a custom chart type or overlay"** → [Plugin SDK](contributing/plugin-sdk.md)
 - **"I want to grasp the design"** → [Architecture overview](architecture/overview.md)
 - **"I want to add a backend"** → choose the port you're extending:

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -246,6 +246,7 @@ Subscribe with `chart.on(event, handler)`; every subscription returns an unsubsc
 | `bar` | the bar (OHLCV) | A live tick — the forming bar updated or a new bar appended. |
 | `viewport:changed` | `{ from, to }` (epoch-ms) | The visible time range moved (pan/zoom/fit) — fires per applied change, not debounced. The seam viewport-sync links between charts build on. |
 | `theme:changed` | the resolved theme object | The app theme changed — `setTheme(...)` or the in-chart settings dialog (Canvas → Theme). Host chrome around the chart (toolbars, panels, page shells) re-skins from the payload. Plot-only cosmetic edits (a `layout.background` set through the config) do **not** fire it. |
+| `mark:click` | `{ id, ids, time, group? }` | A [timeline mark](#chartmarks--the-timeline-marks-control-surface) glyph was clicked — `ids` lists every mark under it (several marks of one group on one bar fold into a cluster), `id`/`time` its first. Fires before the popup opens; a mark without content opens none, so this is where a host shows its own UI. |
 | `alert` | engine alert | A script raised an alert. |
 | `warning` | engine warning | A script raised a warning. |
 
@@ -372,6 +373,89 @@ Drawing lifecycle is also surfaced as chart events (`drawing:created` / `drawing
 primary `id` plus `ids`, every member of a multi-selection), and the tool/mode state as
 `drawing:tool` / `drawing:snap` / `drawing:stay` / `drawing:mode` — the seam an external toolbar mirrors. See
 [Drawing tools](./drawing-tools.md) for the tool catalogue, toolbar UX, and keyboard shortcuts.
+
+---
+
+## `chart.marks` — the timeline-marks control surface
+
+Host events pinned to a moment in time — dividends, splits, earnings, releases — shown as small
+colored **glyphs on a lane just above the time axis**, each opening a **popup** on click. The model
+is core-owned, so every method works on any renderer; on one without the `timelineMarks`
+capability nothing paints (`supported` reports it). Marks are **data, not user state**: the chart
+never persists them — re-supply them on `market:changed`. What *is* saved with the chart's config
+is each group's visibility (the checkboxes on the chart settings' **Events** tab, which
+appears once marks name groups). The [Timeline marks](./timeline-marks.md) guide walks through
+the whole surface with examples.
+
+| Member | Description |
+|---|---|
+| `supported` | Whether the active renderer paints timeline marks. |
+| `add(mark)` | Add one mark; an existing id is replaced in place. Chainable. |
+| `set(marks)` | Replace the whole set (a market switch). |
+| `remove(id)` · `clear()` | Drop one mark, or all of them. |
+| `all()` | Every mark, in insertion order. |
+| `defineGroup({ id, label, visible? })` | Name a visibility group: the label of its checkbox in settings and its default visibility. A mark may name a group that was never defined — it then shows its capitalized id. |
+| `groups()` | The defined groups, in definition order. |
+| `setGroupVisible(id, visible?)` · `isGroupVisible(id)` | The same switch as the settings checkbox; the choice is persisted with the chart's config. On a renderer without the `marks` feature the setter warns and no-ops. |
+
+A mark is `{ id, time, glyph, title?, tooltip?, group?, content? }`:
+
+- **`time`** is epoch-ms, but the glyph never sits at that exact pixel: it centers on **the bar whose
+  span contains the time**. A time in a gap (a weekend, a closed session) goes to the first bar that
+  follows; one past the newest bar projects onto the extrapolated grid in the right whitespace. Change
+  timeframe and the marks re-snap.
+- **`glyph`** is a colored token — `{ shape?, color, letter? }` (`'circle'` · `'square'` · `'diamond'` ·
+  `'pin'`, one or two characters in auto-contrasted ink) or `{ shape?, color, icon }` with an id from the
+  icon registry (`registerIcon` from `vela/ui`). Icons travel as ids, never inline markup, so a mark
+  payload can come from data.
+- **`content`** is what the popup shows under `title`: `{ text }` (escaped), `{ html }` (sanitized
+  through an allowlist — scripts, styles, frames, event handlers and `javascript:` URLs never reach the
+  page; links open in a new tab), or `{ panel: { items } }` — rows of `text`, `field` (label/value)
+  and `button` (`run`, optional `primary`, `close`). Pass a **function** (sync or async) instead and
+  it resolves when the popup needs it — details fetched on click, one entry at a time as the user
+  scrolls. Without `content` a click only emits `mark:click`.
+- **`group`** folds marks of one kind that land on the same bar into **one slightly larger glyph**
+  listing them all (earliest first); marks of *different* groups on one bar **stack** — a small deck
+  that fans out on hover (or a tap on touch) so each can be opened.
+
+```js
+import { registerIcon, svg16 } from '@luxalgo/vela/ui';
+
+registerIcon('myco.split', svg16('<path d="M8 2v12M3 5l5-3 5 3M3 11l5 3 5-3"/>'));
+
+chart.marks
+    .defineGroup({ id: 'dividends', label: 'Dividends' })
+    .defineGroup({ id: 'splits', label: 'Splits' })
+    .add({
+        id: 'div-2024-06-11',
+        time: Date.UTC(2024, 5, 11),
+        title: 'Dividends',
+        group: 'dividends',
+        glyph: { shape: 'circle', color: '#2962ff', letter: 'D' },
+        tooltip: 'Dividend · $0.01',
+        content: {
+            panel: {
+                items: [
+                    { type: 'field', label: 'Ex-dividend date', value: "Tue 11 Jun '24" },
+                    { type: 'field', label: 'Amount', value: '0.01' },
+                    { type: 'button', label: 'More NVDA dividends', primary: true, run: () => openDividends('NVDA') },
+                ],
+            },
+        },
+    })
+    .add({
+        id: 'split-2024-06-10',
+        time: Date.UTC(2024, 5, 10),
+        title: 'Stock split',
+        group: 'splits',
+        glyph: { icon: 'myco.split', color: '#ff9800' },
+        content: async () => ({ html: await fetchSplitDetails('NVDA') }),
+    });
+
+chart.on('mark:click', ({ id, ids, time }) => { /* ids = every mark under the clicked glyph */ });
+chart.on('market:changed', ({ symbol }) => chart.marks.set(marksFor(symbol)));
+chart.renderer.set('marks', false); // hide the whole lane (`{ groups: { splits: false } }` hides one group)
+```
 
 ---
 

--- a/docs/user/options.md
+++ b/docs/user/options.md
@@ -185,6 +185,11 @@ new VelaWorkspace('#chart', {
       'canvas.grid.horizontal',              //     Horizontal lines toggle + color
       'canvas.theme',                        //   Theme group (Dark/Light)
 
+      // ══ Events tab (timeline marks — present once marks name groups) ═
+      'events',                              // the whole tab
+      'events.groups',                       //   Visible events (one checkbox per mark group)
+      'events.groups.<group-id>',            //     a group's checkbox (the group id, kebab-cased)
+
       // ══ Widget & workspace tabs (shell-contributed) ═══════════════
       'status-line',                         // the whole Status line tab
       'status-line.parts',                   //   Status line group (the five rows below)

--- a/docs/user/renderer-features.md
+++ b/docs/user/renderer-features.md
@@ -90,6 +90,7 @@ Available on every renderer:
 |---|---|---|---|
 | `attribution` | boolean | `true` | The in-chart attribution mark (bottom-left logomark linking to the Vela™ project). Disabling it is allowed only when an equivalent visible attribution is displayed elsewhere on the page (see the repository's [`NOTICE`](../../NOTICE) file). |
 | `settings` | boolean | `false` | An in-chart gear button + dialog to edit a curated slice of the rich config (colors, fonts, scale, timezone) with export/import. |
+| `marks` | boolean or `{ visible?, groups? }` | everything on | The [timeline-mark](./api-reference.md#chartmarks--the-timeline-marks-control-surface) lane above the time axis. `false` hides the lane; `{ groups: { dividends: false } }` hides one group — the same switch as the Events tab's checkboxes, persisted with the config. Partial merge; malformed fields drop. |
 
 > **Pane controls.** Hovering a pane reveals a small button cluster in its top-right corner: move
 > the pane up/down, collapse/expand it, and maximize/restore it. Each indicator's legend row also

--- a/docs/user/timeline-marks.md
+++ b/docs/user/timeline-marks.md
@@ -1,0 +1,309 @@
+# Timeline marks
+
+Pin events to the chart — dividends, splits, earnings, news, releases, deployments, anything
+with a moment in time. Vela™ shows each one as a small **glyph on a lane just above the time
+axis**, snapped to the bar it belongs to, and opens a **popup with the details** when it is
+clicked. The surface is `chart.marks`; it needs no scripting engine.
+
+> **Marks are data, not user state.** The chart never persists them — you re-supply them when
+> the market changes. What the chart *does* save is which kinds of event the user chose to hide
+> (the **Events** tab of the chart settings).
+
+---
+
+## Quick start
+
+```js
+import { Vela } from '@luxalgo/vela';
+
+const chart = new Vela('#chart', { symbol: 'NVDA', timeframe: 'D' });
+
+chart.marks
+    .defineGroup({ id: 'dividends', label: 'Dividends' })
+    .add({
+        id: 'div-2024-06-11',
+        time: Date.UTC(2024, 5, 11),
+        title: 'Dividend',
+        group: 'dividends',
+        glyph: { shape: 'circle', color: '#2962ff', letter: 'D' },
+        tooltip: 'Dividend · $0.01',
+        content: {
+            panel: {
+                items: [
+                    { type: 'field', label: 'Ex-dividend date', value: "Tue 11 Jun '24" },
+                    { type: 'field', label: 'Amount', value: '0.01' },
+                    { type: 'field', label: 'Payment date', value: "Fri 28 Jun '24" },
+                ],
+            },
+        },
+    });
+```
+
+A blue token with a **D** appears above the time axis on the 11 June bar. Hover it for the
+tooltip; click it for the popup. Open the chart settings: an **Events** tab now lists a
+**Dividends** checkbox.
+
+---
+
+## What a mark is
+
+| Field | Required | What it does |
+|---|---|---|
+| `id` | yes | Stable identity. Adding a mark with an existing id **replaces** it in place. |
+| `time` | yes | The moment the event belongs to, in epoch-ms. The glyph never sits at this exact pixel — see [Where a mark lands](#where-a-mark-lands). |
+| `glyph` | yes | How the token looks: `{ shape?, color, letter? }` or `{ shape?, color, icon }` — see [Glyphs](#glyphs). |
+| `title` | no | The popup's heading, whatever form the content takes. |
+| `tooltip` | no | Hover text on the glyph. Without it a lone mark shows its `title`. |
+| `group` | no | The kind of event (`'dividends'`, `'news'`…). Marks of one group on one bar fold together; each group gets a checkbox in settings — see [Groups](#groups-clusters-and-stacks). |
+| `content` | no | What the popup shows — text, sanitized HTML, or a panel; a value or a function resolved on click. Without it a click only emits `mark:click` — see [The popup](#the-popup). |
+
+The full type is `TimelineMark`, exported from `@luxalgo/vela`.
+
+---
+
+## Where a mark lands
+
+A mark's `time` is a moment; the lane shows **bars**. The glyph centers on **the bar whose span
+contains the time**:
+
+- a time inside a bar's `[open, open + interval)` span sits on that bar;
+- a time that falls in a **gap** — a weekend, a closed session — goes to the **first bar after
+  it** (an event dated outside trading hours affects the next traded bar, not the previous one);
+- a time **past the newest bar** projects onto the extrapolated bar grid, in the whitespace to
+  the right of the last candle;
+- a time before the first loaded bar has nothing to anchor to yet — the glyph appears once
+  history backfills that far.
+
+Marks re-snap whenever the bars change: switch the timeframe and three news items 15 minutes
+apart become **three glyphs on a 5-minute chart and one cluster on an hourly chart**.
+
+```js
+const t = Date.UTC(2024, 5, 11, 14, 0);
+chart.marks.defineGroup({ id: 'news', label: 'News' }).set(
+    [0, 15, 30].map((minutes, i) => ({
+        id: `news-${i + 1}`,
+        time: t + minutes * 60_000,
+        title: `News ${i + 1}/3`,
+        group: 'news',
+        glyph: { color: '#26a69a', letter: 'N' },
+        content: { text: `Headline ${i + 1}` },
+    })),
+);
+```
+
+---
+
+## Glyphs
+
+A glyph is a colored token: an outline and a symbol in the mark's `color` on the chart
+background. The token swells briefly when the pointer lands on it, and **fills** with its color
+(white symbol) while its popup is open.
+
+- **`shape`** — `'circle'` (default), `'square'`, `'diamond'`, or `'pin'`.
+- **`color`** — any CSS color; the outline, the symbol, and the filled state all use it.
+- **`letter`** — one or two characters drawn inside the token (`'D'`, `'E'`, `'!'`).
+- **`icon`** — an icon id from the icon registry, drawn inside the token instead of a letter.
+  Register the SVG once, from host code; a mark payload only ever carries the id, so marks can
+  come straight from data without carrying markup.
+
+```js
+import { registerIcon, svg16 } from '@luxalgo/vela/ui';
+
+registerIcon('myco.rocket', svg16('<path d="M9.5 2.5c1.8 0 3.5 1.7 4 4.5l-4 4-4-4c.5-2.8 2.2-4.5 4-4.5z"/><path d="M5.5 7 3 9.5l2 .5.5 2L8 9.5"/>'));
+
+chart.marks.add({
+    id: 'release-2-4',
+    time: Date.UTC(2024, 5, 12, 9, 30),
+    title: 'Release v2.4',
+    group: 'releases',
+    glyph: { shape: 'pin', color: '#7e57c2', icon: 'myco.rocket' },
+    content: { text: 'Deployed v2.4.0 to production.' },
+});
+```
+
+Several marks of one group on one bar share a single, slightly larger token that carries the
+**first** mark's glyph (earliest time, then insertion order).
+
+---
+
+## The popup
+
+Clicking a glyph opens a popup centered on it: the mark's `title`, then its `content`. A cluster
+lists every mark it holds, one section each, in a scrollable panel. The popup closes on an
+outside click or `Escape`.
+
+`content` takes one of three forms:
+
+**Plain text** — rendered as text, never as markup:
+
+```js
+content: { text: 'Special dividend of 0.25, declared the same session.' }
+```
+
+**HTML** — formatting kept, hazards removed. The markup goes through an allowlist: paragraphs,
+emphasis, lists, tables, code, links, and images survive; scripts, styles, frames, forms, event
+handlers (`onclick`…), inline `style`, and `javascript:`/`data:` URLs never reach the page. Links
+open in a new tab with `rel="noopener noreferrer"`; images must have an absolute `http(s)`
+source.
+
+```js
+content: {
+    html: '<b>10-for-1 split</b><br>Effective <i>10 Jun 2024</i> · <a href="https://example.com/filing">Filing</a>',
+}
+```
+
+**A panel** — rows of `field` (label / value), `text`, and `button`. Consecutive buttons share
+one row; `primary` emphasizes a button; a button closes the popup after `run` unless `close:
+false`.
+
+```js
+content: {
+    panel: {
+        items: [
+            { type: 'field', label: 'EPS', value: '6.12 (est. 5.59)' },
+            { type: 'field', label: 'Revenue', value: '26.0B (est. 24.6B)' },
+            { type: 'text', text: 'Beat on both lines; guidance raised for Q2.' },
+            { type: 'button', label: 'Transcript', primary: true, run: () => openTranscript('NVDA', '2024Q1') },
+            { type: 'button', label: 'Dismiss', run: () => undefined },
+        ],
+    },
+}
+```
+
+**On demand** — pass a function (sync or async) returning any of the forms above. It runs when
+the popup needs the section: on click for a lone mark, and for a cluster as each section scrolls
+into view — a cluster of forty marks costs one request per entry actually read. While it
+resolves the section shows *Loading…*; a rejection shows a short error line.
+
+```js
+content: async () => ({ html: await fetchDividendDetails('NVDA', '2024-06-11') }),
+```
+
+---
+
+## Groups, clusters, and stacks
+
+`group` names the **kind** of event. It drives three things.
+
+**Clustering.** Marks of one group that land on the same bar fold into **one cluster glyph** —
+slightly larger than a single mark, carrying the first mark's glyph, and hovering as
+`<Group label> · <count>`. Its popup lists every mark, earliest first.
+
+**Stacking.** Marks of *different* groups on one bar form a **stack**: a small deck showing the
+top group's token with the others peeking out behind it. Hovering the deck fans the tokens out
+vertically so each can be opened; on touch, one tap fans it out and a second tap opens a token.
+Defined groups stack in definition order; groups that were never defined follow, and ungrouped
+marks sit last.
+
+**Visibility.** Every group gets a checkbox on the **Events** tab of the chart settings (under
+*Visible events*), labeled with the group's `label`. Define a group to name it and to choose its
+default:
+
+```js
+chart.marks
+    .defineGroup({ id: 'dividends', label: 'Dividends' })
+    .defineGroup({ id: 'splits', label: 'Splits' })
+    .defineGroup({ id: 'news', label: 'News', visible: false }); // hidden until the user opts in
+```
+
+A mark may name a group you never defined — it then shows its capitalized id (`'splits'` →
+*Splits*). Ungrouped marks have no checkbox and always show.
+
+The user's choice is **persisted with the chart's cosmetic config** (`chart.renderer.getConfig()`
+→ `marks.groups`), so it survives a reload and rides workspace templates. A stored choice for a
+group the host has not registered yet is kept verbatim until that group shows up. The same
+switch is available from code:
+
+```js
+chart.marks.setGroupVisible('news', false);
+chart.marks.isGroupVisible('news'); // false — the stored choice, else the group's declared default, else true
+
+chart.renderer.set('marks', false); // hide the whole lane
+chart.renderer.set('marks', { groups: { splits: false } }); // the settings checkbox, from code
+```
+
+---
+
+## Reacting to clicks
+
+Every click on a glyph emits `mark:click` with the mark's `id`, the `ids` of every mark under
+the glyph (a cluster lists them all), the first mark's `time`, and the `group`. It fires
+**before** the popup opens — and a mark **without `content` opens nothing**, so a host that
+wants its own UI simply omits the content and listens:
+
+```js
+chart.marks.add({
+    id: 'alert-42',
+    time: Date.UTC(2024, 5, 13, 15, 30),
+    glyph: { shape: 'diamond', color: '#e0b400', letter: '!' },
+    tooltip: 'Open in the alerts panel',
+});
+
+chart.on('mark:click', ({ id, ids, time, group }) => {
+    if (id === 'alert-42') alertsPanel.open(id);
+});
+```
+
+A content-less token still fills briefly when clicked, so the click reads as acknowledged.
+
+---
+
+## Keeping marks in sync with the market
+
+The chart keeps the marks you gave it across timeframe changes (they re-snap) but has no idea
+which events belong to which symbol. Replace the set when the market changes:
+
+```js
+async function showEventsFor(symbol) {
+    const events = await api.corporateEvents(symbol); // your source
+    chart.marks.set(events.map(toMark));
+}
+
+await chart.ready();
+showEventsFor(chart.market.symbol);
+chart.on('market:changed', ({ symbol }) => showEventsFor(symbol));
+```
+
+`set` replaces everything (and closes an open popup); `add`, `remove`, and `clear` edit in place;
+`all()` returns the current set in insertion order.
+
+In a **workspace**, every cell is its own chart — seed the cells alive now and the ones a later
+layout switch mints:
+
+```js
+const seed = (chart) => void chart.ready().then(() => showEventsFor(chart));
+for (const cell of ws.cells()) seed(cell.chart);
+ws.on('cell:created', ({ id }) => seed(ws.cell(id).chart));
+```
+
+---
+
+## Settings ids and renderer support
+
+The Events tab, its section, and every checkbox carry settings ids, so a host can hide them like
+any other setting: `settings: { hidden: ['events'] }` removes the tab, `'events.groups.<group-id>'`
+one row (the group id, kebab-cased). The tab is present only while marks name groups. See
+[Options](./options.md#the-settings-option--hiding-settings-dialog-entries) for the full catalog.
+
+Timeline marks are a **native-renderer** capability (`capabilities.timelineMarks`).
+`chart.marks.supported` reports it; on a renderer without it the model still fills — `all()`
+works — but nothing paints and `setGroupVisible` warns and no-ops.
+
+---
+
+## API summary
+
+| Member | Description |
+|---|---|
+| `chart.marks.add(mark)` | Add one mark; an existing id is replaced. Chainable. |
+| `chart.marks.set(marks)` | Replace the whole set. |
+| `chart.marks.remove(id)` · `clear()` | Drop one mark, or all. |
+| `chart.marks.all()` | Every mark, in insertion order. |
+| `chart.marks.defineGroup({ id, label, visible? })` | Name a group and choose its default visibility. |
+| `chart.marks.groups()` | The defined groups, in definition order. |
+| `chart.marks.setGroupVisible(id, visible?)` · `isGroupVisible(id)` | The settings checkbox, from code. |
+| `chart.marks.supported` | Whether the active renderer paints marks. |
+| `chart.renderer.set('marks', …)` | The lane's display state: `false`/`true`, or `{ visible?, groups? }`. |
+| `chart.on('mark:click', cb)` | `{ id, ids, time, group? }` on every glyph click. |
+
+The type-level detail lives in the [API reference](./api-reference.md#chartmarks--the-timeline-marks-control-surface).

--- a/playground/marks.ts
+++ b/playground/marks.ts
@@ -1,0 +1,145 @@
+// Sample timeline marks for the playground pages — the `chart.marks` surface exercised end
+// to end: a dividends cluster and a split stacked on one bar (hover the deck, or tap it on
+// touch, to fan them out), an earnings panel, a release with a custom icon whose details
+// load on click, an ungrouped note, an event-only mark (no popup — only `mark:click`), and
+// a scheduled one near the right edge. Marks are pinned to TIMES, spread over the chart's
+// visible range when applied, so they land on any timeframe: switch timeframes and watch
+// them re-snap onto the containing bars and fold together as bars widen — the three news
+// items sit 15 minutes apart: three glyphs on a 5m or 15m chart, one cluster from 1h up.
+import type { Vela, TimelineMark } from '../src';
+import { registerIcon, svg16 } from '../src/ui';
+
+// Marks reference icons by id — the host registers the SVG once; a mark never carries markup.
+registerIcon('play.rocket', svg16('<path d="M9.5 2.5c1.8 0 3.5 1.7 4 4.5l-4 4-4-4c.5-2.8 2.2-4.5 4-4.5z"/><path d="M5.5 7 3 9.5l2 .5.5 2L8 9.5"/>'));
+
+/** Charts whose `mark:click` is already echoed to the console (re-applying never double-subscribes). */
+const wired = new WeakSet<Vela>();
+
+/** Spread the sample marks over `chart`'s visible range — call once the chart is ready. */
+export function addSampleMarks(chart: Vela): void {
+    const range = chart.getVisibleRange();
+    if (!range) return;
+    const span = range.to - range.from;
+    const at = (fraction: number): number => Math.round(range.from + span * fraction);
+
+    const marks: TimelineMark[] = [
+        {
+            id: 'note-1',
+            time: at(0.2),
+            title: 'Note',
+            glyph: { shape: 'circle', color: '#787b86', letter: 'i' },
+            tooltip: 'An ungrouped note',
+            content: { text: 'Ungrouped marks have no checkbox in settings — they always show.' },
+        },
+        {
+            id: 'alert-1',
+            time: at(0.3),
+            glyph: { shape: 'diamond', color: '#e0b400', letter: '!' },
+            tooltip: 'Event-only mark — see the console',
+            // No content: a click only emits `mark:click` (the host owns the UI).
+        },
+        {
+            id: 'div-1',
+            time: at(0.42),
+            title: 'Dividends',
+            group: 'dividends',
+            glyph: { shape: 'circle', color: '#2962ff', letter: 'D' },
+            tooltip: 'Dividend · 0.01',
+            content: {
+                panel: {
+                    items: [
+                        { type: 'field', label: 'Ex-dividend date', value: "Tue 11 Jun '24" },
+                        { type: 'field', label: 'Amount', value: '0.01' },
+                        { type: 'field', label: 'Payment date', value: "Fri 28 Jun '24" },
+                        { type: 'button', label: 'More dividends', primary: true, run: () => console.log('[marks] more dividends') },
+                    ],
+                },
+            },
+        },
+        {
+            id: 'div-2',
+            time: at(0.42) + 1000, // the same bar as div-1 on any timeframe ⇒ one cluster glyph listing both
+            title: 'Special dividend',
+            group: 'dividends',
+            glyph: { color: '#2962ff', letter: 'D' },
+            content: { text: 'Special dividend of 0.25, declared the same session.' },
+        },
+        {
+            id: 'split-1',
+            time: at(0.42), // another group on that bar ⇒ a deck that fans out on hover / tap
+            title: 'Stock split',
+            group: 'splits',
+            glyph: { shape: 'square', color: '#ff9800', letter: 'S' },
+            tooltip: 'Split 10:1',
+            content: {
+                // HTML is sanitized: the script never runs, the link opens in a new tab.
+                html: '<b>10-for-1 split</b><br>Effective <i>10 Jun 2024</i> · <a href="https://example.com/filing">Filing</a><script>alert("never")</script>',
+            },
+        },
+        {
+            id: 'earn-1',
+            time: at(0.63),
+            title: 'Earnings · Q1',
+            group: 'earnings',
+            glyph: { shape: 'diamond', color: '#089981', letter: 'E' },
+            tooltip: 'Earnings call',
+            content: {
+                panel: {
+                    items: [
+                        { type: 'field', label: 'EPS', value: '6.12 (est. 5.59)' },
+                        { type: 'field', label: 'Revenue', value: '26.0B (est. 24.6B)' },
+                        { type: 'text', text: 'Beat on both lines; guidance raised for Q2.' },
+                        { type: 'button', label: 'Transcript', run: () => console.log('[marks] transcript') },
+                        { type: 'button', label: 'Dismiss', run: () => undefined },
+                    ],
+                },
+            },
+        },
+        ...[0, 1, 2].map(
+            (i): TimelineMark => ({
+                id: `news-${i + 1}`,
+                time: at(0.72) + i * 15 * 60_000, // 15 minutes apart: one cluster on 1h, three glyphs on 15m
+                title: `News ${i + 1}/3`,
+                group: 'news',
+                glyph: { shape: 'circle', color: '#26a69a', letter: 'N' },
+                tooltip: `News item ${i + 1}`,
+                content: {
+                    text: ['Regulator opens a consultation on listing rules.', 'The exchange schedules its quarterly fee review.', 'Market-maker program extended through Q4.'][i]!,
+                },
+            }),
+        ),
+        {
+            id: 'rel-1',
+            time: at(0.8),
+            title: 'Release v2.4',
+            group: 'releases',
+            glyph: { shape: 'pin', color: '#7e57c2', icon: 'play.rocket' },
+            tooltip: 'Release — details load on click',
+            content: async () => {
+                await new Promise((resolve) => setTimeout(resolve, 600)); // fetched on demand
+                return { html: '<p>Deployed <code>v2.4.0</code> to production.</p><p>Rollout: 100% of regions.</p>' };
+            },
+        },
+        {
+            id: 'sched-1',
+            time: at(0.985),
+            title: 'Scheduled',
+            glyph: { shape: 'pin', color: '#0ea5e9', letter: 'M' },
+            tooltip: 'Maintenance window',
+            content: { text: 'Exchange maintenance window (announced). Past the newest bar a mark sits on the projected grid.' },
+        },
+    ];
+
+    chart.marks
+        .defineGroup({ id: 'dividends', label: 'Dividends' })
+        .defineGroup({ id: 'splits', label: 'Splits' })
+        .defineGroup({ id: 'earnings', label: 'Earnings' })
+        .defineGroup({ id: 'news', label: 'News' })
+        .defineGroup({ id: 'releases', label: 'Releases' })
+        .set(marks);
+
+    if (!wired.has(chart)) {
+        wired.add(chart);
+        chart.on('mark:click', (e) => console.log('[marks] click', e));
+    }
+}

--- a/playground/widget.ts
+++ b/playground/widget.ts
@@ -16,6 +16,7 @@
 // …which is exactly what the addon's own playground does (repos/Vela-pinets, port 5192).
 import { VelaWorkspace } from '../src/workspace';
 import { BinanceProvider } from '../src/data/providers/binance';
+import { addSampleMarks } from './marks';
 import { DemoEngine, DEMO_SCRIPTS } from './demo-engine';
 import { playgroundStorage } from './persistence';
 
@@ -86,6 +87,10 @@ const ws = new VelaWorkspace('#chart', {
 });
 
 void ws.chart.ready().then(() => console.log('[vela-dev] chart ready'));
+
+// Sample timeline marks (chart.marks) — see marks.ts: a cluster, a fanning stack, a custom
+// icon with details loaded on click… spread over the visible range once the chart painted.
+void ws.chart.ready().then(() => addSampleMarks(ws.chart));
 
 // The page shell follows the app theme — flip it from chart settings → Canvas → Theme
 // (or `ws.setTheme('light')` in the console) and the body around the chart follows.

--- a/playground/workspace.ts
+++ b/playground/workspace.ts
@@ -6,10 +6,12 @@
 // Vela ships no scripting engine — `demo-engine.ts` is the page's own, written against
 // the public port (see widget.ts's header). For Pine Script:
 // `npm i @luxalgo/vela-pinets pinets` and `engines: { pine: () => new PineWorkerEngine() }`.
+import type { Vela } from "../src";
 import { VelaWorkspace } from "../src/workspace";
 import { BinanceProvider } from "../src/data/providers/binance";
 import { DemoEngine } from "./demo-engine";
 import { playgroundStorage } from "./persistence";
+import { addSampleMarks } from "./marks";
 
 const ws = new VelaWorkspace("#workspace", {
   layout: "4",
@@ -100,6 +102,18 @@ for (const cell of ws.cells()) cell.chart.on("theme:changed", syncShellTheme);
 ws.on("cell:created", ({ id }) =>
   ws.cell(id)?.chart.on("theme:changed", syncShellTheme),
 );
+
+// Sample timeline marks (chart.marks) on every cell — the ones alive now and those a
+// later layout switch mints. Each waits for its own chart to paint, then spreads the
+// marks over that chart's visible range (see marks.ts).
+const seedMarks = (chart: Vela): void => {
+  void chart.ready().then(() => addSampleMarks(chart));
+};
+for (const cell of ws.cells()) seedMarks(cell.chart);
+ws.on("cell:created", ({ id }) => {
+  const cell = ws.cell(id);
+  if (cell) seedMarks(cell.chart);
+});
 
 // Handy for poking around from the browser console (and for the automated probes).
 (window as unknown as { __ws: VelaWorkspace }).__ws = ws;

--- a/src/Vela.ts
+++ b/src/Vela.ts
@@ -19,6 +19,7 @@ import { rendererDefaults } from './core/renderer-defaults';
 import { PanesControl } from './core/PanesControl';
 import { DataControl } from './core/DataControl';
 import { DrawingsControl } from './core/DrawingsControl';
+import { MarksControl } from './core/MarksControl';
 import { NativeRenderer } from './renderers/native/NativeRenderer';
 import { MultiProviderFeed } from './data/MultiProviderFeed';
 import { registerBuiltinChartTypes } from './chart-types/builtins';
@@ -61,6 +62,7 @@ export class Vela {
     private readonly panesControl: PanesControl;
     private readonly dataControl: DataControl;
     private readonly drawingsControl: DrawingsControl;
+    private readonly marksControl: MarksControl;
 
     constructor(container: HTMLElement | string, options: VelaOptions = {}, deps: VelaDeps = {}) {
         registerBuiltinChartTypes(); // built-in chart types through the public SDK registry (idempotent)
@@ -121,6 +123,7 @@ export class Vela {
         if (Object.keys(defaults).length > 0) this.rendererControl.set(defaults);
         this.panesControl = new PanesControl(this.orchestrator);
         this.drawingsControl = new DrawingsControl(this.orchestrator.drawings);
+        this.marksControl = new MarksControl(this.orchestrator.marks);
     }
 
     /**
@@ -364,6 +367,18 @@ export class Vela {
      */
     get drawings(): DrawingsControl {
         return this.drawingsControl;
+    }
+
+    /**
+     * The chart's timeline-marks control surface: host events pinned to a bar and shown
+     * as glyphs on a lane above the time axis, each opening a popup on click —
+     * `chart.marks.add({ id, time, glyph, title, content })`, `chart.marks.set(list)`,
+     * `chart.marks.defineGroup({ id, label })`. Marks are data, not user state: re-supply
+     * them on `market:changed`. On a renderer without the `timelineMarks` capability the
+     * model still fills but nothing paints (`chart.marks.supported`).
+     */
+    get marks(): MarksControl {
+        return this.marksControl;
     }
 
     on<K extends keyof VelaEventMap>(event: K, handler: (payload: VelaEventMap[K]) => void): () => void {

--- a/src/core/MarksControl.ts
+++ b/src/core/MarksControl.ts
@@ -1,0 +1,72 @@
+import type { MarksController } from './marks/MarksController';
+import type { MarkGroup, TimelineMark } from './marks/types';
+
+/**
+ * The chart's timeline-marks control surface (`chart.marks`) — sibling of
+ * `chart.drawings` / `chart.panes`. Marks are DATA, not user state: the chart never
+ * persists them; re-supply them when the market changes (`market:changed`). The model
+ * is core-owned, so every method works on any renderer; on one without the
+ * `timelineMarks` capability nothing paints (`supported` reports it) and the group
+ * visibility setter warns + no-ops.
+ */
+export class MarksControl {
+    constructor(private readonly ctrl: MarksController) {}
+
+    /** Whether the active renderer paints timeline marks. */
+    get supported(): boolean {
+        return this.ctrl.supported;
+    }
+
+    /** Add one mark; an existing id is replaced in place. */
+    add(mark: TimelineMark): this {
+        this.ctrl.add(mark);
+        return this;
+    }
+
+    /** Replace the whole set (a market switch). */
+    set(marks: readonly TimelineMark[]): this {
+        this.ctrl.set(marks);
+        return this;
+    }
+
+    remove(id: string): this {
+        this.ctrl.remove(id);
+        return this;
+    }
+
+    clear(): this {
+        this.ctrl.clear();
+        return this;
+    }
+
+    /** Every mark, in insertion order. */
+    all(): TimelineMark[] {
+        return this.ctrl.all();
+    }
+
+    /**
+     * Define a visibility group's presentation: the label of its checkbox in chart
+     * settings (the Events tab) and its default visibility. Marks may name a group
+     * that was never defined — it then shows its capitalized id.
+     */
+    defineGroup(group: MarkGroup): this {
+        this.ctrl.defineGroup(group);
+        return this;
+    }
+
+    /** The defined groups, in definition order. */
+    groups(): MarkGroup[] {
+        return this.ctrl.groupDefinitions();
+    }
+
+    /** Show or hide one group's marks — the same switch as the settings checkbox, persisted with the chart's config. */
+    setGroupVisible(id: string, visible = true): this {
+        this.ctrl.setGroupVisible(id, visible);
+        return this;
+    }
+
+    /** A group's effective visibility (the user's choice, else the group's declared default). */
+    isGroupVisible(id: string): boolean {
+        return this.ctrl.isGroupVisible(id);
+    }
+}

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -29,6 +29,7 @@ import { IndicatorHandleImpl, type IndicatorController } from './IndicatorHandle
 import { inspectModels, type SceneInspection } from './inspect';
 import { presetToRange, type VisibleRangePreset } from '../visible-range';
 import { DrawingController } from '../drawings/DrawingController';
+import { MarksController } from '../marks/MarksController';
 import { DrawingSeriesService } from './DrawingSeriesService';
 import type { DrawingsOption } from '../drawings/toolbar';
 import type { DataControl } from '../DataControl';
@@ -247,6 +248,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             marketKey: () => `${this.config.market.symbol ?? ''}|${this.config.market.session ?? ''}`,
         });
         this.drawings = new DrawingController(this.renderer, this.events, config.drawings, drawingSeries);
+        this.marks = new MarksController(this.renderer, this.events);
         // A symbol nothing can serve leaves the load PARKED; publish it so a host can say so
         // instead of showing a blank chart forever (it still resumes if a provider registers).
         // A parked load also ends the loading state — nothing is coming, and an endless
@@ -268,6 +270,8 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
 
     /** The user-drawings manager (backs `chart.drawings`). */
     readonly drawings: DrawingController;
+    /** The timeline-marks manager (backs `chart.marks`). */
+    readonly marks: MarksController;
 
     /**
      * The visible range to feed a run. Prefer the latest viewport-change event, but
@@ -1470,6 +1474,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         this.unresolvedUnsub = null;
         this.feed.destroy?.(); // parked waits would otherwise outlive the chart
         this.drawings.destroy();
+        this.marks.destroy();
         this.renderer.destroy();
         this.events.clear();
     }

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -5,6 +5,7 @@ import type { DrawingTypeKey, SerializedDrawing } from "../drawings/Drawing";
 import type { VelaTheme } from "../options";
 import type { SnapMode } from "../drawings/geometry";
 import type { DrawingMode } from "../drawings/port";
+import type { MarkClickEvent } from "../marks/types";
 
 /** Chart-level events emitted on `chart.on(...)`. */
 export interface VelaEventMap extends Record<string, unknown> {
@@ -90,6 +91,9 @@ export interface VelaEventMap extends Record<string, unknown> {
   "drawing:removed": { id: string };
   /** The user requested a drawing's settings popup. */
   "drawing:settings": { id: string };
+  /** A timeline-mark glyph was clicked — `ids` lists every mark under it (a cluster). Fires
+   *  before the popup opens; a mark without content opens none, so this is the host's hook. */
+  "mark:click": MarkClickEvent;
   /**
    * A SCRIPT computed — the first run over the history, a live tick, a new bar, an input
    * edit, a viewport move, a market switch. The payload carries the run itself (title,

--- a/src/core/marks/MarksController.ts
+++ b/src/core/marks/MarksController.ts
@@ -1,0 +1,116 @@
+import type { Unsubscribe } from '../util/types';
+import type { IChartRenderer } from '../ports/IChartRenderer';
+import type { TypedEventBus } from '../events/EventBus';
+import type { VelaEventMap } from '../events/types';
+import type { MarkGroup, TimelineMark } from './types';
+
+/**
+ * Renderer-agnostic owner of the timeline-mark model (backs `chart.marks`). Holds the
+ * marks + group definitions (the source of truth), pushes snapshots to the renderer
+ * through its optional `setTimelineMarks` seam, and re-emits the renderer's glyph
+ * clicks as `mark:click`. Inert on a renderer without the `timelineMarks` capability —
+ * the model still fills, so `all()` and a later host UI see it.
+ */
+export class MarksController {
+    /** Insertion-ordered — the order a cluster falls back to for equal times. */
+    private readonly marks = new Map<string, TimelineMark>();
+    private readonly groups = new Map<string, MarkGroup>();
+    private readonly enabled: boolean;
+    private readonly subs: Unsubscribe[] = [];
+
+    constructor(
+        private readonly renderer: IChartRenderer,
+        events: TypedEventBus<VelaEventMap>,
+    ) {
+        this.enabled = !!renderer.capabilities.timelineMarks && typeof renderer.setTimelineMarks === 'function';
+        if (this.enabled && renderer.onMarkClick) this.subs.push(renderer.onMarkClick((e) => events.emit('mark:click', e)));
+    }
+
+    /** Whether the active renderer paints timeline marks. */
+    get supported(): boolean {
+        return this.enabled;
+    }
+
+    /** Add (or replace, by id) one mark. */
+    add(mark: TimelineMark): void {
+        this.marks.set(mark.id, validateMark(mark));
+        this.sync();
+    }
+
+    /** Replace the whole set — a market switch. */
+    set(marks: readonly TimelineMark[]): void {
+        this.marks.clear();
+        for (const m of marks) this.marks.set(m.id, validateMark(m));
+        this.sync();
+    }
+
+    remove(id: string): boolean {
+        const had = this.marks.delete(id);
+        if (had) this.sync();
+        return had;
+    }
+
+    clear(): void {
+        if (this.marks.size === 0) return;
+        this.marks.clear();
+        this.sync();
+    }
+
+    /** Every mark, in insertion order (shallow copies — mutating one changes nothing). */
+    all(): TimelineMark[] {
+        return [...this.marks.values()].map((m) => ({ ...m, glyph: { ...m.glyph } }));
+    }
+
+    /** Define (or replace) a group's presentation — its settings label and default visibility. */
+    defineGroup(group: MarkGroup): void {
+        if (!group || typeof group.id !== 'string' || group.id.length === 0) throw new Error('[vela] marks.defineGroup: `id` must be a non-empty string');
+        if (typeof group.label !== 'string') throw new Error(`[vela] marks.defineGroup: group "${group.id}" needs a string \`label\``);
+        this.groups.set(group.id, { ...group });
+        this.sync();
+    }
+
+    /** The defined groups, in definition order. */
+    groupDefinitions(): MarkGroup[] {
+        return [...this.groups.values()].map((g) => ({ ...g }));
+    }
+
+    /**
+     * Show or hide one group's marks. The choice lives in the renderer's cosmetic config
+     * (the `marks` feature) — what the settings dialog's Events checkboxes edit and what
+     * a persisted chart restores — so it warns + no-ops on a renderer without it.
+     */
+    setGroupVisible(id: string, visible: boolean): void {
+        if (!this.renderer.features.includes('marks')) {
+            console.warn(`[vela] renderer "${this.renderer.name}" does not paint timeline marks — setGroupVisible ignored.`);
+            return;
+        }
+        this.renderer.applyFeature('marks', { groups: { [id]: visible } });
+    }
+
+    /** A group's effective visibility: the user's (persisted) choice, else the group's declared default, else visible. */
+    isGroupVisible(id: string): boolean {
+        const state = this.renderer.readFeature('marks') as { groups?: Record<string, unknown> } | undefined;
+        const chosen = state?.groups?.[id];
+        if (typeof chosen === 'boolean') return chosen;
+        return this.groups.get(id)?.visible !== false;
+    }
+
+    destroy(): void {
+        for (const unsub of this.subs) unsub();
+        this.subs.length = 0;
+    }
+
+    private sync(): void {
+        if (!this.enabled) return;
+        this.renderer.setTimelineMarks!([...this.marks.values()], [...this.groups.values()]);
+    }
+}
+
+/** Reject the malformed shapes a host can plausibly pass — a mark that cannot be placed or drawn is a programming error, not data to tolerate. */
+function validateMark(mark: TimelineMark): TimelineMark {
+    if (!mark || typeof mark !== 'object') throw new Error('[vela] marks: a mark must be an object');
+    if (typeof mark.id !== 'string' || mark.id.length === 0) throw new Error('[vela] marks: `id` must be a non-empty string');
+    if (typeof mark.time !== 'number' || !Number.isFinite(mark.time)) throw new Error(`[vela] marks: mark "${mark.id}" needs a finite epoch-ms \`time\``);
+    if (!mark.glyph || typeof mark.glyph !== 'object' || typeof mark.glyph.color !== 'string') throw new Error(`[vela] marks: mark "${mark.id}" needs a glyph with a \`color\``);
+    return { ...mark, glyph: { ...mark.glyph } };
+}

--- a/src/core/marks/index.ts
+++ b/src/core/marks/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Timeline marks — host events pinned to a moment in time, shown on a lane above the
+ * time axis. Renderer-agnostic: nothing here imports from `renderers/`.
+ */
+export type { MarkShape, MarkGlyph, MarkPanelItem, MarkContent, MarkContentSource, TimelineMark, MarkGroup, MarkClickEvent } from './types';
+export { MarksController } from './MarksController';

--- a/src/core/marks/types.ts
+++ b/src/core/marks/types.ts
@@ -1,0 +1,97 @@
+// Timeline marks — the public model behind `chart.marks`: host-supplied events pinned
+// to a moment in time (a dividend, a split, an earnings call, a deployment) and shown
+// as small glyphs on a lane at the bottom of the plot, each opening a detail popup on
+// click. Renderer-agnostic: nothing here knows how a glyph is painted.
+import type { Millis } from '../model/time';
+
+/** The built-in glyph outlines. */
+export type MarkShape = 'circle' | 'square' | 'diamond' | 'pin';
+
+/**
+ * How a mark looks on the lane: a colored token carrying either a short letter or a
+ * registered icon (`registerIcon` from `vela/ui` — an id, never inline markup, so a mark
+ * payload can come from data without ever carrying SVG). `icon` wins over `letter`
+ * when both are given; the symbol's ink is auto-contrasted against `color`.
+ */
+export interface MarkGlyph {
+    /** Token outline (default `'circle'`). */
+    shape?: MarkShape;
+    /** Token fill — any CSS color. */
+    color: string;
+    /** One or two characters drawn inside the token (`'D'`, `'E'`, `'!'`). */
+    letter?: string;
+    /** Icon id from the icon registry, drawn inside the token. */
+    icon?: string;
+}
+
+/** One row of a structured panel — the callout vocabulary plus a label/value field. */
+export type MarkPanelItem =
+    | { type: 'text'; text: string }
+    | { type: 'field'; label: string; value: string }
+    | {
+          type: 'button';
+          label: string;
+          /** Emphasized (selection-colored) button — the panel's main action. */
+          primary?: boolean;
+          /** Close the popup after `run` (default true). */
+          close?: boolean;
+          run(): void;
+      };
+
+/**
+ * What the popup shows for one mark: plain text (escaped), HTML (sanitized through an
+ * allowlist — scripts, styles, frames, event handlers and `javascript:` URLs never
+ * reach the page), or a structured panel of rows and buttons.
+ */
+export type MarkContent = { text: string } | { html: string } | { panel: { items: MarkPanelItem[] } };
+
+/** A content value, or a thunk resolved when the popup needs it (details fetched on click). */
+export type MarkContentSource = MarkContent | (() => MarkContent | Promise<MarkContent>);
+
+/** One timeline mark. */
+export interface TimelineMark {
+    /** Stable id — re-adding an id replaces the mark. */
+    id: string;
+    /**
+     * The moment the mark belongs to, epoch-ms. The glyph never sits at this exact pixel:
+     * it centers on the bar whose span contains the time (a time falling in a gap — a
+     * weekend, a closed session — goes to the first bar that follows; one past the newest
+     * bar projects onto the extrapolated grid in the right whitespace).
+     */
+    time: Millis;
+    /** Popup heading — shown above the content whatever its form. */
+    title?: string;
+    glyph: MarkGlyph;
+    /** Hover text on the glyph. */
+    tooltip?: string;
+    /**
+     * The visibility group the mark belongs to (`'dividends'`, `'splits'`). Marks of one
+     * group that land on the same bar cluster into one glyph; groups get a checkbox each
+     * in the chart settings (the Events tab). Define the display label with
+     * `chart.marks.defineGroup`; an undefined group shows its capitalized id.
+     */
+    group?: string;
+    /** Popup content. Without it a click only emits `mark:click` — the host owns the UI. */
+    content?: MarkContentSource;
+}
+
+/** A visibility group's presentation (see {@link TimelineMark.group}). */
+export interface MarkGroup {
+    id: string;
+    /** The settings checkbox label (`'Dividends'`). */
+    label: string;
+    /** Default visibility before the user toggles it (default true). A persisted choice wins. */
+    visible?: boolean;
+}
+
+/** The `mark:click` payload — every mark under the clicked glyph (a cluster lists them all). */
+export interface MarkClickEvent {
+    /** The cluster's first mark (earliest time, then insertion order). */
+    id: string;
+    /** Every mark in the clicked cluster, in cluster order. */
+    ids: string[];
+    /** The first mark's time, epoch-ms. */
+    time: Millis;
+    /** The cluster's group, when its marks belong to one. */
+    group?: string;
+}

--- a/src/core/ports/IChartRenderer.ts
+++ b/src/core/ports/IChartRenderer.ts
@@ -8,6 +8,7 @@ import type { VelaTheme, ThemeName, MoveTarget, PriceStyle } from '../options';
 import type { Unsubscribe } from '../util/types';
 import type { WallClock } from '../util/wall-clock';
 import type { IDrawingsRendererPort } from '../drawings/port';
+import type { MarkClickEvent, MarkGroup, TimelineMark } from '../marks/types';
 
 /** What a rendering backend supports — drives graceful degradation + warnings. */
 export interface RendererCapabilities {
@@ -39,6 +40,10 @@ export interface RendererCapabilities {
      *  ticks on the price pane, plus the `tradeMarkers` display feature. Absent/false ⇒ the
      *  channel is carried through mounts/patches but never painted. */
     trades?: boolean;
+    /** Timeline marks (`chart.marks`): host events pinned to a bar, painted as glyphs on a lane
+     *  above the time axis with a detail popup on click. Absent/false ⇒ the model still fills
+     *  (`chart.marks.all()`) but nothing paints. */
+    timelineMarks?: boolean;
     /** Whether the renderer provides the in-chart inputs/settings UI. */
     inputsUI: boolean;
 }
@@ -252,6 +257,16 @@ export interface IChartRenderer {
      * layers omits it.
      */
     setNativeData?(type: string, data: unknown): void;
+
+    /**
+     * Replace the timeline marks + their group definitions (the `chart.marks` model). The
+     * renderer snaps each mark onto its bar, folds same-bar/same-group marks into clusters, and
+     * paints the lane above the time axis; group visibility is its own display state (the
+     * `marks` feature). Present iff `capabilities.timelineMarks`.
+     */
+    setTimelineMarks?(marks: readonly TimelineMark[], groups: readonly MarkGroup[]): void;
+    /** A timeline-mark glyph was clicked — every mark of its cluster is listed. Present iff `capabilities.timelineMarks`. */
+    onMarkClick?(cb: (e: MarkClickEvent) => void): Unsubscribe;
 
     /**
      * Reflect an indicator's live status in its legend row: `'loading'` (a fetch is in flight —

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { BarStore, sharedBarStore } from './data/BarStore';
 export { timeframeToMs } from './data/timeframe';
 export { DataControl } from './core/DataControl';
 export { DrawingsControl } from './core/DrawingsControl';
+export { MarksControl } from './core/MarksControl';
 
 // Native indicators (core-computed, no scripting engine) — register a type, then chart.addNativeIndicator(type)
 export { registerNativeIndicator, unregisterNativeIndicator, getNativeIndicator, nativeIndicatorTypes, nativeIndicatorDescriptors } from './core/native-indicators';
@@ -55,6 +56,9 @@ export type {
     DrawingSeriesState,
     DrawingSeriesGateway,
 } from './core/drawings';
+
+// Timeline marks (`chart.marks`): host events on a lane above the time axis.
+export type { TimelineMark, MarkGlyph, MarkShape, MarkContent, MarkContentSource, MarkPanelItem, MarkGroup, MarkClickEvent } from './core/marks';
 
 // Public types
 export type * from './core/model';

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -58,6 +58,11 @@ import { formatPriceLabel } from './chrome/ticks';
 import { zonedDate } from './chrome/tz';
 import { computePaneScale, expandScaleByPixels, overlaySeriesRange } from './core/autoscale';
 import { mergeTradeMarkersState, tradesPriceHints, type TradeMarkerHints } from '../shared/trade-markers';
+import { markGroupVisible, mergeMarksState } from '../shared/marks-state';
+import { effectiveMarkGroups } from './chrome/marks/layout';
+import { MarkPopover } from './chrome/marks/MarkPopover';
+import { MARK_PULSE_MS } from './chrome/marks/paint';
+import type { MarkClickEvent, MarkGroup, TimelineMark } from '../../core/marks/types';
 import { rescaleAround, shiftScale } from './core/manualScale';
 import { resizeSplit, type PaneSplit } from './core/paneResize';
 import { type ChartConfig, CHART_CONFIG_VERSION, factoryResetConfig, mergeConfig, BASELINE_TOP_LINE, BASELINE_BOTTOM_LINE, BASELINE_FILL_ALPHA, BASELINE_FILL_ALPHA_FAR, withAlpha, priceStyleIds, basePaintingOf, candleOverrideFor, effectiveCandlePaint } from './core/chartConfig';
@@ -109,6 +114,12 @@ const SCROLL_TO_TAU_MS = 130; // scroll-to-latest glide — eases rightOffset ba
 // Fling ends when on-screen motion drops below this (PIXELS/ms). Kept in pixel units
 // so the stop point is zoom-invariant + agrees with InputController's FLING_MIN_SPEED.
 const FLING_STOP_PX = 0.02;
+const MARK_FLASH_MS = 220; // a content-less mark click's filled flash — the acknowledgement when no popup opens
+
+/** The frame clock (ms) the mark lane's hover pulse and click flash run on. */
+function frameNow(): number {
+    return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
 // Price-axis drag sensitivity: the visible price SPAN scales by e^(Δpx·k) — drag down
 // (Δpx>0) expands the span (zoom out), drag up compresses it (zoom in). Kept low so a
 // rescale takes a deliberate, sizeable drag (~2× over ~170px) rather than a twitch.
@@ -181,6 +192,13 @@ export class NativeRenderer implements IChartRenderer {
     private readonly indicatorSlices = new IndicatorDrawingSlices();
     /** Hover tooltips for Pine labels (canvas hit-rects collected by the chrome layer). */
     private labelTooltip: LabelTooltip | null = null;
+    /** The timeline-mark popup (a kit Popover anchored on a lane glyph); null before mount. */
+    private markPopover: MarkPopover | null = null;
+    /** How the fanned mark stack was opened: a hover folds when the pointer leaves, a tap only on a tap elsewhere. */
+    private marksExpandedBy: 'hover' | 'tap' = 'hover';
+    /** The rAF loop keeping the chrome repainting while a lane glyph pulses (hover) or flashes (click); null when idle. */
+    private markPulseRaf: number | null = null;
+    private readonly markClickCbs = new Set<(e: MarkClickEvent) => void>();
     private readonly crosshairLayer = new CrosshairRenderer();
     private scheduler!: Scheduler;
     /** The second pulse the countdown-to-bar-close chip ticks on: the host's (`setWallClock`)
@@ -342,7 +360,7 @@ export class NativeRenderer implements IChartRenderer {
     }
 
     readonly name = 'native';
-    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'animLiveBar', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'sessionZones', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'indicatorTitles', 'indicatorValues'];
+    readonly features: readonly string[] = ['logScale', 'currentPriceLine', 'priceLabel', 'countdown', 'upColor', 'downColor', 'glow', 'animZoom', 'animPan', 'animLiveBar', 'intro', 'zoomAnchor', 'axisDrag', 'paneResize', 'candleZOrder', 'candleVisible', 'seriesOrder', 'highlights', 'sessionZones', 'gridlines', 'axisLabels', 'scaleMode', 'invertScale', 'paneScales', 'autoScale', 'timezone', 'keyboard', 'historyChords', 'priceStyle', 'priceBaseline', 'baselinePrice', 'settings', 'attribution', 'dialogHost', 'tradeMarkers', 'marks', 'indicatorTitles', 'indicatorValues'];
 
     /** Apply a render feature live — mutate the field + invalidate, no engine re-run. */
     applyFeature(key: string, value: unknown): void {
@@ -468,6 +486,11 @@ export class NativeRenderer implements IChartRenderer {
                 // Partial state merge ({ visible?, labels?, qty?, colors? }) — malformed fields drop.
                 this.scene.tradeMarkers = mergeTradeMarkersState(this.scene.tradeMarkers, value);
                 break;
+            case 'marks':
+                // `false`/`true` toggles the lane; `{ visible?, groups? }` merges partially (groups additive).
+                this.scene.marks = mergeMarksState(this.scene.marks, value);
+                this.markPopover?.close(); // the open cluster may just have been hidden
+                break;
             case 'keyboard':
                 this.setKeyboardEnabled(Boolean(value));
                 return; // owns its own DOM (focus/listeners/live region)
@@ -558,6 +581,7 @@ export class NativeRenderer implements IChartRenderer {
                 return price ? this.scene.baselinePriceFor(price.scale) : this.scene.baselineValue;
             }
             case 'tradeMarkers': return { ...this.scene.tradeMarkers, colors: { ...this.scene.tradeMarkers.colors } };
+            case 'marks': return { visible: this.scene.marks.visible, groups: { ...this.scene.marks.groups } };
             case 'keyboard': return this.keyboardEnabled;
             case 'historyChords': return this.historyChordsEnabled;
             case 'settings': return this.settingsEnabled;
@@ -697,6 +721,7 @@ export class NativeRenderer implements IChartRenderer {
                 exitColor: this.scene.tradeMarkers.colors.exit,
             },
             timeScale: { timezone: this.scene.timezone },
+            marks: { visible: this.scene.marks.visible, groups: { ...this.scene.marks.groups } },
             candles: {
                 upColor: this.candleUp,
                 downColor: this.candleDown,
@@ -828,6 +853,8 @@ export class NativeRenderer implements IChartRenderer {
         };
         // time scale
         this.scene.timezone = next.timeScale.timezone;
+        // timeline marks (lane toggle + per-group visibility)
+        this.scene.marks = { visible: next.marks.visible, groups: { ...next.marks.groups } };
         // candles
         this.candleUp = next.candles.upColor;
         this.candleDown = next.candles.downColor;
@@ -988,6 +1015,7 @@ export class NativeRenderer implements IChartRenderer {
         }
         this.settingsDialog.setTheme(this.theme);
         this.settingsDialog.setHostSections(this.hostSettingsSections);
+        this.settingsDialog.setMarkGroups(this.markGroupsInUse(), (id) => markGroupVisible(this.scene.marks, id, this.scene.markGroups));
         this.settingsDialog.setHiddenSettings(this.hiddenSettings);
         this.syncThemeControl();
         this.settingsDialog.toggle(
@@ -1367,7 +1395,8 @@ export class NativeRenderer implements IChartRenderer {
             zoomTo: (target, anchorLogical, anchorX) => this.zoomTo(target, anchorLogical, anchorX),
             fling: (v) => this.fling(v),
             onPointerMove: (x, y) => this.handlePointerMove(x, y),
-            onClick: (x) => {
+            onClick: (x, y) => {
+                if (this.handleMarkClick(x, y)) return; // a lane glyph takes the click whole
                 this.userDrawings?.deselect(); // a click on the empty plot ends a (multi-)selection
                 this.handleClick(x);
             },
@@ -1395,7 +1424,7 @@ export class NativeRenderer implements IChartRenderer {
             drawingsPointerDown: (x, y, snap, shift, mod) => this.userDrawings?.pointerDown(x, y, snap, shift, mod),
             drawingsPointerMove: (x, y, snap, shift, mod) => this.userDrawings?.pointerMove(x, y, snap, shift, mod),
             drawingsPointerUp: (x, y, snap) => this.userDrawings?.pointerUp(x, y, snap),
-            drawingsCursor: (x, y) => this.userDrawings?.cursorAt(x, y) ?? null,
+            drawingsCursor: (x, y) => this.userDrawings?.cursorAt(x, y) ?? (this.chrome.markGlyphAt(x, y) ? 'pointer' : null),
             drawingsDblClick: (x, y) => this.userDrawings?.dblClick(x, y) ?? false,
             drawingsClearTransient: () => this.userDrawings?.clearTransient(),
         });
@@ -1419,8 +1448,19 @@ export class NativeRenderer implements IChartRenderer {
         // The hit-rects are collected by the slice prepainter (drawings paint there now).
         this.labelTooltip = new LabelTooltip(this.plot, {
             theme: () => this.chromeTheme(),
-            lookup: (x, y) => this.indicatorSlices.labelTooltipAt(x, y),
+            lookup: (x, y) => this.indicatorSlices.labelTooltipAt(x, y) ?? this.chrome.markTooltipAt(x, y, this.markGroupsInUse()),
         });
+        // Timeline-mark popup, plus the chrome repaint a lane icon asks for once it has rasterized.
+        this.markPopover = new MarkPopover({
+            plot: this.plot,
+            host: () => this.dialogHost ?? this.plot,
+            theme: () => this.chromeTheme(),
+            onOpenChange: (key) => {
+                this.scene.marksActiveKey = key; // the glyph paints filled while its popup shows
+                this.scheduler?.invalidate(InvalidateLevel.Chrome);
+            },
+        });
+        this.chrome.setMarkIconReady(() => this.scheduler?.invalidate(InvalidateLevel.Chrome));
 
         // User-drawings layer (paints L1.5 plus the interleave layers the geometry backend
         // composites into the series stack, and owns the interaction/settings popup). It
@@ -1723,6 +1763,11 @@ export class NativeRenderer implements IChartRenderer {
         this.plot?.removeEventListener('pointerleave', this.onScrollProximityLeave);
         this.labelTooltip?.destroy();
         this.labelTooltip = null;
+        this.markPopover?.destroy();
+        this.markPopover = null;
+        this.chrome.setMarkIconReady(null);
+        if (this.markPulseRaf !== null) cancelAnimationFrame(this.markPulseRaf);
+        this.markPulseRaf = null;
         this.scrollButton?.remove();
         this.scrollButton = null;
         for (const l of this.extLayers) l.instance.destroy?.();
@@ -2195,7 +2240,7 @@ export class NativeRenderer implements IChartRenderer {
     }
 
     listSettingsIds(): string[] {
-        return settingsIdCatalog(this.hostSettingsSections);
+        return settingsIdCatalog(this.hostSettingsSections, this.markGroupsInUse());
     }
 
     onChartTypeSettingsChange(cb: (typeId: string, values: Record<string, unknown>) => void): Unsubscribe {
@@ -2226,6 +2271,25 @@ export class NativeRenderer implements IChartRenderer {
     onAxisLongPress(cb: (e: AxisLongPressEvent) => void): Unsubscribe {
         this.axisLongPressCbs.add(cb);
         return () => this.axisLongPressCbs.delete(cb);
+    }
+
+    // ── timeline marks (the `chart.marks` model; see the port) ──
+    setTimelineMarks(marks: readonly TimelineMark[], groups: readonly MarkGroup[]): void {
+        this.scene.timelineMarks = marks;
+        this.scene.markGroups = groups;
+        this.scene.marksExpandedStack = null;
+        this.markPopover?.close(); // the open cluster may no longer exist (a market switch replaced the set)
+        this.scheduler?.invalidate(InvalidateLevel.Chrome);
+    }
+
+    onMarkClick(cb: (e: MarkClickEvent) => void): Unsubscribe {
+        this.markClickCbs.add(cb);
+        return () => this.markClickCbs.delete(cb);
+    }
+
+    /** Every group the lane knows: the defined ones, then those marks name without a definition. */
+    private markGroupsInUse(): MarkGroup[] {
+        return effectiveMarkGroups(this.scene.timelineMarks, this.scene.markGroups);
     }
 
     onViewportChange(cb: (range: VisibleRange) => void): Unsubscribe {
@@ -2468,6 +2532,9 @@ export class NativeRenderer implements IChartRenderer {
             this.scene.crosshair = null;
             this.hoverSeparatorY = null;
             this.lastPointer = null;
+            // A touch release also lands here (no resting pointer): a fan a tap opened must survive it.
+            if (this.marksExpandedBy === 'hover') this.setMarksExpanded(null);
+            this.setMarkHover(null);
             this.scheduler.invalidate(InvalidateLevel.Cursor);
             this.hoverLogical = null; // off the plot ⇒ the readout falls back to the latest bar
             const empty: CrosshairEvent = { time: null, price: null, paneKind: null, values: new Map(), ohlc: null };
@@ -2482,6 +2549,9 @@ export class NativeRenderer implements IChartRenderer {
         this.hoverSeparatorY = x >= 0 && y >= 0 && y <= this.coords.height ? this.separatorHoverY(y) : null;
         // Cursor tier: repaint only the crosshair overlay, not the data layer.
         this.scheduler.invalidate(InvalidateLevel.Cursor);
+        // A multi-group mark stack fans out while the pointer is over it (or over the gaps of its fan).
+        this.setMarksExpanded(inData ? this.chrome.markStackAt(x, y) : null);
+        this.setMarkHover(inData ? (this.chrome.markGlyphAt(x, y)?.cluster.key ?? null) : null);
 
         // Only report a time/value when the cursor is over a real bar (not the
         // right-offset whitespace) — matches LWC emitting null off any data point.
@@ -2516,6 +2586,82 @@ export class NativeRenderer implements IChartRenderer {
         const logical = Math.round(this.coords.xToLogical(x));
         const onBar = logical >= 0 && logical < this.coords.barCount;
         for (const cb of this.clickCbs) cb({ time: onBar ? this.coords.logicalToTime(logical) : null, price: null });
+    }
+
+    /**
+     * Fan out (or collapse, with null) a multi-group mark stack; repaints the chrome tier when
+     * it changes. A stack whose glyph holds the open popup stays fanned — the pointer leaving
+     * the plot for the popup must not bury the glyph under the deck (which would close it).
+     */
+    private setMarksExpanded(stack: number | null, by: 'hover' | 'tap' = 'hover'): void {
+        if (this.scene.marksExpandedStack === stack) return;
+        if (stack === null && this.markPopover?.key) {
+            const open = this.chrome.markGlyphByKey(this.markPopover.key);
+            if (open && open.stack === this.scene.marksExpandedStack) return;
+        }
+        this.scene.marksExpandedStack = stack;
+        this.marksExpandedBy = by;
+        this.scheduler?.invalidate(InvalidateLevel.Chrome);
+    }
+
+    /**
+     * A click on the mark lane: a collapsed deck fans out (the touch path — a mouse already
+     * fanned it by hovering), a glyph reports its cluster (`onMarkClick`) and opens the popup
+     * when any of its marks carries content. True when the click landed on the lane.
+     */
+    private handleMarkClick(x: number, y: number): boolean {
+        const glyph = this.chrome.markGlyphAt(x, y);
+        if (!glyph) {
+            if (this.scene.marksExpandedStack !== null && this.chrome.markStackAt(x, y) === null) this.setMarksExpanded(null);
+            return false;
+        }
+        if (glyph.decked) {
+            this.setMarksExpanded(glyph.stack, 'tap');
+            return true;
+        }
+        const marks = glyph.cluster.marks;
+        const first = marks[0]!;
+        const event: MarkClickEvent = { id: first.id, ids: marks.map((m) => m.id), time: first.time, ...(glyph.cluster.group !== undefined ? { group: glyph.cluster.group } : {}) };
+        for (const cb of this.markClickCbs) cb(event);
+        if (marks.some((m) => m.content !== undefined)) {
+            this.markPopover?.open(glyph.cluster, { x: glyph.x, y: glyph.y, size: glyph.size });
+        } else {
+            // Nothing to open — a brief filled flash acknowledges the click all the same.
+            this.scene.marksFlash = { key: glyph.cluster.key, until: frameNow() + MARK_FLASH_MS };
+            this.syncMarkPulse();
+        }
+        return true;
+    }
+
+    /** After a chrome frame: keep the open mark popup on its glyph, or close it once the glyph is gone. */
+    private trackMarkPopover(): void {
+        const key = this.markPopover?.key;
+        if (!key) return;
+        const g = this.chrome.markGlyphByKey(key);
+        this.markPopover!.track(g && !(g.decked && g.depth !== 0) ? { x: g.x, y: g.y, size: g.size } : null);
+    }
+
+    /** The lane glyph under the pointer — it swells once as the pointer lands (a rAF-driven chrome repaint for the pulse's duration). */
+    private setMarkHover(key: string | null): void {
+        if (this.scene.marksHoverKey === key) return;
+        this.scene.marksHoverKey = key;
+        this.scene.marksHoverSince = frameNow();
+        this.scheduler?.invalidate(InvalidateLevel.Chrome);
+        this.syncMarkPulse();
+    }
+
+    /** Run a chrome-tier repaint loop while a glyph's hover pulse or click flash plays; it stops itself once both are over. */
+    private syncMarkPulse(): void {
+        if (this.markPulseRaf !== null || typeof requestAnimationFrame !== 'function') return;
+        const tick = (): void => {
+            this.markPulseRaf = null;
+            const now = frameNow();
+            if (this.scene.marksFlash && this.scene.marksFlash.until <= now) this.scene.marksFlash = null;
+            this.scheduler?.invalidate(InvalidateLevel.Chrome);
+            const pulsing = this.scene.marksHoverKey !== null && now - this.scene.marksHoverSince < MARK_PULSE_MS;
+            if (pulsing || this.scene.marksFlash !== null) this.markPulseRaf = requestAnimationFrame(tick);
+        };
+        this.markPulseRaf = requestAnimationFrame(tick);
     }
 
     private paneAtY(y: number): { scale: { min: number; max: number }; bounds: { top: number; height: number } } | null {
@@ -2968,6 +3114,7 @@ export class NativeRenderer implements IChartRenderer {
             // re-wires the drawing resolvers (three closures over live refs — cheap).
             this.chrome.prepare(this.scene, this.coords, this.theme);
             this.chrome.render(this.scene, this.coords, this.theme, this.axisSurface());
+            this.trackMarkPopover();
         }
         this.crosshairLayer.render(this.scene, this.coords, this.theme, this.hoverSeparatorY, this.externalCrossPx()); // L2 crosshair
         // Hover-testing SDK layers (repaintOnCursor) follow pointer moves too — each owns
@@ -3097,6 +3244,7 @@ export class NativeRenderer implements IChartRenderer {
         this.backdropRenderer.render(this.scene, this.coords, this.theme, gridAlpha); // L-2, under every layer canvas
         this.backend.render(this.scene, this.coords, this.theme);
         this.chrome.render(this.scene, this.coords, this.theme, this.axisSurface());
+        this.trackMarkPopover();
         this.userDrawings?.render(); // L1.5 — above Pine drawings, below the crosshair
 
         if (easeLive && liveActual) this.bars[li] = liveActual; // restore the true forming bar

--- a/src/renderers/native/capabilities.ts
+++ b/src/renderers/native/capabilities.ts
@@ -20,6 +20,7 @@ export const NATIVE_CAPABILITIES: RendererCapabilities = {
     drawingDepth: true, // drawings share the series' z space (backend-composited interleave layers)
     tables: true, // canvas-painted into the owning indicator's interleave slice
     trades: true, // strategy order-fill markers (arrows + labels + fill-price ticks)
+    timelineMarks: true, // host events on a lane above the time axis (glyphs + detail popup)
     inputsUI: true, // reuses the DOM InputsUI
 };
 

--- a/src/renderers/native/chrome/ChromeRenderer.ts
+++ b/src/renderers/native/chrome/ChromeRenderer.ts
@@ -12,10 +12,13 @@ import { renderTradeMarkers } from '../../shared/trade-markers';
 import type { TradeExecution } from '../../../core/model/trades';
 import { paneAxisTicks, formatAxisValue, timeTicks } from './ticks';
 import { axisColumnX, PANE_SEPARATOR_PX } from './axisLayout';
-import { parseColor } from '../backend/gl/color';
 import { DARK_THEME } from '../../../core/theme';
 import { tzOffsetMs } from './tz';
 import { countdownText } from './countdown';
+import { tagTextColor } from './contrast';
+import { markGroupVisible } from '../../shared/marks-state';
+import { clusterTooltip, layoutMarkLane, markGlyphAt, markStackAt, type MarkLaneLayout, type PlacedGlyph } from './marks/layout';
+import { MarkIconRaster, paintMarkLane } from './marks/paint';
 
 /**
  * Renderer-owned chrome layer (canvas2d) on its own canvas, stacked above the
@@ -33,10 +36,44 @@ export class ChromeRenderer {
     private axisTextColor = DARK_THEME.textColor;
     // Shared Pine-drawing renderer, used here for autoscale geometry only; widthCache persists.
     private readonly drawScene = new DrawingSceneRenderer({ timeToLogical: () => 0, barAt: () => null, theme: {} as VelaTheme });
+    /** The timeline-mark lane as laid out by the last frame — what hover/click hit-test against. */
+    private markLayout: MarkLaneLayout = { glyphs: [], stacks: new Map() };
+    /** Registry icons rasterized for the lane; the owner is asked for a chrome repaint when one lands. */
+    private readonly markIcons = new MarkIconRaster(() => this.onMarkIconReady?.());
+    private onMarkIconReady: (() => void) | null = null;
+    /** Bar open times of the current series, rebuilt only when the array or its length changes (a live tick keeps both). */
+    private barTimesSrc: readonly OHLCV[] | null = null;
+    private barTimesCache: number[] = [];
 
     mount(canvas: HTMLCanvasElement): void {
         this.canvas = canvas;
         this.ctx = canvas.getContext('2d');
+    }
+
+    /** Where to ask for a chrome repaint when a lane icon finishes rasterizing. */
+    setMarkIconReady(cb: (() => void) | null): void {
+        this.onMarkIconReady = cb;
+    }
+
+    /** The interactive mark glyph under a plot point (last frame's layout), or null. */
+    markGlyphAt(x: number, y: number): PlacedGlyph | null {
+        return markGlyphAt(this.markLayout, x, y);
+    }
+
+    /** The mark stack (bar index) whose glyphs — or the gaps of its fan — cover a plot point. */
+    markStackAt(x: number, y: number): number | null {
+        return markStackAt(this.markLayout, x, y);
+    }
+
+    /** A glyph of the last frame by its cluster key — how an open popup follows its anchor. */
+    markGlyphByKey(key: string): PlacedGlyph | null {
+        return this.markLayout.glyphs.find((g) => g.cluster.key === key) ?? null;
+    }
+
+    /** Hover text of the mark glyph under a plot point, or null. */
+    markTooltipAt(x: number, y: number, groups: ReadonlyArray<{ id: string; label: string }>): string | null {
+        const g = this.markGlyphAt(x, y);
+        return g ? clusterTooltip(g.cluster, groups) : null;
     }
 
     /** Wire the drawing coordinate resolvers + theme (call once per frame before use). */
@@ -101,6 +138,7 @@ export class ChromeRenderer {
             // alone, not bars — so they must survive the empty frame, or the stacked
             // panes read as one undivided plot until the load completes.
             this.drawPaneSeparators(ctx, scene, theme, fullW, panes);
+            this.markLayout = { glyphs: [], stacks: new Map() }; // no bars ⇒ nothing to click either
             return;
         }
         const pricePane = panes.find((p) => p.kind === 'price') ?? null;
@@ -123,6 +161,48 @@ export class ChromeRenderer {
         this.drawPaneSeparators(ctx, scene, theme, fullW, panes);
         this.drawPriceLineAndCountdown(ctx, scene, coords, theme, dataW, pricePane);
         this.drawTimeAxis(ctx, scene, coords, theme, dataW, dataH, fullH);
+        this.drawMarkLane(ctx, scene, coords, theme, dataW, dataH);
+    }
+
+    /** The timeline-mark lane — after the axis, so the tokens read over the plot's bottom edge. */
+    private drawMarkLane(ctx: CanvasRenderingContext2D, scene: SceneGraph, coords: CoordinateSystem, theme: VelaTheme, dataW: number, dataH: number): void {
+        if (!scene.marks.visible || scene.timelineMarks.length === 0) {
+            this.markLayout = { glyphs: [], stacks: new Map() };
+            return;
+        }
+        this.markLayout = layoutMarkLane({
+            marks: scene.timelineMarks,
+            groups: scene.markGroups,
+            hidden: (groupId) => !markGroupVisible(scene.marks, groupId, scene.markGroups),
+            barTimes: this.barTimes(scene),
+            intervalMs: coords.barInterval,
+            xOf: (bar) => coords.logicalToX(bar),
+            axisY: dataH,
+            dataW,
+            expanded: scene.marksExpandedStack,
+        });
+        const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        paintMarkLane(ctx, this.markLayout, {
+            axisY: dataH,
+            background: theme.background,
+            stemColor: scene.style.borderColor ?? theme.borderColor,
+            fontFamily: theme.fontFamily,
+            dpr: coords.dpr,
+            icons: this.markIcons,
+            hoverKey: scene.marksHoverKey,
+            hoverSince: scene.marksHoverSince,
+            activeKey: scene.marksActiveKey,
+            flashKey: scene.marksFlash && scene.marksFlash.until > nowMs ? scene.marksFlash.key : null,
+            nowMs,
+        });
+    }
+
+    private barTimes(scene: SceneGraph): readonly number[] {
+        if (this.barTimesSrc !== scene.bars || this.barTimesCache.length !== scene.bars.length) {
+            this.barTimesSrc = scene.bars;
+            this.barTimesCache = scene.bars.map((b) => b.time);
+        }
+        return this.barTimesCache;
     }
 
     destroy(): void {
@@ -401,26 +481,4 @@ function setDash(ctx: CanvasRenderingContext2D, style: LineStyle): void {
     else ctx.setLineDash([]);
 }
 
-/**
- * White or black text for a colored price tag, biased toward white so saturated brand
- * colors (the default candle green / red sit at L≈0.22–0.24) read as white,
- * while genuinely light colors (a white or pale candle color) still get dark text. Uses
- * relative luminance with a flip point of 0.4 — higher than `readableText`'s WCAG crossover
- * (~0.18) which perceptually over-picks black on mid-tone fills. Translucent `bg` is
- * composited over `over` first so the choice reflects what's actually seen.
- */
-function tagTextColor(bg: string, over: string): string {
-    const [r, g, b, a] = parseColor(bg);
-    let R = r;
-    let G = g;
-    let B = b;
-    if (a < 1) {
-        const [or, og, ob] = parseColor(over);
-        R = r * a + or * (1 - a);
-        G = g * a + og * (1 - a);
-        B = b * a + ob * (1 - a);
-    }
-    const lin = (c: number): number => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
-    const L = 0.2126 * lin(R) + 0.7152 * lin(G) + 0.0722 * lin(B);
-    return L >= 0.4 ? '#000000' : '#ffffff';
-}
+

--- a/src/renderers/native/chrome/SettingsDialog.ts
+++ b/src/renderers/native/chrome/SettingsDialog.ts
@@ -33,9 +33,13 @@ import {
     filterHiddenHostRows,
     filterHiddenRows,
     hostSectionId,
+    markGroupSettingsId,
+    MARKS_GROUPS_SETTINGS_ID,
+    MARKS_SETTINGS_ID,
     settingsIdHidden,
     settingsIdSlug,
 } from './settings-visibility';
+import type { MarkGroup } from '../../../core/marks/types';
 
 /** A nested partial of `ChartConfig` — what a single control edit emits. */
 type ConfigPatch = Record<string, unknown>;
@@ -187,6 +191,9 @@ export class SettingsDialog {
     private config: ChartConfig | null = null;
     private syncTypeTabs: ((style: string) => void) | null = null;
     private hostSections: HostSettingsSection[] = [];
+    /** The timeline-mark groups (defined + named by marks) — one checkbox each on the Events tab. */
+    private markGroups: MarkGroup[] = [];
+    private markGroupVisible: (id: string) => boolean = () => true;
     /** The Canvas → Theme row: current app theme + where a pick is raised. The row is a
      *  host callback, NOT a config patch — the app theme stays out of the persisted
      *  `ChartConfig`, so exported templates never carry it. */
@@ -209,6 +216,12 @@ export class SettingsDialog {
     /** Host-app sections (e.g. the widget's Status line tab) — re-shown on next open. */
     setHostSections(sections: HostSettingsSection[]): void {
         this.hostSections = sections;
+    }
+
+    /** The timeline-mark groups and their current visibility — the Events tab's rows on next open. */
+    setMarkGroups(groups: MarkGroup[], visible: (id: string) => boolean): void {
+        this.markGroups = groups;
+        this.markGroupVisible = visible;
     }
 
     /** Replace the visibility policy — an open dialog rebuilds in place to honor it. */
@@ -522,6 +535,15 @@ export class SettingsDialog {
             const tc = this.themeControl;
             body.append(sid(this.sectionTitle('Theme'), 'canvas.theme'));
             body.append(sid(this.selectRow('Color theme', tc.current === 'dark' ? 'Dark' : 'Light', ['Dark', 'Light'], (v) => tc.onSelect(v === 'Dark' ? 'dark' : 'light')), 'canvas.theme'));
+        }
+
+        // ══ EVENTS — timeline-mark group visibility, a tab of its own (present only while marks name groups) ══
+        if (this.markGroups.length > 0) {
+            body.append(sid(this.section('Events'), MARKS_SETTINGS_ID));
+            body.append(sid(this.sectionTitle('Visible events'), MARKS_GROUPS_SETTINGS_ID));
+            for (const g of this.markGroups) {
+                body.append(sid(this.boolRow(g.label, this.markGroupVisible(g.id), (v) => this.emit({ marks: { groups: { [g.id]: v } } })), markGroupSettingsId(g.id)));
+            }
         }
 
         renderChartTypeSections('end');

--- a/src/renderers/native/chrome/contrast.ts
+++ b/src/renderers/native/chrome/contrast.ts
@@ -1,0 +1,26 @@
+import { parseColor } from '../backend/gl/color';
+
+/**
+ * White or black text for a colored chip (a price tag, a timeline-mark token), biased
+ * toward white so saturated brand colors (the default candle green / red sit at
+ * L≈0.22–0.24) read as white, while genuinely light colors (a white or pale candle
+ * color) still get dark text. Uses relative luminance with a flip point of 0.4 — higher
+ * than `readableText`'s WCAG crossover (~0.18) which perceptually over-picks black on
+ * mid-tone fills. Translucent `bg` is composited over `over` first so the choice
+ * reflects what's actually seen.
+ */
+export function tagTextColor(bg: string, over: string): string {
+    const [r, g, b, a] = parseColor(bg);
+    let R = r;
+    let G = g;
+    let B = b;
+    if (a < 1) {
+        const [or, og, ob] = parseColor(over);
+        R = r * a + or * (1 - a);
+        G = g * a + og * (1 - a);
+        B = b * a + ob * (1 - a);
+    }
+    const lin = (c: number): number => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+    const L = 0.2126 * lin(R) + 0.7152 * lin(G) + 0.0722 * lin(B);
+    return L >= 0.4 ? '#000000' : '#ffffff';
+}

--- a/src/renderers/native/chrome/marks/MarkPopover.ts
+++ b/src/renderers/native/chrome/marks/MarkPopover.ts
@@ -1,0 +1,271 @@
+// The timeline-mark POPUP: the kit Popover anchored on a glyph of the canvas lane,
+// deploying every mark of the clicked cluster as a scrollable run of sections — each
+// its title over its content (escaped text, allowlisted HTML, or a structured panel of
+// fields and buttons). Lazy content resolves as its section scrolls into view, so a
+// cluster of many marks costs one fetch per entry actually looked at. The glyph is
+// canvas pixels, not DOM, so an invisible anchor element inside the plot stands in as
+// the popover's trigger; the renderer moves it as the glyph moves (pan/zoom).
+import type { VelaTheme } from '../../../../core/options';
+import type { MarkContent, MarkContentSource, MarkPanelItem } from '../../../../core/marks/types';
+import { Popover } from '../../../../ui/components/popover';
+import { CALLOUT_CSS, CALLOUT_STYLE_ID } from '../../../../ui/components/callout-bubble';
+import { injectStyles } from '../../../../ui/styles';
+import { sanitizeHtml } from '../../../../ui/sanitize-html';
+import type { MarkCluster } from './layout';
+
+const MARKS_STYLE_ID = 'vela-marks-popover';
+const MARKS_CSS = `
+.vela-marks-panel { padding: 0; gap: 0; min-width: 220px; max-width: 320px; max-height: 320px; overflow-y: auto; overscroll-behavior: contain; }
+.vela-marks-section { display: flex; flex-direction: column; gap: 8px; padding: 10px 12px; }
+.vela-marks-section + .vela-marks-section { border-top: 1px solid var(--vela-border); }
+.vela-marks-field { display: flex; justify-content: space-between; gap: 16px; line-height: 1.45; }
+.vela-marks-field-label { color: var(--vela-fg-muted); }
+.vela-marks-field-value { color: var(--vela-fg-bright); text-align: right; font-variant-numeric: tabular-nums; }
+.vela-marks-html { color: var(--vela-fg); line-height: 1.45; overflow-wrap: anywhere; }
+.vela-marks-html p { margin: 0 0 6px; }
+.vela-marks-html p:last-child { margin-bottom: 0; }
+.vela-marks-html a { color: var(--vela-accent); }
+.vela-marks-html img { max-width: 100%; height: auto; }
+.vela-marks-html table { border-collapse: collapse; }
+.vela-marks-html td, .vela-marks-html th { padding: 2px 6px; border: 1px solid var(--vela-border); }
+.vela-marks-html pre, .vela-marks-html code { font-family: var(--vela-font-mono, monospace); font-size: 0.92em; }
+.vela-marks-loading, .vela-marks-error { color: var(--vela-fg-muted); font-style: italic; }
+`;
+
+export interface MarkPopoverDeps {
+    /** The positioned plot element — the anchor lives in it. */
+    plot: HTMLElement;
+    /** Where the popup portals: the host's dialog root when it set one, else the plot. */
+    host: () => HTMLElement;
+    /** Live theme, read at open time. */
+    theme: () => VelaTheme;
+    /** The cluster whose popup shows changed — its key while one is open, null once it closed (the glyph paints "active" meanwhile). */
+    onOpenChange?: (key: string | null) => void;
+}
+
+/** A glyph's box in plot space (center + size). */
+export interface MarkGlyphRect {
+    x: number;
+    y: number;
+    size: number;
+}
+
+export class MarkPopover {
+    private readonly anchor: HTMLDivElement;
+    private pop: Popover | null = null;
+    private openKey: string | null = null;
+    /** Bumped per open/close — a lazy content resolving after its popup went away is dropped. */
+    private generation = 0;
+
+    constructor(private readonly deps: MarkPopoverDeps) {
+        const doc = deps.plot.ownerDocument;
+        injectStyles(CALLOUT_STYLE_ID, CALLOUT_CSS, doc);
+        injectStyles(MARKS_STYLE_ID, MARKS_CSS, doc);
+        this.anchor = doc.createElement('div');
+        this.anchor.className = 'vela-marks-anchor';
+        Object.assign(this.anchor.style, { position: 'absolute', pointerEvents: 'none', left: '0', top: '0', width: '0', height: '0' });
+        deps.plot.appendChild(this.anchor);
+    }
+
+    /** The cluster key the open popup belongs to, or null. */
+    get key(): string | null {
+        return this.openKey;
+    }
+
+    open(cluster: MarkCluster, rect: MarkGlyphRect): void {
+        this.close();
+        this.place(rect);
+        const gen = ++this.generation;
+        this.openKey = cluster.key;
+        this.pop = new Popover({
+            trigger: this.anchor,
+            host: this.deps.host(),
+            theme: this.deps.theme(),
+            gap: 8,
+            align: 'center', // centered on the glyph
+            fadeMs: 120, // a short, discreet fade in and out
+            className: 'vela-marks-pop',
+            content: (body) => this.build(body, cluster, gen),
+            onClose: () => {
+                // Outside click / Escape — the shell closed itself; forget it unless a newer one replaced it.
+                if (this.generation === gen) {
+                    this.openKey = null;
+                    this.pop = null;
+                    this.deps.onOpenChange?.(null);
+                }
+            },
+        });
+        this.pop.show();
+        this.deps.onOpenChange?.(cluster.key);
+    }
+
+    /** Follow the anchor glyph after a repaint; `null` (glyph gone — hidden, scrolled off, marks replaced) closes. */
+    track(rect: MarkGlyphRect | null): void {
+        if (!this.pop) return;
+        if (!rect) {
+            this.close();
+            return;
+        }
+        this.place(rect);
+        this.pop.reposition();
+    }
+
+    close(): void {
+        const pop = this.pop;
+        const wasOpen = this.openKey !== null;
+        this.pop = null;
+        this.openKey = null;
+        this.generation++; // bumped before destroy(): the shell's own onClose then sees a stale generation
+        pop?.destroy();
+        if (wasOpen) this.deps.onOpenChange?.(null);
+    }
+
+    destroy(): void {
+        this.close();
+        this.anchor.remove();
+    }
+
+    private place(rect: MarkGlyphRect): void {
+        Object.assign(this.anchor.style, {
+            left: `${rect.x - rect.size / 2}px`,
+            top: `${rect.y - rect.size / 2}px`,
+            width: `${rect.size}px`,
+            height: `${rect.size}px`,
+        });
+    }
+
+    private build(body: HTMLElement, cluster: MarkCluster, gen: number): void {
+        const doc = body.ownerDocument;
+        const root = doc.createElement('div');
+        root.className = 'vela-callout-panel vela-marks-panel';
+        const pending: Array<{ el: HTMLElement; resolve: () => void }> = [];
+        for (const mark of cluster.marks) {
+            const section = doc.createElement('section');
+            section.className = 'vela-marks-section';
+            if (mark.title) {
+                const title = doc.createElement('div');
+                title.className = 'vela-callout-title';
+                title.textContent = mark.title;
+                section.appendChild(title);
+            }
+            const content = mark.content;
+            if (typeof content === 'function') {
+                const slot = doc.createElement('div');
+                slot.className = 'vela-marks-loading';
+                slot.textContent = 'Loading…';
+                section.appendChild(slot);
+                pending.push({ el: section, resolve: () => this.resolveLazy(content, slot, gen) });
+            } else if (content !== undefined) {
+                this.renderContent(section, content);
+            }
+            if (section.childElementCount > 0) root.appendChild(section);
+        }
+        body.appendChild(root);
+        if (pending.length > 0) scheduleLazy(root, pending);
+    }
+
+    private resolveLazy(source: Exclude<MarkContentSource, MarkContent>, slot: HTMLElement, gen: number): void {
+        let result: Promise<MarkContent>;
+        try {
+            result = Promise.resolve(source());
+        } catch (err) {
+            result = Promise.reject(err instanceof Error ? err : new Error(String(err)));
+        }
+        void result.then(
+            (content) => {
+                if (gen !== this.generation) return;
+                const section = slot.parentElement;
+                if (!section) return;
+                slot.remove();
+                this.renderContent(section, content);
+                this.pop?.reposition(); // the panel grew — keep it inside the viewport
+            },
+            () => {
+                if (gen !== this.generation) return;
+                slot.className = 'vela-marks-error';
+                slot.textContent = 'Couldn’t load this entry.';
+            },
+        );
+    }
+
+    private renderContent(section: HTMLElement, content: MarkContent): void {
+        const doc = section.ownerDocument;
+        if (!content || typeof content !== 'object') return;
+        if ('text' in content) {
+            const text = doc.createElement('div');
+            text.className = 'vela-callout-text';
+            text.textContent = String(content.text);
+            section.appendChild(text);
+            return;
+        }
+        if ('html' in content) {
+            const html = doc.createElement('div');
+            html.className = 'vela-marks-html';
+            html.appendChild(sanitizeHtml(String(content.html), doc));
+            section.appendChild(html);
+            return;
+        }
+        if ('panel' in content && content.panel && Array.isArray(content.panel.items)) {
+            let actions: HTMLElement | null = null; // consecutive buttons share one row
+            for (const item of content.panel.items as MarkPanelItem[]) {
+                if (!item || typeof item !== 'object') continue;
+                if (item.type === 'button') {
+                    if (!actions) {
+                        actions = doc.createElement('div');
+                        actions.className = 'vela-callout-actions';
+                        section.appendChild(actions);
+                    }
+                    const btn = doc.createElement('button');
+                    btn.type = 'button';
+                    btn.className = 'vela-callout-btn' + (item.primary ? ' vela-callout-btn-primary' : '');
+                    btn.textContent = item.label;
+                    btn.addEventListener('click', () => {
+                        item.run();
+                        if (item.close !== false) this.close();
+                    });
+                    actions.appendChild(btn);
+                    continue;
+                }
+                actions = null;
+                if (item.type === 'text') {
+                    const text = doc.createElement('div');
+                    text.className = 'vela-callout-text';
+                    text.textContent = item.text;
+                    section.appendChild(text);
+                } else if (item.type === 'field') {
+                    const row = doc.createElement('div');
+                    row.className = 'vela-marks-field';
+                    const label = doc.createElement('span');
+                    label.className = 'vela-marks-field-label';
+                    label.textContent = item.label;
+                    const value = doc.createElement('span');
+                    value.className = 'vela-marks-field-value';
+                    value.textContent = item.value;
+                    row.append(label, value);
+                    section.appendChild(row);
+                }
+            }
+        }
+    }
+}
+
+/** Resolve each pending section as it scrolls into the panel's view (all at once where the observer is unavailable). */
+function scheduleLazy(scroller: HTMLElement, pending: Array<{ el: HTMLElement; resolve: () => void }>): void {
+    if (typeof IntersectionObserver === 'undefined') {
+        for (const p of pending) p.resolve();
+        return;
+    }
+    const io = new IntersectionObserver(
+        (entries) => {
+            for (const e of entries) {
+                if (!e.isIntersecting) continue;
+                const p = pending.find((q) => q.el === e.target);
+                if (!p) continue;
+                io.unobserve(e.target);
+                p.resolve();
+            }
+        },
+        { root: scroller },
+    );
+    for (const p of pending) io.observe(p.el);
+}

--- a/src/renderers/native/chrome/marks/layout.ts
+++ b/src/renderers/native/chrome/marks/layout.ts
@@ -1,0 +1,228 @@
+// The timeline-mark LANE's geometry — pure functions, node-testable: where each mark
+// snaps on the bar grid, how marks fold into clusters and stacks, where every glyph
+// sits, and which glyph is under a point. The painter and the renderer's hit-tests both
+// read the same `MarkLaneLayout`, so what is drawn is exactly what is clickable.
+import type { MarkGroup, TimelineMark } from '../../../../core/marks/types';
+
+/** Token size of a single mark, px. */
+export const MARK_GLYPH_PX = 16;
+/** Token size of a cluster (several marks of one group on one bar) — a little larger, px. */
+export const MARK_CLUSTER_PX = 20;
+/** Air between a glyph's bottom edge and the time-axis line, px. */
+export const MARK_LANE_INSET = 4;
+/** In a collapsed stack (several groups on one bar) each deeper group peeks out this far above the one over it, px. */
+export const MARK_DECK_STEP = 3;
+/** Gap between the fanned-out glyphs of an expanded stack, px. */
+export const MARK_FAN_GAP = 4;
+/** Forgiveness around a glyph for hover/click, px. */
+export const MARK_HIT_PAD = 3;
+/** Extra reach above a fanned stack's top glyph before the fan folds — a pointer overshooting the top by a few px keeps it open, px. */
+export const MARK_FAN_HOLD = 8;
+
+/** The marks of one visibility group that snapped onto one bar. */
+export interface MarkCluster {
+    /** `${bar}|${group}` — stable across frames, what an open popup is keyed by. */
+    key: string;
+    /** The snapped bar index (may lie past the loaded range: the extrapolated grid). */
+    bar: number;
+    group: string | undefined;
+    /** Earliest time first, then insertion order. */
+    marks: TimelineMark[];
+}
+
+/** One glyph as laid out for this frame. */
+export interface PlacedGlyph {
+    cluster: MarkCluster;
+    /** Center, plot-space px. */
+    x: number;
+    y: number;
+    size: number;
+    /** The stack (bar index) this glyph belongs to, and its depth in it (0 = the top group). */
+    stack: number;
+    depth: number;
+    /** The stack holds several groups and is drawn collapsed (a deck): only its top glyph is interactive. */
+    decked: boolean;
+}
+
+export interface MarkLaneLayout {
+    /** In paint order (a deck's deeper glyphs first, its top glyph last). */
+    glyphs: PlacedGlyph[];
+    /** Per stack (bar index), depth-ordered. */
+    stacks: Map<number, PlacedGlyph[]>;
+}
+
+export interface MarkLaneInput {
+    marks: readonly TimelineMark[];
+    /** The defined groups, in definition order — the deck order of a multi-group stack. */
+    groups: readonly MarkGroup[];
+    /** Whether a group's marks are hidden (settings) — never called for ungrouped marks. */
+    hidden: (groupId: string) => boolean;
+    /** The chart's bar open times, ascending. */
+    barTimes: readonly number[];
+    intervalMs: number;
+    /** Bar index → plot x of the bar's center. */
+    xOf: (bar: number) => number;
+    /** The y of the time-axis line (the plot's data height). */
+    axisY: number;
+    dataW: number;
+    /** The stack (bar index) fanned out by hover/tap, if any. */
+    expanded: number | null;
+}
+
+/**
+ * The bar a mark time belongs to: the bar whose `[open, open + interval)` span contains
+ * it; a time in a gap (weekend, closed session) goes to the first bar that follows; a
+ * time past the newest bar's span lands on the extrapolated grid (a virtual bar in the
+ * right whitespace). `null` before the first loaded bar — nothing to anchor to yet.
+ */
+export function snapMarkBar(time: number, barTimes: readonly number[], intervalMs: number): number | null {
+    const n = barTimes.length;
+    if (n === 0 || !(intervalMs > 0) || !Number.isFinite(time)) return null;
+    if (time < barTimes[0]!) return null;
+    const last = barTimes[n - 1]!;
+    if (time >= last + intervalMs) return n - 1 + Math.floor((time - last) / intervalMs);
+    // Greatest i with barTimes[i] <= time.
+    let lo = 0;
+    let hi = n - 1;
+    while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (barTimes[mid]! <= time) lo = mid;
+        else hi = mid - 1;
+    }
+    if (time < barTimes[lo]! + intervalMs) return lo;
+    return lo + 1; // in a gap — `time < last + interval` guarantees lo < n - 1
+}
+
+/** Fold the visible marks into clusters keyed by (snapped bar, group); each cluster's marks run earliest-first, then insertion order. */
+export function clusterMarks(marks: readonly TimelineMark[], barTimes: readonly number[], intervalMs: number, hidden: (groupId: string) => boolean): MarkCluster[] {
+    const byKey = new Map<string, MarkCluster & { seq: number[] }>();
+    marks.forEach((m, seq) => {
+        if (m.group !== undefined && hidden(m.group)) return;
+        const bar = snapMarkBar(m.time, barTimes, intervalMs);
+        if (bar === null) return;
+        const key = `${bar}|${m.group ?? ''}`;
+        let c = byKey.get(key);
+        if (!c) {
+            c = { key, bar, group: m.group, marks: [], seq: [] };
+            byKey.set(key, c);
+        }
+        c.marks.push(m);
+        c.seq.push(seq);
+    });
+    const out: MarkCluster[] = [];
+    for (const c of byKey.values()) {
+        const order = c.marks.map((m, i) => ({ m, seq: c.seq[i]! })).sort((a, b) => a.m.time - b.m.time || a.seq - b.seq);
+        out.push({ key: c.key, bar: c.bar, group: c.group, marks: order.map((o) => o.m) });
+    }
+    return out;
+}
+
+/** Deck order of the groups: defined groups first (definition order), then undefined ones by first appearance, ungrouped marks last. */
+function groupRank(groups: readonly MarkGroup[], clusters: readonly MarkCluster[]): (group: string | undefined) => number {
+    const rank = new Map<string, number>();
+    groups.forEach((g, i) => rank.set(g.id, i));
+    for (const c of clusters) {
+        if (c.group !== undefined && !rank.has(c.group)) rank.set(c.group, rank.size);
+    }
+    return (group) => (group === undefined ? Number.MAX_SAFE_INTEGER : (rank.get(group) ?? Number.MAX_SAFE_INTEGER - 1));
+}
+
+/** Lay the lane out for one frame. */
+export function layoutMarkLane(input: MarkLaneInput): MarkLaneLayout {
+    const clusters = clusterMarks(input.marks, input.barTimes, input.intervalMs, input.hidden);
+    const rankOf = groupRank(input.groups, clusters);
+    const byBar = new Map<number, MarkCluster[]>();
+    for (const c of clusters) {
+        const list = byBar.get(c.bar);
+        if (list) list.push(c);
+        else byBar.set(c.bar, [c]);
+    }
+    const glyphs: PlacedGlyph[] = [];
+    const stacks = new Map<number, PlacedGlyph[]>();
+    for (const [bar, list] of byBar) {
+        const x = input.xOf(bar);
+        if (!Number.isFinite(x) || x < -MARK_CLUSTER_PX || x > input.dataW + MARK_CLUSTER_PX) continue;
+        list.sort((a, b) => rankOf(a.group) - rankOf(b.group));
+        const multi = list.length > 1;
+        const expanded = multi && input.expanded === bar;
+        const decked = multi && !expanded;
+        const placed: PlacedGlyph[] = [];
+        // A deck draws every glyph at the TOP glyph's size so the peeking edges line up.
+        const deckSize = list[0]!.marks.length > 1 ? MARK_CLUSTER_PX : MARK_GLYPH_PX;
+        let bottom = input.axisY - MARK_LANE_INSET; // bottom edge of the next fanned glyph
+        list.forEach((cluster, depth) => {
+            const size = decked ? deckSize : cluster.marks.length > 1 ? MARK_CLUSTER_PX : MARK_GLYPH_PX;
+            let y: number;
+            if (expanded) {
+                y = bottom - size / 2;
+                bottom -= size + MARK_FAN_GAP;
+            } else {
+                y = input.axisY - MARK_LANE_INSET - size / 2 - depth * MARK_DECK_STEP;
+            }
+            placed.push({ cluster, x, y, size, stack: bar, depth, decked });
+        });
+        // Deeper glyphs paint first so the top group ends up on top of the deck.
+        for (let i = placed.length - 1; i >= 0; i--) glyphs.push(placed[i]!);
+        stacks.set(bar, placed);
+    }
+    return { glyphs, stacks };
+}
+
+/** The interactive glyph under a plot point, topmost first; a collapsed deck answers with its top glyph only. */
+export function markGlyphAt(layout: MarkLaneLayout, x: number, y: number): PlacedGlyph | null {
+    for (let i = layout.glyphs.length - 1; i >= 0; i--) {
+        const g = layout.glyphs[i]!;
+        if (g.decked && g.depth !== 0) continue;
+        const r = g.size / 2 + MARK_HIT_PAD;
+        if (Math.abs(x - g.x) <= r && Math.abs(y - g.y) <= r) return g;
+    }
+    return null;
+}
+
+/** The stack (bar index) whose fanned or decked glyphs cover a plot point — what keeps a fan open while the pointer climbs it. */
+export function markStackAt(layout: MarkLaneLayout, x: number, y: number): number | null {
+    for (const [bar, placed] of layout.stacks) {
+        for (const g of placed) {
+            const r = g.size / 2 + MARK_HIT_PAD;
+            if (Math.abs(x - g.x) <= r && Math.abs(y - g.y) <= r) return bar;
+        }
+        // The gaps between fanned glyphs count too — a pointer climbing the fan must not collapse
+        // it — and so does a short reach past the top glyph, so overshooting it by a few pixels
+        // does not fold the fan under the pointer.
+        if (placed.length > 1 && !placed[0]!.decked) {
+            const top = placed[placed.length - 1]!;
+            const base = placed[0]!;
+            const r = Math.max(top.size, base.size) / 2 + MARK_HIT_PAD;
+            if (Math.abs(x - base.x) <= r && y >= top.y - top.size / 2 - MARK_FAN_HOLD && y <= base.y + base.size / 2 + MARK_HIT_PAD) return bar;
+        }
+    }
+    return null;
+}
+
+/** Hover text for a glyph: the mark's own tooltip (or title) alone; a cluster names its group and size. */
+export function clusterTooltip(cluster: MarkCluster, groups: readonly MarkGroup[]): string | null {
+    const first = cluster.marks[0];
+    if (!first) return null;
+    if (cluster.marks.length === 1) return first.tooltip ?? first.title ?? null;
+    const label = cluster.group !== undefined ? markGroupLabel(cluster.group, groups) : (first.title ?? first.tooltip ?? 'Marks');
+    return `${label} · ${cluster.marks.length}`;
+}
+
+/** A group's display label: its definition, else the capitalized id. */
+export function markGroupLabel(groupId: string, groups: readonly MarkGroup[]): string {
+    const def = groups.find((g) => g.id === groupId);
+    if (def) return def.label;
+    return groupId.charAt(0).toUpperCase() + groupId.slice(1);
+}
+
+/** Every group the chart knows about: the defined ones (definition order), then the ids marks name without a definition (first appearance), each with its display label. */
+export function effectiveMarkGroups(marks: readonly TimelineMark[], groups: readonly MarkGroup[]): MarkGroup[] {
+    const out: MarkGroup[] = groups.map((g) => ({ ...g }));
+    const seen = new Set(out.map((g) => g.id));
+    for (const m of marks) {
+        if (m.group === undefined || seen.has(m.group)) continue;
+        seen.add(m.group);
+        out.push({ id: m.group, label: markGroupLabel(m.group, groups) });
+    }
+    return out;
+}

--- a/src/renderers/native/chrome/marks/paint.ts
+++ b/src/renderers/native/chrome/marks/paint.ts
@@ -1,0 +1,192 @@
+// Canvas painting of the timeline-mark lane: one outlined token per glyph (circle, square,
+// diamond or pin) drawn in the mark's color on the plot background, carrying a letter or a
+// registry icon in that same color; a hairline stem down to the time-axis line; and a
+// background-colored halo so the cards of a collapsed deck separate. The token the pointer
+// lands on swells once and settles; the one whose popup is open (or that was just clicked)
+// paints filled — color for the body and outline, white ink. Icons are SVG in the registry; the
+// canvas gets them as images rasterized once per (icon, ink, size) and cached — the first
+// frame after a cache miss paints the bare token and the renderer repaints when the image
+// lands.
+import { iconMarkup } from '../../../../core/icons';
+import type { MarkShape } from '../../../../core/marks/types';
+import type { MarkLaneLayout } from './layout';
+
+/** The hover pulse — one swell-and-settle when the pointer lands on a token — ms. */
+export const MARK_PULSE_MS = 360;
+/** How much the token grows at the pulse's peak (a fraction of its size). */
+export const MARK_PULSE_AMPLITUDE = 0.1;
+/** Ink of a filled (active) token. */
+const ACTIVE_INK = '#ffffff';
+
+export interface MarkPaintDeps {
+    /** The time-axis line's y — every stack's base glyph drops a stem onto it. */
+    axisY: number;
+    /** The plot background: the idle token's fill and the separating halo. */
+    background: string;
+    /** Stem color (the axis border). */
+    stemColor: string;
+    fontFamily: string;
+    dpr: number;
+    icons: MarkIconRaster;
+    /** The cluster under the pointer (it pulsed once when the pointer landed) and when that hover began, frame-clock ms. */
+    hoverKey: string | null;
+    hoverSince: number;
+    /** The cluster whose popup is open — painted filled. */
+    activeKey: string | null;
+    /** A just-clicked content-less cluster — painted filled for a moment. */
+    flashKey: string | null;
+    /** The frame clock, ms. */
+    nowMs: number;
+}
+
+/** The hovered token's size multiplier `elapsed` ms into the hover: one swell to 1 + amplitude at mid-pulse, back to 1 at its end, 1 ever after. */
+export function pulseScale(elapsedMs: number): number {
+    if (!(elapsedMs > 0) || elapsedMs >= MARK_PULSE_MS) return 1;
+    return 1 + MARK_PULSE_AMPLITUDE * Math.sin((Math.PI * elapsedMs) / MARK_PULSE_MS);
+}
+
+export function paintMarkLane(ctx: CanvasRenderingContext2D, layout: MarkLaneLayout, deps: MarkPaintDeps): void {
+    if (layout.glyphs.length === 0) return;
+    ctx.save();
+    ctx.setLineDash([]);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    for (const g of layout.glyphs) {
+        const mark = g.cluster.marks[0];
+        if (!mark) continue;
+        const key = g.cluster.key;
+        const color = mark.glyph.color;
+        const active = key === deps.activeKey || key === deps.flashKey;
+        const size = g.size * (key === deps.hoverKey ? pulseScale(deps.nowMs - deps.hoverSince) : 1);
+        if (g.depth === 0) {
+            // The stem ties the stack to its bar on the axis line.
+            const sx = Math.round(g.x) + 0.5;
+            ctx.lineWidth = 1;
+            ctx.strokeStyle = deps.stemColor;
+            ctx.beginPath();
+            ctx.moveTo(sx, g.y + g.size / 2);
+            ctx.lineTo(sx, deps.axisY);
+            ctx.stroke();
+        }
+        const shape = mark.glyph.shape ?? 'circle';
+        // Halo: a background-colored ring under the outline separates deck cards and lifts the token off the candles.
+        const center = traceShape(ctx, shape, g.x, g.y, size);
+        ctx.lineWidth = 4;
+        ctx.strokeStyle = deps.background;
+        ctx.stroke();
+        ctx.fillStyle = active ? color : deps.background;
+        ctx.fill();
+        ctx.lineWidth = 1.5;
+        ctx.strokeStyle = color;
+        ctx.stroke();
+        const ink = active ? ACTIVE_INK : color;
+        const symbolPx = Math.round(size * 0.62);
+        if (mark.glyph.icon) {
+            const img = deps.icons.get(mark.glyph.icon, ink, symbolPx, deps.dpr);
+            if (img) ctx.drawImage(img, center.x - symbolPx / 2, center.y - symbolPx / 2, symbolPx, symbolPx);
+        } else if (mark.glyph.letter) {
+            ctx.fillStyle = ink;
+            ctx.font = `600 ${Math.round(size * 0.58)}px ${deps.fontFamily}`;
+            ctx.fillText(mark.glyph.letter.slice(0, 2), center.x, center.y + 0.5);
+        }
+    }
+    ctx.restore();
+}
+
+/** Trace a token outline centered at (x, y) and return where its symbol centers (a pin's head sits above its tail). */
+function traceShape(ctx: CanvasRenderingContext2D, shape: MarkShape, x: number, y: number, size: number): { x: number; y: number } {
+    const r = size / 2;
+    ctx.beginPath();
+    switch (shape) {
+        case 'square': {
+            const c = Math.min(3, r / 2);
+            roundedRect(ctx, x - r, y - r, size, size, c);
+            return { x, y };
+        }
+        case 'diamond':
+            ctx.moveTo(x, y - r);
+            ctx.lineTo(x + r, y);
+            ctx.lineTo(x, y + r);
+            ctx.lineTo(x - r, y);
+            ctx.closePath();
+            return { x, y };
+        case 'pin': {
+            // A round head over a short tail that points at the bar.
+            const hr = r * 0.82;
+            const hy = y - r + hr;
+            ctx.arc(x, hy, hr, Math.PI * 0.75, Math.PI * 0.25, false);
+            ctx.lineTo(x, y + r);
+            ctx.closePath();
+            return { x, y: hy };
+        }
+        case 'circle':
+        default:
+            ctx.arc(x, y, r, 0, Math.PI * 2);
+            return { x, y };
+    }
+}
+
+function roundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, radius: number): void {
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + w - radius, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+    ctx.lineTo(x + w, y + h - radius);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+    ctx.lineTo(x + radius, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
+    ctx.lineTo(x, y + radius);
+    ctx.quadraticCurveTo(x, y, x + radius, y);
+    ctx.closePath();
+}
+
+/**
+ * Registry icons as canvas-drawable images, keyed by (icon, ink, px, dpr). A miss starts
+ * the load and answers null; `onReady` fires when the image lands so the owner can
+ * repaint. Icons are HTML-parsed then XML-serialized: the registry's markup is written
+ * for `innerHTML` (duplicate attributes, no namespace), which a standalone SVG image
+ * would refuse.
+ */
+export class MarkIconRaster {
+    private readonly cache = new Map<string, HTMLImageElement | null>();
+
+    constructor(private readonly onReady: () => void) {}
+
+    get(icon: string, ink: string, px: number, dpr: number): HTMLImageElement | null {
+        const key = `${icon}|${ink}|${px}|${dpr}`;
+        if (this.cache.has(key)) {
+            const img = this.cache.get(key);
+            return img && img.complete && img.naturalWidth > 0 ? img : null;
+        }
+        const markup = iconMarkup(icon);
+        if (!markup || typeof document === 'undefined' || typeof Image === 'undefined' || typeof XMLSerializer === 'undefined') {
+            this.cache.set(key, null);
+            return null;
+        }
+        const svg = standaloneSvg(markup, ink, Math.max(1, Math.ceil(px * dpr)));
+        if (!svg) {
+            this.cache.set(key, null);
+            return null;
+        }
+        const img = new Image();
+        img.onload = () => this.onReady();
+        img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+        this.cache.set(key, img);
+        return null;
+    }
+
+    clear(): void {
+        this.cache.clear();
+    }
+}
+
+function standaloneSvg(markup: string, ink: string, px: number): string | null {
+    const tpl = document.createElement('template');
+    tpl.innerHTML = markup;
+    const svg = tpl.content.firstElementChild;
+    if (!svg || svg.tagName.toLowerCase() !== 'svg') return null;
+    svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    svg.setAttribute('width', String(px));
+    svg.setAttribute('height', String(px));
+    svg.setAttribute('color', ink); // what `currentColor` resolves to in a standalone image
+    return new XMLSerializer().serializeToString(svg);
+}

--- a/src/renderers/native/chrome/settings-visibility.ts
+++ b/src/renderers/native/chrome/settings-visibility.ts
@@ -27,6 +27,16 @@ export function settingsIdSlug(label: string): string {
         .replace(/^-+|-+$/g, '');
 }
 
+/** The Events tab — timeline-mark visibility; present once marks name groups. */
+export const MARKS_SETTINGS_ID = 'events';
+/** Its "Visible events" section: one checkbox per mark group (the id names the groups, not the label). */
+export const MARKS_GROUPS_SETTINGS_ID = 'events.groups';
+
+/** A mark group's settings-row id (`events.groups.<group-id>`, the id kebab-cased). */
+export function markGroupSettingsId(groupId: string): string {
+    return `${MARKS_GROUPS_SETTINGS_ID}.${settingsIdSlug(groupId)}`;
+}
+
 /** True when `id` — or any of its dot-path ancestors — is in the hidden set. */
 export function settingsIdHidden(id: string, hidden: ReadonlySet<string>): boolean {
     if (hidden.size === 0) return false;
@@ -203,12 +213,19 @@ export const BUILTIN_SETTINGS_IDS: readonly string[] = [
 /**
  * Every addressable setting id of a chart instance: the built-ins, the registered
  * chart types' sections (rows enumerated across flat rows, instances, and
- * subsections), and the given host sections. The discovery surface behind
+ * subsections), the given host sections, and the timeline-mark groups (the Events tab,
+ * present once marks name groups). The discovery surface behind
  * `chart.renderer.listSettingsIds()` — hosts enumerate this instead of reading
  * contributor source.
  */
-export function settingsIdCatalog(hostSections: readonly HostSectionIdSource[]): string[] {
+export function settingsIdCatalog(hostSections: readonly HostSectionIdSource[], markGroups: readonly { id: string }[] = []): string[] {
     const ids = new Set<string>(BUILTIN_SETTINGS_IDS);
+    // Dynamic rows — one per mark group — so they enumerate here, not in the static list.
+    if (markGroups.length > 0) {
+        ids.add(MARKS_SETTINGS_ID);
+        ids.add(MARKS_GROUPS_SETTINGS_ID);
+        for (const g of markGroups) ids.add(markGroupSettingsId(g.id));
+    }
     for (const def of chartTypes()) {
         // A plugin style painting its own candles gets the per-style cosmetics group
         // in the Symbol tab (settings section or not) — same row set as the built-in.

--- a/src/renderers/native/core/SceneGraph.ts
+++ b/src/renderers/native/core/SceneGraph.ts
@@ -7,6 +7,8 @@ import type { PriceStyle } from '../../../core/options';
 import type { PriceScale, PaneBounds } from './CoordinateSystem';
 import { type CandlePaintOverride, type ChartStyle, defaultChartStyle } from './chartConfig';
 import { defaultTradeMarkersState, type TradeMarkersState } from '../../shared/trade-markers';
+import { defaultMarksState, type MarksDisplayState } from '../../shared/marks-state';
+import type { MarkGroup, TimelineMark } from '../../../core/marks/types';
 
 /** A user-defined shaded time band spanning the full plot height (all panes) — the
  *  generic primitive behind session highlighting (weekends, pre/regular/post). Unlike
@@ -188,6 +190,20 @@ export class SceneGraph {
     /** Strategy trade-marker display (the `tradeMarkers` feature): master toggle, the
      *  two text lines, and the palette. Trade markers always paint on the price pane. */
     tradeMarkers: TradeMarkersState = defaultTradeMarkersState();
+    /** Timeline-mark display (the `marks` feature): the lane's master toggle + per-group visibility. */
+    marks: MarksDisplayState = defaultMarksState();
+    /** The host's timeline marks + group definitions (`setTimelineMarks`), painted on the lane above the time axis. */
+    timelineMarks: readonly TimelineMark[] = [];
+    markGroups: readonly MarkGroup[] = [];
+    /** The mark stack (bar index) fanned out by hover or tap, if any. */
+    marksExpandedStack: number | null = null;
+    /** The lane glyph (cluster key) under the pointer — it pulses — and when the hover began (frame-clock ms). */
+    marksHoverKey: string | null = null;
+    marksHoverSince = 0;
+    /** The cluster whose popup is open: its glyph paints filled ("active"). */
+    marksActiveKey: string | null = null;
+    /** A content-less click's brief filled flash — the cluster key and the frame-clock time it ends. */
+    marksFlash: { key: string; until: number } | null = null;
     /** Renderer-owned shaded time bands (session highlighting), behind grid + data. */
     highlights: HighlightArea[] = [];
     /** Pre/post-market bands pushed by the host (`sessionZones` feature); null ⇒ no sessions. */

--- a/src/renderers/native/core/chartConfig.ts
+++ b/src/renderers/native/core/chartConfig.ts
@@ -246,6 +246,12 @@ export interface ChartConfig {
     timeScale: {
         timezone: string;
     };
+    /** Timeline marks (the `marks` feature): the lane's master toggle + per-group visibility
+     *  (the Events tab's checkboxes). `groups` merges additively, like `stacking.series`. */
+    marks: {
+        visible: boolean;
+        groups: Record<string, boolean>;
+    };
     /** Per-chart-type settings (plugin SDK sections), keyed by type id then row key. */
     chartTypes: Record<string, Record<string, unknown>>;
     candles: {
@@ -530,6 +536,8 @@ export function mergeConfig(base: ChartConfig, patch: unknown): ChartConfig {
     const panes = asObject(p.panes);
     const trades = asObject(p.trades);
     const ts = asObject(p.timeScale);
+    const marks = asObject(p.marks);
+    const markGroups = asObject(marks.groups);
     const candles = asObject(p.candles);
     const bars = asObject(p.bars);
     const line = asObject(p.line);
@@ -590,6 +598,15 @@ export function mergeConfig(base: ChartConfig, patch: unknown): ChartConfig {
         },
         timeScale: {
             timezone: typeof ts.timezone === 'string' && ts.timezone ? ts.timezone : base.timeScale.timezone,
+        },
+        marks: {
+            visible: isBool(marks.visible) ? marks.visible : base.marks.visible,
+            // Additive like `stacking.series`: a patch names only the groups it carries, so a
+            // choice stored for a group the host has not registered yet survives verbatim.
+            groups: {
+                ...base.marks.groups,
+                ...Object.fromEntries(Object.entries(markGroups).filter(([, v]) => isBool(v)) as Array<[string, boolean]>),
+            },
         },
         candles: {
             upColor: isColor(candles.upColor) ? candles.upColor : base.candles.upColor,

--- a/src/renderers/shared/marks-state.ts
+++ b/src/renderers/shared/marks-state.ts
@@ -1,0 +1,38 @@
+// Display state of the `marks` renderer feature — the timeline-mark lane's master
+// toggle plus per-group visibility. Pure (no DOM, no renderer types): the settings
+// dialog, the config reducer and the lane painter all read it, and it is node-testable.
+import type { MarkGroup } from '../../core/marks/types';
+
+export interface MarksDisplayState {
+    /** Master visibility of the lane. */
+    visible: boolean;
+    /** Per-group visibility keyed by group id. An absent id follows the group's own declared default. */
+    groups: Record<string, boolean>;
+}
+
+export function defaultMarksState(): MarksDisplayState {
+    return { visible: true, groups: {} };
+}
+
+/**
+ * Validated merge of an untrusted partial onto a state: a bare boolean toggles the
+ * lane; an object patches `visible` and/or `groups`. Groups merge ADDITIVELY — a patch
+ * names only the ids it carries and the rest keep their values, so a persisted choice
+ * for a group the host has not (yet) registered survives verbatim. Malformed values drop.
+ */
+export function mergeMarksState(base: MarksDisplayState, patch: unknown): MarksDisplayState {
+    if (typeof patch === 'boolean') return { visible: patch, groups: { ...base.groups } };
+    const p = (patch && typeof patch === 'object' ? patch : {}) as Record<string, unknown>;
+    const g = (p.groups && typeof p.groups === 'object' ? p.groups : {}) as Record<string, unknown>;
+    const groups: Record<string, boolean> = { ...base.groups };
+    for (const [id, v] of Object.entries(g)) if (typeof v === 'boolean') groups[id] = v;
+    return { visible: typeof p.visible === 'boolean' ? p.visible : base.visible, groups };
+}
+
+/** Whether a group's marks paint: the user's choice when one is stored, else the group's declared default, else visible. Ungrouped marks always paint. */
+export function markGroupVisible(state: MarksDisplayState, groupId: string | undefined, groups: readonly MarkGroup[]): boolean {
+    if (groupId === undefined) return true;
+    const chosen = state.groups[groupId];
+    if (typeof chosen === 'boolean') return chosen;
+    return groups.find((g) => g.id === groupId)?.visible !== false;
+}

--- a/src/ui/components/popover/controller.ts
+++ b/src/ui/components/popover/controller.ts
@@ -1,7 +1,7 @@
 // Popover CONTROLLER — placement math only. No DOM: the view measures rects and
 // the vanilla (or a future React) projection applies the returned coordinates.
 
-export type PopoverAlign = 'start' | 'end';
+export type PopoverAlign = 'start' | 'end' | 'center';
 export type PopoverPosition = 'fixed' | 'absolute';
 
 /** Axis-aligned rectangle in viewport coordinates. */
@@ -67,10 +67,11 @@ export function intersectRects(a: Rect, b: Rect): Rect {
 /**
  * Place a popover under `trigger`, flipping above when it would leave `clamp`.
  * Prefers the side with more room when neither fully fits. `align: 'end'` right-aligns
- * to the trigger (swatches and width fields sit at the row's right edge).
+ * to the trigger (swatches and width fields sit at the row's right edge); `'center'`
+ * centers it on the trigger (a popup over a small glyph).
  */
 export function placePopover(a: PlaceArgs): PlaceResult {
-    let left = a.align === 'end' ? a.trigger.right - a.pop.width : a.trigger.left;
+    let left = a.align === 'end' ? a.trigger.right - a.pop.width : a.align === 'center' ? a.trigger.left + a.trigger.width / 2 - a.pop.width / 2 : a.trigger.left;
     const below = a.trigger.bottom + a.gap;
     const above = a.trigger.top - a.pop.height - a.gap;
     const fitsBelow = below + a.pop.height <= a.clamp.bottom;

--- a/src/ui/components/popover/view.ts
+++ b/src/ui/components/popover/view.ts
@@ -28,6 +28,8 @@ export interface PopoverOptions extends PopoverControllerOptions {
     zIndex?: string | number;
     /** Clamp rectangle. `'viewport'` (default) or an element (dialog / chart host). */
     boundary?: PopoverBoundary;
+    /** Fade the shell in on show and out on hide over this many ms (default 0 — instant). */
+    fadeMs?: number;
 }
 
 let open: Popover | null = null;
@@ -77,6 +79,9 @@ export class Popover {
     private onKey: ((e: KeyboardEvent) => void) | null = null;
     private onReflow: (() => void) | null = null;
     private shown = false;
+    private readonly fadeMs: number;
+    /** The pending removal of a fading-out shell; a show() that reuses the shell cancels it. */
+    private leaveTimer: ReturnType<typeof setTimeout> | null = null;
 
     constructor(opts: PopoverOptions) {
         const doc = opts.trigger.ownerDocument;
@@ -86,6 +91,7 @@ export class Popover {
         this.ctrl = popoverController(opts);
         this.boundary = opts.boundary ?? 'viewport';
         this.theme = opts.theme;
+        this.fadeMs = Math.max(0, opts.fadeMs ?? 0);
 
         this.el = doc.createElement('div');
         this.el.className = 'vela-popover vela-ui-layer' + (opts.className ? ` ${opts.className}` : '');
@@ -115,11 +121,22 @@ export class Popover {
             return;
         }
         if (open && open !== this) open.hide();
+        if (this.leaveTimer !== null) {
+            clearTimeout(this.leaveTimer);
+            this.leaveTimer = null;
+        }
         ensureUIHost(this.el, this.theme);
+        if (this.fadeMs > 0) {
+            this.el.style.transition = `opacity ${this.fadeMs}ms ease`;
+            this.el.style.opacity = '0';
+            this.el.style.pointerEvents = '';
+        }
         this.host.appendChild(this.el);
         this.shown = true;
         open = this;
         this.place();
+        // place() measured the shell (a style flush at opacity 0) — flipping it now runs the transition.
+        if (this.fadeMs > 0) this.el.style.opacity = '1';
         const onOutside = (ev: Event): void => {
             const t = ev.target as Node;
             if (this.el.contains(t) || this.trigger.contains(t)) return;
@@ -158,7 +175,17 @@ export class Popover {
         this.onOutside = null;
         this.onKey = null;
         this.onReflow = null;
-        this.el.remove();
+        if (this.fadeMs > 0) {
+            // Fade out, then leave the DOM; the shell is inert meanwhile (no listeners, not `open`, no hits).
+            this.el.style.opacity = '0';
+            this.el.style.pointerEvents = 'none';
+            this.leaveTimer = setTimeout(() => {
+                this.leaveTimer = null;
+                this.el.remove();
+            }, this.fadeMs);
+        } else {
+            this.el.remove();
+        }
         this.shown = false;
         if (open === this) open = null;
         this.ctrl.onClose?.();

--- a/src/ui/sanitize-html.ts
+++ b/src/ui/sanitize-html.ts
@@ -1,0 +1,116 @@
+// A conservative HTML allowlist for host-supplied rich text (the timeline-mark popups).
+// The policy is pure string logic (node-testable); `sanitizeHtml` applies it with the
+// real DOM parser — a `<template>` parses without executing anything — and rebuilds a
+// fragment from allowed elements and attributes only, so scripts, styles, frames,
+// event handlers and `javascript:` URLs never reach the page. Escaping would defeat the
+// point (the markup would show as source); filtering keeps the formatting and drops the
+// hazards.
+
+/** Elements kept as-is (with their allowed attributes). */
+const ALLOWED_TAGS = new Set([
+    'a', 'abbr', 'b', 'blockquote', 'br', 'code', 'dd', 'del', 'div', 'dl', 'dt', 'em',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'ins', 'kbd', 'li', 'mark', 'ol', 'p', 'pre', 'q',
+    's', 'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'u', 'ul',
+]);
+
+/** Elements dropped WITH their content — anything active, embedded, or form-shaped. */
+const DROPPED_TAGS = new Set([
+    'script', 'style', 'iframe', 'frame', 'frameset', 'object', 'embed', 'applet', 'form', 'input', 'textarea', 'button',
+    'select', 'option', 'link', 'meta', 'base', 'svg', 'math', 'template', 'noscript', 'audio', 'video', 'canvas', 'dialog', 'head', 'title',
+]);
+
+/** Per-element attributes kept, beyond the global `title`. */
+const ALLOWED_ATTRS: Record<string, ReadonlySet<string>> = {
+    a: new Set(['href']),
+    img: new Set(['src', 'alt', 'width', 'height']),
+    td: new Set(['colspan', 'rowspan']),
+    th: new Set(['colspan', 'rowspan']),
+    ol: new Set(['start']),
+};
+
+/** URL schemes that run code or smuggle content; a URL with any of these is dropped. */
+const BLOCKED_SCHEMES = new Set(['javascript', 'vbscript', 'data', 'file', 'blob']);
+
+/** Whether an element survives (kept or unwrapped) or is dropped with its content. */
+export function tagDisposition(tag: string): 'keep' | 'unwrap' | 'drop' {
+    const t = tag.toLowerCase();
+    if (DROPPED_TAGS.has(t)) return 'drop';
+    return ALLOWED_TAGS.has(t) ? 'keep' : 'unwrap';
+}
+
+/** Whether an attribute is kept on an element. Event handlers (`on*`) and `style` never are. */
+export function attributeAllowed(tag: string, name: string): boolean {
+    const n = name.toLowerCase();
+    if (n.startsWith('on') || n === 'style') return false;
+    if (n === 'title') return true;
+    return ALLOWED_ATTRS[tag.toLowerCase()]?.has(n) ?? false;
+}
+
+/**
+ * A URL cleared for `href`/`src`, or `null`. Scheme-less (relative, `#anchor`) URLs pass;
+ * `absoluteOnly` (image sources) additionally requires `http(s):`, so a page can never
+ * be made to load an inline or local resource through a mark.
+ */
+export function safeUrl(value: string, absoluteOnly = false): string | null {
+    // Control characters and whitespace are stripped first: a scheme split by a tab or a
+    // newline (`java\tscript:`) still runs once the browser normalizes it.
+    let url = '';
+    for (const ch of value) if (ch.charCodeAt(0) > 32) url += ch;
+    const m = /^([a-z][a-z0-9+.-]*):/i.exec(url);
+    const scheme = m ? m[1]!.toLowerCase() : null;
+    if (scheme !== null && BLOCKED_SCHEMES.has(scheme)) return null;
+    if (absoluteOnly && scheme !== 'http' && scheme !== 'https') return null;
+    return url;
+}
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+/**
+ * Parse untrusted HTML and return a fragment carrying only the allowed subset. Links
+ * open in a new browsing context with `rel="noopener noreferrer"` — a mark's link must
+ * never navigate the chart's page nor reach back into it.
+ */
+export function sanitizeHtml(html: string, doc: Document): DocumentFragment {
+    const tpl = doc.createElement('template');
+    tpl.innerHTML = html;
+    const out = doc.createDocumentFragment();
+    copyChildren(tpl.content, out, doc);
+    return out;
+}
+
+function copyChildren(from: Node, to: Node, doc: Document): void {
+    for (const child of Array.from(from.childNodes)) {
+        if (child.nodeType === TEXT_NODE) {
+            to.appendChild(doc.createTextNode(child.textContent ?? ''));
+            continue;
+        }
+        if (child.nodeType !== ELEMENT_NODE) continue; // comments, processing instructions
+        const el = child as Element;
+        const tag = el.tagName.toLowerCase();
+        const disposition = tagDisposition(tag);
+        if (disposition === 'drop') continue;
+        if (disposition === 'unwrap') {
+            copyChildren(el, to, doc);
+            continue;
+        }
+        const clean = doc.createElement(tag);
+        for (const attr of Array.from(el.attributes)) {
+            const name = attr.name.toLowerCase();
+            if (!attributeAllowed(tag, name)) continue;
+            let value = attr.value;
+            if (name === 'href' || name === 'src') {
+                const safe = safeUrl(value, name === 'src');
+                if (safe === null) continue;
+                value = safe;
+            }
+            clean.setAttribute(name, value);
+        }
+        if (tag === 'a') {
+            clean.setAttribute('target', '_blank');
+            clean.setAttribute('rel', 'noopener noreferrer');
+        }
+        copyChildren(el, clean, doc);
+        to.appendChild(clean);
+    }
+}

--- a/test/mark-lane-layout.test.ts
+++ b/test/mark-lane-layout.test.ts
@@ -1,0 +1,202 @@
+// The timeline-mark lane's geometry (src/renderers/native/chrome/marks/layout): bar
+// snapping, clustering, stacking, fan-out, hit-testing — pure, node env.
+import { describe, it, expect } from 'vitest';
+import {
+    snapMarkBar,
+    clusterMarks,
+    layoutMarkLane,
+    markGlyphAt,
+    markStackAt,
+    clusterTooltip,
+    markGroupLabel,
+    effectiveMarkGroups,
+    MARK_GLYPH_PX,
+    MARK_CLUSTER_PX,
+    MARK_LANE_INSET,
+    MARK_DECK_STEP,
+    MARK_FAN_GAP,
+    MARK_FAN_HOLD,
+} from '../src/renderers/native/chrome/marks/layout';
+import type { TimelineMark } from '../src/core/marks/types';
+
+const H = 3_600_000;
+const T0 = Date.UTC(2024, 5, 10);
+// Hourly bars with a closed session after bar 4: bars 0–4 are contiguous, bar 5 opens four hours after bar 4.
+const times = [0, 1, 2, 3, 4, 8, 9, 10].map((h) => T0 + h * H);
+const mark = (id: string, time: number, extra: Partial<TimelineMark> = {}): TimelineMark => ({ id, time, glyph: { color: '#2962ff', letter: id[0]! }, ...extra });
+
+describe('marks · snapMarkBar', () => {
+    it('lands inside the bar whose span contains the time', () => {
+        expect(snapMarkBar(T0 + 2 * H + 15 * 60_000, times, H)).toBe(2);
+        expect(snapMarkBar(T0 + 2 * H, times, H)).toBe(2); // exactly at the open
+        expect(snapMarkBar(T0 + 3 * H - 1, times, H)).toBe(2); // last ms of the span
+    });
+
+    it('a time in a gap goes to the first bar after it', () => {
+        expect(snapMarkBar(T0 + 5 * H, times, H)).toBe(5); // bar 4 closed at 5h; next bar opens at 8h
+        expect(snapMarkBar(T0 + 6.5 * H, times, H)).toBe(5);
+    });
+
+    it('past the newest bar it projects onto the extrapolated grid', () => {
+        expect(snapMarkBar(T0 + 10 * H + 59 * 60_000, times, H)).toBe(7); // still inside the last bar
+        expect(snapMarkBar(T0 + 11 * H, times, H)).toBe(8);
+        expect(snapMarkBar(T0 + 13.5 * H, times, H)).toBe(10);
+    });
+
+    it('has nothing to anchor to before the first bar, without bars, or without a cadence', () => {
+        expect(snapMarkBar(T0 - 1, times, H)).toBeNull();
+        expect(snapMarkBar(T0, [], H)).toBeNull();
+        expect(snapMarkBar(T0, times, 0)).toBeNull();
+        expect(snapMarkBar(Number.NaN, times, H)).toBeNull();
+    });
+});
+
+describe('marks · clusterMarks', () => {
+    it('folds same-bar, same-group marks and orders them by time, then insertion', () => {
+        const marks = [mark('b', T0 + 2 * H + 30 * 60_000, { group: 'g' }), mark('a', T0 + 2 * H + 5 * 60_000, { group: 'g' }), mark('c', T0 + 2 * H + 30 * 60_000, { group: 'g' })];
+        const out = clusterMarks(marks, times, H, () => false);
+        expect(out).toHaveLength(1);
+        expect(out[0]!.key).toBe('2|g');
+        expect(out[0]!.marks.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('a coarser timeframe folds marks that were bars apart on a finer one', () => {
+        const fiveMin = 300_000;
+        const fine = Array.from({ length: 24 }, (_, i) => T0 + i * fiveMin);
+        const marks = [mark('a', T0 + 5 * fiveMin), mark('b', T0 + 9 * fiveMin)]; // 00:25 and 00:45 — two 5-minute bars, one hourly bar
+        expect(clusterMarks(marks, fine, fiveMin, () => false)).toHaveLength(2);
+        expect(clusterMarks(marks, times, H, () => false)).toHaveLength(1);
+    });
+
+    it('keeps groups apart and drops hidden ones', () => {
+        const marks = [mark('a', T0 + H, { group: 'x' }), mark('b', T0 + H, { group: 'y' }), mark('c', T0 + H)];
+        expect(clusterMarks(marks, times, H, () => false).map((c) => c.key).sort()).toEqual(['1|', '1|x', '1|y']);
+        expect(clusterMarks(marks, times, H, (g) => g === 'y').map((c) => c.key).sort()).toEqual(['1|', '1|x']);
+    });
+});
+
+describe('marks · layoutMarkLane', () => {
+    const base = {
+        groups: [
+            { id: 'x', label: 'X' },
+            { id: 'y', label: 'Y' },
+        ],
+        hidden: () => false,
+        barTimes: times,
+        intervalMs: H,
+        xOf: (bar: number) => 100 + bar * 10,
+        axisY: 400,
+        dataW: 500,
+        expanded: null as number | null,
+    };
+
+    it('a lone mark is a 16 px token centered on its bar, its bottom MARK_LANE_INSET above the axis line', () => {
+        const l = layoutMarkLane({ ...base, marks: [mark('a', T0 + 3 * H + 10, { group: 'x' })] });
+        expect(l.glyphs).toHaveLength(1);
+        const g = l.glyphs[0]!;
+        expect(g.size).toBe(MARK_GLYPH_PX);
+        expect(g.x).toBe(130);
+        expect(g.y + g.size / 2).toBe(400 - MARK_LANE_INSET);
+        expect(g.decked).toBe(false);
+    });
+
+    it('a cluster is the larger token', () => {
+        const l = layoutMarkLane({ ...base, marks: [mark('a', T0 + 3 * H, { group: 'x' }), mark('b', T0 + 3 * H + 1, { group: 'x' })] });
+        expect(l.glyphs).toHaveLength(1);
+        expect(l.glyphs[0]!.size).toBe(MARK_CLUSTER_PX);
+        expect(l.glyphs[0]!.cluster.marks.map((m) => m.id)).toEqual(['a', 'b']);
+    });
+
+    it('several groups on one bar deck: the first-defined group on top, deeper ones peeking up, painted deeper-first', () => {
+        const l = layoutMarkLane({ ...base, marks: [mark('b', T0 + 3 * H, { group: 'y' }), mark('a', T0 + 3 * H, { group: 'x' }), mark('c', T0 + 3 * H)] });
+        const stack = l.stacks.get(3)!;
+        expect(stack.map((g) => g.cluster.group)).toEqual(['x', 'y', undefined]);
+        expect(stack.every((g) => g.decked)).toBe(true);
+        expect(stack[0]!.y - stack[1]!.y).toBe(MARK_DECK_STEP);
+        expect(stack[1]!.y - stack[2]!.y).toBe(MARK_DECK_STEP);
+        expect(l.glyphs.map((g) => g.depth)).toEqual([2, 1, 0]);
+    });
+
+    it('an expanded stack fans upward with MARK_FAN_GAP between tokens', () => {
+        const l = layoutMarkLane({ ...base, expanded: 3, marks: [mark('a', T0 + 3 * H, { group: 'x' }), mark('b', T0 + 3 * H, { group: 'y' }), mark('c', T0 + 3 * H)] });
+        const s = l.stacks.get(3)!;
+        expect(s.every((g) => !g.decked)).toBe(true);
+        expect(s[0]!.y + s[0]!.size / 2).toBe(400 - MARK_LANE_INSET);
+        expect(s[0]!.y - s[0]!.size / 2 - (s[1]!.y + s[1]!.size / 2)).toBe(MARK_FAN_GAP);
+        expect(s[1]!.y - s[1]!.size / 2 - (s[2]!.y + s[2]!.size / 2)).toBe(MARK_FAN_GAP);
+    });
+
+    it('a single-group bar never decks or fans, whatever `expanded` says', () => {
+        const l = layoutMarkLane({ ...base, expanded: 3, marks: [mark('a', T0 + 3 * H, { group: 'x' })] });
+        expect(l.glyphs[0]!.decked).toBe(false);
+        expect(l.glyphs[0]!.y + l.glyphs[0]!.size / 2).toBe(400 - MARK_LANE_INSET);
+    });
+
+    it('skips stacks off the plot', () => {
+        const l = layoutMarkLane({ ...base, xOf: () => -100, marks: [mark('a', T0 + 3 * H)] });
+        expect(l.glyphs).toHaveLength(0);
+        expect(layoutMarkLane({ ...base, xOf: () => 800, marks: [mark('a', T0 + 3 * H)] }).glyphs).toHaveLength(0);
+    });
+});
+
+describe('marks · hit-testing', () => {
+    const base = {
+        groups: [
+            { id: 'x', label: 'X' },
+            { id: 'y', label: 'Y' },
+        ],
+        hidden: () => false,
+        barTimes: times,
+        intervalMs: H,
+        xOf: (bar: number) => 100 + bar * 10,
+        axisY: 400,
+        dataW: 500,
+    };
+    const marks = [mark('a', T0 + 3 * H, { group: 'x' }), mark('b', T0 + 3 * H, { group: 'y' })];
+
+    it('markGlyphAt answers the topmost glyph and ignores a deck’s buried cards', () => {
+        const l = layoutMarkLane({ ...base, expanded: null, marks });
+        const top = l.stacks.get(3)![0]!;
+        const buried = l.stacks.get(3)![1]!;
+        expect(markGlyphAt(l, top.x, top.y)?.cluster.group).toBe('x');
+        // The buried card's own center is covered by the top card; a point on its peeking
+        // edge is NOT interactive either — the deck opens as a whole (hover/tap), not by card.
+        expect(markGlyphAt(l, buried.x, buried.y - buried.size / 2 - 1)).toBeNull();
+        expect(markGlyphAt(l, 300, 300)).toBeNull();
+    });
+
+    it('a fanned stack exposes every glyph, and markStackAt keeps the fan open across its gaps', () => {
+        const l = layoutMarkLane({ ...base, expanded: 3, marks });
+        const [bottom, top] = l.stacks.get(3)! as [ReturnType<typeof markGlyphAt> & object, ReturnType<typeof markGlyphAt> & object];
+        expect(markGlyphAt(l, top.x, top.y)?.cluster.group).toBe('y');
+        expect(markGlyphAt(l, bottom.x, bottom.y)?.cluster.group).toBe('x');
+        const gapY = (bottom.y - bottom.size / 2 + (top.y + top.size / 2)) / 2;
+        expect(markStackAt(l, bottom.x, gapY)).toBe(3);
+        // A short overshoot past the top glyph keeps the fan; further up it folds.
+        expect(markStackAt(l, bottom.x, top.y - top.size / 2 - MARK_FAN_HOLD)).toBe(3);
+        expect(markStackAt(l, bottom.x, top.y - top.size / 2 - MARK_FAN_HOLD - 1)).toBeNull();
+    });
+});
+
+describe('marks · labels', () => {
+    const groups = [{ id: 'dividends', label: 'Dividends' }];
+
+    it('a lone mark shows its tooltip, else its title; a cluster names its group and size', () => {
+        const single = { key: '1|dividends', bar: 1, group: 'dividends', marks: [mark('a', T0, { title: 'Dividend', tooltip: 'Div · 0.01' })] };
+        expect(clusterTooltip(single, groups)).toBe('Div · 0.01');
+        expect(clusterTooltip({ ...single, marks: [mark('a', T0, { title: 'Dividend' })] }, groups)).toBe('Dividend');
+        const cluster = { key: '1|dividends', bar: 1, group: 'dividends', marks: [mark('a', T0), mark('b', T0)] };
+        expect(clusterTooltip(cluster, groups)).toBe('Dividends · 2');
+        expect(clusterTooltip({ ...cluster, group: 'splits', key: '1|splits' }, groups)).toBe('Splits · 2');
+    });
+
+    it('an undefined group falls back to its capitalized id; effectiveMarkGroups lists defined groups first', () => {
+        expect(markGroupLabel('splits', groups)).toBe('Splits');
+        expect(markGroupLabel('dividends', groups)).toBe('Dividends');
+        const marks = [mark('a', T0, { group: 'splits' }), mark('b', T0, { group: 'dividends' }), mark('c', T0)];
+        expect(effectiveMarkGroups(marks, groups)).toEqual([
+            { id: 'dividends', label: 'Dividends' },
+            { id: 'splits', label: 'Splits' },
+        ]);
+    });
+});

--- a/test/marks-controller.test.ts
+++ b/test/marks-controller.test.ts
@@ -1,0 +1,135 @@
+// The timeline-mark model (src/core/marks/MarksController) and its facade
+// (src/core/MarksControl): the store, the renderer push, the click re-emission, the
+// group-visibility seam, and the inert path on a renderer without the capability.
+import { describe, it, expect, vi } from 'vitest';
+import { TypedEventBus } from '../src/core/events/EventBus';
+import type { VelaEventMap } from '../src/core/events/types';
+import { MarksController } from '../src/core/marks/MarksController';
+import { MarksControl } from '../src/core/MarksControl';
+import type { MarkClickEvent, MarkGroup, TimelineMark } from '../src/core/marks/types';
+import type { IChartRenderer } from '../src/core/ports/IChartRenderer';
+import { defaultMarksState, mergeMarksState } from '../src/renderers/shared/marks-state';
+
+function fakeRenderer(opts: { capable?: boolean } = {}) {
+    const capable = opts.capable !== false;
+    const pushes: Array<{ marks: TimelineMark[]; groups: MarkGroup[] }> = [];
+    const features: Array<[string, unknown]> = [];
+    let clickCb: ((e: MarkClickEvent) => void) | null = null;
+    let state = defaultMarksState();
+    const renderer = {
+        name: 'fake',
+        capabilities: { timelineMarks: capable },
+        features: capable ? ['marks'] : [],
+        setTimelineMarks: capable ? (marks: readonly TimelineMark[], groups: readonly MarkGroup[]) => pushes.push({ marks: [...marks], groups: [...groups] }) : undefined,
+        onMarkClick: (cb: (e: MarkClickEvent) => void) => {
+            clickCb = cb;
+            return () => {
+                clickCb = null;
+            };
+        },
+        applyFeature: (key: string, value: unknown) => {
+            features.push([key, value]);
+            if (key === 'marks') state = mergeMarksState(state, value);
+        },
+        readFeature: (key: string) => (capable && key === 'marks' ? state : undefined),
+    } as unknown as IChartRenderer;
+    return { renderer, pushes, features, click: (e: MarkClickEvent) => clickCb?.(e), subscribed: () => clickCb !== null };
+}
+
+const T = Date.UTC(2024, 5, 11);
+const mark = (id: string, extra: Partial<TimelineMark> = {}): TimelineMark => ({ id, time: T, glyph: { color: '#2962ff', letter: 'D' }, ...extra });
+
+describe('MarksController', () => {
+    it('pushes marks + group definitions to the renderer on every change, in insertion order', () => {
+        const { renderer, pushes } = fakeRenderer();
+        const ctrl = new MarksController(renderer, new TypedEventBus<VelaEventMap>());
+        expect(ctrl.supported).toBe(true);
+        ctrl.add(mark('b'));
+        ctrl.add(mark('a'));
+        ctrl.defineGroup({ id: 'dividends', label: 'Dividends' });
+        expect(pushes).toHaveLength(3);
+        expect(pushes[2]!.marks.map((m) => m.id)).toEqual(['b', 'a']);
+        expect(pushes[2]!.groups).toEqual([{ id: 'dividends', label: 'Dividends' }]);
+        // Re-adding an id replaces it in place.
+        ctrl.add(mark('b', { title: 'B2' }));
+        expect(pushes[3]!.marks.map((m) => `${m.id}:${m.title ?? ''}`)).toEqual(['b:B2', 'a:']);
+        ctrl.remove('b');
+        expect(pushes[4]!.marks.map((m) => m.id)).toEqual(['a']);
+        ctrl.set([mark('x'), mark('y')]);
+        expect(pushes[5]!.marks.map((m) => m.id)).toEqual(['x', 'y']);
+        ctrl.clear();
+        expect(pushes[6]!.marks).toEqual([]);
+        ctrl.clear(); // already empty — no push
+        expect(pushes).toHaveLength(7);
+    });
+
+    it('hands out copies and rejects marks it could not place or draw', () => {
+        const { renderer } = fakeRenderer();
+        const ctrl = new MarksController(renderer, new TypedEventBus<VelaEventMap>());
+        ctrl.add(mark('a'));
+        const copy = ctrl.all()[0]!;
+        copy.glyph.color = 'red';
+        expect(ctrl.all()[0]!.glyph.color).toBe('#2962ff');
+        expect(() => ctrl.add({ ...mark('bad'), time: Number.NaN })).toThrow(/finite/);
+        expect(() => ctrl.add({ ...mark(''), id: '' })).toThrow(/id/);
+        expect(() => ctrl.add({ id: 'g', time: T } as unknown as TimelineMark)).toThrow(/glyph/);
+        expect(() => ctrl.defineGroup({ id: '', label: 'x' })).toThrow(/id/);
+    });
+
+    it('re-emits the renderer’s glyph clicks as `mark:click` and unsubscribes on destroy', () => {
+        const fake = fakeRenderer();
+        const events = new TypedEventBus<VelaEventMap>();
+        const seen: MarkClickEvent[] = [];
+        events.on('mark:click', (e) => seen.push(e));
+        const ctrl = new MarksController(fake.renderer, events);
+        expect(fake.subscribed()).toBe(true);
+        fake.click({ id: 'a', ids: ['a', 'b'], time: T, group: 'dividends' });
+        expect(seen).toEqual([{ id: 'a', ids: ['a', 'b'], time: T, group: 'dividends' }]);
+        ctrl.destroy();
+        expect(fake.subscribed()).toBe(false);
+    });
+
+    it('routes group visibility through the renderer’s `marks` feature, with the group default as fallback', () => {
+        const { renderer, features } = fakeRenderer();
+        const ctrl = new MarksController(renderer, new TypedEventBus<VelaEventMap>());
+        ctrl.defineGroup({ id: 'quiet', label: 'Quiet', visible: false });
+        expect(ctrl.isGroupVisible('quiet')).toBe(false); // declared default
+        expect(ctrl.isGroupVisible('other')).toBe(true); // unknown ⇒ visible
+        ctrl.setGroupVisible('quiet', true);
+        expect(features).toEqual([['marks', { groups: { quiet: true } }]]);
+        expect(ctrl.isGroupVisible('quiet')).toBe(true); // the stored choice wins over the default
+    });
+
+    it('stays inert on a renderer without the capability: the model fills, nothing is pushed, the setter warns', () => {
+        const { renderer, pushes, features } = fakeRenderer({ capable: false });
+        const ctrl = new MarksController(renderer, new TypedEventBus<VelaEventMap>());
+        expect(ctrl.supported).toBe(false);
+        ctrl.add(mark('a'));
+        expect(ctrl.all().map((m) => m.id)).toEqual(['a']);
+        expect(pushes).toHaveLength(0);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        ctrl.setGroupVisible('x', false);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(features).toHaveLength(0);
+        expect(ctrl.isGroupVisible('x')).toBe(true);
+        warn.mockRestore();
+    });
+});
+
+describe('MarksControl (chart.marks)', () => {
+    it('chains and mirrors the controller', () => {
+        const { renderer, pushes } = fakeRenderer();
+        const control = new MarksControl(new MarksController(renderer, new TypedEventBus<VelaEventMap>()));
+        const out = control.defineGroup({ id: 'g', label: 'G' }).add(mark('a', { group: 'g' })).add(mark('b'));
+        expect(out).toBe(control);
+        expect(control.supported).toBe(true);
+        expect(control.all().map((m) => m.id)).toEqual(['a', 'b']);
+        expect(control.groups()).toEqual([{ id: 'g', label: 'G' }]);
+        control.remove('a').clear();
+        expect(pushes[pushes.length - 1]!.marks).toEqual([]);
+        control.setGroupVisible('g', false);
+        expect(control.isGroupVisible('g')).toBe(false);
+        expect(control.setGroupVisible('g')).toBe(control); // default: show
+        expect(control.isGroupVisible('g')).toBe(true);
+    });
+});

--- a/test/marks-paint.test.ts
+++ b/test/marks-paint.test.ts
@@ -1,0 +1,37 @@
+// The timeline-mark lane's hover pulse (src/renderers/native/chrome/marks/paint): the
+// size multiplier the painter applies to the token the pointer landed on — pure, node env.
+import { describe, it, expect } from 'vitest';
+import { pulseScale, MARK_PULSE_AMPLITUDE, MARK_PULSE_MS } from '../src/renderers/native/chrome/marks/paint';
+
+describe('marks · pulseScale', () => {
+    it('plays once: 1 at rest, 1 + amplitude at mid-pulse, back to 1 at the end and ever after', () => {
+        expect(pulseScale(0)).toBe(1);
+        expect(pulseScale(-50)).toBe(1);
+        expect(pulseScale(Number.NaN)).toBe(1);
+        expect(pulseScale(MARK_PULSE_MS / 2)).toBeCloseTo(1 + MARK_PULSE_AMPLITUDE, 6);
+        expect(pulseScale(MARK_PULSE_MS)).toBe(1);
+        expect(pulseScale(MARK_PULSE_MS * 1.5)).toBe(1);
+        expect(pulseScale(MARK_PULSE_MS * 10)).toBe(1);
+    });
+
+    it('swells and settles smoothly — a slight, brief grow, never a jump or a second beat', () => {
+        let prev = 1;
+        for (let t = 0; t <= MARK_PULSE_MS / 2; t += 10) {
+            const s = pulseScale(t);
+            expect(s).toBeGreaterThanOrEqual(prev); // rising half
+            prev = s;
+        }
+        for (let t = MARK_PULSE_MS / 2; t <= MARK_PULSE_MS; t += 10) {
+            const s = pulseScale(t);
+            expect(s).toBeLessThanOrEqual(prev + 1e-9); // settling half
+            prev = s;
+        }
+        for (let t = 0; t <= MARK_PULSE_MS * 3; t += 7) {
+            const s = pulseScale(t);
+            expect(s).toBeGreaterThanOrEqual(1);
+            expect(s).toBeLessThanOrEqual(1 + MARK_PULSE_AMPLITUDE + 1e-9);
+        }
+        expect(MARK_PULSE_AMPLITUDE).toBeLessThanOrEqual(0.12);
+        expect(MARK_PULSE_MS).toBeLessThanOrEqual(500);
+    });
+});

--- a/test/marks-state.test.ts
+++ b/test/marks-state.test.ts
@@ -1,0 +1,45 @@
+// The `marks` renderer feature's display state (src/renderers/shared/marks-state):
+// the validated partial merge and the group-visibility precedence.
+import { describe, it, expect } from 'vitest';
+import { defaultMarksState, mergeMarksState, markGroupVisible } from '../src/renderers/shared/marks-state';
+
+describe('marks · mergeMarksState', () => {
+    it('a bare boolean toggles the lane and keeps the groups', () => {
+        const base = { visible: true, groups: { a: false } };
+        expect(mergeMarksState(base, false)).toEqual({ visible: false, groups: { a: false } });
+        expect(mergeMarksState(base, true).groups).toEqual({ a: false });
+    });
+
+    it('an object patches `visible` and merges `groups` additively', () => {
+        const base = { visible: true, groups: { a: false, b: true } };
+        const out = mergeMarksState(base, { groups: { b: false, c: false } });
+        expect(out).toEqual({ visible: true, groups: { a: false, b: false, c: false } });
+        expect(mergeMarksState(base, { visible: false }).groups).toEqual(base.groups);
+    });
+
+    it('drops malformed values and never mutates the base', () => {
+        const base = defaultMarksState();
+        const out = mergeMarksState(base, { visible: 'no', groups: { a: 'off', b: 0, c: true } });
+        expect(out).toEqual({ visible: true, groups: { c: true } });
+        expect(base).toEqual({ visible: true, groups: {} });
+        expect(mergeMarksState(base, null)).toEqual(base);
+        expect(mergeMarksState(base, 'x')).toEqual(base);
+    });
+});
+
+describe('marks · markGroupVisible', () => {
+    const groups = [
+        { id: 'shown', label: 'Shown' },
+        { id: 'quiet', label: 'Quiet', visible: false },
+    ];
+
+    it('the stored choice wins, else the group’s declared default, else visible; ungrouped marks always show', () => {
+        const state = { visible: true, groups: { shown: false, quiet: true } };
+        expect(markGroupVisible(state, 'shown', groups)).toBe(false);
+        expect(markGroupVisible(state, 'quiet', groups)).toBe(true);
+        expect(markGroupVisible(defaultMarksState(), 'quiet', groups)).toBe(false);
+        expect(markGroupVisible(defaultMarksState(), 'shown', groups)).toBe(true);
+        expect(markGroupVisible(defaultMarksState(), 'unknown', groups)).toBe(true);
+        expect(markGroupVisible({ visible: true, groups: { x: false } }, undefined, groups)).toBe(true);
+    });
+});

--- a/test/sanitize-html.test.ts
+++ b/test/sanitize-html.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+// The HTML allowlist behind timeline-mark popups (src/ui/sanitize-html): the pure policy
+// and the DOM rebuild, proven on the hazards a host-supplied string can carry.
+import { describe, it, expect } from 'vitest';
+import { sanitizeHtml, safeUrl, tagDisposition, attributeAllowed } from '../src/ui/sanitize-html';
+
+function render(html: string): string {
+    const div = document.createElement('div');
+    div.appendChild(sanitizeHtml(html, document));
+    return div.innerHTML;
+}
+
+describe('sanitize-html · policy', () => {
+    it('classifies elements: formatting kept, active content dropped, the rest unwrapped', () => {
+        expect(tagDisposition('b')).toBe('keep');
+        expect(tagDisposition('TABLE')).toBe('keep');
+        expect(tagDisposition('script')).toBe('drop');
+        expect(tagDisposition('iframe')).toBe('drop');
+        expect(tagDisposition('svg')).toBe('drop');
+        expect(tagDisposition('section')).toBe('unwrap');
+        expect(tagDisposition('font')).toBe('unwrap');
+    });
+
+    it('keeps only the per-element attributes, never handlers or styles', () => {
+        expect(attributeAllowed('a', 'href')).toBe(true);
+        expect(attributeAllowed('a', 'onclick')).toBe(false);
+        expect(attributeAllowed('a', 'ONMOUSEOVER')).toBe(false);
+        expect(attributeAllowed('p', 'style')).toBe(false);
+        expect(attributeAllowed('p', 'title')).toBe(true);
+        expect(attributeAllowed('img', 'src')).toBe(true);
+        expect(attributeAllowed('img', 'srcset')).toBe(false);
+        expect(attributeAllowed('td', 'colspan')).toBe(true);
+        expect(attributeAllowed('div', 'class')).toBe(false);
+    });
+
+    it('rejects code and content-smuggling URL schemes, whitespace-split ones included', () => {
+        expect(safeUrl('https://example.com/a')).toBe('https://example.com/a');
+        expect(safeUrl('/relative/path')).toBe('/relative/path');
+        expect(safeUrl('#anchor')).toBe('#anchor');
+        expect(safeUrl('mailto:a@b.c')).toBe('mailto:a@b.c');
+        expect(safeUrl('javascript:alert(1)')).toBeNull();
+        expect(safeUrl('JavaScript:alert(1)')).toBeNull();
+        expect(safeUrl('java\tscript:alert(1)')).toBeNull();
+        expect(safeUrl(' \n javascript:alert(1)')).toBeNull();
+        expect(safeUrl('data:text/html,hi')).toBeNull();
+        expect(safeUrl('vbscript:x')).toBeNull();
+    });
+
+    it('image sources must be absolute http(s)', () => {
+        expect(safeUrl('https://cdn.example.com/x.png', true)).toBe('https://cdn.example.com/x.png');
+        expect(safeUrl('/x.png', true)).toBeNull();
+        expect(safeUrl('data:image/png;base64,AAAA', true)).toBeNull();
+    });
+});
+
+describe('sanitize-html · DOM rebuild', () => {
+    it('keeps formatting and text, drops scripts with their content', () => {
+        expect(render('<b>10-for-1 split</b><br>Effective <i>10 Jun</i><script>alert(1)</script>')).toBe('<b>10-for-1 split</b><br>Effective <i>10 Jun</i>');
+        expect(render('<p>a<iframe src="https://x"></iframe>b</p>')).toBe('<p>ab</p>');
+        expect(render('<style>body{display:none}</style>text')).toBe('text');
+    });
+
+    it('strips event handlers, inline styles and unsafe URLs, keeping the element', () => {
+        expect(render('<img src="x" onerror="alert(1)">')).toBe('<img>');
+        expect(render('<p style="color:red" onclick="x()" title="t">hi</p>')).toBe('<p title="t">hi</p>');
+        expect(render('<a href="javascript:alert(1)">x</a>')).toBe('<a target="_blank" rel="noopener noreferrer">x</a>');
+        expect(render('<img src="data:image/png;base64,AAAA" alt="a">')).toBe('<img alt="a">');
+    });
+
+    it('links open in a new context with noopener; unknown elements unwrap to their content', () => {
+        expect(render('<a href="https://example.com/f">Filing</a>')).toBe('<a href="https://example.com/f" target="_blank" rel="noopener noreferrer">Filing</a>');
+        expect(render('<section><font color="red">plain</font></section>')).toBe('plain');
+        expect(render('<table><tr><td colspan="2" bgcolor="red">c</td></tr></table>')).toBe('<table><tbody><tr><td colspan="2">c</td></tr></tbody></table>');
+    });
+
+    it('escapes what is already text', () => {
+        expect(render('1 &lt; 2 &amp; <b>ok</b>')).toBe('1 &lt; 2 &amp; <b>ok</b>');
+        expect(render('<!-- comment -->x')).toBe('x');
+    });
+});

--- a/test/settings-visibility.test.ts
+++ b/test/settings-visibility.test.ts
@@ -7,6 +7,7 @@ import {
     filterHiddenRows,
     hostRowId,
     hostSectionId,
+    markGroupSettingsId,
     settingsIdCatalog,
     settingsIdHidden,
     settingsIdSlug,
@@ -146,6 +147,16 @@ describe('settingsIdCatalog', () => {
         expect(ids).toContain('type:viz-test.ovl');
         expect(ids).toContain('advanced');
         expect(ids).toContain('advanced.bars');
+    });
+
+    it('lists the Events tab and one row per timeline-mark group — only while groups exist', () => {
+        expect(settingsIdCatalog([])).not.toContain('events');
+        const ids = settingsIdCatalog([], [{ id: 'dividends' }, { id: 'stock splits' }]);
+        expect(ids).toContain('events');
+        expect(ids).toContain('events.groups');
+        expect(ids).toContain('events.groups.dividends');
+        expect(ids).toContain('events.groups.stock-splits');
+        expect(markGroupSettingsId('Stock Splits')).toBe('events.groups.stock-splits');
     });
 
     it('built-in ids are unique and rows nest under their tab', () => {

--- a/test/ui-form-primitives.test.ts
+++ b/test/ui-form-primitives.test.ts
@@ -51,6 +51,20 @@ describe('placePopover', () => {
         expect(pos.top).toBe(140);
     });
 
+    it('centers on the trigger when align is center', () => {
+        const pos = placePopover({
+            trigger,
+            pop: { width: 80, height: 40 },
+            gap: 4,
+            align: 'center',
+            clamp: viewportRect(800, 600, 6),
+            originX: 0,
+            originY: 0,
+        });
+        expect(pos.left).toBe(110); // 100 + 100/2 - 80/2
+        expect(pos.top).toBe(138);
+    });
+
     it('flips above when it would leave the clamp', () => {
         const pos = placePopover({
             trigger: { left: 100, top: 500, right: 200, bottom: 534, width: 100, height: 34 },


### PR DESCRIPTION
## Background

Charts of equities and other markets need to surface events that sit on the timeline rather than on a price — dividends, splits, earnings, news, releases — with the details one click away. Vela had no seam for this: `plotshape` markers are price-anchored and carry no interaction, legend callouts live in the legend, and renderer layers receive no clicks. Hosts had to overlay their own DOM on top of the chart and re-derive bar positions themselves.

## Summary

Adds **timeline marks**: `chart.marks` pins host-supplied events to the bar their time falls in and paints them as small outlined tokens (a letter or a registered icon in the event's color) on a lane just above the time axis, with a popup on click.

- **Placement** — a mark snaps to the bar whose span contains its time; a time in a gap (weekend, closed session) goes to the next bar, a time past the newest bar projects onto the extrapolated grid. Marks re-snap on every timeframe change.
- **Clusters and stacks** — marks of one group on the same bar fold into one slightly larger token listing them all; marks of different groups on one bar form a deck that fans out on hover (or a tap on touch) so each can be opened.
- **Popup** — centered on the token with a short fade: the mark's title over escaped text, allowlist-sanitized HTML (scripts, styles, frames, event handlers and `javascript:` URLs never reach the page; links open in a new tab with `noopener`), or a panel of fields and buttons; content given as a function resolves on demand, one section at a time as the popup scrolls.
- **Token states** — outline and symbol in the mark's color at rest, one brief swell when the pointer lands, filled with white ink while the popup is open (or as a short flash for a content-less click).
- **Settings** — a new **Events** tab (section "Visible events") with one checkbox per group; the choice lives in the renderer config (`marks.groups`, additive merge) and persists with the chart. Ids `events`, `events.groups`, `events.groups.<group-id>` join the visibility catalog.
- **Public surface** — `chart.marks` (`add` / `set` / `remove` / `clear` / `all` / `defineGroup` / `groups` / `setGroupVisible` / `isGroupVisible` / `supported`), the `mark:click` event, the `marks` renderer feature, the `timelineMarks` capability, the `setTimelineMarks` / `onMarkClick` port seams, and the exported `TimelineMark` / `MarkGlyph` / `MarkContent` / `MarkGroup` / `MarkClickEvent` types. The UI kit's `Popover` gains `align: 'center'` and `fadeMs`.
- **Docs and demo** — a `docs/user/timeline-marks.md` guide (linked from the docs index and the API reference), API/options/renderer-feature updates, and a sample set on both playground pages (`playground/marks.ts`), including three news items 15 minutes apart to watch clustering across timeframes.

Marks are data, not user state: the chart never persists them — hosts re-supply them on `market:changed`.

## End-to-end verification

`npm run playground`, Chromium (Playwright-driven), live Binance data, on `widget.html` (one chart) and `workspace.html` (four cells on 1h / 15m / 4h / 1D):

- The lane shows the sample set on every cell: an ungrouped note, an event-only mark, a dividends cluster stacked with a split, an earnings diamond, a news cluster, a release with the custom rocket icon, and a scheduled mark near the right edge.
- Hovering the deck fans it out; climbing the fan keeps it open; clicking the top token opens the split popup with the `<script>` stripped and the link carrying `target="_blank" rel="noopener noreferrer"`. Moving the pointer onto the popup, or off the plot, keeps it open; an outside click or Escape closes it. The same flow works by tap in a touch context (tap the deck → fan, tap a token → popup, tap elsewhere → fold).
- The dividends cluster popup lists both marks with their fields and primary button; the release popup shows "Loading…" then the fetched HTML.
- The popup's center lands on the token's x (Δ = 0 px); its opacity reads ~0.57 thirty milliseconds after opening and 1 afterwards; Escape sets it to 0 and the shell leaves the DOM ~120 ms later.
- Reading the chrome canvas pixels: the token's symbol is in the mark's color at rest, white on a filled body while its popup is open, and a content-less click paints the token filled for a moment; frame crops differ right after the pointer lands and are identical again once the single pulse has settled — and replay on re-entry.
- The three news items are one cluster on 1h (a popup with three sections) and three tokens on 15m.
- Chart settings: the rail reads Symbol · Status line · Scales and lines · Canvas · **Events** · Advanced; unchecking News hides its token, `getConfig().marks.groups.news` is `false`, `isGroupVisible('news')` agrees, the workspace state carries it, and `settings: { hidden: ['events'] }` removes the tab. `chart.renderer.set('marks', false)` empties the lane; `true` brings it back.
- The workspace-level oracle suite (`oracle-tests/vela-pinets`) is unchanged: 18/19, the one failure being the pre-existing `plotshape` label-count mismatch, unrelated to this change.

## Checklist

- [x] This PR does one thing (one fix, one feature, one refactor, or one docs change)
- [x] `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` all pass
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation in `docs/` has been added / updated (for public interface or feature changes)
- [x] `CHANGELOG.md` has an entry under `[Unreleased]` (for user-visible changes)
- [x] I have signed the CLA (the bot asks in this PR)
- [x] I have reviewed this pull request myself (self-review)

## Future work

- A pull-based source (`chart.marks.registerSource({ fetch({ symbol, from, to }) })`) queried per market and visible range, so a host does not have to feed the whole set itself.
- Keyboard access to the lane (focus a token, open its popup with Enter).
- An optional count badge on cluster tokens.
- Auto-contrasted ink for the filled state on light mark colors (it is white today, as designed).


