### PR TITLE
Blank indicator visuals on a market identity switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to Vela, newest first.
   only the anchor markers until the second point is placed. The Schiff and modified
   Schiff pitchforks also keep that pivot line in the finished shape, so the pivot handle
   no longer floats detached from the fork it defines.
+- **Indicator visuals no longer linger across a market switch.** Switching the symbol,
+  timeframe, or session now clears every indicator's painted output the moment the
+  switch starts, and each indicator repaints once its recomputation over the new market
+  completes. Previously, outputs that are not tied to the bar series — drawing objects
+  such as lines, boxes, labels, and polylines, plus background tints and horizontal
+  levels — could stay visible over the new market's candles until the script finished
+  recomputing, which for heavy scripts took many seconds.
 
 ## [v0.7.0]
 

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -696,6 +696,12 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             if (identityChanged) {
                 this.beginLoad(false);
                 this.setBarSeries([], { clearing: true });
+                // Mounted indicator models are stale the moment the identity changes, but
+                // their re-runs land only AFTER the new bars paint. Index-aligned series
+                // stop on their own (their anchor matches no new bar) — time-anchored
+                // content (drawings, bgcolor spans) and price-anchored hlines would
+                // re-project onto the incoming axis and linger. Blank them all now.
+                this.blankIndicatorVisuals();
                 // The active style's DATA ENGINE still rides the old market — its rebuild only
                 // follows the load. Silence it for the gap (its live pushes are stale the moment
                 // the identity changed) and blank its channels: per-bar payloads are keyed by
@@ -1011,6 +1017,24 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         this.bars = transform ? transform.full(this.rawBars) : this.rawBars;
         this.renderer.setBars(this.bars, { preserveView: true });
         this.reexecuteIndicators();
+    }
+
+    /**
+     * Blank every mounted indicator's painted output — series data, fills, backgrounds,
+     * price lines, drawings, bar colors, trades — while keeping the mount (legend row,
+     * pane, settings) intact, via the same idempotent-by-id remount an input edit uses.
+     * Called on a market identity switch: the fresh models arrive only after the new
+     * bars load, so nothing blanked here is ever restored — each consumer's re-run
+     * remounts a full model over it.
+     */
+    private blankIndicatorVisuals(): void {
+        for (const record of this.registry.all()) {
+            if (record.hidden || !record.renderHandle || !record.model) continue;
+            record.model = blankedModel(record.model);
+            record.renderHandle = this.renderer.mountIndicator(record.model);
+            record.pendingStructural = true; // the next model remounts; never a patch over the blank
+            this.setLoading(record, true);
+        }
     }
 
     /** Stop + re-run every visible Pine indicator (its input bars changed wholesale). */
@@ -1945,6 +1969,13 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         const record = this.registry.get(id);
         if (!record || record.hidden) return true; // a model arriving for a just-hidden indicator is dropped
 
+        // A model arriving MID-SWITCH was computed over the outgoing market (a run already
+        // in flight when setMarket quiesced — every poke is gated and the re-executions
+        // only start after the load): applying it would repaint the just-blanked scene
+        // with stale content. It counts as no run at all — the pending cause stays for
+        // the post-load re-execution, whose model paints the new market.
+        if (this.switchingMarket) return false;
+
         // While the CHART ITSELF has no bars, an output-free model is the signature of a
         // run over zero bars (empty initial load: auth race, unresolved symbol, transient
         // feed failure) — an engine may then fabricate default metadata (generic title,
@@ -2165,6 +2196,29 @@ function yieldToPaint(): Promise<void> {
 }
 
 /** Build a value-only patch from a freshly-run model (used on live ticks / re-runs). */
