### PR TITLE
Close a timeline mark popup on a second click instead of reopening it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Vela, newest first.
 
+## [Unreleased]
+
+### Fixed
+
+- **Timeline mark popups now toggle with a click.** Clicking the mark whose popup is
+  open closes it; previously that second click closed and immediately reopened the popup,
+  so it took a click elsewhere to dismiss it.
+
 ## [v0.7.0]
 
 ### Added

--- a/src/renderers/native/chrome/marks/MarkPopover.ts
+++ b/src/renderers/native/chrome/marks/MarkPopover.ts
@@ -56,6 +56,22 @@ export class MarkPopover {
     private openKey: string | null = null;
     /** Bumped per open/close — a lazy content resolving after its popup went away is dropped. */
     private generation = 0;
+    /**
+     * The cluster whose popup was open when the current pointer press began. The anchor is
+     * hit-transparent (the glyph is canvas pixels), so the shell's outside-dismiss closes the
+     * popup on pointerdown; the click the renderer derives from the same pointerup must then
+     * read as "close", not reopen that cluster. Captured on the document ahead of the shell's
+     * (deferred) listener, cleared once the release has dispatched.
+     */
+    private pressKey: string | null = null;
+    private readonly onPress = (): void => {
+        if (this.openKey === null) return;
+        this.pressKey = this.openKey;
+        const doc = this.deps.plot.ownerDocument;
+        const clear = (): void => void setTimeout(() => (this.pressKey = null), 0);
+        doc.addEventListener('pointerup', clear, { capture: true, once: true });
+        doc.addEventListener('pointercancel', clear, { capture: true, once: true });
+    };
 
     constructor(private readonly deps: MarkPopoverDeps) {
         const doc = deps.plot.ownerDocument;
@@ -65,6 +81,7 @@ export class MarkPopover {
         this.anchor.className = 'vela-marks-anchor';
         Object.assign(this.anchor.style, { position: 'absolute', pointerEvents: 'none', left: '0', top: '0', width: '0', height: '0' });
         deps.plot.appendChild(this.anchor);
+        doc.addEventListener('pointerdown', this.onPress, true);
     }
 
     /** The cluster key the open popup belongs to, or null. */
@@ -73,6 +90,7 @@ export class MarkPopover {
     }
 
     open(cluster: MarkCluster, rect: MarkGlyphRect): void {
+        if (this.pressKey === cluster.key) return; // this press already closed that popup — the click toggles it off
         this.close();
         this.place(rect);
         const gen = ++this.generation;
@@ -122,6 +140,7 @@ export class MarkPopover {
 
     destroy(): void {
         this.close();
+        this.deps.plot.ownerDocument.removeEventListener('pointerdown', this.onPress, true);
         this.anchor.remove();
     }
 

--- a/test/mark-popover-toggle.test.ts
+++ b/test/mark-popover-toggle.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MarkPopover } from '../src/renderers/native/chrome/marks/MarkPopover';
+import type { MarkCluster } from '../src/renderers/native/chrome/marks/layout';
+import type { VelaTheme } from '../src/core/options';
+
+// The renderer's gesture on a lane glyph, as the DOM sees it: pointerdown on the canvas
+// (the kit Popover's outside-dismiss runs here — the glyph is canvas pixels, so the
+// popup's hit-transparent anchor is never the target), pointerup, then the renderer
+// turns that release into `open()` for the glyph under it.
+
+const theme: VelaTheme = { background: '#000', textColor: '#fff', gridColor: '#222', borderColor: '#333', upColor: '#0f0', downColor: '#f00', fontFamily: 'sans-serif' };
+
+function cluster(key: string): MarkCluster {
+    return { key, bar: 10, group: 'news', marks: [{ id: key, time: 1, glyph: { color: '#4af', letter: 'N' }, title: key, content: { text: 'body' } }] };
+}
+
+describe('MarkPopover click toggle', () => {
+    let plot: HTMLElement;
+    let canvas: HTMLElement;
+    let popover: MarkPopover;
+    let openChanges: Array<string | null>;
+
+    const press = (target: HTMLElement): void => {
+        target.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    };
+    const release = (target: HTMLElement): void => {
+        target.dispatchEvent(new Event('pointerup', { bubbles: true }));
+    };
+    // The deferred outside-dismiss listener (setTimeout 0 after show) and the release clear.
+    const settle = async (): Promise<void> => {
+        await vi.runAllTimersAsync();
+    };
+
+    beforeEach(() => {
+        // jsdom ships no CSS.escape; the kit's style injection needs it for id lookups.
+        if (typeof CSS === 'undefined' || typeof CSS.escape !== 'function') {
+            (globalThis as { CSS?: unknown }).CSS = { ...(globalThis as { CSS?: object }).CSS, escape: (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, (ch) => `\\${ch}`) };
+        }
+        vi.useFakeTimers();
+        plot = document.createElement('div');
+        canvas = document.createElement('canvas');
+        plot.appendChild(canvas);
+        document.body.appendChild(plot);
+        openChanges = [];
+        popover = new MarkPopover({ plot, host: () => plot, theme: () => theme, onOpenChange: (k) => openChanges.push(k) });
+    });
+
+    afterEach(() => {
+        popover.destroy();
+        plot.remove();
+        vi.useRealTimers();
+    });
+
+    it('opens on the first click and closes — without reopening — on the second click of the same glyph', async () => {
+        const c = cluster('10|news');
+        press(canvas);
+        release(canvas);
+        popover.open(c, { x: 50, y: 50, size: 12 });
+        await settle();
+        expect(popover.key).toBe('10|news');
+
+        press(canvas); // the shell's outside-dismiss closes the popup here
+        release(canvas);
+        popover.open(c, { x: 50, y: 50, size: 12 }); // the renderer's click on the same glyph
+        await settle();
+        expect(popover.key).toBeNull();
+        expect(openChanges).toEqual(['10|news', null]);
+
+        // A third click opens it again: the toggle is per press, not sticky.
+        press(canvas);
+        release(canvas);
+        popover.open(c, { x: 50, y: 50, size: 12 });
+        await settle();
+        expect(popover.key).toBe('10|news');
+    });
+
+    it('switches to another glyph in one click', async () => {
+        popover.open(cluster('10|news'), { x: 50, y: 50, size: 12 });
+        await settle();
+        press(canvas);
+        release(canvas);
+        popover.open(cluster('20|news'), { x: 90, y: 50, size: 12 });
+        await settle();
+        expect(popover.key).toBe('20|news');
+    });
+
+    it('reopens after an Escape dismissal without needing two clicks', async () => {
+        const c = cluster('10|news');
+        popover.open(c, { x: 50, y: 50, size: 12 });
+        await settle();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        await settle();
+        expect(popover.key).toBeNull();
+        press(canvas);
+        release(canvas);
+        popover.open(c, { x: 50, y: 50, size: 12 });
+        await settle();
+        expect(popover.key).toBe('10|news');
+    });
+});


### PR DESCRIPTION
## Background

Timeline marks shipped in v0.7.0. Clicking the mark whose popup is already open closed the popup and immediately reopened it, so a second click on the same glyph never dismissed it — only a click elsewhere or Escape did. Expected flow: click → opens → click → closes.

## Summary

The mark glyph is canvas pixels, so the popup's trigger is a hit-transparent anchor. On the second click the popover's outside-dismiss fires on `pointerdown` (the canvas is the target) and closes the popup; the renderer then turns the same gesture's `pointerup` into a click on the glyph and reopens it.

`MarkPopover` now remembers which cluster's popup was open when a pointer press began and treats an `open()` for that same cluster during that press as the closing half of a toggle. The key is cleared once the release has dispatched, so a third click opens the popup again. Escape dismissals arm nothing, and clicking a different glyph still switches popups in one click.

## End-to-end verification

Playground (`npm run playground`, `widget.html`, live Binance data) in Chromium:

- First click on the "News 1/3" glyph opened its popup.
- Second click on the same glyph closed it; no `.vela-marks-pop` element remained in the DOM.
- Third click reopened it with the same content.

## Checklist

- [x] This PR does one thing (one fix, one feature, one refactor, or one docs change)
- [x] `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` all pass
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation in `docs/` has been added / updated (for public interface or feature changes)
- [x] `CHANGELOG.md` has an entry under `[Unreleased]` (for user-visible changes)
- [x] I have signed the CLA (the bot asks in this PR)
- [x] I have reviewed this pull request myself (self-review)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI gesture fix in MarkPopover with regression tests; no data, auth, or API surface changes.
> 
> **Overview**
> **Timeline mark popups now close on a second click** on the same glyph instead of dismissing and immediately reopening.
> 
> Because mark glyphs are drawn on the canvas, the popover uses a hit-transparent anchor; outside-dismiss on `pointerdown` closes the popup before the renderer’s click handler calls `open()` on `pointerup`. **`MarkPopover`** records which cluster was open at press start (capture-phase `pointerdown`) and **ignores `open()` for that cluster until the pointer releases**, so the gesture reads as toggle-off. Switching glyphs and Escape dismissals behave as before.
> 
> Changelog updated; **jsdom tests** cover same-glyph toggle, glyph switch, and post-Escape reopen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500bd33f0984f4d0a3109af239c4665792f79dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->