### PR TITLE
Keep menus and dropdowns on the app-theme surface, not the plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Vela, newest first.
 
 ### Fixed
 
+- **Right-click menus and dropdowns follow the app theme, not the plot.** Changing the
+  chart background in settings used to recolor those panels with the plot. They now
+  use the same surface as the drawing toolbar and the chart settings dialog, and only
+  a theme switch restyles them.
 - **Timeline mark popups now toggle with a click.** Clicking the mark whose popup is
   open closes it; previously that second click closed and immediately reopened the popup,
   so it took a click elsewhere to dismiss it.

--- a/src/ui/components/menu/styles.ts
+++ b/src/ui/components/menu/styles.ts
@@ -5,7 +5,7 @@ export const MENU_CSS = `
     /* The list is a <ul>: without this, block rows (the separator) paint a ::marker dot. */
     list-style: none;
     margin: 0;
-    background: var(--vela-surface-elev);
+    background: var(--vela-surface);
     color: var(--vela-fg);
     border: 1px solid var(--vela-border-strong);
     border-radius: 6px;

--- a/src/ui/components/menu/view.ts
+++ b/src/ui/components/menu/view.ts
@@ -5,6 +5,7 @@
 // chain across levels instead of the view faking any of it.
 import { runMachine, spreadProps, type HandleOf } from '../../zag';
 import { injectStyles } from '../../styles';
+import { floatingLayerHost } from '../../tokens';
 import { iconEl } from '../../icons';
 import { menuController, type MenuControllerOptions, type MenuItemDescriptor } from './controller';
 import { MENU_CSS, MENU_STYLE_ID } from './styles';
@@ -265,7 +266,7 @@ export class Menu {
         const anchor = opts.trigger ?? opts.host ?? document.body;
         const doc = anchor.ownerDocument;
         injectStyles(MENU_STYLE_ID, MENU_CSS, doc);
-        const host = opts.host ?? (anchor.closest?.('.vela-ui') as HTMLElement | null) ?? doc.body;
+        const host = floatingLayerHost(opts.host ?? anchor, doc.body);
         this.root = new Surface(doc, {
             host,
             placement: opts.placement,

--- a/src/ui/components/popover/view.ts
+++ b/src/ui/components/popover/view.ts
@@ -2,7 +2,7 @@
 // owns portal, placement, capture-phase outside-dismiss, and the single-open registry.
 import type { VelaTheme } from '../../../core/options';
 import { injectStyles } from '../../styles';
-import { ensureUIHost } from '../../tokens';
+import { ensureUIHost, floatingLayerHost } from '../../tokens';
 import {
     insetRect,
     intersectRects,
@@ -75,6 +75,8 @@ export class Popover {
     private readonly ctrl: ReturnType<typeof popoverController>;
     private readonly boundary: PopoverBoundary;
     private readonly theme?: VelaTheme;
+    /** Hosted under a `.vela-ui` we resolved ourselves — its tokens win over `theme`. */
+    private readonly inheritsTokens: boolean;
     private onOutside: ((e: Event) => void) | null = null;
     private onKey: ((e: KeyboardEvent) => void) | null = null;
     private onReflow: (() => void) | null = null;
@@ -87,7 +89,10 @@ export class Popover {
         const doc = opts.trigger.ownerDocument;
         injectStyles(POPOVER_STYLE_ID, POPOVER_CSS, doc);
         this.trigger = opts.trigger;
-        this.host = opts.host ?? doc.body;
+        // No explicit host: portal to the trigger's `.vela-ui` (app-theme tokens) rather
+        // than <body>. Explicit hosts (drawing chrome, mark popups) keep their own tokens.
+        this.host = opts.host ?? floatingLayerHost(opts.trigger, doc.body);
+        this.inheritsTokens = !opts.host && this.host !== doc.body;
         this.ctrl = popoverController(opts);
         this.boundary = opts.boundary ?? 'viewport';
         this.theme = opts.theme;
@@ -125,7 +130,10 @@ export class Popover {
             clearTimeout(this.leaveTimer);
             this.leaveTimer = null;
         }
-        ensureUIHost(this.el, this.theme);
+        // A caller theme is often the live plot surface (settings dialogs pass
+        // `this.theme`); stamping it on a `.vela-ui`-hosted shell would recolor the
+        // list to layout.background.
+        ensureUIHost(this.el, this.inheritsTokens ? undefined : this.theme);
         if (this.fadeMs > 0) {
             this.el.style.transition = `opacity ${this.fadeMs}ms ease`;
             this.el.style.opacity = '0';

--- a/src/ui/tokens.ts
+++ b/src/ui/tokens.ts
@@ -44,16 +44,25 @@ export function applyThemeTokens(el: HTMLElement, t: VelaTheme): void {
     for (const key in tokens) el.style.setProperty(key, tokens[key]!);
 }
 
-/** Re-token a chart-overlay host (statusline, watermark, toast, context menu — chrome
- *  floating OVER the plot) from the LIVE plot surface: a config edit can recolor the
- *  plot background independently of the app theme (a white plot typed into settings on
- *  the dark theme), and the overlay ink must stay readable either way. `config` is the
- *  renderer's `getConfig()` snapshot; a missing/shapeless one falls back to the base
- *  app theme. */
+/** Re-token a chart-overlay host (statusline, watermark, toast — chrome floating OVER
+ *  the plot) from the LIVE plot surface: a config edit can recolor the plot background
+ *  independently of the app theme (a white plot typed into settings on the dark theme),
+ *  and the overlay ink must stay readable either way. `config` is the renderer's
+ *  `getConfig()` snapshot; a missing/shapeless one falls back to the base app theme.
+ *  Floating menus and dropdowns do NOT use this — they mount on {@link floatingLayerHost}
+ *  so their surface follows the app theme alone. */
 export function applyPlotOverlayTokens(host: HTMLElement, base: VelaTheme, config: unknown): void {
     const layout = (config as { layout?: { background?: string; textColor?: string } } | null)?.layout;
     const t = layout?.background && layout.textColor ? { ...base, background: layout.background, textColor: layout.textColor } : base;
     applyThemeTokens(host, t);
+}
+
+/** Mount floating kit layers (menus, select lists) on the nearest `.vela-ui` so they
+ *  inherit the app-theme tokens. A plot-overlay host (the cell) retokens from
+ *  `layout.background`; chrome panels must not follow that. Falls back to `fallback`
+ *  (typically `document.body`) when no kit host is an ancestor. */
+export function floatingLayerHost(from: HTMLElement, fallback?: HTMLElement): HTMLElement {
+    return (from.closest('.vela-ui') as HTMLElement | null) ?? fallback ?? from;
 }
 
 /** Mark an element as a kit host: static token sheet + the `.vela-ui` class. */

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -897,7 +897,8 @@ export class ChartCell {
     }
 
     /** The workspace shell keeps the app theme; the cell host's tokens re-derive from
-     *  the LIVE plot surface (see {@link applyPlotOverlayTokens}). */
+     *  the LIVE plot surface for overlay ink (statusline, watermark). Menus portal to
+     *  `.vela-ui` and keep the app-theme surface (see {@link applyPlotOverlayTokens}). */
     private syncPlotOverlayTokens(): void {
         applyPlotOverlayTokens(this.host, this.appTheme, this.inner?.renderer.getConfig() ?? null);
     }

--- a/test/floating-layer-host.test.ts
+++ b/test/floating-layer-host.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { floatingLayerHost } from '../src/ui/tokens';
+
+describe('floatingLayerHost', () => {
+    it('mounts on the nearest .vela-ui so menus inherit the app theme, not a plot-overlay cell', () => {
+        const ui = document.createElement('div');
+        ui.className = 'vela-ui';
+        const cell = document.createElement('div');
+        cell.className = 'vela-cell';
+        ui.appendChild(cell);
+        document.body.appendChild(ui);
+        expect(floatingLayerHost(cell, document.body)).toBe(ui);
+        ui.remove();
+    });
+
+    it('returns the kit host itself when that is the starting node', () => {
+        const ui = document.createElement('div');
+        ui.className = 'vela-ui';
+        document.body.appendChild(ui);
+        expect(floatingLayerHost(ui, document.body)).toBe(ui);
+        ui.remove();
+    });
+
+    it('falls back when no kit host is an ancestor', () => {
+        const orphan = document.createElement('div');
+        document.body.appendChild(orphan);
+        expect(floatingLayerHost(orphan, document.body)).toBe(document.body);
+        orphan.remove();
+    });
+});


### PR DESCRIPTION
## What

Right-click menus and dropdown lists now paint the **app-theme chrome surface** — the same one the drawing toolbar and the chart settings dialog use. Editing the plot background in settings no longer recolors them; only a theme switch does.

## Why

The chart cell host re-tokens itself from the live plot background (`applyPlotOverlayTokens`) so overlay ink (status line, watermark) stays readable on a custom plot color. Menus mounted on that same host, so they followed the plot too — a white plot on the dark theme gave a white context menu next to a dark toolbar.

## How

- `Menu` and host-less `Popover`s (settings select lists) portal to the nearest `.vela-ui` instead of the cell / `<body>`, inheriting the app-theme tokens. A small `floatingLayerHost` helper in `src/ui/tokens.ts` does the lookup (internal, not exported).
- A `Popover` that resolved a `.vela-ui` host skips stamping the caller's `theme` — the settings dialog passes the live plot theme, which would have undone the fix. Explicit hosts (drawing chrome, mark popups) keep today's behavior.
- `.vela-menu` fills with `--vela-surface` (the toolbar/dialog surface) instead of the elevated wash.

## Verification

- Gate: typecheck · lint · test (1677 passing, +3 new for `floatingLayerHost`) · build.
- Playground, dark theme, plot set to `#ffffff`: context menu, timeframe dropdown and a settings-dialog select list all measure `rgb(21, 22, 25)` — identical to the toolbar and settings dialog. Select list still anchors under its trigger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI theming and portal placement only; explicit popover hosts and plot overlay tokens for statusline/watermark are unchanged.
> 
> **Overview**
> **Right-click menus and dropdown lists now use app-theme chrome**, matching the drawing toolbar and chart settings dialog. Changing only the plot background in settings no longer recolors those panels.
> 
> **Menus and host-less popovers** (e.g. settings select lists) portal to the nearest `.vela-ui` via new `floatingLayerHost`, instead of the chart cell overlay host that re-tokens from `layout.background`. When a popover resolves that host itself, it **does not** apply the caller’s `theme` (settings often pass the live plot surface). Explicit `host` options are unchanged.
> 
> **`.vela-menu`** background switches from `--vela-surface-elev` to `--vela-surface`. Changelog and `ChartCell` comments document the split between plot-overlay ink and floating kit layers. **Tests** cover `floatingLayerHost` ancestor lookup and fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1004f2270bca787c680ee5bb737d868c9d6794be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->