+/**
+ * A copy of a mounted model with every painted output emptied. The structure — series
+ * specs (ids, titles, styles), pane routing, inputs — survives, so an idempotent
+ * remount keeps the legend and settings while nothing stale paints.
+ */
+function blankedModel(model: IndicatorModel): IndicatorModel {
+    return {
+        ...model,
+        series: model.series.map((s) => (s.kind === 'candle' || s.kind === 'bar' ? { ...s, bars: [] } : s.kind === 'markers' ? { ...s, markers: [] } : { ...s, points: [] })),
+        fills: [],
+        backgrounds: [],
+        priceLines: [],
+        lines: [],
+        boxes: [],
+        labels: [],
+        polylines: [],
+        linefills: [],
+        tables: [],
+        barColors: [],
+        trades: [],
+    };
+}
+
 function modelToValuePatch(model: IndicatorModel): ValuePatch {
     const series: SeriesValueDelta[] = [];
     let from = Number.POSITIVE_INFINITY;

--- a/test/set-market.test.ts
+++ b/test/set-market.test.ts
@@ -154,7 +154,8 @@ class FakeRenderer implements IChartRenderer {
     ensurePane(_p: Pane): void {}
     removePane(_id: string): void {}
     mountIndicator(model: IndicatorModel): IndicatorRenderHandle { this.mountedModels.push(model); return { id: model.id }; }
-    updateIndicator(_h: IndicatorRenderHandle, _p: ScenePatch): void {}
+    updates: ScenePatch[] = [];
+    updateIndicator(_h: IndicatorRenderHandle, p: ScenePatch): void { this.updates.push(p); }
     removeIndicator(_h: IndicatorRenderHandle): void {}
     setIndicatorInputs(_h: IndicatorRenderHandle, _v: Record<string, InputValue>): void {}
     setIndicatorVisible(_h: IndicatorRenderHandle, _v: boolean): void {}
@@ -207,6 +208,62 @@ class RecordingEngine implements ScriptingEngine {
             setVisibleRange: () => {},
             notifyBars: () => {},
         };
+    }
+}
+
+/**
+ * Static engine whose model carries every LINGER VECTOR of a market switch: content
+ * that does not ride the bar series (drawings, bgcolor spans, hlines) keeps painting
+ * on the incoming market's axis until the re-run's model lands. The handlers are kept
+ * so a test can emit a STALE model mid-switch (a run already in flight at quiesce).
+ */
+class DrawingEngine implements ScriptingEngine {
+    readonly language = 'pine';
+    readonly capabilities: EngineCapabilities = { streaming: false, visibleRange: false, inputs: true };
+    handlers: ExecutionHandlers | null = null;
+    private id = '';
+    private bars: OHLCV[] = [];
+
+    prepare(_source: string, instanceId: string): Promise<PreparedScript> {
+        return Promise.resolve({
+            language: 'pine',
+            inputs: [],
+            meta: { title: 'Draw', overlay: true },
+            reactsToViewport: false,
+            token: { instanceId },
+        });
+    }
+
+    execute(req: ExecutionRequest, handlers: ExecutionHandlers): ExecutionSession {
+        this.handlers = handlers;
+        this.id = (req.prepared.token as { instanceId: string }).instanceId;
+        this.bars = req.getBars?.() ?? req.bars;
+        this.emitModel();
+        handlers.onDone?.();
+        return { stop: () => {}, update: () => {}, setVisibleRange: () => {}, notifyBars: () => {} };
+    }
+
+    /** Emit a full model over the last-seen bars (call again to simulate a stale in-flight run). */
+    emitModel(): void {
+        const id = this.id;
+        const t0 = this.bars[0]?.time ?? 0;
+        const t1 = this.bars[this.bars.length - 1]?.time ?? 0;
+        const price = this.bars[0]?.close ?? 0;
+        this.handlers?.onModel({
+            id,
+            title: 'Draw',
+            overlay: true,
+            paneHint: 'price',
+            series: [{ id: `${id}:line:x#0`, title: 'Draw', paneId: 'unrouted', kind: 'line', points: this.bars.map((b) => ({ time: b.time, value: b.close })), style: { color: '#f00', width: 1, lineStyle: 'solid' } }],
+            fills: [],
+            backgrounds: [{ id: `${id}:bg0`, paneId: 'unrouted', from: t0, to: t1, color: '#00f' }],
+            priceLines: [{ id: `${id}:hl0`, paneId: 'unrouted', price }],
+            lines: [{ id: `${id}:l0`, paneId: 'unrouted', xloc: 'bar_time', x1: t0, y1: price, x2: t1, y2: price, extend: 'right', color: '#0f0', invisible: false, width: 1, style: 'solid', arrowLeft: false, arrowRight: false }],
+            boxes: [{ id: `${id}:b0`, paneId: 'unrouted', xloc: 'bar_time', left: t0, top: price + 1, right: t1, bottom: price - 1, extend: 'none', bgColor: '#333', borderWidth: 1, borderStyle: 'solid', textSize: 'auto', hAlign: 'center', vAlign: 'center', wrap: false, fontFamily: 'default', bold: false, italic: false }],
+            labels: [{ id: `${id}:lb0`, paneId: 'unrouted', xloc: 'bar_time', x: t1, y: price, yloc: 'price', style: 'label_up', color: '#ff0', size: 'small', textAlign: 'center', fontFamily: 'default' }],
+            inputs: [],
+            inputValues: {},
+        });
     }
 }
 
