### PR TITLE
feat(native): one renderer layer per instance of a multi-instance native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **A plugin indicator restored hidden no longer crashes the chart on load.** A saved
+  layout that carried a hidden plugin native indicator could throw while the chart was
+  being built, because the indicator was asked to suspend before it had ever started.
+  Such an indicator is now left alone until it is first shown, at which point it starts
+  as usual; removing it or closing the chart while it is still hidden is equally safe.
 - **Timeline mark popups now toggle with a click.** Clicking the mark whose popup is
   open closes it; previously that second click closed and immediately reopened the popup,
   so it took a click elsewhere to dismiss it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vela, newest first.
 
 ## [Unreleased]
 
+### Added
+
+- **Plugin indicators drawn by a renderer layer can now be added several times.** A
+  plugin native indicator that paints through its own renderer layer and allows several
+  instances (`multiInstance` on its descriptor) now gets one layer per instance: each
+  instance draws on its own canvas, on its own pane, with its own stacking order, and its
+  data never overwrites a sibling's. Previously such types had to stay single-instance.
+  Running native indicators also learn their own id (`ctx.id`), so an instance can
+  identify itself to host code — a picker or a drag handle — without ambiguity.
+
 ### Fixed
 
 - **Timeline mark popups now toggle with a click.** Clicking the mark whose popup is

