### PR TITLE
Keep candle wick colors when zoomed far out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Candle wicks keep their color when zoomed far out.** Once bars are packed tighter
+  than a pixel, the candles sharing a column are drawn as thin sticks; a stick used to
+  take one direction for all of its bars, so a bearish candle's long wick could turn
+  bullish green the moment the recovery candle next to it landed in the same column.
+  Each bar's range now keeps its own color — direction, `barcolor()` tint, or the
+  wick color from the candle settings, the same rules as at every other zoom level.
 - **Timeline mark popups now toggle with a click.** Clicking the mark whose popup is
   open closes it; previously that second click closed and immediately reopened the popup,
   so it took a click elsewhere to dismiss it.

--- a/src/renderers/native/backend/Canvas2dBackend.ts
+++ b/src/renderers/native/backend/Canvas2dBackend.ts
@@ -221,7 +221,7 @@ export class Canvas2dBackend implements IRenderBackend {
         const spacing = coords.bodySpacing();
         const tier = candleTier(spacing);
         if (tier === 'aggregate') {
-            this.drawCandlesAggregated(ctx, bars, i0, i1, coords, pane, up, down, barColors);
+            this.drawCandlesAggregated(ctx, bars, i0, i1, coords, pane, (b) => barColors.get(b.time) ?? (b.close >= b.open ? up : down));
             return;
         }
         const tickW = Math.max(1, Math.round(spacing * 0.35));
@@ -428,12 +428,17 @@ export class Canvas2dBackend implements IRenderBackend {
         // A candle-based plugin style paints with its OWN cosmetics (unset keys inherit
         // the shared candles block); built-ins pass through untouched.
         const paint = effectiveCandlePaint(scene.style.candle, scene.candleOverride, theme.upColor, theme.downColor);
+        const cs = paint.candle;
         if (tier === 'aggregate') {
-            this.drawCandlesAggregated(ctx, bars, i0, i1, coords, pane, paint.up, paint.down, barColors);
+            // The stick IS the candle, so a bar's paint resolves as in the stick-only tier
+            // below: the wick color setting wins, then barcolor(), then the direction color.
+            this.drawCandlesAggregated(ctx, bars, i0, i1, coords, pane, (b) => {
+                const up = b.close >= b.open;
+                return (up ? cs.wickUpColor : cs.wickDownColor) ?? barColors.get(b.time) ?? (up ? paint.up : paint.down);
+            });
             return;
         }
         const drawBody = tier === 'full';
-        const cs = paint.candle;
         // When a fading style drops the body below the structure, draw a body outline even
         // if no border is configured — so the candle keeps a visible (hollow) skeleton.
         const fading = this.candleStructureAlpha > this.candleBodyAlpha + 0.001;
@@ -509,10 +514,11 @@ export class Canvas2dBackend implements IRenderBackend {
 
     /**
      * Sub-pixel LOD: bars sharing a rounded pixel column collapse into high-low
-     * sticks (one per contiguous coverage run — see {@link aggregateCandleColumns}),
-     * so draw cost is bounded by screen width (not bar count) when zoomed far out
-     * and a price gap inside the column stays a void. Each stick's color follows
-     * its first-open→last-close direction (a barcolor() on the head bar still wins).
+     * sticks (one per contiguous SAME-COLOR coverage run — see
+     * {@link aggregateCandleColumns}), so draw cost is bounded by screen width (not
+     * bar count) when zoomed far out, a price gap inside the column stays a void, and
+     * every bar's extent keeps its own color. `colorOf` is the calling style's per-bar
+     * paint rule (candles and OHLC bars resolve theirs differently).
      */
     private drawCandlesAggregated(
         ctx: CanvasRenderingContext2D,
@@ -521,15 +527,13 @@ export class Canvas2dBackend implements IRenderBackend {
         i1: number,
         coords: CoordinateSystem,
         pane: PaneNode,
-        up: string,
-        down: string,
-        barColors: ReadonlyMap<number, string>,
+        colorOf: (bar: OHLCV) => string,
     ): void {
         const yOf = (price: number): number => coords.priceToY(price, pane.scale, pane.bounds);
         ctx.lineWidth = 1;
-        for (const s of aggregateCandleColumns(bars, i0, i1, (i) => coords.logicalToX(i), yOf)) {
+        for (const s of aggregateCandleColumns(bars, i0, i1, (i) => coords.logicalToX(i), yOf, colorOf)) {
             const x = s.x + 0.5;
-            ctx.strokeStyle = barColors.get(s.headTime) ?? (s.close >= s.open ? up : down);
+            ctx.strokeStyle = s.color;
             ctx.beginPath();
             ctx.moveTo(x, yOf(s.hi));
             ctx.lineTo(x, yOf(s.lo));

--- a/src/renderers/native/backend/WebGL2Backend.ts
+++ b/src/renderers/native/backend/WebGL2Backend.ts
@@ -700,7 +700,7 @@ export class WebGL2Backend implements IRenderBackend {
         const spacing = coords.bodySpacing();
         const tier = candleTier(spacing);
         if (tier === 'aggregate') {
-            this.emitCandlesAggregated(b, bars, i0, i1, coords, pane, up, down, barColors);
+            this.emitCandlesAggregated(b, bars, i0, i1, coords, pane, (bar) => barColors.get(bar.time) ?? (bar.close >= bar.open ? up : down));
             return;
         }
         const tickW = Math.max(1, Math.round(spacing * 0.35));
@@ -855,14 +855,19 @@ export class WebGL2Backend implements IRenderBackend {
         // A candle-based plugin style paints with its OWN cosmetics (unset keys inherit
         // the shared candles block); built-ins pass through untouched.
         const paint = effectiveCandlePaint(scene.style.candle, scene.candleOverride, theme.upColor, theme.downColor);
-        if (tier === 'aggregate') {
-            this.emitCandlesAggregated(b, bars, i0, i1, coords, pane, paint.up, paint.down, barColors);
-            return;
-        }
-        const drawBody = tier === 'full';
         const up = paint.up;
         const down = paint.down;
         const cs = paint.candle;
+        if (tier === 'aggregate') {
+            // The stick IS the candle, so a bar's paint resolves as in the stick-only tier
+            // below: the wick color setting wins, then barcolor(), then the direction color.
+            this.emitCandlesAggregated(b, bars, i0, i1, coords, pane, (bar) => {
+                const isUp = bar.close >= bar.open;
+                return (isUp ? cs.wickUpColor : cs.wickDownColor) ?? barColors.get(bar.time) ?? (isUp ? up : down);
+            });
+            return;
+        }
+        const drawBody = tier === 'full';
         // When a fading style drops the body below the structure, draw a body outline even
         // if no border is configured — so the candle keeps a visible (hollow) skeleton.
         const fading = this.candleStructureAlpha > this.candleBodyAlpha + 0.001;
@@ -930,14 +935,15 @@ export class WebGL2Backend implements IRenderBackend {
     /**
      * Sub-pixel LOD (mirrors Canvas2dBackend.drawCandlesAggregated): bars sharing a
      * rounded pixel column collapse into high-low sticks — one per contiguous
-     * coverage run (see {@link aggregateCandleColumns}), so a price gap inside the
-     * column stays a void. Draw cost stays bounded by screen width, not bar count;
-     * stick color follows its own first-open→last-close.
+     * SAME-COLOR coverage run (see {@link aggregateCandleColumns}), so a price gap
+     * inside the column stays a void and every bar's extent keeps its own color. Draw
+     * cost stays bounded by screen width, not bar count. `colorOf` is the calling
+     * style's per-bar paint rule (candles and OHLC bars resolve theirs differently).
      */
-    private emitCandlesAggregated(b: Batch, bars: OHLCV[], i0: number, i1: number, coords: CoordinateSystem, pane: PaneNode, up: string, down: string, barColors: ReadonlyMap<number, string>): void {
+    private emitCandlesAggregated(b: Batch, bars: OHLCV[], i0: number, i1: number, coords: CoordinateSystem, pane: PaneNode, colorOf: (bar: OHLCV) => string): void {
         const yOf = (price: number): number => coords.priceToY(price, pane.scale, pane.bounds);
-        for (const s of aggregateCandleColumns(bars, i0, i1, (i) => coords.logicalToX(i), yOf)) {
-            const c = parseColor(barColors.get(s.headTime) ?? (s.close >= s.open ? up : down));
+        for (const s of aggregateCandleColumns(bars, i0, i1, (i) => coords.logicalToX(i), yOf, colorOf)) {
+            const c = parseColor(s.color);
             const hY = yOf(s.hi);
             b.rect(s.x - 0.5, hY, 1, yOf(s.lo) - hY, c);
         }

--- a/src/renderers/native/backend/candle-lod.ts
+++ b/src/renderers/native/backend/candle-lod.ts
@@ -87,28 +87,23 @@ export function candleGeometry(xCss: number, spacing: number, dpr: number, bodyS
     };
 }
 
-/** One aggregate-tier stick: a contiguous run of price coverage inside one pixel column. */
+/** One aggregate-tier stick: a contiguous run of SAME-COLOR price coverage inside one pixel column. */
 export interface AggregatedStick {
     /** The rounded CSS-px column shared by the stick's bars (canvas2d strokes at `x + 0.5`). */
     x: number;
     hi: number;
     lo: number;
-    /** The stick's FIRST bar — the barcolor() lookup key and the direction's open. */
-    headTime: number;
-    open: number;
-    /** The stick's LAST bar's close (direction = `close >= open`, as everywhere). */
-    close: number;
+    /** The resolved paint shared by every bar in the run — the grouping key. */
+    color: string;
 }
 
-/** One in-progress coverage interval of the current column (price space, index-tracked). */
+/** One in-progress coverage run of the current column (price space, index-tracked). */
 interface Coverage {
     lo: number;
     hi: number;
-    headIdx: number;
-    headTime: number;
-    open: number;
+    color: string;
+    /** The run's most recent bar — the column's paint order key. */
     lastIdx: number;
-    close: number;
 }
 
 /**
@@ -119,9 +114,15 @@ interface Coverage {
  * an overnight jump, once zoomed far out) stays a visible void instead of being
  * painted over as a solid connection. Runs whose separation is under one pixel
  * (`yOf` measures it) merge anyway: an invisible void isn't worth a second stick, and
- * ordinary contiguous data keeps producing exactly one stick per column. Each stick
- * carries its own first-open/last-close direction and its head bar's time, so
- * barcolor() and up/down coloring follow the run that actually holds those bars.
+ * ordinary contiguous data keeps producing exactly one stick per column.
+ *
+ * Runs are kept PER COLOR (`colorOf` resolves each bar's paint — direction, barcolor(),
+ * wick setting): bars of different colors never merge, so a down bar's long wick stays
+ * the down color even when the up bar next to it shares the column. Merging them into
+ * one first-open→last-close stick would recolor that wick by whichever bar closed last.
+ * Within a column the sticks come out in order of their most recent bar, so where runs
+ * of different colors overlap in price the latest bar paints on top — the same result
+ * drawing the bars one by one would give.
  */
 export function aggregateCandleColumns(
     bars: ArrayLike<OHLCV | undefined>,
@@ -129,34 +130,36 @@ export function aggregateCandleColumns(
     i1: number,
     xOf: (index: number) => number,
     yOf: (price: number) => number,
+    colorOf: (bar: OHLCV) => string,
 ): AggregatedStick[] {
     const out: AggregatedStick[] = [];
     let col = NaN;
-    let intervals: Coverage[] = []; // sorted by `lo`; typically length 1
+    let runs: Coverage[] = []; // the current column's runs, any color; typically length 1
     const flush = (): void => {
-        if (intervals.length === 0) return;
-        // Coalesce runs whose void is sub-pixel — it cannot render anyway.
-        const merged: Coverage[] = [intervals[0]!];
-        for (let k = 1; k < intervals.length; k += 1) {
-            const prev = merged[merged.length - 1]!;
-            const next = intervals[k]!;
-            if (Math.abs(yOf(prev.hi) - yOf(next.lo)) < 1) {
+        if (runs.length === 0) return;
+        // Coalesce same-color runs whose void is sub-pixel — it cannot render anyway.
+        // Same-color runs are disjoint (overlaps merged on insert), so in `lo` order the
+        // previous run of a color is the one just below.
+        runs.sort((a, b) => a.lo - b.lo);
+        const merged: Coverage[] = [];
+        for (const next of runs) {
+            let prev: Coverage | undefined;
+            for (let k = merged.length - 1; k >= 0; k -= 1) {
+                if (merged[k]!.color === next.color) {
+                    prev = merged[k];
+                    break;
+                }
+            }
+            if (prev && Math.abs(yOf(prev.hi) - yOf(next.lo)) < 1) {
                 prev.hi = next.hi;
-                if (next.headIdx < prev.headIdx) {
-                    prev.headIdx = next.headIdx;
-                    prev.headTime = next.headTime;
-                    prev.open = next.open;
-                }
-                if (next.lastIdx > prev.lastIdx) {
-                    prev.lastIdx = next.lastIdx;
-                    prev.close = next.close;
-                }
+                if (next.lastIdx > prev.lastIdx) prev.lastIdx = next.lastIdx;
             } else {
                 merged.push(next);
             }
         }
-        for (const iv of merged) out.push({ x: col, hi: iv.hi, lo: iv.lo, headTime: iv.headTime, open: iv.open, close: iv.close });
-        intervals = [];
+        merged.sort((a, b) => a.lastIdx - b.lastIdx);
+        for (const r of merged) out.push({ x: col, hi: r.hi, lo: r.lo, color: r.color });
+        runs = [];
     };
     for (let i = i0; i <= i1; i += 1) {
         const b = bars[i];
@@ -166,27 +169,18 @@ export function aggregateCandleColumns(
             flush();
             col = x;
         }
-        // Merge the bar's range into every overlapping interval (usually zero or one).
+        // Merge the bar's range into every overlapping run OF ITS COLOR (usually zero or one).
+        const color = colorOf(b);
         let lo = b.low;
         let hi = b.high;
-        let headIdx = i;
-        let headTime = b.time;
-        let open = b.open;
-        for (let k = intervals.length - 1; k >= 0; k -= 1) {
-            const iv = intervals[k]!;
-            if (iv.lo > hi || iv.hi < lo) continue;
-            if (iv.lo < lo) lo = iv.lo;
-            if (iv.hi > hi) hi = iv.hi;
-            if (iv.headIdx < headIdx) {
-                headIdx = iv.headIdx;
-                headTime = iv.headTime;
-                open = iv.open;
-            }
-            intervals.splice(k, 1);
+        for (let k = runs.length - 1; k >= 0; k -= 1) {
+            const r = runs[k]!;
+            if (r.color !== color || r.lo > hi || r.hi < lo) continue;
+            if (r.lo < lo) lo = r.lo;
+            if (r.hi > hi) hi = r.hi;
+            runs.splice(k, 1);
         }
-        let insertAt = 0;
-        while (insertAt < intervals.length && intervals[insertAt]!.lo < lo) insertAt += 1;
-        intervals.splice(insertAt, 0, { lo, hi, headIdx, headTime, open, lastIdx: i, close: b.close });
+        runs.push({ lo, hi, color, lastIdx: i }); // `i` is the newest bar, so it is the run's last
     }
     flush();
     return out;

--- a/test/native-candle-lod.test.ts
+++ b/test/native-candle-lod.test.ts
@@ -112,35 +112,37 @@ describe('aggregateCandleColumns (sub-pixel LOD bucketing)', () => {
     // 10 px per price unit, chart top at price 100 — plenty of resolution for the void checks.
     const yOf = (price: number): number => (100 - price) * 10;
     const oneColumn = (): number => 0;
+    // The backends' paint resolution, reduced to its direction fallback.
+    const dirColor = (b: OHLCV): string => (b.close >= b.open ? 'up' : 'down');
 
-    it('collapses a column of overlapping bars into ONE min-to-max stick', () => {
+    it('collapses a column of overlapping same-color bars into ONE min-to-max stick', () => {
         const bars = [bar(1, 10, 12, 9, 11), bar(2, 11, 13, 10, 12), bar(3, 12, 14, 11, 13)];
-        const sticks = aggregateCandleColumns(bars, 0, 2, oneColumn, yOf);
-        expect(sticks).toEqual([{ x: 0, hi: 14, lo: 9, headTime: 1, open: 10, close: 13 }]);
+        const sticks = aggregateCandleColumns(bars, 0, 2, oneColumn, yOf, dirColor);
+        expect(sticks).toEqual([{ x: 0, hi: 14, lo: 9, color: 'up' }]);
     });
 
     it('keeps a PRICE GAP inside a column as a void — two sticks, never one solid span', () => {
         // The regression: the bars around a large price jump land in the same pixel
         // column once zoomed far out; a single min-to-max stick would paint the void.
         const bars = [bar(1, 10, 12, 9, 11), bar(2, 40, 42, 39, 41)];
-        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf);
+        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf, dirColor);
         expect(sticks).toEqual([
-            { x: 0, hi: 12, lo: 9, headTime: 1, open: 10, close: 11 },
-            { x: 0, hi: 42, lo: 39, headTime: 2, open: 40, close: 41 },
+            { x: 0, hi: 12, lo: 9, color: 'up' },
+            { x: 0, hi: 42, lo: 39, color: 'up' },
         ]);
     });
 
     it('coalesces a SUB-PIXEL void — an invisible gap is not worth a second stick', () => {
         // 0.05 price units = 0.5 px: below one pixel, the runs merge back into one.
         const bars = [bar(1, 10, 12, 9, 11), bar(2, 12.1, 12.15, 12.05, 12.1)];
-        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf);
-        expect(sticks).toEqual([{ x: 0, hi: 12.15, lo: 9, headTime: 1, open: 10, close: 12.1 }]);
+        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf, dirColor);
+        expect(sticks).toEqual([{ x: 0, hi: 12.15, lo: 9, color: 'up' }]);
     });
 
-    it('a later bar bridging two disjoint runs merges them (head stays the earliest bar)', () => {
+    it('a later bar bridging two disjoint same-color runs merges them', () => {
         const bars = [bar(1, 10, 12, 9, 11), bar(2, 40, 42, 39, 41), bar(3, 25, 41, 10, 30)];
-        const sticks = aggregateCandleColumns(bars, 0, 2, oneColumn, yOf);
-        expect(sticks).toEqual([{ x: 0, hi: 42, lo: 9, headTime: 1, open: 10, close: 30 }]);
+        const sticks = aggregateCandleColumns(bars, 0, 2, oneColumn, yOf, dirColor);
+        expect(sticks).toEqual([{ x: 0, hi: 42, lo: 9, color: 'up' }]);
     });
 
     it('emits one stick per pixel column and skips holes and zero-range bars', () => {
@@ -153,20 +155,53 @@ describe('aggregateCandleColumns (sub-pixel LOD bucketing)', () => {
         ];
         // Two bars in column 0, the last one in column 1.
         const xOf = (i: number): number => (i < 2 ? 0 : 1);
-        const sticks = aggregateCandleColumns(bars, 0, 4, xOf, yOf);
+        const sticks = aggregateCandleColumns(bars, 0, 4, xOf, yOf, dirColor);
         expect(sticks).toEqual([
-            { x: 0, hi: 13, lo: 9, headTime: 1, open: 10, close: 12 },
-            { x: 1, hi: 32, lo: 29, headTime: 5, open: 30, close: 31 },
+            { x: 0, hi: 13, lo: 9, color: 'up' },
+            { x: 1, hi: 32, lo: 29, color: 'up' },
         ]);
     });
 
-    it('sticks carry their OWN run direction (a gap-up column colors each side by its bars)', () => {
-        // Below the gap: a down run (open 12 → close 10). Above: an up run (40 → 42).
+    it('sticks carry their OWN bars\u2019 color (a gap-up column colors each side by its bars)', () => {
+        // Below the gap: a down bar (open 12 → close 10). Above: an up bar (40 → 42).
         const bars = [bar(1, 12, 13, 9, 10), bar(2, 40, 43, 39, 42)];
-        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf);
-        const below = sticks.find((s) => s.hi === 13)!;
-        const above = sticks.find((s) => s.hi === 43)!;
-        expect(below.close).toBeLessThan(below.open);
-        expect(above.close).toBeGreaterThan(above.open);
+        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf, dirColor);
+        expect(sticks.find((s) => s.hi === 13)!.color).toBe('down');
+        expect(sticks.find((s) => s.hi === 43)!.color).toBe('up');
+    });
+
+    it('a down bar\u2019s long wick keeps the down color when an up bar shares its column', () => {
+        // The regression: zoomed in, a down bar with a deep lower wick is red; once the
+        // tall up bar right after it lands in the same pixel column, one merged
+        // first-open→last-close stick turns the whole wick green. Bars of different
+        // colors must stay separate sticks, each covering only its own bars' range.
+        const down = bar(1, 94.4, 94.5, 82, 94.1); // wick down to 82
+        const up = bar(2, 94.1, 100.2, 94.05, 100.1); // recovery, barely overlapping the down bar
+        const sticks = aggregateCandleColumns([down, up], 0, 1, oneColumn, yOf, dirColor);
+        expect(sticks).toEqual([
+            { x: 0, hi: 94.5, lo: 82, color: 'down' },
+            { x: 0, hi: 100.2, lo: 94.05, color: 'up' },
+        ]);
+    });
+
+    it('paints a column\u2019s sticks latest-bar-last so the newest bar wins where colors overlap', () => {
+        // An up bar fully inside an earlier down bar's range: both sticks exist, the up
+        // one comes out AFTER (drawn on top), as sequential per-bar drawing would give.
+        const bars = [bar(1, 20, 30, 10, 15), bar(2, 18, 22, 16, 21)];
+        const sticks = aggregateCandleColumns(bars, 0, 1, oneColumn, yOf, dirColor);
+        expect(sticks.map((s) => s.color)).toEqual(['down', 'up']);
+        // Reverse the time order and the down bar paints on top instead.
+        const flipped = aggregateCandleColumns([bars[1]!, bars[0]!], 0, 1, oneColumn, yOf, dirColor);
+        expect(flipped.map((s) => s.color)).toEqual(['up', 'down']);
+    });
+
+    it('groups by the RESOLVED paint, so a barcolor()ed bar forms its own run', () => {
+        const bars = [bar(1, 10, 12, 9, 11), bar(2, 11, 13, 10, 12), bar(3, 12, 14, 11, 13)];
+        const tinted = (b: OHLCV): string => (b.time === 2 ? '#ff0' : dirColor(b));
+        const sticks = aggregateCandleColumns(bars, 0, 2, oneColumn, yOf, tinted);
+        expect(sticks).toEqual([
+            { x: 0, hi: 13, lo: 10, color: '#ff0' },
+            { x: 0, hi: 14, lo: 9, color: 'up' }, // bars 1 and 3 bridge across bar 2's range
+        ]);
     });
 });


### PR DESCRIPTION
## Problem

Below one pixel of bar spacing the native renderer draws each pixel column's bars as high–low sticks. A stick took a single direction for all of its bars (first open → last close), so a bearish bar's long wick turned bullish green as soon as the tall recovery bar next to it landed in the same column. The same path also painted with the body colors, ignoring the `wickUpColor` / `wickDownColor` settings.

## Fix

- `candle-lod.ts` — `aggregateCandleColumns` takes a `colorOf(bar)` resolver and keeps coverage runs **per color**. Bars of different colors never merge, so every bar's range keeps its own paint. Within a column, sticks come out latest-bar-last so overlapping ranges resolve the way sequential drawing would. Sub-pixel void coalescing stays, within a color.
- `Canvas2dBackend.ts` / `WebGL2Backend.ts` — the aggregated drawer takes the calling style's paint rule. Candles resolve it as in the stick-only tier (wick color setting → `barcolor()` → direction); OHLC bars keep their own up/down + `barcolor()` rule.
- Tests: aggregate tests updated to the new shape, plus regressions for the merged-wick case (fails on the old code), paint order, and grouping by `barcolor()`.
- `CHANGELOG.md` — `Fixed` entry under `[Unreleased]`.

## Verification

Reproduced in the playground with a crafted dataset (bearish bar with a deep lower wick + tall bullish neighbor) and sampled the renderer's own screenshot pixels on both backends:

| Zoom | Spike wick before | after |
| --- | --- | --- |
| Full candles | 199 red / 0 green | 199 red / 0 green |
| Stick-only tier (~1.3 px) | 120 red / 0 green | 120 red / 0 green |
| Aggregate tier (~0.5 px) | **1 red / 288 green** | **101 red / 0 green** |

Gate: typecheck ✅ · lint ✅ · test ✅ (136 files, 1677 tests) · build ✅.
Oracle `vela` suite: 22/23 — the `plotshape` label-count failure is pre-existing on unmodified `dev` (confirmed by stash + rebuild) and unrelated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to far-zoom LOD rendering in both native backends, with targeted unit tests and no API or data-path changes.
> 
> **Overview**
> Fixes **wrong wick/body colors when zoomed out** so sub-pixel “stick” candles no longer inherit one color from a merged column of bars.
> 
> **`aggregateCandleColumns`** now takes a per-bar **`colorOf`** resolver and builds sticks from **same-color** coverage runs instead of merging an entire pixel column by first-open→last-close. Different colors stay separate sticks (so a bearish wick stays red when a bullish neighbor shares the column); overlapping runs paint **latest-bar-last**, and sub-pixel void coalescing still applies **within** a color.
> 
> **Canvas2D and WebGL2** aggregated paths pass style-specific rules: candles use **wick settings → `barcolor()` → direction** (matching stick-only tier); OHLC bars keep **direction + `barcolor()`**. Tests and the changelog document the regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda359a5eb035ddc411c495fae19cfe7e15df0cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->