@@ -412,6 +469,70 @@ describe('setMarket — in-place market switch', () => {
 
         expect(engine.stops).toBe(1); // the old session was torn down
         expect(engine.executions[1]).toEqual({ symbol: 'BBB', timeframe: '60', barClose: PRICE.BBB });
+    });
+
+    it('an identity switch blanks mounted indicator visuals for the gap (nothing stale outlives the old market)', async () => {
+        const feed = new SwitchFeed();
+        feed.gatedLoads.add('SLOW');
+        const renderer = new FakeRenderer();
+        const engine = new DrawingEngine();
+        const chart = make({ symbol: 'AAA', timeframe: '60', volume: false }, { renderer, engines: [engine], dataFeed: feed });
+        chart.addIndicator('draw');
+        await chart.ready();
+        await flush();
+        const mounted = renderer.mountedModels[renderer.mountedModels.length - 1]!;
+        expect(mounted.lines).toHaveLength(1);
+        expect(mounted.boxes).toHaveLength(1);
+        expect(mounted.labels).toHaveLength(1);
+
+        const done = chart.setMarket({ symbol: 'SLOW' });
+        // Synchronously at the switch: the model is remounted BLANK. The new market's bars
+        // land before the script's re-run completes, and time-anchored drawings, bgcolor
+        // spans, and hlines would otherwise keep painting on the new axis for that window.
+        const blanked = renderer.mountedModels[renderer.mountedModels.length - 1]!;
+        expect(blanked.id).toBe(mounted.id);
+        expect(blanked.lines).toEqual([]);
+        expect(blanked.boxes).toEqual([]);
+        expect(blanked.labels).toEqual([]);
+        expect(blanked.backgrounds).toEqual([]);
+        expect(blanked.priceLines).toEqual([]);
+        expect(blanked.series.map((s) => (s.kind === 'line' ? s.points : null))).toEqual([[]]);
+        // The structure survives — legend/settings keep working through the gap.
+        expect(blanked.series[0]!.id).toBe(mounted.series[0]!.id);
+
+        feed.release();
+        await done;
+        await flush();
+        // The re-run's model repaints over the new market.
+        const fresh = renderer.mountedModels[renderer.mountedModels.length - 1]!;
+        expect(fresh.lines).toHaveLength(1);
+        expect(fresh.lines![0]!.x1).toBe(renderer.bars[0]!.time);
+    });
+
+    it('a stale model landing MID-SWITCH is dropped (a run in flight at quiesce cannot repaint the blank)', async () => {
+        const feed = new SwitchFeed();
+        feed.gatedLoads.add('SLOW');
+        const renderer = new FakeRenderer();
+        const engine = new DrawingEngine();
+        const chart = make({ symbol: 'AAA', timeframe: '60', volume: false }, { renderer, engines: [engine], dataFeed: feed });
+        chart.addIndicator('draw');
+        await chart.ready();
+        await flush();
+
+        const done = chart.setMarket({ symbol: 'SLOW' });
+        const mounts = renderer.mountedModels.length;
+        const updates = renderer.updates.length;
+        engine.emitModel(); // the OLD session's run completes mid-switch, over the OLD bars
+        expect(renderer.mountedModels.length).toBe(mounts); // dropped, not remounted…
+        expect(renderer.updates.length).toBe(updates); // …and never value-patched
+
+        feed.release();
+        await done;
+        await flush();
+        // The post-load re-execution still delivers the new market's model.
+        const fresh = renderer.mountedModels[renderer.mountedModels.length - 1]!;
+        expect(fresh.lines).toHaveLength(1);
+        expect(fresh.lines![0]!.x1).toBe(renderer.bars[0]!.time);
     });
 
     it('restarts a native indicator with a fresh context, keeping the record id', async () => {

--- a/test/set-market.test.ts
+++ b/test/set-market.test.ts
@@ -26,6 +26,7 @@ import type { MarketConfig } from '../src/core/options';
 import type { OHLCV } from '../src/core/model/ohlcv';
 import type { Pane } from '../src/core/model/scene';
 import type { IndicatorModel } from '../src/core/model/indicator';
+import type { DrawingLine } from '../src/core/model/drawings';
 import type { ScenePatch } from '../src/core/model/patch';
 import type { InputValue } from '../src/core/model/inputs';
 import type { VelaTheme } from '../src/core/options';
@@ -249,18 +250,28 @@ class DrawingEngine implements ScriptingEngine {
         const t0 = this.bars[0]?.time ?? 0;
         const t1 = this.bars[this.bars.length - 1]?.time ?? 0;
         const price = this.bars[0]?.close ?? 0;
+        const mkLine = (n: number): DrawingLine => ({ id: `${id}:l${n}`, paneId: 'unrouted', xloc: 'bar_time', x1: t0, y1: price + n, x2: t1, y2: price + n, extend: 'right', color: '#0f0', invisible: false, width: 1, style: 'solid', arrowLeft: false, arrowRight: false });
         this.handlers?.onModel({
             id,
             title: 'Draw',
             overlay: true,
             paneHint: 'price',
-            series: [{ id: `${id}:line:x#0`, title: 'Draw', paneId: 'unrouted', kind: 'line', points: this.bars.map((b) => ({ time: b.time, value: b.close })), style: { color: '#f00', width: 1, lineStyle: 'solid' } }],
-            fills: [],
+            series: [
+                { id: `${id}:line:x#0`, title: 'Hi', paneId: 'unrouted', kind: 'line', points: this.bars.map((b) => ({ time: b.time, value: b.close + 1 })), style: { color: '#f00', width: 1, lineStyle: 'solid' } },
+                { id: `${id}:line:x#1`, title: 'Lo', paneId: 'unrouted', kind: 'line', points: this.bars.map((b) => ({ time: b.time, value: b.close - 1 })), style: { color: '#f00', width: 1, lineStyle: 'solid' } },
+                { id: `${id}:markers:x#2`, title: 'Marks', paneId: 'unrouted', kind: 'markers', markers: [{ time: t1, position: 'aboveBar', shape: 'arrowUp', color: '#0f0' }] },
+            ],
+            fills: [{ id: `${id}:f0`, paneId: 'unrouted', fromSeriesId: `${id}:line:x#0`, toSeriesId: `${id}:line:x#1`, color: '#808' }],
             backgrounds: [{ id: `${id}:bg0`, paneId: 'unrouted', from: t0, to: t1, color: '#00f' }],
             priceLines: [{ id: `${id}:hl0`, paneId: 'unrouted', price }],
-            lines: [{ id: `${id}:l0`, paneId: 'unrouted', xloc: 'bar_time', x1: t0, y1: price, x2: t1, y2: price, extend: 'right', color: '#0f0', invisible: false, width: 1, style: 'solid', arrowLeft: false, arrowRight: false }],
+            lines: [mkLine(0)],
             boxes: [{ id: `${id}:b0`, paneId: 'unrouted', xloc: 'bar_time', left: t0, top: price + 1, right: t1, bottom: price - 1, extend: 'none', bgColor: '#333', borderWidth: 1, borderStyle: 'solid', textSize: 'auto', hAlign: 'center', vAlign: 'center', wrap: false, fontFamily: 'default', bold: false, italic: false }],
             labels: [{ id: `${id}:lb0`, paneId: 'unrouted', xloc: 'bar_time', x: t1, y: price, yloc: 'price', style: 'label_up', color: '#ff0', size: 'small', textAlign: 'center', fontFamily: 'default' }],
+            polylines: [{ id: `${id}:pl0`, paneId: 'unrouted', points: [{ xloc: 'bar_time', x: t0, price }, { xloc: 'bar_time', x: t1, price: price + 2 }], curved: false, closed: false, lineColor: '#fa0', lineWidth: 1, lineStyle: 'solid', arrowLeft: false, arrowRight: false }],
+            linefills: [{ id: `${id}:lf0`, paneId: 'unrouted', line1: mkLine(1), line2: mkLine(2), color: '#088' }],
+            tables: [{ id: `${id}:t0`, paneId: 'unrouted', position: 'top_right', columns: 1, rows: 1, frameWidth: 0, borderWidth: 0, cells: [[{ text: 'X', hAlign: 'center', vAlign: 'center', textSize: 'auto', fontFamily: 'default', bold: false, italic: false }]], merges: [] }],
+            barColors: [{ time: t1, color: '#f0f' }],
+            trades: [{ time: t1, price, side: 'buy', kind: 'entry' }],
             inputs: [],
             inputValues: {},
         });
@@ -491,12 +502,20 @@ describe('setMarket — in-place market switch', () => {
         // spans, and hlines would otherwise keep painting on the new axis for that window.
         const blanked = renderer.mountedModels[renderer.mountedModels.length - 1]!;
         expect(blanked.id).toBe(mounted.id);
+        // EVERY output vocabulary is emptied — plots, markers, fills, bgcolor spans,
+        // hlines, all six drawing kinds, barcolor, and strategy trades.
         expect(blanked.lines).toEqual([]);
         expect(blanked.boxes).toEqual([]);
         expect(blanked.labels).toEqual([]);
+        expect(blanked.polylines).toEqual([]);
+        expect(blanked.linefills).toEqual([]);
+        expect(blanked.tables).toEqual([]);
         expect(blanked.backgrounds).toEqual([]);
         expect(blanked.priceLines).toEqual([]);
-        expect(blanked.series.map((s) => (s.kind === 'line' ? s.points : null))).toEqual([[]]);
+        expect(blanked.fills).toEqual([]);
+        expect(blanked.barColors).toEqual([]);
+        expect(blanked.trades).toEqual([]);
+        expect(blanked.series.map((s) => (s.kind === 'markers' ? s.markers : s.kind === 'line' ? s.points : null))).toEqual([[], [], []]);
         // The structure survives — legend/settings keep working through the gap.
         expect(blanked.series[0]!.id).toBe(mounted.series[0]!.id);
 


### PR DESCRIPTION
## Problem

Switching the symbol, timeframe, or session blanks the bar series immediately, but every indicator's model stays mounted until its asynchronous re-run delivers a fresh one. In that window:

- **Plots/fills** stop painting only by accident: their anchor time matches no bar of the new market, so the index-aligned lookup runs off the array.
- **Drawing objects** (`line.new`, `box.new`, `label.new`, `polyline.new`, ...), **bgcolor spans** (time-anchored), and **hlines** (price-anchored) keep painting: they are re-projected onto the current axis every frame, so stale shapes sit over the new market's candles until the script finishes recomputing - many seconds for scripts with lower-timeframe `request.security` calls.

Reproduced with a Pine script that draws no-wick retest levels: after a 1h -> 15m switch, its stale level lines, labels and boxes stayed visible for ~30 s while the script refetched 1m data.

## Fix

Two changes in `EngineOrchestrator`:

1. **`blankIndicatorVisuals()`** - on an identity switch, right after the bar series is cleared, every mounted indicator is remounted with a blanked copy of its model (empty series data, drawings, fills, backgrounds, price lines, bar colors, trades). The structure survives, so the legend row, pane, and settings stay intact, with the loading spinner up until the re-run lands. Nothing needs restoring: the post-load re-execution always remounts a full model.
2. **Mid-switch model drop in `applyModel()`** - a model arriving while the switch is in flight was computed over the outgoing market (a run already in flight at quiesce; every poke is gated during a switch), so it is dropped like a deferred model instead of repainting the just-blanked scene.

## Testing

- Two regression tests in `test/set-market.test.ts` (blank-at-switch with a drawings-emitting fake engine; mid-switch stale-model drop). Both fail on the pre-fix code.
- Full gate green: typecheck, lint, 1676 tests, build.
- Browser-verified on the Vela-pinets playground with the reproducing script: visuals blank at the switch, new candles paint with no stale drawings, and the script's output returns when its re-run completes.
- Workspace oracle suites: vela-pro 11/11; vela 22/23 - the single failure (`plotshape.pine` label count) reproduces identically on the pre-fix build (pre-existing drift, tracked separately).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core orchestrator model application during market switches; behavior is guarded by existing `switchingMarket` gating and covered by new regression tests, but any missed output channel in `blankedModel` could still linger briefly.
> 
> **Overview**
> **Indicator output is cleared immediately on symbol, timeframe, or session changes**, instead of leaving drawings, bgcolor spans, hlines, and other non-series visuals painted over the new market until Pine re-runs.
> 
> On an identity switch, right after the bar series is blanked, `EngineOrchestrator` calls **`blankIndicatorVisuals()`**, which remounts each visible indicator with a **`blankedModel`** copy—empty plots, markers, fills, backgrounds, price lines, all drawing kinds, bar colors, and trades, while legend rows, panes, and settings stay put and loading stays on until the post-load re-execution.
> 
> **`applyModel()`** now **returns false** while **`switchingMarket`** is set, so a model from a run that was already in flight over the outgoing market cannot repaint over the blank scene; the post-load re-run owns the first real paint.
> 
> **CHANGELOG** documents the fix; **`set-market.test.ts`** adds a drawings-heavy fake engine and two regressions (blank-at-switch and mid-switch stale-model drop).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3ad57b2057c5d6ab6c8bc7b40785e5d6b95603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->