--- a/docs/contributing/plugin-sdk.md
+++ b/docs/contributing/plugin-sdk.md
@@ -90,7 +90,7 @@ registerRendererLayer({
     id: 'mytype',                    // = the `setNativeData` channel it receives
     placement: 'above-data',         // or 'below-data' (behind the candles)
     repaintOnCursor: true,           // opt-in: pointer moves repaint this layer too
-    create: () => ({
+    create: () => ({                 // once per mounted renderer (+ once per instance of a multi-instance owner)
         mount(canvas) { /* keep the canvas reference */ },
         render({ bars, data, pending, coords, scale, bounds, theme, priceStyle, nowMs, cursor }) {
             // Always clear + repaint your own canvas. Gate on `priceStyle` if the
@@ -127,6 +127,13 @@ normal object model instead of sitting outside it:
   collapsed host pane blanks the layer, and `modulateBase` is consulted only while the
   owner sits on the price pane.
 
+- **Multi-instance owners:** when the owning type allows several instances
+  (`multiInstance: true` on its descriptor), each instance owns a layer of its own — the
+  definition's `create()` runs once per mounted renderer for the base layer AND once per
+  such instance, each on its own canvas, fed by that instance's channel, stacked and
+  paned by that instance. The base layer of such a type receives no data (every instance
+  has its own channel) and paints nothing.
+
 Chart-type channels (no owning indicator) keep the declared `placement` and the price
 pane, exactly as before.
 
@@ -153,8 +160,15 @@ volume and VPVR ride this seam. See `NativeIndicator` types in `@luxalgo/vela/pl
 A type is **single-instance** by default: a second `addNativeIndicator` of the same type
 returns the existing handle. Set `multiInstance: true` on the descriptor when a chart may
 carry several instances (a study users stack at different settings); every add then
-creates a fresh instance. A type that pushes a bespoke layer payload through `pushData`
-must stay single-instance — the renderer's native layer is keyed by type.
+creates a fresh instance. This holds for layer-backed types too: each instance of a
+multi-instance type that paints through a registered renderer layer gets its **own layer
+instance** — the layer's `create()` runs once more per instance, on its own canvas,
+reading that instance's own data channel (the channel is stamped on the model as
+`native.channel`; `pushData` routes there automatically) and following that instance's
+pane and stacking. Nothing changes for the layer code: `args.data` is still "my payload".
+Every running instance also knows its own id (`ctx.id` — the same id its handle and
+`inspect()` report), so an instance can name itself to host code and tell itself apart
+from its siblings.
 
 A native that is really **host-owned chrome** — trade markers from a journal, event flags,
 anything whose on/off switch lives in the host's own UI — can opt out of in-chart chrome with

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -767,7 +767,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
     private restartNativeIndicators(): void {
         for (const record of this.registry.all()) {
             if (!record.native) continue;
-            record.native.instance.stop();
+            if (record.native.started) record.native.instance.stop();
             record.native.instance = record.native.descriptor.create();
             record.native.started = false;
             record.pendingStructural = true; // the next emitted model remounts over the old visuals
@@ -1332,7 +1332,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         // opt-out a removed volume resurrected on the next symbol/timeframe switch.
         if (record?.native?.type === 'volume') this.volumeOptedOut = true;
         record?.session?.stop();
-        record?.native?.instance.stop();
+        // A native added hidden and never started (a restored ledger entry) has nothing
+        // to tear down — and its `stop()` may not expect to run without a context.
+        if (record?.native?.started) record.native.instance.stop();
         this.handles.delete(id);
         if (record?.renderHandle) this.renderer.removeIndicator(record.renderHandle);
         const paneId = record?.model?.paneId;
@@ -1360,7 +1362,10 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         if (!visible) {
             record.session?.stop();
             record.session = undefined;
-            record.native?.instance.suspend();
+            // Only a RUNNING instance is suspended: a record hidden right after its add
+            // (a restored hidden ledger entry) has not started yet, so there is nothing
+            // to suspend — and the instance's suspend() is entitled to assume start() ran.
+            if (record.native?.started) record.native.instance.suspend();
             if (record.renderHandle) this.renderer.setIndicatorVisible?.(record.renderHandle, false);
             // Hidden before anything mounted (a restored ledger entry hides the record
             // right after add, before start): the row must exist anyway, or the
@@ -1466,7 +1471,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         // native instances free their own caches/timers in stop()
         for (const record of this.registry.all()) {
             record.session?.stop();
-            record.native?.instance.stop();
+            if (record.native?.started) record.native.instance.stop();
         }
         for (const engine of this.typeEngines.values()) engine.stop(); // chart-type data engines (SDK)
         this.typeEngines.clear();

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -20,6 +20,7 @@ import { IndicatorRegistry, type IndicatorRecord } from './IndicatorRegistry';
 import {
     getNativeIndicator,
     nativeIndicatorDescriptors,
+    nativeInstanceChannel,
     type NativeIndicatorContext,
     type NativeIndicatorInfo,
     type NativeIndicatorOutput,
@@ -1587,7 +1588,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             await this.readyPromise;
             const record = this.registry.get(id);
             if (!record?.native || record.hidden) return; // removed/hidden during the await
+            const channel = this.nativeChannel(record);
             const ctx: NativeIndicatorContext = {
+                id,
                 symbol: this.config.market.symbol ?? 'TEST',
                 timeframe: this.config.market.timeframe ?? '60',
                 live: this.config.live,
@@ -1595,7 +1598,7 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
                 bars: () => this.bars,
                 data: this.dataControl,
                 emit: (out) => this.applyModel(id, this.buildNativeModel(record, out)),
-                pushData: (data) => this.renderer.setNativeData?.(record.native!.type, data),
+                pushData: (data) => this.renderer.setNativeData?.(channel, data),
                 setStatus: (status) => {
                     if (record.renderHandle && !record.hidden) this.renderer.setIndicatorStatus?.(record.renderHandle, status);
                 },
@@ -1607,16 +1610,27 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         }
     }
 
+    /** The renderer-layer channel a native instance's `pushData` lands on: the type itself
+     *  for a single-instance type (the layer id doubles as the channel), a per-instance
+     *  channel for a `multiInstance` type — otherwise every instance would overwrite the
+     *  one layer. Stamped on the model so the renderer mounts a dedicated layer for it. */
+    private nativeChannel(record: IndicatorRecord): string {
+        const { type, descriptor } = record.native!;
+        return descriptor.multiInstance ? nativeInstanceChannel(type, record.id) : type;
+    }
+
     /** Wrap a native indicator's emitted visuals into a full IndicatorModel, tagged `native`. */
     private buildNativeModel(record: IndicatorRecord, out: NativeIndicatorOutput): IndicatorModel {
         const d = record.native!.descriptor;
+        const type = record.native!.type;
+        const channel = this.nativeChannel(record);
         return {
             id: record.id,
             title: record.title,
             ...(d.shortTitle ? { shorttitle: d.shortTitle } : {}),
             overlay: d.overlay,
             paneHint: d.paneHint,
-            native: { type: record.native!.type },
+            native: { type, ...(channel !== type ? { channel } : {}) },
             ...(d.legend === false ? { legend: false } : {}),
             ...(out.paneAxis != null ? { paneAxis: out.paneAxis } : {}),
             series: out.series ?? [],

--- a/src/core/model/indicator.ts
+++ b/src/core/model/indicator.ts
@@ -50,7 +50,17 @@ export interface IndicatorModel {
      * `'volume'`). Absent ⇒ an ordinary Pine indicator. Drives native-only legend styling
      * (distinct title color) + list ordering (native indicators pin to the top).
      */
-    native?: { type: string };
+    native?: {
+        type: string;
+        /**
+         * The renderer-layer data channel this instance's bespoke payload (`pushData`) lands
+         * on, when it differs from the type: set for an instance of a `multiInstance` type,
+         * so a renderer mounts a DEDICATED layer instance (own canvas, own pane, own stacking)
+         * reading this channel instead of the shared per-type layer. Absent ⇒ the type is the
+         * channel (single-instance natives, the built-in volume/VPVR).
+         */
+        channel?: string;
+    };
     /** `false` ⇒ no legend row and no pane listing for this indicator (host-owned chrome); absent ⇒ a row. */
     legend?: boolean;
     /**

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -36,6 +36,10 @@ export interface NativeIndicatorOutput {
 
 /** Services the host gives a running native indicator. */
 export interface NativeIndicatorContext {
+    /** This instance's indicator id — the same id its `IndicatorHandle`, `inspect()` and
+     *  the pane listing report. Lets an instance name itself to host code (a picker, a
+     *  hit-test) and tell itself apart from siblings of a `multiInstance` type. */
+    readonly id: string;
     readonly symbol: string;
     readonly timeframe: string;
     readonly live: boolean;
@@ -114,8 +118,10 @@ export interface NativeIndicatorDescriptor {
     /**
      * Allow several instances of this type on one chart — every add creates a new one (a study
      * like a moving average is typically stacked at different lengths). Absent ⇒ SINGLE instance
-     * per type: a second add returns the existing handle. A type that pushes a bespoke layer
-     * payload through `pushData` must stay single-instance (the layer is keyed by type).
+     * per type: a second add returns the existing handle. A type that paints through a renderer
+     * layer (`pushData`) gets ONE layer instance per indicator instance, each fed by that
+     * instance's own channel and painting on that instance's pane — so instances never
+     * overwrite each other (see `IndicatorModel.native.channel`).
      */
     readonly multiInstance?: boolean;
     inputsSchema(): InputSchema[];
@@ -146,6 +152,18 @@ export interface NativeIndicatorInfo {
     readonly multiInstance?: boolean;
     /** The type is flagged beta (for a badge in the picker). */
     readonly beta?: boolean;
+}
+
+/**
+ * The renderer-layer data channel of ONE instance of a `multiInstance` native type. A
+ * single-instance type's channel is its type (the layer id doubles as the channel); a
+ * multi-instance type needs one channel per instance, or every instance's `pushData`
+ * would land on the same layer. The orchestrator stamps it on the model
+ * (`IndicatorModel.native.channel`) and routes the instance's pushes to it; the renderer
+ * mounts a dedicated layer instance reading it.
+ */
+export function nativeInstanceChannel(type: string, instanceId: string): string {
+    return `${type}#${instanceId}`;
 }
 
 /** Process-wide catalog of native-indicator types. Built-ins (volume, VPVR) register via the composition root. */

--- a/src/core/native-indicators/NativeIndicator.ts
+++ b/src/core/native-indicators/NativeIndicator.ts
@@ -77,11 +77,13 @@ export interface NativeIndicator {
     onViewport(range: VisibleRange): void;
     /** Settings changed — recompute + emit. */
     setInputs(inputs: Record<string, InputValue>): void;
-    /** Hidden — stop timers/fetches (free resources); the instance + its state are kept for resume. */
+    /** Hidden — stop timers/fetches (free resources); the instance + its state are kept for resume.
+     *  Only ever called after `start` (an instance added hidden is not suspended — it is
+     *  started when first shown). */
     suspend(): void;
     /** Shown again — resume + re-emit. */
     resume(): void;
-    /** Removed — full teardown (clear caches, stop timers). */
+    /** Removed — full teardown (clear caches, stop timers). Only ever called after `start`. */
     stop(): void;
 }
 

--- a/src/renderers/native/NativeRenderer.ts
+++ b/src/renderers/native/NativeRenderer.ts
@@ -95,6 +95,17 @@ import { applyChromeTokens } from '../shared/theme-tokens';
  *  Both expose the same four fields, so axis-drag / reset work uniformly on either. */
 type ScaleHolder = { scale: PriceScale; scaleTarget: PriceScale; manualScale: PriceScale | null; initialized: boolean };
 
+/** One mounted SDK layer (see `NativeRenderer.extLayers`). */
+interface ExtLayer {
+    def: RendererLayerDefinition;
+    instance: RendererLayerInstance;
+    canvas: HTMLCanvasElement;
+    /** The native-data channel this entry paints (`def.id` for the base entry). */
+    channel: string;
+    /** The indicator instance this entry is dedicated to (null = the base entry). */
+    owner: string | null;
+}
+
 const PRICE_PANE_ID = 'price';
 const WEAK_SNAP_PX = 8; // 'weak' magnet only snaps when a candle point is within this many px of the cursor
 const TRANSPARENT = 'rgba(0,0,0,0)'; // default area/baseline fill edge (fades out)
@@ -172,7 +183,14 @@ export class NativeRenderer implements IChartRenderer {
     private readonly backdropRenderer = new BackdropRenderer();
     private readonly volumeRenderer = new VolumeRenderer();
     /** SDK renderer layers instantiated at mount ({@link registerRendererLayer}). */
-    private extLayers: Array<{ def: RendererLayerDefinition; instance: RendererLayerInstance; canvas: HTMLCanvasElement }> = [];
+    /**
+     * The mounted SDK layers. One BASE entry per registered definition (channel = the layer
+     * id, no owner of its own), plus one DEDICATED entry per mounted native indicator whose
+     * model names its own channel (`native.channel` — an instance of a multi-instance type):
+     * same definition, its own canvas, reading that instance's channel and following that
+     * instance's pane and z key. `channel` is unique across the array.
+     */
+    private extLayers: ExtLayer[] = [];
     /** Last applied layer-canvas order (ids below + above the data canvas) — re-slotted only on change. */
     private layerOrderSig = '';
     // The attribution mark (see chrome/AttributionMark + the NOTICE file): default-on;
@@ -1398,11 +1416,7 @@ export class NativeRenderer implements IChartRenderer {
         Object.assign(this.plot.style, { position: 'absolute', top: '0', right: '0', bottom: '0', left: '0' });
         // SDK renderer layers: one transparent canvas each, stacked by placement —
         // 'below-data' behind the candles, 'above-data' over them (under the chrome/axes).
-        this.extLayers = rendererLayers().map((def) => {
-            const canvas = document.createElement('canvas');
-            Object.assign(canvas.style, { position: 'absolute', inset: '0', width: '100%', height: '100%', pointerEvents: 'none' });
-            return { def, instance: def.create(), canvas };
-        });
+        this.extLayers = rendererLayers().map((def) => ({ def, instance: def.create(), canvas: this.createLayerCanvas(), channel: def.id, owner: null }));
         const below = this.extLayers.filter((l) => l.def.placement === 'below-data').map((l) => l.canvas);
         const above = this.extLayers.filter((l) => l.def.placement !== 'below-data').map((l) => l.canvas);
         this.plot.append(this.backdropCanvas, ...below, this.dataCanvas, this.volumeCanvas, this.vpvrCanvas, ...above, this.chromeCanvas, this.drawingsCanvas, this.cursorCanvas, this.overlayRoot);
@@ -1420,6 +1434,8 @@ export class NativeRenderer implements IChartRenderer {
         this.volumeRenderer.mount(this.volumeCanvas);
         this.vpvrRenderer.mount(this.vpvrCanvas);
         for (const l of this.extLayers) l.instance.mount(l.canvas);
+        // Indicators mounted before the renderer (a re-mount) bring their dedicated layers back.
+        for (const m of this.scene.indicators.values()) this.ensureInstanceLayer(m);
         this.chrome.mount(this.chromeCanvas);
         this.crosshairLayer.mount(this.cursorCanvas);
         this.coords.setViewport(defaultViewport());
@@ -2102,6 +2118,7 @@ export class NativeRenderer implements IChartRenderer {
         // say so or the recorded order (object tree, seriesOrder reads) starts out a lie.
         if (model.native && this.extLayers.some((l) => l.def.id === model.native!.type)) this.scene.assignIndicatorZTop(model.id);
         else this.scene.assignIndicatorZ(model.id);
+        this.ensureInstanceLayer(model);
         // The legend chip, the settings dialog and the object tree's rows all show the compact
         // shorttitle when declared; the full title stays on the picker and inspect(). A
         // `legend: false` native gets none of it — the scene model still mounts and paints.
@@ -2152,6 +2169,7 @@ export class NativeRenderer implements IChartRenderer {
             this.scene.vpvrLayer = null;
         }
         this.scene.indicators.delete(handle.id);
+        this.dropInstanceLayer(handle.id);
         this.scene.forgetIndicatorZ(handle.id);
         this.scene.forgetAnchorOffset(handle.id);
         this.scene.dropIndicatorScale(handle.id);
@@ -3176,9 +3194,9 @@ export class NativeRenderer implements IChartRenderer {
         const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
         for (const l of this.extLayers) {
             if (!l.def.repaintOnCursor) continue;
-            const lp = this.layerPane(l.def.id) ?? pane;
+            const lp = this.layerPane(l) ?? pane;
             if (lp.collapsed) continue; // blanked by the data frame; nothing to hover
-            l.instance.render(this.extLayerArgs(l.def.id, lp.scale, lp.bounds, nowMs));
+            l.instance.render(this.extLayerArgs(l, lp.scale, lp.bounds, nowMs));
             if (this.animZoom.on && l.instance.animating?.()) this.animator.start();
         }
     }
@@ -3189,13 +3207,15 @@ export class NativeRenderer implements IChartRenderer {
         canvas.getContext('2d')?.clearRect(0, 0, canvas.width, canvas.height);
     }
 
-    /** One frame's args for an SDK renderer layer (shared by the data + cursor paint paths). */
-    private extLayerArgs(id: string, scale: PriceScale, bounds: PaneBounds, nowMs: number): RendererLayerArgs {
+    /** One frame's args for an SDK renderer layer (shared by the data + cursor paint paths).
+     *  Data + pending come from the entry's channel (per instance for a dedicated entry);
+     *  the settings bag is the TYPE's — a chart type's dialog values, one bag per type. */
+    private extLayerArgs(l: ExtLayer, scale: PriceScale, bounds: PaneBounds, nowMs: number): RendererLayerArgs {
         return {
             bars: this.scene.bars,
-            data: this.scene.nativeData.get(id),
-            settings: (this.scene.nativeData.get(`${id}-settings`) as Record<string, unknown> | undefined) ?? {},
-            pending: this.scene.nativePending.get(id) ?? [],
+            data: this.scene.nativeData.get(l.channel),
+            settings: (this.scene.nativeData.get(`${l.def.id}-settings`) as Record<string, unknown> | undefined) ?? {},
+            pending: this.scene.nativePending.get(l.channel) ?? [],
             coords: this.coords,
             scale,
             bounds,
@@ -3247,14 +3267,14 @@ export class NativeRenderer implements IChartRenderer {
             const nowMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
             let folded: BasePaintingModulation | null = null;
             for (const l of this.extLayers) {
-                const lp: PaneNode = this.layerPane(l.def.id) ?? pane;
+                const lp: PaneNode = this.layerPane(l) ?? pane;
                 // A collapsed host pane shows its legend strip only — blank the layer for
                 // the duration (the instance isn't poked, so it can't clear itself).
                 if (lp.collapsed) {
                     this.clearLayerCanvas(l.canvas);
                     continue;
                 }
-                const args = this.extLayerArgs(l.def.id, lp.scale, lp.bounds, nowMs);
+                const args = this.extLayerArgs(l, lp.scale, lp.bounds, nowMs);
                 l.instance.render(args);
                 // Any mounted layer may dim/slim the base painting (chart type or overlay)
                 // — folded this same frame, applied below before the backend paints. Only
@@ -3619,20 +3639,65 @@ export class NativeRenderer implements IChartRenderer {
         return null;
     }
 
-    /** The mounted native indicator that OWNS an SDK layer — the one whose type equals the
-     *  layer id (the id doubles as the data channel, so the pairing is the SDK's own
-     *  contract). Null for chart-type channels and while the owner is hidden (a hidden
-     *  indicator leaves the scene; its cleared data channel paints nothing anyway). */
-    private layerOwner(layerId: string): IndicatorModel | null {
+    /** One transparent, pointer-transparent SDK layer canvas covering the plot. */
+    private createLayerCanvas(): HTMLCanvasElement {
+        const canvas = document.createElement('canvas');
+        Object.assign(canvas.style, { position: 'absolute', inset: '0', width: '100%', height: '100%', pointerEvents: 'none' });
+        return canvas;
+    }
+
+    /**
+     * Mount the DEDICATED layer of a native indicator that names its own channel (an
+     * instance of a multi-instance type painting through a registered layer): a fresh
+     * instance of the layer's definition on its own canvas, reading that channel. Idempotent
+     * — a show after hide re-mounts the model, and the layer (kept across the hide, like the
+     * z key) is simply reused. Skipped while the renderer itself is unmounted (`mount()`
+     * catches up from the scene).
+     */
+    private ensureInstanceLayer(model: IndicatorModel): void {
+        const channel = model.native?.channel;
+        if (!channel || !this.plot) return;
+        if (this.extLayers.some((l) => l.owner === model.id)) return;
+        const base = this.extLayers.find((l) => l.owner === null && l.def.id === model.native!.type);
+        if (!base) return; // no layer registered for the type — the model paints through its series alone
+        const canvas = this.createLayerCanvas();
+        // Match the pile's current backing size; the next resize re-sizes every layer anyway.
+        canvas.width = this.dataCanvas.width;
+        canvas.height = this.dataCanvas.height;
+        canvas.style.width = this.dataCanvas.style.width || '100%';
+        canvas.style.height = this.dataCanvas.style.height || '100%';
+        const entry: ExtLayer = { def: base.def, instance: base.def.create(), canvas, channel, owner: model.id };
+        this.extLayers.push(entry);
+        this.plot.insertBefore(canvas, this.chromeCanvas); // re-slotted by the owner's z on the next data frame
+        entry.instance.mount(canvas);
+    }
+
+    /** Tear down the dedicated layer of a removed indicator (a hide keeps it). */
+    private dropInstanceLayer(indicatorId: string): void {
+        const i = this.extLayers.findIndex((l) => l.owner === indicatorId);
+        if (i < 0) return;
+        const [l] = this.extLayers.splice(i, 1);
+        l!.instance.destroy?.();
+        l!.canvas.remove();
+    }
+
+    /** The mounted native indicator that OWNS an SDK layer entry. A dedicated entry is
+     *  owned by the instance it was mounted for; the base entry by the mounted indicator
+     *  whose type equals the layer id and that has no channel of its own (the id doubles
+     *  as the data channel, so the pairing is the SDK's own contract). Null for chart-type
+     *  channels and while the owner is hidden (a hidden indicator leaves the scene; its
+     *  cleared data channel paints nothing anyway). */
+    private layerOwner(l: ExtLayer): IndicatorModel | null {
+        if (l.owner !== null) return this.scene.indicators.get(l.owner) ?? null;
         for (const m of this.scene.indicators.values()) {
-            if (m.native?.type === layerId) return m;
+            if (m.native?.type === l.def.id && !m.native.channel) return m;
         }
         return null;
     }
 
     /** The pane an SDK layer paints on: its owner's pane, else the price pane. */
-    private layerPane(layerId: string): PaneNode | null {
-        const owner = this.layerOwner(layerId);
+    private layerPane(l: ExtLayer): PaneNode | null {
+        const owner = this.layerOwner(l);
         const paneId = owner ? (owner.paneId ?? PRICE_PANE_ID) : PRICE_PANE_ID;
         return this.scene.panes.get(paneId) ?? null;
     }
@@ -3641,12 +3706,13 @@ export class NativeRenderer implements IChartRenderer {
      *  owned layers by their owner's z key against the candles' (an indicator restacked
      *  below the candles takes its layer canvas along), unowned by declared placement. */
     private orderedLayerCanvases(): { below: HTMLCanvasElement[]; above: HTMLCanvasElement[] } {
-        const byId = new Map(this.extLayers.map((l) => [l.def.id, l.canvas]));
+        // Keyed by channel — unique per entry (a dedicated entry's channel names its instance).
+        const byId = new Map(this.extLayers.map((l) => [l.channel, l.canvas]));
         const { below, above } = stackLayers(
             this.extLayers.map((l) => {
-                const owner = this.layerOwner(l.def.id);
+                const owner = this.layerOwner(l);
                 return {
-                    id: l.def.id,
+                    id: l.channel,
                     placement: l.def.placement === 'below-data' ? 'below-data' as const : 'above-data' as const,
                     ownerZ: owner ? this.scene.zOf(owner.id) : null,
                 };
@@ -3670,7 +3736,7 @@ export class NativeRenderer implements IChartRenderer {
     private syncLayerCanvasOrder(): void {
         if (this.extLayers.length === 0 || !this.plot) return;
         const { below, above } = this.orderedLayerCanvases();
-        const sig = [...below.map((c) => this.extLayers.find((l) => l.canvas === c)!.def.id), '|', ...above.map((c) => this.extLayers.find((l) => l.canvas === c)!.def.id)].join(',');
+        const sig = [...below.map((c) => this.extLayers.find((l) => l.canvas === c)!.channel), '|', ...above.map((c) => this.extLayers.find((l) => l.canvas === c)!.channel)].join(',');
         if (sig === this.layerOrderSig) return;
         this.layerOrderSig = sig;
         for (const c of below) this.plot.insertBefore(c, this.dataCanvas);

--- a/src/renderers/native/layers.ts
+++ b/src/renderers/native/layers.ts
@@ -106,7 +106,9 @@ export interface RendererLayerDefinition {
     /** Repaint this layer when the pointer moves (hover hit-testing UIs). Off by default:
      *  pointer moves normally repaint only the crosshair overlay, not the layers. */
     repaintOnCursor?: boolean;
-    /** Instance factory — called once per mounted renderer. */
+    /** Instance factory — called once per mounted renderer, plus once per mounted instance
+     *  of a `multiInstance` native indicator whose type equals this id (each instance paints
+     *  through its own layer instance and canvas, fed by its own channel). */
     create(): RendererLayerInstance;
 }
 

--- a/test/classic-indicators.test.ts
+++ b/test/classic-indicators.test.ts
@@ -248,6 +248,7 @@ describe('classic descriptor adapter', () => {
         const instance = desc.create();
         let captured: NativeIndicatorOutput | undefined;
         const ctx: NativeIndicatorContext = {
+            id: 'native-test',
             symbol: 'TEST',
             timeframe: '1m',
             live: false,

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -578,6 +578,57 @@ describe('EngineOrchestrator', () => {
         }
     });
 
+    it('a native hidden before it started is neither suspended nor stopped — start runs when it is first shown', async () => {
+        // An instance that assumes the contract: suspend/stop only after start (it reads
+        // its context there, like the layer-backed natives that clear their channel).
+        class StrictNative implements NativeIndicator {
+            calls = { start: 0, suspend: 0, stop: 0 };
+            private ctx: NativeIndicatorContext | null = null;
+            start(ctx: NativeIndicatorContext): void { this.calls.start += 1; this.ctx = ctx; ctx.emit({}); }
+            onBars(): void {}
+            onViewport(): void {}
+            setInputs(): void {}
+            suspend(): void { this.calls.suspend += 1; this.ctx!.pushData(null); }
+            resume(): void {}
+            stop(): void { this.calls.stop += 1; this.ctx!.pushData(null); }
+        }
+        const made: StrictNative[] = [];
+        // multiInstance so every add below mints a fresh instance to observe.
+        registerNativeIndicator({ ...testNativeDescriptor, type: 'strict-native', title: 'Strict', multiInstance: true, create: () => { const n = new StrictNative(); made.push(n); return n; } });
+        try {
+            const renderer = new FakeRenderer();
+            const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [], dataFeed: new MockDataFeed() });
+            // The restored-ledger shape: add, then hide immediately — before ready/start.
+            const h = chart.addNativeIndicator('strict-native');
+            h.setVisible(false);
+            await chart.ready();
+            await flush();
+            expect(made[0]!.calls).toEqual({ start: 0, suspend: 0, stop: 0 }); // never started ⇒ never suspended
+            expect(renderer.mountedModels.some((m) => m.id === h.id)).toBe(true); // the hidden row still mounts
+
+            h.setVisible(true);
+            await flush();
+            expect(made[0]!.calls.start).toBe(1); // first show STARTS it
+            h.setVisible(false);
+            expect(made[0]!.calls.suspend).toBe(1); // a running instance is suspended as usual
+
+            // A second one, removed while still never-started: no stop() either.
+            const h2 = chart.addNativeIndicator('strict-native');
+            h2.setVisible(false);
+            h2.remove();
+            expect(made[1]!.calls).toEqual({ start: 0, suspend: 0, stop: 0 });
+
+            // And destroy() only stops what ran.
+            const h3 = chart.addNativeIndicator('strict-native');
+            h3.setVisible(false);
+            chart.destroy();
+            expect(made[0]!.calls.stop).toBe(1);
+            expect(made[2]!.calls.stop).toBe(0);
+        } finally {
+            unregisterNativeIndicator('strict-native');
+        }
+    });
+
     it('native context: each instance knows its own id; a multiInstance type pushes layer data on a per-instance channel stamped on its model', async () => {
         // A layer-backed native: pushes a payload tagged with its context id, and emits an
         // empty model (the legend row) like the built-in layer natives do.

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -578,6 +578,56 @@ describe('EngineOrchestrator', () => {
         }
     });
 
+    it('native context: each instance knows its own id; a multiInstance type pushes layer data on a per-instance channel stamped on its model', async () => {
+        // A layer-backed native: pushes a payload tagged with its context id, and emits an
+        // empty model (the legend row) like the built-in layer natives do.
+        class LayerNative implements NativeIndicator {
+            ctx: NativeIndicatorContext | null = null;
+            start(ctx: NativeIndicatorContext): void { this.ctx = ctx; ctx.emit({}); ctx.pushData({ from: ctx.id }); }
+            onBars(): void {}
+            onViewport(): void {}
+            setInputs(): void {}
+            suspend(): void {}
+            resume(): void {}
+            stop(): void {}
+        }
+        const singles: LayerNative[] = [];
+        const multis: LayerNative[] = [];
+        registerNativeIndicator({ ...testNativeDescriptor, type: 'layer-single', title: 'Single', create: () => { const n = new LayerNative(); singles.push(n); return n; } });
+        registerNativeIndicator({ ...testNativeDescriptor, type: 'layer-multi', title: 'Multi', multiInstance: true, create: () => { const n = new LayerNative(); multis.push(n); return n; } });
+        try {
+            const renderer = new FakeRenderer();
+            const chart = new Vela({} as unknown as HTMLElement, { live: false, volume: false }, { renderer, engines: [], dataFeed: new MockDataFeed() });
+            const s = chart.addNativeIndicator('layer-single');
+            const m1 = chart.addNativeIndicator('layer-multi');
+            const m2 = chart.addNativeIndicator('layer-multi');
+            await chart.ready();
+            await flush();
+
+            // The context id IS the handle id, per instance.
+            expect(singles[0]!.ctx!.id).toBe(s.id);
+            expect(multis.map((n) => n.ctx!.id)).toEqual([m1.id, m2.id]);
+
+            // Single-instance: the type is the channel, the model names no channel of its own.
+            expect(renderer.nativePushes).toContainEqual(['layer-single', { from: s.id }]);
+            expect(renderer.mountedModels.find((mm) => mm.id === s.id)?.native).toEqual({ type: 'layer-single' });
+
+            // Multi-instance: one channel per instance (never the bare type), and the model
+            // carries it so the renderer can mount a dedicated layer reading it.
+            const m1Channel = renderer.mountedModels.find((mm) => mm.id === m1.id)?.native?.channel;
+            const m2Channel = renderer.mountedModels.find((mm) => mm.id === m2.id)?.native?.channel;
+            expect(m1Channel).toBeTruthy();
+            expect(m2Channel).toBeTruthy();
+            expect(m1Channel).not.toBe(m2Channel);
+            expect(renderer.nativePushes).toContainEqual([m1Channel, { from: m1.id }]);
+            expect(renderer.nativePushes).toContainEqual([m2Channel, { from: m2.id }]);
+            expect(renderer.nativePushes.some(([ch]) => ch === 'layer-multi')).toBe(false);
+        } finally {
+            unregisterNativeIndicator('layer-single');
+            unregisterNativeIndicator('layer-multi');
+        }
+    });
+
     it("an output's paneAxis override is stamped onto the mounted model (and only then)", async () => {
         // A layer-painting native: series-less output declaring a categorical pane axis.
         class UnscaledNative implements NativeIndicator {


### PR DESCRIPTION
## What

A native indicator that paints through a registered renderer layer (`pushData` → `args.data`) can now be `multiInstance`. Each instance gets **its own layer instance and canvas**, on its own pane, with its own stacking order, fed by its own data channel — so instances never overwrite each other. Running native indicators also learn their own id (`ctx.id`).

Motivation: Vela-pro's layer-backed order-flow indicators (volume profiles, volume tails, overlay Footprint/TPO, Volume Bubbles, Bar Stats) were pinned to one instance per chart because the renderer keyed the layer and its channel by type. Downstream: [LuxAlgo/Vela-pro#90](https://github.com/LuxAlgo/Vela-pro/pull/90).

Second commit — a pre-existing bug found while verifying this: **a native hidden before it ever started was still suspended/stopped** (hide, remove, market restart, destroy). A layer-backed plugin native that reads its context in `suspend()`/`stop()` threw inside chart construction, so a saved layout with one hidden such indicator failed to load. The orchestrator now only suspends/stops instances it started; the `NativeIndicator` contract states the guarantee.

## How

- **Core** (`NativeIndicator.ts`, `model/indicator.ts`): `nativeInstanceChannel(type, id)`; `IndicatorModel.native.channel?` (set only for instances of a `multiInstance` type); `NativeIndicatorContext.id`.
- **Orchestrator**: a `multiInstance` type's `pushData` routes to the per-instance channel and the model carries it; single-instance types keep the type as channel (unchanged). `suspend()`/`stop()` are gated on `record.native.started` at the four call sites.
- **Native renderer**: `extLayers` entries now carry `channel` + `owner`. On `mountIndicator` of a model with `native.channel`, a **dedicated** entry is created (`def.create()` again, own canvas, inserted into the pile and re-slotted by the owner's z on the next data frame); it reads `data`/`pending` from its channel and the type's `-settings` bag; pane/z resolve from its owner. Torn down on `removeIndicator`, kept across hide/show (like the z key), re-created from the scene if the renderer mounts after the indicators. The base entry of a multi-instance type has no owner and receives no data, so it paints nothing. Stacking/order signatures are keyed by channel (unique) instead of layer id.
- **Docs**: `docs/contributing/plugin-sdk.md` (native-indicator and layer-ownership sections), `layers.ts` `create()` contract, `CHANGELOG.md` `[Unreleased]` → Added + Fixed.

No behavior change for single-instance natives (volume, VPVR, chart-type channels): same channel, same single base layer. Vela's multi-instance classics (SMA…) get a `channel` on their model but no layer exists for their type, so nothing is mounted for them (verified: two SMAs, zero extra canvases).

## Verification

- Gate: `typecheck` · `lint` · `test` (1676 passing) · `build`. New orchestrator tests: `ctx.id` = handle id, per-instance channels on the model and in `setNativeData`, the bare type never pushed for a multi-instance type; and the hidden-before-start case (no suspend/stop until started, start on first show, remove/destroy of a never-started instance is a no-op) — fails without the fix.
- Browser (Vela-pro playground linked to this branch, BTCUSDT via the shared dev fleet), pixel-sampled per layer canvas via the renderer's `extLayers`:
  - two Session VPs + two Bar Stats → exactly four dedicated canvases; each Bar Stats canvas paints only inside **its own pane band**; both Session VPs on the price pane; the base `bar-stats`/`session-vp` entries paint nothing;
  - hidden Bar Stats → its canvas has **zero** painted pixels (nothing leaks to the price pane); show → repaints in its band;
  - remove → the canvas is torn down, the sibling keeps painting;
  - **reload with a persisted layout** (two Bar Stats, one hidden with a non-default input, two Session VPs): everything restores, the hidden one comes back hidden with its input, showing it starts it and paints in its pane — this is the scenario that crashed before the second commit;
  - two overlay Footprints (stateful shared `FootprintLayer`, two modes) each paint on their own canvas.
- `mount()` is called once per chart (orchestrator constructor), so the re-mount path only matters for the from-scene catch-up.
- Workspace oracle suites: `oracle-tests/vela-pro` 11/11; `oracle-tests/vela` 22/23 with the one failure (`plotshape` labels 42 vs 84) reproducing on `origin/dev` without this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native indicator lifecycle and renderer layer mounting/stacking; incorrect gating or channel routing could affect multi-instance plugins or hidden restore paths, though single-instance behavior is explicitly preserved and covered by new tests.
> 
> **Overview**
> **Multi-instance layer-backed native indicators** can now stack on one chart without sharing a single renderer layer. For descriptors with `multiInstance: true`, each instance gets its own SDK layer (`create()` again), canvas, pane, z-order, and data channel (`type#instanceId` via `nativeInstanceChannel`); `pushData` and `IndicatorModel.native.channel` route the renderer accordingly. Running natives receive **`ctx.id`** so host/plugin code can distinguish siblings. Single-instance layer natives (volume, VPVR) are unchanged.
> 
> **Lifecycle fix for never-started hidden natives:** hide, remove, market restart, and `destroy()` no longer call `suspend()`/`stop()` until `start()` has run—fixes chart load crashes when a saved layout restores a hidden layer-backed plugin that assumes a started context.
> 
> Docs (`plugin-sdk.md`, `layers.ts`) and **CHANGELOG** document both behaviors; orchestrator and **NativeRenderer** (`ensureInstanceLayer` / `dropInstanceLayer`, stacking keyed by channel) implement the plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9ff748a83d2452faba1fe2d34e3368bdcd322b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->