### PR TITLE
Add an Exchange option to the time-zone picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Vela, newest first.
 
 ## [Unreleased]
 
+### Added
+
+- **Exchange time zone.** The time-zone picker (bottom bar, time-axis menu, mobile sheet)
+  offers an **Exchange** row, right under UTC: pick it and every chart renders in its own market's
+  zone — Chicago for a CME future, New York for a US equity, UTC for crypto — as declared
+  by its provider. In a multi-chart grid each cell follows its own market, and the
+  bottom-bar clock shows the active chart's. The choice persists with the workspace and
+  can be set from code with `timezone: 'exchange'` or `setTimezone('exchange')`;
+  choosing a fixed zone anywhere returns the whole workspace to that zone.
+
 ### Fixed
 
 - **Right-click menus and dropdowns follow the app theme, not the plot.** Changing the

--- a/docs/user/workspace.md
+++ b/docs/user/workspace.md
@@ -333,7 +333,7 @@ silently reorder them).
 | `engines` | — | Factories; one instance per cell (merged over `registerDefaultEngine`). |
 | `indicators` | — | Shared manifest; `enabled` entries auto-add to fresh cells. |
 | `timeframes` | presets | Topbar timeframe presets. |
-| `timezone` | `'Etc/UTC'` | Display timezone (every cell). |
+| `timezone` | `'Etc/UTC'` | Display timezone (every cell): an IANA zone, or `'exchange'` — each cell renders in its own market's zone (Chicago for a CME future, New York for a US equity, UTC for crypto), as declared by its provider's symbol metadata. |
 | `statusline` / `watermark` / `bottombar` | `true` | Chrome toggles. |
 | `topbar` | defaults | Declarative topbar composition — `{ left, right }` lists of the VISIBLE entries, in order (see [Composing the topbar](#composing-the-topbar)). |
 | `indicatorPicker` | `true` | **Deprecated (removal in 0.7.0).** `false` removes the built-in indicator dialog's entry points. Replace it with the composition (omit `'indicators'` from `topbar.left` — same effect) or a plugin [slot override](../contributing/plugin-sdk.md#replacing-a-built-in-button--slot-overrides). |
@@ -456,7 +456,11 @@ they work from the very first keystroke, before any click.
   the active chart's timeframe, **fetches the depth its window needs**, and frames it:
   `1D`→1m, `7D`→5m, `1M`→30m, `3M`→1h, `6M`→4h, `YTD`/`1Y`→1D, `5Y`/`ALL`→1W. Changing
   the timeframe by hand leaves range mode (the chip clears and the fetch depth returns
-  to the chart's own `bars` setting).
+  to the chart's own `bars` setting). The picker's **Exchange** row (right under UTC) follows each
+  chart's own market: a CME future renders in Chicago time, a US equity in New York, crypto
+  in UTC — and in a multi-chart grid every cell reads its own market's clock. The bar's
+  clock and offset show the active cell's zone; picking a fixed zone anywhere (including
+  the settings dialog's Time zone row) switches the whole workspace back to that zone.
 - **Context menus** — right-click the chart body for reset view, removing all drawings or all
   indicators, and the settings dialog; the price axis for that pane's own scale (autoscale,
   invert, regular/percent/indexed/logarithmic, and the label and level toggles); the time axis

--- a/src/core/timezones.ts
+++ b/src/core/timezones.ts
@@ -64,10 +64,55 @@ export const TIMEZONES: readonly TimezoneEntry[] = [
     { value: 'Pacific/Kiritimati', label: 'Kiritimati' },
 ];
 
+/**
+ * The "follow the market" choice: not a zone but a RULE, resolved per chart to the
+ * symbol's own trading timezone (`SymbolInfo.timezone` — Chicago for CME futures, New
+ * York for US equities, UTC for crypto). It is what the workspace stores and persists;
+ * a renderer only ever receives the resolved IANA zone (see {@link resolveTimezone}).
+ */
+export const EXCHANGE_TIMEZONE = 'exchange';
+
+export function isExchangeTimezone(zone: string): boolean {
+    return zone === EXCHANGE_TIMEZONE;
+}
+
+/**
+ * The IANA zone a chart actually renders in. The exchange rule resolves to the market's
+ * zone, falling back to UTC while symbol metadata is unknown (not landed yet, or a
+ * provider that declares none); an explicit zone passes through untouched.
+ */
+export function resolveTimezone(zone: string, exchangeZone: string | undefined): string {
+    if (!isExchangeTimezone(zone)) return zone;
+    return exchangeZone && exchangeZone !== '' ? exchangeZone : 'Etc/UTC';
+}
+
 /** The renderer's config default is the bare `'UTC'` alias — fold it (and any other
  *  UTC spelling) onto the catalog's `'Etc/UTC'` so selection checks land on one entry. */
 export function normalizeTimezone(zone: string): string {
     return zone === 'UTC' || zone === 'Etc/UTC' || zone === 'Etc/GMT' ? 'Etc/UTC' : zone;
+}
+
+export interface TimezoneRow {
+    /** The value a pick stores — an IANA zone, or {@link EXCHANGE_TIMEZONE}. */
+    value: string;
+    label: string;
+    checked: boolean;
+}
+
+/**
+ * The rows every zone PICKER offers (bottom bar, time-axis menu, mobile sheet): UTC,
+ * then the exchange rule, then the rest of the catalog. `current` is the stored choice
+ * (rule or zone); `exchangeZone` is the active chart's market zone, which labels the
+ * exchange row with its live offset — unknown, the row reads bare "Exchange". The
+ * renderer's own settings dialog does NOT use this: it edits a resolved zone and lists
+ * {@link TIMEZONES} alone.
+ */
+export function timezoneMenuRows(current: string, exchangeZone: string | undefined): TimezoneRow[] {
+    const active = normalizeTimezone(current);
+    const [utc, ...zones] = TIMEZONES.map((t) => ({ value: t.value, label: tzMenuLabel(t.value, t.label), checked: t.value === active }));
+    // `tzButtonLabel`, not `tzOffset`: a UTC market must read "(UTC)", not an ICU "GMT+0".
+    const exchange = { value: EXCHANGE_TIMEZONE, label: exchangeZone ? `(${tzButtonLabel(exchangeZone)}) Exchange` : 'Exchange', checked: isExchangeTimezone(current) };
+    return [utc!, exchange, ...zones];
 }
 
 /** Current UTC offset of an IANA zone as `"UTC"`, `"UTC+2"` or `"UTC-9:30"`. */

--- a/src/core/timezones.ts
+++ b/src/core/timezones.ts
@@ -102,17 +102,15 @@ export interface TimezoneRow {
 /**
  * The rows every zone PICKER offers (bottom bar, time-axis menu, mobile sheet): UTC,
  * then the exchange rule, then the rest of the catalog. `current` is the stored choice
- * (rule or zone); `exchangeZone` is the active chart's market zone, which labels the
- * exchange row with its live offset — unknown, the row reads bare "Exchange". The
+ * (rule or zone). The exchange row reads plain "Exchange" — it is a rule, not a zone, so
+ * it carries no offset (the bar's clock/offset label shows the resolved zone). The
  * renderer's own settings dialog does NOT use this: it edits a resolved zone and lists
  * {@link TIMEZONES} alone.
  */
-export function timezoneMenuRows(current: string, exchangeZone: string | undefined): TimezoneRow[] {
+export function timezoneMenuRows(current: string): TimezoneRow[] {
     const active = normalizeTimezone(current);
     const [utc, ...zones] = TIMEZONES.map((t) => ({ value: t.value, label: tzMenuLabel(t.value, t.label), checked: t.value === active }));
-    // `tzButtonLabel`, not `tzOffset`: a UTC market must read "(UTC)", not an ICU "GMT+0".
-    const exchange = { value: EXCHANGE_TIMEZONE, label: exchangeZone ? `(${tzButtonLabel(exchangeZone)}) Exchange` : 'Exchange', checked: isExchangeTimezone(current) };
-    return [utc!, exchange, ...zones];
+    return [utc!, { value: EXCHANGE_TIMEZONE, label: 'Exchange', checked: isExchangeTimezone(current) }, ...zones];
 }
 
 /** Current UTC offset of an IANA zone as `"UTC"`, `"UTC+2"` or `"UTC-9:30"`. */

--- a/src/widget/bottombar.ts
+++ b/src/widget/bottombar.ts
@@ -8,7 +8,7 @@ import { Menu } from '../ui/components/menu';
 import { Tooltip } from '../ui/components/tooltip';
 import { iconEl } from '../ui/icons';
 import { injectStyles } from '../ui/styles';
-import { TIMEZONES, tzMenuLabel, tzButtonLabel, normalizeTimezone } from './timezones';
+import { timezoneMenuRows, tzButtonLabel, resolveTimezone } from './timezones';
 
 export interface RangePreset {
     /** Button label. */
@@ -116,7 +116,10 @@ const CSS = `
 `;
 
 export interface BottombarOptions {
+    /** The stored display-timezone choice — an IANA zone or the exchange rule. */
     timezone: string;
+    /** The active chart's market zone, resolving the exchange rule (see {@link Bottombar.setTimezone}). */
+    exchangeTimezone?: string;
     /** The second pulse the clock ticks on. Share one with the charts' countdown chips
      *  (`renderer.setWallClock`) so every time display reads the same second; omitted,
      *  the bar runs its own second-aligned clock. */
@@ -139,10 +142,12 @@ export class Bottombar {
     private readonly sessionButtons = new Map<'regular' | 'extended', HTMLButtonElement>();
     private sessionEl: HTMLElement | null = null;
     private timezone: string;
+    private exchangeTimezone: string | undefined;
     private readonly unsubClock: Unsubscribe;
 
     constructor(host: HTMLElement, opts: BottombarOptions) {
         this.timezone = opts.timezone;
+        this.exchangeTimezone = opts.exchangeTimezone;
         const doc = host.ownerDocument;
         injectStyles(STYLE_ID, CSS, doc);
 
@@ -169,7 +174,7 @@ export class Bottombar {
         this.clockEl = doc.createElement('span');
         this.clockEl.className = 'vela-bb-clock';
         this.tzLabelEl = doc.createElement('span');
-        this.tzLabelEl.textContent = tzButtonLabel(this.timezone);
+        this.tzLabelEl.textContent = tzButtonLabel(this.displayZone);
         this.tzButton.append(this.clockEl, this.tzLabelEl);
         const session = doc.createElement('span');
         session.className = 'vela-bb-session';
@@ -207,7 +212,7 @@ export class Bottombar {
             placement: 'top-end',
             items: this.tzItems(),
             onSelect: (zone) => {
-                this.setTimezone(zone);
+                this.setTimezone(zone, this.exchangeTimezone);
                 opts.onTimezone(zone);
             },
         });
@@ -216,11 +221,25 @@ export class Bottombar {
         this.unsubClock = (opts.clock ?? new SecondClock()).onTick(() => this.tick());
     }
 
-    setTimezone(zone: string): void {
+    /**
+     * Reflect the stored choice AND the active chart's market zone. The clock, the
+     * offset label and the exchange row's offset all read the RESOLVED zone, so a
+     * workspace on the exchange rule re-labels when the active cell (or its symbol)
+     * changes market — the host re-projects on both. Idempotent: unchanged inputs
+     * leave the menu alone.
+     */
+    setTimezone(zone: string, exchangeTimezone?: string): void {
+        if (zone === this.timezone && exchangeTimezone === this.exchangeTimezone) return;
         this.timezone = zone;
-        this.tzLabelEl.textContent = tzButtonLabel(zone);
+        this.exchangeTimezone = exchangeTimezone;
+        this.tzLabelEl.textContent = tzButtonLabel(this.displayZone);
         this.tzMenu.setItems(this.tzItems());
         this.tick();
+    }
+
+    /** The zone the bar's clock and label render in. */
+    private get displayZone(): string {
+        return resolveTimezone(this.timezone, this.exchangeTimezone);
     }
 
     /** Highlight (or clear with null) the active range chip — cleared on manual tf changes. */
@@ -253,11 +272,7 @@ export class Bottombar {
     }
 
     private tzItems() {
-        return TIMEZONES.map((t) => ({
-            id: t.value,
-            label: tzMenuLabel(t.value, t.label),
-            checked: t.value === normalizeTimezone(this.timezone),
-        }));
+        return timezoneMenuRows(this.timezone, this.exchangeTimezone).map((r) => ({ id: r.value, label: r.label, checked: r.checked }));
     }
 
     private tick(): void {
@@ -267,7 +282,7 @@ export class Bottombar {
                 minute: '2-digit',
                 second: '2-digit',
                 hour12: false,
-                timeZone: this.timezone,
+                timeZone: this.displayZone,
             }).format(new Date());
         } catch {
             this.clockEl.textContent = '';

--- a/src/widget/bottombar.ts
+++ b/src/widget/bottombar.ts
@@ -222,18 +222,18 @@ export class Bottombar {
     }
 
     /**
-     * Reflect the stored choice AND the active chart's market zone. The clock, the
-     * offset label and the exchange row's offset all read the RESOLVED zone, so a
-     * workspace on the exchange rule re-labels when the active cell (or its symbol)
-     * changes market — the host re-projects on both. Idempotent: unchanged inputs
-     * leave the menu alone.
+     * Reflect the stored choice AND the active chart's market zone. The clock and the
+     * offset label read the RESOLVED zone, so a workspace on the exchange rule re-labels
+     * when the active cell (or its symbol) changes market — the host re-projects on
+     * both. Idempotent: unchanged inputs leave the menu alone.
      */
     setTimezone(zone: string, exchangeTimezone?: string): void {
         if (zone === this.timezone && exchangeTimezone === this.exchangeTimezone) return;
+        const choiceChanged = zone !== this.timezone;
         this.timezone = zone;
         this.exchangeTimezone = exchangeTimezone;
         this.tzLabelEl.textContent = tzButtonLabel(this.displayZone);
-        this.tzMenu.setItems(this.tzItems());
+        if (choiceChanged) this.tzMenu.setItems(this.tzItems()); // the rows only depend on the choice
         this.tick();
     }
 
@@ -272,7 +272,7 @@ export class Bottombar {
     }
 
     private tzItems() {
-        return timezoneMenuRows(this.timezone, this.exchangeTimezone).map((r) => ({ id: r.value, label: r.label, checked: r.checked }));
+        return timezoneMenuRows(this.timezone).map((r) => ({ id: r.value, label: r.label, checked: r.checked }));
     }
 
     private tick(): void {

--- a/src/widget/context-menu-model.ts
+++ b/src/widget/context-menu-model.ts
@@ -3,7 +3,7 @@
 // be tested without a DOM; `ChartContextMenu` reads the renderer, calls these and shows
 // the result.
 import type { MenuItemDescriptor } from '../ui/components/menu';
-import { TIMEZONES, tzMenuLabel } from './timezones';
+import { timezoneMenuRows } from './timezones';
 
 /** Zone a right-click landed in — the chart body, the right price scale, the bottom time axis. */
 export type Zone = 'body' | 'price-axis' | 'time-axis';
@@ -128,14 +128,14 @@ export function priceAxisItems(s: PriceAxisState): MenuItemDescriptor[] {
     ];
 }
 
-export function timeAxisItems(timezone: string): MenuItemDescriptor[] {
-    // A renderer defaulting to the bare `'UTC'` means the same zone as the list's `'Etc/UTC'`.
-    const active = timezone === 'UTC' ? 'Etc/UTC' : timezone;
+/** `timezone` is the host's STORED choice (an IANA zone, or the exchange rule);
+ *  `exchangeTimezone` the chart's market zone, labeling the exchange row's offset. */
+export function timeAxisItems(timezone: string, exchangeTimezone?: string): MenuItemDescriptor[] {
     return [
         {
             id: 'timezone',
             label: 'Time zone',
-            submenu: TIMEZONES.map((t) => ({ id: `tz:${t.value}`, label: tzMenuLabel(t.value, t.label), checked: t.value === active })),
+            submenu: timezoneMenuRows(timezone, exchangeTimezone).map((r) => ({ id: `tz:${r.value}`, label: r.label, checked: r.checked })),
         },
         settingsItem('time-axis', 'More settings…'),
     ];

--- a/src/widget/context-menu-model.ts
+++ b/src/widget/context-menu-model.ts
@@ -128,14 +128,13 @@ export function priceAxisItems(s: PriceAxisState): MenuItemDescriptor[] {
     ];
 }
 
-/** `timezone` is the host's STORED choice (an IANA zone, or the exchange rule);
- *  `exchangeTimezone` the chart's market zone, labeling the exchange row's offset. */
-export function timeAxisItems(timezone: string, exchangeTimezone?: string): MenuItemDescriptor[] {
+/** `timezone` is the host's STORED choice — an IANA zone, or the exchange rule. */
+export function timeAxisItems(timezone: string): MenuItemDescriptor[] {
     return [
         {
             id: 'timezone',
             label: 'Time zone',
-            submenu: timezoneMenuRows(timezone, exchangeTimezone).map((r) => ({ id: `tz:${r.value}`, label: r.label, checked: r.checked })),
+            submenu: timezoneMenuRows(timezone).map((r) => ({ id: `tz:${r.value}`, label: r.label, checked: r.checked })),
         },
         settingsItem('time-axis', 'More settings…'),
     ];

--- a/src/widget/context-menu.ts
+++ b/src/widget/context-menu.ts
@@ -17,6 +17,7 @@ import {
     type ScaleChoice,
     type Zone,
 } from './context-menu-model';
+import { resolveTimezone } from './timezones';
 
 /** Approximate chrome insets used only to classify the right-clicked zone. */
 const PRICE_AXIS_W = 60;
@@ -25,8 +26,10 @@ const TIME_AXIS_H = 26;
 export interface ContextMenuCallbacks {
     /** Reset the view (all history, autoscale back on). */
     resetView: () => void;
-    /** The display timezone the host holds (the time-axis menu checks it). */
+    /** The display-timezone choice the host holds — a zone or the exchange rule (the time-axis menu checks it). */
     timezone?: () => string;
+    /** The chart's market zone, once its symbol metadata is known — labels the exchange row's offset. */
+    exchangeTimezone?: () => string | undefined;
     /** Switch the display timezone through the host, so its own chrome follows. */
     setTimezone?: (zone: string) => void;
     /** Live widget context for contributed `context:*` actions. */
@@ -119,7 +122,7 @@ export class ChartContextMenu {
         }
         if (zone === 'time-axis') {
             const tz = this.cbs.timezone?.() ?? String(this.chart?.renderer.get('timezone') ?? 'Etc/UTC');
-            return [...timeAxisItems(tz), ...this.contributed('time-axis')];
+            return [...timeAxisItems(tz, this.cbs.exchangeTimezone?.()), ...this.contributed('time-axis')];
         }
         const chart = this.chart;
         return [
@@ -147,7 +150,8 @@ export class ChartContextMenu {
         } else if (id.startsWith('tz:')) {
             const zone = id.slice('tz:'.length);
             if (this.cbs.setTimezone) this.cbs.setTimezone(zone);
-            else chart.renderer.set('timezone', zone);
+            // No host to hold the rule: the renderer only understands a real zone.
+            else chart.renderer.set('timezone', resolveTimezone(zone, this.cbs.exchangeTimezone?.()));
         } else if (id === 'auto') {
             chart.renderer.set('autoScale', chart.renderer.get('autoScale') === false);
         } else if (id === 'invert') {

--- a/src/widget/context-menu.ts
+++ b/src/widget/context-menu.ts
@@ -28,8 +28,6 @@ export interface ContextMenuCallbacks {
     resetView: () => void;
     /** The display-timezone choice the host holds — a zone or the exchange rule (the time-axis menu checks it). */
     timezone?: () => string;
-    /** The chart's market zone, once its symbol metadata is known — labels the exchange row's offset. */
-    exchangeTimezone?: () => string | undefined;
     /** Switch the display timezone through the host, so its own chrome follows. */
     setTimezone?: (zone: string) => void;
     /** Live widget context for contributed `context:*` actions. */
@@ -122,7 +120,7 @@ export class ChartContextMenu {
         }
         if (zone === 'time-axis') {
             const tz = this.cbs.timezone?.() ?? String(this.chart?.renderer.get('timezone') ?? 'Etc/UTC');
-            return [...timeAxisItems(tz, this.cbs.exchangeTimezone?.()), ...this.contributed('time-axis')];
+            return [...timeAxisItems(tz), ...this.contributed('time-axis')];
         }
         const chart = this.chart;
         return [
@@ -150,8 +148,8 @@ export class ChartContextMenu {
         } else if (id.startsWith('tz:')) {
             const zone = id.slice('tz:'.length);
             if (this.cbs.setTimezone) this.cbs.setTimezone(zone);
-            // No host to hold the rule: the renderer only understands a real zone.
-            else chart.renderer.set('timezone', resolveTimezone(zone, this.cbs.exchangeTimezone?.()));
+            // No host to hold (and resolve) the rule: the renderer only understands a real zone.
+            else chart.renderer.set('timezone', resolveTimezone(zone, undefined));
         } else if (id === 'auto') {
             chart.renderer.set('autoScale', chart.renderer.get('autoScale') === false);
         } else if (id === 'invert') {

--- a/src/widget/shell-options.ts
+++ b/src/widget/shell-options.ts
@@ -29,7 +29,8 @@ export interface VelaShellOptions {
     indicators?: string | IndicatorManifest | IndicatorLoader;
     /** Topbar timeframe presets (chart timeframe values). */
     timeframes?: string[];
-    /** Display timezone (IANA; default 'Etc/UTC') — one zone for the whole shell. */
+    /** Display timezone — one choice for the whole shell: an IANA zone (default
+     *  'Etc/UTC'), or `'exchange'` to render every chart in its own market's zone. */
     timezone?: string;
     /** Chrome toggles (all default true). */
     statusline?: boolean;

--- a/src/widget/timezone-drawer.ts
+++ b/src/widget/timezone-drawer.ts
@@ -1,9 +1,10 @@
-// Timezone drawer (mobile) — opened by a long-press on the time axis. Lists every
-// IANA zone the desktop bottom-bar picker offers; picking one applies and closes.
+// Timezone drawer (mobile) — opened by a long-press on the time axis. Lists the same
+// rows as the desktop bottom-bar picker (exchange rule + every IANA zone); picking one
+// applies and closes.
 import { Drawer } from '../ui/components/drawer';
 import { iconEl } from '../ui/icons';
 import { injectStyles } from '../ui/styles';
-import { TIMEZONES, tzMenuLabel, normalizeTimezone } from './timezones';
+import { timezoneMenuRows } from './timezones';
 
 const STYLE_ID = 'vela-widget-timezone-drawer';
 const CSS = `
@@ -25,7 +26,10 @@ const CSS = `
 
 export interface TimezoneDrawerOptions {
     host: HTMLElement;
+    /** The stored choice — a zone or the exchange rule. */
     timezone: () => string;
+    /** The active chart's market zone (labels the exchange row's offset). */
+    exchangeTimezone?: () => string | undefined;
     onTimezone: (zone: string) => void;
     onOpenChange?: (open: boolean) => void;
 }
@@ -56,15 +60,14 @@ export class TimezoneDrawer {
         this.drawer.body.replaceChildren();
         const list = doc.createElement('div');
         list.className = 'vela-tzd-list';
-        const current = normalizeTimezone(this.opts.timezone());
-        for (const tz of TIMEZONES) {
+        for (const tz of timezoneMenuRows(this.opts.timezone(), this.opts.exchangeTimezone?.())) {
             const row = doc.createElement('div');
             row.className = 'vela-tzd-row';
             const label = doc.createElement('span');
             label.className = 'vela-tzd-row-label';
-            label.textContent = tzMenuLabel(tz.value, tz.label);
+            label.textContent = tz.label;
             row.appendChild(label);
-            if (tz.value === current) row.appendChild(iconEl('check', doc));
+            if (tz.checked) row.appendChild(iconEl('check', doc));
             row.addEventListener('click', () => {
                 this.opts.onTimezone(tz.value);
                 this.drawer.hide();

--- a/src/widget/timezone-drawer.ts
+++ b/src/widget/timezone-drawer.ts
@@ -28,8 +28,6 @@ export interface TimezoneDrawerOptions {
     host: HTMLElement;
     /** The stored choice — a zone or the exchange rule. */
     timezone: () => string;
-    /** The active chart's market zone (labels the exchange row's offset). */
-    exchangeTimezone?: () => string | undefined;
     onTimezone: (zone: string) => void;
     onOpenChange?: (open: boolean) => void;
 }
@@ -60,7 +58,7 @@ export class TimezoneDrawer {
         this.drawer.body.replaceChildren();
         const list = doc.createElement('div');
         list.className = 'vela-tzd-list';
-        for (const tz of timezoneMenuRows(this.opts.timezone(), this.opts.exchangeTimezone?.())) {
+        for (const tz of timezoneMenuRows(this.opts.timezone())) {
             const row = doc.createElement('div');
             row.className = 'vela-tzd-row';
             const label = doc.createElement('span');

--- a/src/widget/timezones.ts
+++ b/src/widget/timezones.ts
@@ -1,4 +1,4 @@
 // Timezone catalog + labels — canonical data lives in the core (`src/core/timezones`)
 // so the renderer's settings dialog shares the exact same list; re-exported here to keep
 // the widget's public surface stable.
-export { TIMEZONES, normalizeTimezone, tzOffset, tzMenuLabel, tzButtonLabel, type TimezoneEntry } from '../core/timezones';
+export { TIMEZONES, EXCHANGE_TIMEZONE, resolveTimezone, timezoneMenuRows, normalizeTimezone, tzOffset, tzMenuLabel, tzButtonLabel, type TimezoneEntry } from '../core/timezones';

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -459,7 +459,6 @@ export class ChartCell {
         this.contextMenu = new ChartContextMenu(this.host, {
             resetView: () => this.resetView(),
             timezone: () => this.deps.timezone(),
-            exchangeTimezone: () => this.exchangeZone,
             setTimezone: (zone) => this.deps.setTimezone(zone),
             // Right-clicking activates the cell first (capture-phase pointerdown), so the
             // context the actions receive is this cell's — the active one.

--- a/src/workspace/ChartCell.ts
+++ b/src/workspace/ChartCell.ts
@@ -37,7 +37,7 @@ import {
 } from '../widget/contributions';
 import { prefixedSymbol, type CellState } from '../state/document';
 import { parseSymbol } from '../data/ProviderRegistry';
-import { normalizeTimezone } from '../core/timezones';
+import { normalizeTimezone, resolveTimezone } from '../core/timezones';
 import { applyPlotOverlayTokens } from '../ui';
 
 /** The seed/mutable market state of one cell (all optional — an empty cell parks).
@@ -141,7 +141,8 @@ export interface CellDeps {
     /** Where the renderer mounts its MODAL dialogs (chart/indicator settings) — the
      *  workspace root, so dialogs center over the whole grid instead of one cell. */
     dialogHost: HTMLElement;
-    /** The workspace-global display timezone (applied to every cell's renderer). */
+    /** The workspace-global display-timezone CHOICE — an IANA zone, or the exchange
+     *  rule, which each cell resolves to its own market's zone ({@link ChartCell.applyTimezone}). */
     timezone(): string;
     /** Switch the workspace-global display timezone (a cell's time-axis menu). */
     setTimezone(zone: string): void;
@@ -229,6 +230,9 @@ export class ChartCell {
     /** Latched: the symbol's extended tape wraps midnight (an overnight roll market) —
      *  one extended-hours shading phase instead of the pre/post split. */
     private sessionOvernightFlag = false;
+    /** Latched: the symbol's own trading zone (`SymbolInfo.timezone`) — what the exchange
+     *  rule resolves to on this cell. Undefined until metadata lands or when none is declared. */
+    private exchangeZone: string | undefined;
 
     private inner: Vela | null;
     /** The live app theme — seeded from deps, updated on `theme:changed` (the base the
@@ -351,10 +355,13 @@ export class ChartCell {
         // The renderer's settings dialog owns a Time zone row too (it commits through
         // applyConfig) — mirror it back so the workspace bottom bar, the other cells and
         // the persisted state never disagree with this cell's axis. `renderer.set` is a
-        // feature write, not an applyConfig, so adopting the value cannot loop.
+        // feature write, not an applyConfig, so adopting the value cannot loop. The
+        // comparison is against the RESOLVED zone: under the exchange rule the renderer
+        // legitimately holds the market's zone, and that must not read as a user edit
+        // (which would demote the rule to that fixed zone).
         this.inner.renderer.onConfigChanged(() => {
             const zone = this.inner?.renderer.get('timezone');
-            if (typeof zone === 'string' && normalizeTimezone(zone) !== normalizeTimezone(this.deps.timezone())) {
+            if (typeof zone === 'string' && normalizeTimezone(zone) !== normalizeTimezone(this.displayTimezone)) {
                 this.deps.setTimezone(normalizeTimezone(zone));
             }
             this.syncStatuslineColors(); // a settings edit may have recolored the active style
@@ -406,8 +413,7 @@ export class ChartCell {
             this.refreshSessionShading(); // the first painted bars now define the exact range
         });
         this.inner.on('viewport:changed', (range) => this.sessionShading.updateRange(range));
-        const tz = deps.timezone();
-        if (tz !== 'Etc/UTC') this.inner.renderer.set('timezone', tz);
+        this.applyTimezone();
 
         this.indicatorTitlesOn = seed.indicatorTitles ?? true;
         if (!this.indicatorTitlesOn) this.inner.renderer.set('indicatorTitles', false);
@@ -436,7 +442,7 @@ export class ChartCell {
                 this.statusline?.setSymbol(this.state.symbol);
                 this.statusline?.setMeta(this.state.timeframe ?? '60', this.inner.data.displayPrefix(this.state.symbol) ?? this.state.provider ?? '');
             }
-            this.refreshSessionAvailable();
+            this.refreshSymbolMetadata();
             if (this.inner && this.state.symbol) this.marketStatus?.track(this.inner.data, this.state.symbol);
         });
         this.syncStatuslineColors();
@@ -453,6 +459,7 @@ export class ChartCell {
         this.contextMenu = new ChartContextMenu(this.host, {
             resetView: () => this.resetView(),
             timezone: () => this.deps.timezone(),
+            exchangeTimezone: () => this.exchangeZone,
             setTimezone: (zone) => this.deps.setTimezone(zone),
             // Right-clicking activates the cell first (capture-phase pointerdown), so the
             // context the actions receive is this cell's — the active one.
@@ -532,7 +539,7 @@ export class ChartCell {
         this.offMarket = this.inner.on('market:changed', ({ symbol, timeframe }) => {
             this.projectMarket(symbol, timeframe);
             this.refreshNativeCatalog(); // per-symbol support flags may differ
-            this.refreshSessionAvailable(); // the new symbol may (not) have sessions
+            this.refreshSymbolMetadata(); // the new symbol may (not) have sessions, and its own zone
             if (this.inner) this.marketStatus?.track(this.inner.data, symbol); // …and its own market clock
             this.deps.onMarketChanged(this.id);
         });
@@ -578,7 +585,40 @@ export class ChartCell {
         void this.inner?.setMarket({ session });
     }
 
-    private refreshSessionAvailable(): void {
+    /**
+     * The symbol's own trading zone, once its metadata has landed — what the exchange
+     * rule resolves to on this cell (the workspace labels the shared bottom bar with the
+     * ACTIVE cell's). Undefined = unknown or undeclared (the rule then renders UTC).
+     */
+    get exchangeTimezone(): string | undefined {
+        return this.exchangeZone;
+    }
+
+    /** The IANA zone this cell's axis renders in: the workspace choice, resolved. */
+    get displayTimezone(): string {
+        return resolveTimezone(this.deps.timezone(), this.exchangeZone);
+    }
+
+    /**
+     * Push the resolved zone to the renderer — on the workspace choice changing, and on
+     * this cell's market zone changing under the exchange rule. Skips the write when the
+     * renderer already holds it (its config default is the bare `'UTC'` alias).
+     */
+    applyTimezone(): void {
+        const chart = this.inner;
+        if (!chart) return;
+        const zone = this.displayTimezone;
+        const current = chart.renderer.get('timezone');
+        // A renderer without the feature reads `undefined` — treat it as the default so a
+        // UTC workspace never issues a write it would only warn about.
+        const held = typeof current === 'string' && current ? current : 'UTC';
+        if (normalizeTimezone(held) === normalizeTimezone(zone)) return;
+        chart.renderer.set('timezone', zone);
+    }
+
+    /** Re-read the symbol's metadata: session posture (RTH/ETH toggle, shading) and its
+     *  trading zone (the exchange rule). Async — the workspace re-projects when a verdict lands. */
+    private refreshSymbolMetadata(): void {
         const chart = this.inner;
         const symbol = this.state.symbol;
         if (!chart || !symbol) return;
@@ -586,10 +626,16 @@ export class ChartCell {
             if (this.inner !== chart) return;
             const available = typeof si?.session === 'string' && si.session !== '' && si.session !== '24x7';
             const overnight = parseSessionSpec(si)?.overnight === true;
-            if (available !== this.sessionAvailableFlag || overnight !== this.sessionOvernightFlag) {
+            const zone = typeof si?.timezone === 'string' && si.timezone !== '' ? si.timezone : undefined;
+            const zoneChanged = zone !== this.exchangeZone;
+            if (zoneChanged) {
+                this.exchangeZone = zone;
+                this.applyTimezone(); // a no-op unless the workspace follows the exchange
+            }
+            if (available !== this.sessionAvailableFlag || overnight !== this.sessionOvernightFlag || zoneChanged) {
                 this.sessionAvailableFlag = available;
                 this.sessionOvernightFlag = overnight;
-                this.deps.onMarketChanged(this.id); // re-project the shared bottombar toggle
+                this.deps.onMarketChanged(this.id); // re-project the shared bottombar toggle + zone label
                 this.pushSettingsSections(); // the Trading session group follows the symbol
             }
             this.refreshSessionShading();

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -1061,12 +1061,23 @@ export class VelaWorkspace {
         }
     }
 
-    /** Set the workspace-global display timezone — applied to EVERY cell. */
+    /**
+     * Set the workspace-global display timezone — applied to EVERY cell. An IANA zone,
+     * or `'exchange'` (the exchange rule): each cell then renders in its OWN market's
+     * zone (Chicago for a CME future, New York for a US equity, UTC for crypto), and the
+     * bottom bar follows the active cell's.
+     */
     setTimezone(zone: string): void {
         this.timezone = zone;
-        this.bottombar?.setTimezone(zone);
-        for (const cell of this.cellsById.values()) cell.chart.renderer.set('timezone', zone);
+        this.projectTimezone();
+        for (const cell of this.cellsById.values()) cell.applyTimezone();
         this.markStateDirty();
+    }
+
+    /** Bottom bar ⇐ the stored choice + the ACTIVE cell's market zone (labels the exchange row). */
+    private projectTimezone(): void {
+        const active = this.activeId ? this.cellsById.get(this.activeId) : undefined;
+        this.bottombar?.setTimezone(this.timezone, active?.exchangeTimezone);
     }
 
     /**
@@ -1292,6 +1303,7 @@ export class VelaWorkspace {
         this.dock.onChart(cell.chart); // every docked panel follows the active cell
         this.bottombar?.setActiveRange(cell.activeRangeId);
         this.bottombar?.setSession({ session: cell.session, enabled: cell.sessionAvailable });
+        this.projectTimezone(); // under the exchange rule the bar's zone is the active cell's
         this.indicatorPicker?.sync(); // the dialog may be open while the active cell changes
         this.glider.stop(); // a mid-glide switch must not steer the next cell's viewport
         // Shared drawing toolbar ⇄ the active cell: re-apply the GLOBAL tool + magnet + stay
@@ -1932,6 +1944,7 @@ export class VelaWorkspace {
         this.mobileBar?.setTimeframe(cell.timeframe);
         this.objectTree.setSymbol(cell.symbol);
         this.bottombar?.setSession({ session: cell.session, enabled: cell.sessionAvailable });
+        this.projectTimezone(); // the new symbol's market zone, once its metadata lands
         // The chip highlight must track the cell through EVERY market path: a timeframe
         // change (cell API, contribution context, sync link) leaves range mode and a
         // direct `applyRange` enters it — the bar follows the cell's own record.
@@ -2100,6 +2113,7 @@ export class VelaWorkspace {
         this.timezoneDrawer ??= new TimezoneDrawer({
             host: this.root,
             timezone: () => this.timezone,
+            exchangeTimezone: () => (this.activeId ? this.cellsById.get(this.activeId)?.exchangeTimezone : undefined),
             onTimezone: (zone) => this.setTimezone(zone),
             onOpenChange: (open) => this.trackDialog(open),
         });

--- a/src/workspace/VelaWorkspace.ts
+++ b/src/workspace/VelaWorkspace.ts
@@ -2113,7 +2113,6 @@ export class VelaWorkspace {
         this.timezoneDrawer ??= new TimezoneDrawer({
             host: this.root,
             timezone: () => this.timezone,
-            exchangeTimezone: () => (this.activeId ? this.cellsById.get(this.activeId)?.exchangeTimezone : undefined),
             onTimezone: (zone) => this.setTimezone(zone),
             onOpenChange: (open) => this.trackDialog(open),
         });

--- a/test/chart-cell-timezone.test.ts
+++ b/test/chart-cell-timezone.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+// This jsdom build ships no `CSS` global; the style injector only needs `escape`.
+(globalThis as { CSS?: unknown }).CSS ??= { escape: (v: string) => v };
+
+import { ChartCell, type CellBoot, type CellDeps } from '../src/workspace/ChartCell';
+import { MultiProviderFeed } from '../src/data/MultiProviderFeed';
+import { BarStore } from '../src/data/BarStore';
+import type { DataProvider } from '../src/core/ports/DataProvider';
+import type {
+    IChartRenderer,
+    RendererCapabilities,
+    IndicatorRenderHandle,
+    VisibleRange,
+    InputChangeEvent,
+    ClickEvent,
+    CrosshairEvent,
+} from '../src/core/ports/IChartRenderer';
+import type { OHLCV } from '../src/core/model/ohlcv';
+import type { InputValue } from '../src/core/model/inputs';
+import type { IndicatorModel, Pane, ScenePatch } from '../src/core/model';
+import type { PriceStyle } from '../src/core/options';
+import type { Unsubscribe } from '../src/core/util/types';
+import { DARK_THEME } from '../src/core/theme';
+
+/**
+ * The exchange time-zone rule at the cell seam: the workspace stores `'exchange'`, and
+ * each cell resolves it to ITS market's `SymbolInfo.timezone` — Chicago for a future,
+ * UTC for crypto — re-resolving when the symbol changes and never writing the rule
+ * itself into the renderer. A real MultiProviderFeed routes two fake providers; only
+ * the renderer is a fake that records the `timezone` feature.
+ */
+
+const HOUR = 3_600_000;
+const makeBars = (n: number): OHLCV[] =>
+    Array.from({ length: n }, (_, i) => ({ time: 1_700_000_000_000 + i * HOUR, open: 100, high: 101, low: 99, close: 100.5, volume: 1 }));
+
+function fakeProvider(tickers: string[], symInfo: Record<string, unknown> | null): DataProvider {
+    return {
+        getBars: (_t, _tf, range) => Promise.resolve(makeBars(range.limit ?? 10)),
+        listSymbols: () => Promise.resolve(tickers.map((ticker) => ({ ticker }))),
+        ...(symInfo ? { getSymbolInfo: (ticker: string) => Promise.resolve({ ticker, ...symInfo }) } : {}),
+    };
+}
+
+/** Minimal renderer that only remembers the `timezone` feature (the axis zone). */
+class ZoneRenderer implements IChartRenderer {
+    readonly capabilities: RendererCapabilities = {
+        panes: true,
+        paneManagement: false,
+        fills: 'primitive',
+        bgcolor: 'primitive',
+        hline: 'native',
+        markers: true,
+        barcolor: 'approximated',
+        perPointColor: true,
+        drawings: true,
+        userDrawings: false,
+        tables: true,
+        inputsUI: true,
+    };
+    readonly name = 'zone-fake';
+    readonly features: readonly string[] = ['timezone'];
+    timezone = 'UTC'; // the native renderer's config default
+    writes: string[] = [];
+    mount(): void {}
+    setTheme(): void {}
+    resize(): void {}
+    applyFeature(feature: string, value: unknown): void {
+        if (feature === 'timezone') {
+            this.timezone = String(value);
+            this.writes.push(this.timezone);
+        }
+    }
+    readFeature(feature: string): unknown {
+        return feature === 'timezone' ? this.timezone : undefined;
+    }
+    destroy(): void {}
+    setBars(): void {}
+    updateBar(): void {}
+    ensurePane(_p: Pane): void {}
+    removePane(): void {}
+    mountIndicator(model: IndicatorModel): IndicatorRenderHandle {
+        return { id: model.id };
+    }
+    updateIndicator(_h: IndicatorRenderHandle, _p: ScenePatch): void {}
+    removeIndicator(): void {}
+    setIndicatorInputs(_h: IndicatorRenderHandle, _v: Record<string, InputValue>): void {}
+    setIndicatorVisible(): void {}
+    onInputChange(_cb: (e: InputChangeEvent) => void): Unsubscribe {
+        return () => {};
+    }
+    onRemoveIndicator(_cb: (id: string) => void): Unsubscribe {
+        return () => {};
+    }
+    onToggleIndicatorVisible(_cb: (id: string, visible: boolean) => void): Unsubscribe {
+        return () => {};
+    }
+    onCrosshairMove(_cb: (e: CrosshairEvent) => void): Unsubscribe {
+        return () => {};
+    }
+    onClick(_cb: (e: ClickEvent) => void): Unsubscribe {
+        return () => {};
+    }
+    getVisibleRange(): VisibleRange | null {
+        return null;
+    }
+    setVisibleRange(): void {}
+    onViewportChange(_cb: (r: VisibleRange) => void): Unsubscribe {
+        return () => {};
+    }
+    onPriceStyleChange(_cb: (style: PriceStyle) => void): Unsubscribe {
+        return () => {};
+    }
+    setNativeData(): void {}
+    setIndicatorStatus(): void {}
+}
+
+let lastRenderer: ZoneRenderer | null = null;
+class TrackedZoneRenderer extends ZoneRenderer {
+    constructor() {
+        super();
+        lastRenderer = this;
+    }
+}
+
+function makeFeed(): MultiProviderFeed {
+    const feed = new MultiProviderFeed(new BarStore());
+    void feed.registerProvider('cme', fakeProvider(['ES1!'], { timezone: 'America/Chicago', session: '1700-1600' }));
+    void feed.registerProvider('binance', fakeProvider(['BTCUSDT'], { timezone: 'Etc/UTC', session: '24x7' }));
+    void feed.registerProvider('bare', fakeProvider(['XYZ'], null)); // no metadata at all
+    return feed;
+}
+
+function makeDeps(feed: MultiProviderFeed, timezone: () => string, over: Partial<CellDeps> = {}): CellDeps {
+    return {
+        feed,
+        engines: {},
+        chartDefaults: { renderer: TrackedZoneRenderer, drawings: false } as CellDeps['chartDefaults'],
+        theme: DARK_THEME,
+        live: false,
+        volume: false,
+        statusline: false,
+        watermark: false,
+        nativeBackend: 'canvas2d',
+        dialogHost: document.body,
+        timezone,
+        setTimezone: () => {},
+        context: () => ({}) as never,
+        manifestSettled: () => true,
+        activate: () => {},
+        multiCell: () => false,
+        isMaximized: () => false,
+        toggleMaximize: () => {},
+        cellDragTarget: () => null,
+        previewDropTarget: () => {},
+        dropCell: () => {},
+        onMarketChanged: () => {},
+        onPriceStyleChanged: () => {},
+        onIndicatorsChanged: () => {},
+        onStatusPrefsChanged: () => {},
+        onStateDirty: () => {},
+        toast: () => {},
+        ...over,
+    };
+}
+
+function makeCell(symbol: string, deps: CellDeps): ChartCell {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    return new ChartCell('c1', host, { symbol, timeframe: '60', priceStyle: 'candles' } as CellBoot, deps);
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 30));
+
+describe('ChartCell — the exchange time-zone rule', () => {
+    it("resolves 'exchange' to the symbol's own zone once its metadata lands", async () => {
+        const onMarketChanged = vi.fn();
+        const cell = makeCell('cme:ES1!', makeDeps(makeFeed(), () => 'exchange', { onMarketChanged }));
+        const renderer = lastRenderer!;
+        expect(renderer.writes).toEqual([]); // unknown yet: UTC (the default) — no write
+        await settle();
+        expect(cell.exchangeTimezone).toBe('America/Chicago');
+        expect(cell.displayTimezone).toBe('America/Chicago');
+        expect(renderer.timezone).toBe('America/Chicago');
+        expect(renderer.writes).not.toContain('exchange'); // the renderer only ever sees a real zone
+        expect(onMarketChanged).toHaveBeenCalled(); // the workspace re-labels the shared bottom bar
+        cell.destroy();
+    });
+
+    it('re-resolves when the symbol changes market — and falls back to UTC without metadata', async () => {
+        const cell = makeCell('cme:ES1!', makeDeps(makeFeed(), () => 'exchange'));
+        const renderer = lastRenderer!;
+        await settle();
+        expect(renderer.timezone).toBe('America/Chicago');
+
+        cell.setSymbol('binance:BTCUSDT');
+        await settle();
+        expect(cell.exchangeTimezone).toBe('Etc/UTC');
+        expect(renderer.timezone).toBe('Etc/UTC');
+
+        cell.setSymbol('bare:XYZ');
+        await settle();
+        expect(cell.exchangeTimezone).toBeUndefined();
+        expect(cell.displayTimezone).toBe('Etc/UTC');
+        cell.destroy();
+    });
+
+    it('a fixed workspace zone ignores the market zone; switching to the rule adopts it', async () => {
+        let zone = 'Europe/Paris';
+        const cell = makeCell('cme:ES1!', makeDeps(makeFeed(), () => zone));
+        const renderer = lastRenderer!;
+        await settle();
+        expect(cell.exchangeTimezone).toBe('America/Chicago'); // known…
+        expect(renderer.timezone).toBe('Europe/Paris'); // …but not applied under a fixed zone
+
+        zone = 'exchange';
+        cell.applyTimezone(); // what VelaWorkspace.setTimezone does per cell
+        expect(renderer.timezone).toBe('America/Chicago');
+
+        zone = 'Asia/Tokyo';
+        cell.applyTimezone();
+        expect(renderer.timezone).toBe('Asia/Tokyo');
+        cell.destroy();
+    });
+
+    it('applyTimezone skips the write when the renderer already holds the resolved zone', async () => {
+        const cell = makeCell('cme:ES1!', makeDeps(makeFeed(), () => 'exchange'));
+        const renderer = lastRenderer!;
+        await settle();
+        const before = renderer.writes.length;
+        cell.applyTimezone();
+        cell.applyTimezone();
+        expect(renderer.writes.length).toBe(before);
+        cell.destroy();
+    });
+});

--- a/test/context-menu-model.test.ts
+++ b/test/context-menu-model.test.ts
@@ -137,16 +137,12 @@ describe('time-axis menu', () => {
         }
     });
 
-    it('the exchange row checks under the rule and carries the market zone offset when known', () => {
-        const known = timeAxisItems('exchange', 'Asia/Tokyo')[0]!.submenu!;
-        expect(known.filter((z) => z.checked).map((z) => z.id)).toEqual(['tz:exchange']);
-        expect(known[1]!.label).toBe('(UTC+9) Exchange');
-        // Metadata not landed (or none declared): the row stays offered, unlabeled.
-        const unknown = timeAxisItems('exchange')[0]!.submenu!;
-        expect(unknown[1]!.label).toBe('Exchange');
-        expect(unknown[1]!.checked).toBe(true);
+    it('the exchange row reads plain "Exchange" (a rule, no offset) and checks under the rule', () => {
+        const zones = timeAxisItems('exchange')[0]!.submenu!;
+        expect(zones.filter((z) => z.checked).map((z) => z.id)).toEqual(['tz:exchange']);
+        expect(zones[1]!.label).toBe('Exchange');
         // A fixed zone active: the exchange row is offered but not checked.
-        expect(timeAxisItems('Europe/Paris', 'Asia/Tokyo')[0]!.submenu![1]!.checked).toBe(false);
+        expect(timeAxisItems('Europe/Paris')[0]!.submenu![1]!.checked).toBe(false);
     });
 });
 

--- a/test/context-menu-model.test.ts
+++ b/test/context-menu-model.test.ts
@@ -121,11 +121,12 @@ describe('price-axis menu', () => {
 });
 
 describe('time-axis menu', () => {
-    it('lists every timezone and checks the active one', () => {
+    it('lists UTC, the exchange rule, then every other timezone, and checks the active one', () => {
         const items = timeAxisItems('Europe/Paris');
         expect(items.map((i) => i.id)).toEqual(['timezone', 'settings:Scales and lines']);
         const zones = items[0]!.submenu!;
-        expect(zones).toHaveLength(TIMEZONES.length);
+        expect(zones).toHaveLength(TIMEZONES.length + 1);
+        expect(zones.slice(0, 2).map((z) => z.id)).toEqual(['tz:Etc/UTC', 'tz:exchange']);
         expect(zones.filter((z) => z.checked).map((z) => z.id)).toEqual(['tz:Europe/Paris']);
         expect(zones.find((z) => z.id === 'tz:Asia/Tokyo')?.label).toBe('(UTC+9) Tokyo');
     });
@@ -134,6 +135,18 @@ describe('time-axis menu', () => {
         for (const tz of ['UTC', 'Etc/UTC']) {
             expect(timeAxisItems(tz)[0]!.submenu!.filter((z) => z.checked).map((z) => z.id)).toEqual(['tz:Etc/UTC']);
         }
+    });
+
+    it('the exchange row checks under the rule and carries the market zone offset when known', () => {
+        const known = timeAxisItems('exchange', 'Asia/Tokyo')[0]!.submenu!;
+        expect(known.filter((z) => z.checked).map((z) => z.id)).toEqual(['tz:exchange']);
+        expect(known[1]!.label).toBe('(UTC+9) Exchange');
+        // Metadata not landed (or none declared): the row stays offered, unlabeled.
+        const unknown = timeAxisItems('exchange')[0]!.submenu!;
+        expect(unknown[1]!.label).toBe('Exchange');
+        expect(unknown[1]!.checked).toBe(true);
+        // A fixed zone active: the exchange row is offered but not checked.
+        expect(timeAxisItems('Europe/Paris', 'Asia/Tokyo')[0]!.submenu![1]!.checked).toBe(false);
     });
 });
 

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -134,19 +134,17 @@ describe('widget chrome pure helpers', () => {
         expect(resolveTimezone('UTC', 'America/Chicago')).toBe('UTC'); // the renderer's alias is left alone
     });
 
-    it('picker rows: UTC, then the exchange rule with the market offset, then the catalog with one check', () => {
-        const rows = timezoneMenuRows(EXCHANGE_TIMEZONE, 'Asia/Tokyo');
+    it('picker rows: UTC, then a plain "Exchange" rule row, then the catalog with one check', () => {
+        const rows = timezoneMenuRows(EXCHANGE_TIMEZONE);
         expect(rows).toHaveLength(TIMEZONES.length + 1);
         expect(rows[0]!.value).toBe('Etc/UTC');
-        expect(rows[1]).toEqual({ value: 'exchange', label: '(UTC+9) Exchange', checked: true });
+        expect(rows[1]).toEqual({ value: 'exchange', label: 'Exchange', checked: true });
         expect(rows.filter((r) => r.checked)).toHaveLength(1);
         expect(rows.filter((r) => r.value !== 'exchange').map((r) => r.value)).toEqual(TIMEZONES.map((t) => t.value));
 
-        const fixed = timezoneMenuRows('UTC', 'Asia/Tokyo');
+        const fixed = timezoneMenuRows('UTC');
         expect(fixed[1]!.checked).toBe(false);
         expect(fixed.filter((r) => r.checked).map((r) => r.value)).toEqual(['Etc/UTC']);
-        // A UTC market (crypto) labels the rule with the bare offset.
-        expect(timezoneMenuRows(EXCHANGE_TIMEZONE, 'Etc/UTC')[1]!.label).toBe('(UTC) Exchange');
     });
 
     it('price-style labels: built-ins + registry labels + raw id fallback', () => {

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -5,7 +5,7 @@ import { parseTimeframe, timeframeMs, timeframeLabel, favoriteTimeframeChips } f
 import { inputDeltas } from '../src/core/model/inputs';
 import { indicatorLedger, resolveIndicators } from '../src/widget/indicators';
 import { fmtPrice, fmtChange, decimalsFor } from '../src/widget/format';
-import { tzMenuLabel, tzButtonLabel } from '../src/widget/timezones';
+import { tzMenuLabel, tzButtonLabel, resolveTimezone, timezoneMenuRows, EXCHANGE_TIMEZONE, TIMEZONES } from '../src/widget/timezones';
 import { priceStyleLabel } from '../src/widget/topbar';
 import { RANGE_PRESETS } from '../src/widget/bottombar';
 import { filterSymbols } from '../src/widget/symbol-picker';
@@ -124,6 +124,29 @@ describe('widget chrome pure helpers', () => {
         expect(tzMenuLabel('Europe/Paris', 'Paris')).toMatch(/^\(UTC\+[12]\) Paris$/); // CET/CEST
         expect(tzButtonLabel('Etc/UTC')).toBe('UTC');
         expect(tzButtonLabel('Asia/Tokyo')).toBe('UTC+9');
+    });
+
+    it('the exchange rule resolves to the market zone, UTC while unknown; fixed zones pass through', () => {
+        expect(resolveTimezone(EXCHANGE_TIMEZONE, 'America/Chicago')).toBe('America/Chicago');
+        expect(resolveTimezone(EXCHANGE_TIMEZONE, undefined)).toBe('Etc/UTC');
+        expect(resolveTimezone(EXCHANGE_TIMEZONE, '')).toBe('Etc/UTC');
+        expect(resolveTimezone('Europe/Paris', 'America/Chicago')).toBe('Europe/Paris');
+        expect(resolveTimezone('UTC', 'America/Chicago')).toBe('UTC'); // the renderer's alias is left alone
+    });
+
+    it('picker rows: UTC, then the exchange rule with the market offset, then the catalog with one check', () => {
+        const rows = timezoneMenuRows(EXCHANGE_TIMEZONE, 'Asia/Tokyo');
+        expect(rows).toHaveLength(TIMEZONES.length + 1);
+        expect(rows[0]!.value).toBe('Etc/UTC');
+        expect(rows[1]).toEqual({ value: 'exchange', label: '(UTC+9) Exchange', checked: true });
+        expect(rows.filter((r) => r.checked)).toHaveLength(1);
+        expect(rows.filter((r) => r.value !== 'exchange').map((r) => r.value)).toEqual(TIMEZONES.map((t) => t.value));
+
+        const fixed = timezoneMenuRows('UTC', 'Asia/Tokyo');
+        expect(fixed[1]!.checked).toBe(false);
+        expect(fixed.filter((r) => r.checked).map((r) => r.value)).toEqual(['Etc/UTC']);
+        // A UTC market (crypto) labels the rule with the bare offset.
+        expect(timezoneMenuRows(EXCHANGE_TIMEZONE, 'Etc/UTC')[1]!.label).toBe('(UTC) Exchange');
     });
 
     it('price-style labels: built-ins + registry labels + raw id fallback', () => {


### PR DESCRIPTION
## What

Adds an **Exchange** option to the time-zone picker (bottom bar, time-axis context menu, mobile sheet), listed right under UTC. Picking it renders every chart in its own market's zone — Chicago for a CME future, New York for a US equity, UTC for crypto — as declared by the provider's `SymbolInfo.timezone`. In a multi-chart grid each cell follows its own market; the bottom-bar clock and offset follow the active cell.

Hosts can also set it from code: `timezone: 'exchange'` or `setTimezone('exchange')`. The choice persists with the workspace document.

## How

- `src/core/timezones.ts` — the `'exchange'` sentinel, `resolveTimezone(choice, marketZone)` (rule → market zone, UTC while unknown; fixed zones pass through), and `timezoneMenuRows()`, the one row list every picker consumes. `TIMEZONES` stays IANA-only.
- `ChartCell` — latches `SymbolInfo.timezone` alongside the existing session-metadata read, resolves the rule per cell, and pushes only a real IANA zone to the renderer. The settings-dialog mirror now compares against the *resolved* zone, so an unrelated config edit under the rule no longer demotes it to a fixed zone.
- `VelaWorkspace` — stores the choice, re-resolves each cell on change, labels the bottom bar from the active cell's market zone.
- The renderer's own settings dialog is untouched: it edits a resolved zone and shows that zone checked; picking a fixed zone there returns the whole workspace to it.

No data-server or engine change: the Lux provider already attaches `timezone` from the catalogue's per-market `session.tz`, and the built-in Binance provider declares `Etc/UTC`.

## Verification

- Gate: typecheck · lint · test (1684, incl. new `test/chart-cell-timezone.test.ts` driving a real `MultiProviderFeed` with Chicago / UTC / no-metadata providers) · build — all green.
- Playground, real clicks: picker shows `(UTC) Exchange` on Binance; after picking it and switching to a runtime-registered Chicago-zoned symbol the axis/clock read `UTC-5` and the row reads `(UTC-5) Exchange`; an unrelated settings edit keeps the rule; picking Tokyo in the settings dialog demotes to `Asia/Tokyo`; `setTimezone('exchange')` re-resolves; the rule survives reload.

## Notes for review

- `oracle-tests/vela` not run: it pins the Pine model→render path, which this widget-layer change does not touch.
- `CHANGELOG.md` entry under `[Unreleased]` → Added; `docs/user/workspace.md` updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared timezone state across workspace cells, renderer config sync, and multiple UI entry points; incorrect resolution or mirroring could show wrong axis times or persist the wrong mode.
> 
> **Overview**
> Adds a workspace-level **`exchange`** display-timezone mode so charts can follow each symbol’s market zone from provider metadata instead of a single fixed IANA zone.
> 
> **Core behavior:** `EXCHANGE_TIMEZONE`, `resolveTimezone()`, and shared `timezoneMenuRows()` (UTC, then **Exchange**, then the catalog) feed the bottom bar, time-axis context menu, and mobile timezone drawer. Picking **Exchange** persists `'exchange'`; each `ChartCell` latches `SymbolInfo.timezone`, pushes only the resolved IANA zone to the renderer, and re-applies when the symbol or workspace choice changes. The bottom-bar clock/offset label uses the **active** cell’s resolved zone; choosing any fixed zone from chrome or settings demotes the whole workspace to that zone. Config mirroring from the renderer compares against the resolved zone so exchange mode is not accidentally overwritten.
> 
> **API/docs:** `timezone: 'exchange'` / `setTimezone('exchange')` on the shell; changelog and workspace docs updated. Tests cover resolution, menu rows, and cell behavior via `chart-cell-timezone.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880328b01f998777ff851b191e8654f40b54a5cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->