### PR TITLE
Preview the first line of pitchfork and triangle tools after the first anchor click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Three-point tools preview their first line right away.** The pitchfork family
+  (Andrews', Schiff, modified Schiff, inside) and the triangle now draw a line from the
+  first placed point to the cursor as soon as the first click lands, instead of showing
+  only the anchor markers until the second point is placed.
+
 ## [v0.7.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to Vela, newest first.
 - **Three-point tools preview their first line right away.** The pitchfork family
   (Andrews', Schiff, modified Schiff, inside) and the triangle now draw a line from the
   first placed point to the cursor as soon as the first click lands, instead of showing
-  only the anchor markers until the second point is placed.
+  only the anchor markers until the second point is placed. The Schiff and modified
+  Schiff pitchforks also keep that pivot line in the finished shape, so the pivot handle
+  no longer floats detached from the fork it defines.
 
 ## [v0.7.0]
 

--- a/src/core/drawings/types/InsidePitchfork.ts
+++ b/src/core/drawings/types/InsidePitchfork.ts
@@ -28,17 +28,19 @@ export class InsidePitchfork extends SegmentDrawing {
     geometry(proj: Projector): SegmentGeometry | null {
         const a = this.anchors[0];
         const b = this.anchors[1];
-        const c = this.anchors[2];
-        if (!a || !b || !c) return null;
+        if (!a || !b) return null;
         const px = (p: DrawingPoint): [number, number] | null => {
             const y = proj.yOf(p.price, this.paneId);
             return y == null ? null : [proj.xOf(p.time), y];
         };
-        const B = px({ time: (a.time + b.time) / 2, price: (a.price + b.price) / 2 }); // modified base
         const P0 = px(a);
         const P1 = px(b);
+        if (!P0 || !P1) return null;
+        const c = this.anchors[2];
+        if (!c) return { segments: [[P0[0], P0[1], P1[0], P1[1]]], fill: null }; // back trend line only (placing)
+        const B = px({ time: (a.time + b.time) / 2, price: (a.price + b.price) / 2 }); // modified base
         const P2 = px(c);
-        if (!B || !P0 || !P1 || !P2) return null;
+        if (!B || !P2) return null;
         const mx = (P1[0] + P2[0]) / 2;
         const my = (P1[1] + P2[1]) / 2; // median target M
         const dx = P2[0] - B[0];

--- a/src/core/drawings/types/Pitchfork.ts
+++ b/src/core/drawings/types/Pitchfork.ts
@@ -28,16 +28,18 @@ export class Pitchfork extends SegmentDrawing {
     geometry(proj: Projector): SegmentGeometry | null {
         const a = this.anchors[0];
         const b = this.anchors[1];
-        const c = this.anchors[2];
-        if (!a || !b || !c) return null;
+        if (!a || !b) return null;
         const px = (p: DrawingPoint): [number, number] | null => {
             const y = proj.yOf(p.price, this.paneId);
             return y == null ? null : [proj.xOf(p.time), y];
         };
         const P0 = px(a);
         const P1 = px(b);
+        if (!P0 || !P1) return null;
+        const c = this.anchors[2];
+        if (!c) return { segments: [[P0[0], P0[1], P1[0], P1[1]]], fill: null }; // pivot → cursor only (placing)
         const P2 = px(c);
-        if (!P0 || !P1 || !P2) return null;
+        if (!P2) return null;
         const mx = (P1[0] + P2[0]) / 2;
         const my = (P1[1] + P2[1]) / 2; // midpoint of the two tine anchors
         const dx = mx - P0[0];

--- a/src/core/drawings/types/PitchforkVariant.ts
+++ b/src/core/drawings/types/PitchforkVariant.ts
@@ -9,7 +9,8 @@ import { SegmentDrawing } from './SegmentDrawing';
  * Shared base for the Schiff pitchfork family. Identical to an Andrews' pitchfork —
  * median through M = midpoint(p2, p3), tines through p2/p3 parallel to it, base line
  * p2–p3 — except the median STARTS at a shifted origin S (computed in data space by
- * each subclass) instead of the pivot p1. The tines track the new median direction.
+ * each subclass) instead of the pivot p1. The tines track the new median direction, and a
+ * construction line p1–p2 keeps the pivot attached to the shape.
  */
 export abstract class PitchforkVariant extends SegmentDrawing {
     anchorSchema(): { min: number; max: number; slots: AnchorSlot[] } {
@@ -35,17 +36,14 @@ export abstract class PitchforkVariant extends SegmentDrawing {
             const y = proj.yOf(p.price, this.paneId);
             return y == null ? null : [proj.xOf(p.time), y];
         };
-        const c = this.anchors[2];
-        if (!c) {
-            // Placing: the shifted origin needs all three anchors, so preview the pivot → cursor line.
-            const P0 = px(a);
-            const P1 = px(b);
-            return P0 && P1 ? { segments: [[P0[0], P0[1], P1[0], P1[1]]], fill: null } : null;
-        }
-        const S = px(this.medianStart(a, b, c));
+        const P0 = px(a);
         const P1 = px(b);
+        if (!P0 || !P1) return null;
+        const c = this.anchors[2];
+        if (!c) return { segments: [[P0[0], P0[1], P1[0], P1[1]]], fill: null }; // pivot → cursor only (placing)
+        const S = px(this.medianStart(a, b, c));
         const P2 = px(c);
-        if (!S || !P1 || !P2) return null;
+        if (!S || !P2) return null;
         const mx = (P1[0] + P2[0]) / 2;
         const my = (P1[1] + P2[1]) / 2; // median target = midpoint of the tine anchors
         const dx = mx - S[0];
@@ -58,6 +56,9 @@ export abstract class PitchforkVariant extends SegmentDrawing {
                 extendRay(P1[0], P1[1], P1[0] + dx, P1[1] + dy, 'right', w, h), // upper tine
                 extendRay(P2[0], P2[1], P2[0] + dx, P2[1] + dy, 'right', w, h), // lower tine
                 [P1[0], P1[1], P2[0], P2[1]], // base line
+                // The median leaves from the shifted origin, not the pivot — without this construction
+                // line the pivot handle would float unattached to the shape it defines.
+                [P0[0], P0[1], P1[0], P1[1]], // pivot → first tine anchor
             ],
             fill: null,
         };

--- a/src/core/drawings/types/PitchforkVariant.ts
+++ b/src/core/drawings/types/PitchforkVariant.ts
@@ -30,12 +30,18 @@ export abstract class PitchforkVariant extends SegmentDrawing {
     geometry(proj: Projector): SegmentGeometry | null {
         const a = this.anchors[0];
         const b = this.anchors[1];
-        const c = this.anchors[2];
-        if (!a || !b || !c) return null;
+        if (!a || !b) return null;
         const px = (p: DrawingPoint): [number, number] | null => {
             const y = proj.yOf(p.price, this.paneId);
             return y == null ? null : [proj.xOf(p.time), y];
         };
+        const c = this.anchors[2];
+        if (!c) {
+            // Placing: the shifted origin needs all three anchors, so preview the pivot → cursor line.
+            const P0 = px(a);
+            const P1 = px(b);
+            return P0 && P1 ? { segments: [[P0[0], P0[1], P1[0], P1[1]]], fill: null } : null;
+        }
         const S = px(this.medianStart(a, b, c));
         const P1 = px(b);
         const P2 = px(c);

--- a/src/core/drawings/types/Triangle.ts
+++ b/src/core/drawings/types/Triangle.ts
@@ -23,16 +23,18 @@ export class Triangle extends SegmentDrawing {
     geometry(proj: Projector): SegmentGeometry | null {
         const a = this.anchors[0];
         const b = this.anchors[1];
-        const c = this.anchors[2];
-        if (!a || !b || !c) return null;
+        if (!a || !b) return null;
         const px = (p: DrawingPoint): [number, number] | null => {
             const y = proj.yOf(p.price, this.paneId);
             return y == null ? null : [proj.xOf(p.time), y];
         };
         const A = px(a);
         const B = px(b);
+        if (!A || !B) return null;
+        const c = this.anchors[2];
+        if (!c) return { segments: [[A[0], A[1], B[0], B[1]]], fill: null }; // first edge only (placing)
         const C = px(c);
-        if (!A || !B || !C) return null;
+        if (!C) return null;
         return {
             segments: [
                 [A[0], A[1], B[0], B[1]],

--- a/test/drawings-pitchfork-variants.test.ts
+++ b/test/drawings-pitchfork-variants.test.ts
@@ -31,9 +31,14 @@ describe('drawings/SchiffPitchfork', () => {
 
     it('starts the median at the PRICE-shifted origin (not the Andrews pivot)', () => {
         const d = make();
-        // S = (10, mean(60,80)=70) → px (10,30); the Andrews median would instead pass through px(10,40)
+        // S = (10, mean(60,80)=70) → px (10,30); the Andrews median px(10,40)→px(30,50) passes (20,45)
         expect(d.hitTest(10, 30, proj, 2)).toBe(true);
-        expect(d.hitTest(10, 40, proj, 2)).toBe(false);
+        expect(d.hitTest(20, 45, proj, 2)).toBe(false);
+    });
+
+    it('keeps the pivot attached with a pivot → first tine construction line', () => {
+        // px(10,40) → px(30,20) passes (15,35); the shifted median (10,30)→(30,50) does not
+        expect(make().hitTest(15, 35, proj, 2)).toBe(true);
     });
 
     it('reports the anchor price span + round-trips', () => {
@@ -53,6 +58,11 @@ describe('drawings/ModifiedSchiffPitchfork', () => {
         // S = (mean(10,30)=20, mean(60,80)=70) → px (20,30)
         expect(d.hitTest(20, 30, proj, 2)).toBe(true);
         expect(d.hitTest(20, 40, proj, 2)).toBe(false);
+    });
+
+    it('keeps the pivot attached with a pivot → first tine construction line', () => {
+        // px(10,40) → px(30,20) passes (15,35); the shifted median starts at (20,30)
+        expect(make().hitTest(15, 35, proj, 2)).toBe(true);
     });
 
     it('round-trips through serialize', () => {

--- a/test/drawings-pitchfork-variants.test.ts
+++ b/test/drawings-pitchfork-variants.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createDrawing, deserializeDrawing, type Projector } from '../src/core/drawings';
+import { createDrawing, deserializeDrawing, type Projector, type SegmentDrawing } from '../src/core/drawings';
 
 /** Linear projector: x = time, y = 100 − price, single pane 'price', 200×100 plot. */
 function fakeProjector(): Projector {
@@ -80,6 +80,27 @@ describe('drawings/InsidePitchfork', () => {
         const a = make().serialize();
         expect(deserializeDrawing(a)!.serialize()).toEqual(a);
         expect(a.type).toBe('insidepitchfork');
+    });
+});
+
+describe('drawings/pitchfork family · placing preview', () => {
+    const proj = fakeProjector();
+    const types = ['pitchfork', 'schiffpitchfork', 'modifiedschiffpitchfork', 'insidepitchfork'] as const;
+
+    // While placing, the ghost carries the pivot + the cursor. Two anchors must already show
+    // the pivot → cursor line, or the first click leaves nothing on the chart until the second.
+    it.each(types)('%s draws the pivot → cursor line with only two anchors', (type) => {
+        const d = createDrawing(type, { paneId: 'price', anchors: [forkAnchors[0]!, forkAnchors[1]!] }) as SegmentDrawing;
+        const g = d.geometry(proj);
+        expect(g).not.toBeNull();
+        expect(g!.segments).toEqual([[10, 40, 30, 20]]); // px(10,60)→px(10,40), px(30,80)→px(30,20)
+        expect(g!.fill).toBeNull();
+        expect(d.hitTest(20, 30, proj, 2)).toBe(true); // midpoint of the pivot → cursor line
+    });
+
+    it.each(types)('%s still draws nothing with a single anchor', (type) => {
+        const d = createDrawing(type, { paneId: 'price', anchors: [forkAnchors[0]!] }) as SegmentDrawing;
+        expect(d.geometry(proj)).toBeNull();
     });
 });
 

--- a/test/drawings-shapes.test.ts
+++ b/test/drawings-shapes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createDrawing, deserializeDrawing, type Projector } from '../src/core/drawings';
+import { createDrawing, deserializeDrawing, type Projector, type SegmentDrawing } from '../src/core/drawings';
 
 /** Linear projector: x = time, y = 100 − price, single pane 'price'. */
 function fakeProjector(): Projector {
@@ -115,5 +115,15 @@ describe('drawings/Triangle', () => {
         const a = make().serialize();
         expect(deserializeDrawing(a)!.serialize()).toEqual(a);
         expect(a.type).toBe('triangle');
+    });
+
+    it('previews the first edge while placing (two anchors, no fill)', () => {
+        const partial = (n: number) =>
+            createDrawing('triangle', { paneId: 'price', anchors: [{ time: 0, price: 0 }, { time: 40, price: 0 }].slice(0, n) }) as SegmentDrawing;
+        const g = partial(2).geometry(proj);
+        expect(g).not.toBeNull();
+        expect(g!.segments).toEqual([[0, 100, 40, 100]]);
+        expect(g!.fill).toBeNull();
+        expect(partial(1).geometry(proj)).toBeNull();
     });
 });


### PR DESCRIPTION
## Background

With the pitchfork tool armed, the first click placed the pivot but nothing followed the cursor: only the anchor marker showed until the second point was clicked. The same gap existed in the whole pitchfork family and in the triangle.

Cause: while placing, the ghost carries the committed anchors plus the cursor. `Pitchfork`, `PitchforkVariant` (Schiff, modified Schiff), `InsidePitchfork` and `Triangle` returned `null` from `geometry()` unless all three anchors existed, so the painter had nothing to draw after the first click. Other three-point tools (`FlatTopBottom`, `Arc`, `Curve`, `RotatedRect`) already return a partial preview in that state.

A related gap on the Schiff variants: their median leaves from a shifted origin rather than the pivot, so once the third anchor landed the pivot handle floated with no line attached to it.

## Summary

- With exactly two anchors, the four pitchfork types and the triangle now return the first-point → cursor segment (no fill), following the existing `// baseline only (placing)` convention. The finished three-anchor shape of the Andrews pitchfork, inside pitchfork and triangle is unchanged.
- The finished Schiff and modified Schiff pitchforks keep the pivot → first-tine diagonal as a construction line (the way the inside pitchfork already draws its back trend line), so the pivot stays attached to the fork it defines.
- Targeted tests cover the two-anchor preview and the single-anchor `null` for all five types, plus the construction line on finished Schiff variants; `CHANGELOG.md` gets a `[Unreleased]` → `Fixed` entry.

Reviewed but left alone: `FibExtensionTrend` and `TrendFibTime` also draw nothing after the first click, but their finished shape never includes an anchor connector (level lines only), so a preview there would be a new visual rather than a fix.

## End-to-end verification

`npm run playground` → `widget.html` (Chromium, live Binance data). Armed each tool via `ws.chart.drawings.setTool(type)`, clicked once on the plot, moved the cursor, and sampled the drawings canvas: for `pitchfork`, `schiffpitchfork`, `modifiedschiffpitchfork`, `insidepitchfork` and `triangle`, 5×5 probes at the quarter and midpoint of the pivot → cursor line are inked and a probe off the line is not; no drawing is committed before the third click, and a three-click pitchfork still commits. Then placed a Schiff and a modified Schiff with three clicks each and confirmed in a screenshot that the finished shapes show the pivot → first-tine diagonal while the median still starts at the shifted origin.

Workspace oracle suite (`oracle-tests/vela`): 22/23; the one failure (`plotshape` label count) reproduces on clean `dev` and is unrelated.

## Checklist

- [x] This PR does one thing (one fix, one feature, one refactor, or one docs change)
- [x] `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` all pass
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation in `docs/` has been added / updated (for public interface or feature changes)
- [x] `CHANGELOG.md` has an entry under `[Unreleased]` (for user-visible changes)
- [ ] I have signed the CLA (the bot asks in this PR)
- [x] I have reviewed this pull request myself (self-review)
