### PR TITLE
Add handle.updateCode: replace an indicator's script in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Vela, newest first.
 
 ## [Unreleased]
 
+### Added
+
+- **Replace an indicator's script in place.** `handle.updateCode(source)` re-runs an
+  indicator on new code without taking it off the chart: it keeps its identity, legend
+  row, pane placement, visibility and any handle you hold, and input values carry over
+  wherever the new script still declares them. The new source is compiled before the
+  running one is stopped, so a script that fails to compile leaves the current indicator
+  computing and painting and reports through the handle's `error` event. Runs caused this
+  way report `cause: 'code'` on `script:run`. Native indicators, which have no script,
+  ignore the call.
+
 ### Fixed
 
 - **Right-click menus and dropdowns follow the app theme, not the plot.** Changing the

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -87,9 +87,9 @@ What `addIndicator` returns. Usable immediately.
 
 | Member | Description |
 |---|---|
-| `id` | Stable, content-addressed identity for this indicator. |
+| `id` | This instance's identity on the chart — stable for as long as the indicator stays on it (input edits, hide/show and `updateCode` all keep it). |
 | `title` | Display title (overridable via the `title` option). |
-| `source` | The script source the indicator was added with; `undefined` for a native indicator. |
+| `source` | The script source the indicator currently runs — the one it was added with, until `updateCode` replaces it; `undefined` for a native indicator. |
 | `nativeType` | The registered type of a native indicator (`'volume'`, `'sma'`, …); `undefined` for a script indicator. A handle has one of `source` or `nativeType`, never both. |
 | `inputs` | The inputs parsed from the script source — each with a `key`, `title`, `type`, `defval`, and optional `min`/`max`/`step`/`options`/`group`/`inline`/`tab`/`tooltip`. Populated once the script is prepared. |
 | `props` | The script's declaration properties (a strategy's `initial_capital`, an indicator's `precision`, …) in the same schema shape as `inputs`. Empty when the engine exposes none. |
@@ -98,6 +98,7 @@ What `addIndicator` returns. Usable immediately.
 | `setInputs(values)` | Change several inputs at once, keyed by input key or title. |
 | `setProp(key, value)` | Override one declaration property (e.g. `initial_capital`). A prop change replays the whole script. |
 | `setProps(values)` | Override several declaration properties at once. |
+| `updateCode(source)` | Replace the script and re-run it **in place** — same `id`, legend row, pane placement and handle. The new source is compiled first; only then is the running script stopped and the new one started, so a broken edit leaves the current indicator computing and painting and reports through `error`. Input and prop values survive where the new script still declares their key; anything else takes the new default. No-op for a native indicator and for an unchanged source. |
 | `setVisible(visible)` | Hide or show the indicator. Hiding suspends it — its visuals are dropped and its computation stops; showing re-runs it over the current bars. |
 | `on(event, handler)` | Per-indicator events — `ready`, `error` (`{ error }`), `alert` (`{ id, message, title?, time }`). Returns an unsubscribe function. |
 | `context(select?)` | `Promise` of a **read-only, serializable snapshot** of the engine's execution context — see [below](#capturing-what-a-script-computes). `null` when the engine lacks the capability or nothing ran yet. |
@@ -115,6 +116,10 @@ macd.on('error', ({ error }) => console.error('MACD failed:', error.message));
 // Retune inputs — each change triggers a re-run.
 macd.setInput('fast', 8);
 macd.setInputs({ slow: 21, signal: 5 });
+
+// Swap the code under the same row — an editor's "run my edit". A source that fails
+// to compile leaves the current MACD running and fires `error` instead.
+macd.updateCode(editedMacdSource);
 
 // Hiding suspends it (visuals dropped, computation stopped); showing re-runs it.
 macd.setVisible(false);
@@ -160,6 +165,7 @@ and nothing to await.
 | `'tick'` | The forming bar changed — **values can still move**. |
 | `'bar'` | A new bar opened, so the one before it is **final**. |
 | `'inputs'` | An input was edited. |
+| `'code'` | The script was replaced in place (`handle.updateCode`). |
 | `'viewport'` | The visible range moved (viewport-aware scripts only). |
 | `'market'` | The chart's market changed and the script re-executed. |
 

--- a/src/core/IndicatorHandle.ts
+++ b/src/core/IndicatorHandle.ts
@@ -16,9 +16,10 @@ export interface IndicatorEventMap extends Record<string, unknown> {
 export interface IndicatorHandle {
     readonly id: string;
     readonly title: string;
-    /** The script source this indicator was added with. `undefined` for a NATIVE
-     *  (core-computed) indicator — there is no script to show. What a host editor
-     *  opens when a legend action asks for "the code behind this row". */
+    /** The script source this indicator currently runs (the one it was added with,
+     *  until {@link updateCode} replaces it). `undefined` for a NATIVE (core-computed)
+     *  indicator — there is no script to show. What a host editor opens when a legend
+     *  action asks for "the code behind this row". */
     readonly source?: string;
     /** The registered type of a NATIVE (core-computed) indicator — `undefined` for a
      *  script indicator. The two are exclusive: a handle has a `source` or a `nativeType`. */
@@ -43,6 +44,17 @@ export interface IndicatorHandle {
     setProp(key: string, value: InputValue): void;
     /** Override several declaration props at once and re-run. */
     setProps(values: Record<string, InputValue>): void;
+    /**
+     * Replace the script and re-run it **in place** — same `id`, same legend row, same
+     * pane placement, same handle; the seam for a host editor's "run my edit" and for a
+     * library's "update to the new version". The new source is prepared first: only once
+     * it compiles is the running script stopped and the new one started, so a broken edit
+     * leaves the current indicator computing and painting and reports through `error`.
+     * Input and prop values survive where the new script still declares their key;
+     * anything else takes the new declaration default. No-op for a native indicator and
+     * for an unchanged source.
+     */
+    updateCode(source: string): void;
     /**
      * Hide or show the indicator. Hiding **suspends** it — its visuals are dropped (the legend
      * row stays, marked hidden) and its computation stops (the engine session is torn down), so a

--- a/src/core/engine/EngineOrchestrator.ts
+++ b/src/core/engine/EngineOrchestrator.ts
@@ -1,12 +1,12 @@
 import type { IChartRenderer, VisibleRange } from '../ports/IChartRenderer';
 import type { MarketDataFeed, BarRange } from '../ports/MarketDataFeed';
-import type { ScriptingEngine, ExecutionMarket, VisibleBarRange, BarsChangeReason } from '../ports/ScriptingEngine';
+import type { ScriptingEngine, ExecutionMarket, VisibleBarRange, BarsChangeReason, PreparedScript } from '../ports/ScriptingEngine';
 import type { Unsubscribe } from '../util/types';
 import type { OHLCV } from '../model/ohlcv';
 import type { IndicatorModel } from '../model/indicator';
 import type { ValuePatch, SeriesValueDelta } from '../model/patch';
 import { isLineLikeSeries } from '../model/series';
-import type { InputValue } from '../model/inputs';
+import type { InputSchema, InputValue } from '../model/inputs';
 import type { VelaTheme, MarketConfig, MarketSwitch, MarketSnapshot, AddIndicatorOptions, PriceStyle, MoveTarget, PaneInfo } from '../options';
 import type { PaneController } from '../PanesControl';
 import type { PaneAction } from '../ports/IChartRenderer';
@@ -1312,6 +1312,67 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
         this.events.emit('indicator:inputs', { id });
     }
 
+    /**
+     * IndicatorController: replace a SCRIPT indicator's source in place (see
+     * {@link IndicatorHandle.updateCode}). Prepare-first: the running session keeps
+     * computing until the new source has compiled, so a broken edit costs the user
+     * nothing but an `error` event. Natives have no script — warn and leave them alone.
+     */
+    updateCode(id: string, source: string): void {
+        const record = this.registry.get(id);
+        const handle = this.handles.get(id);
+        if (!record || !handle) return;
+        if (record.native) {
+            console.warn(`[vela] updateCode("${id}") — a native indicator has no script to update.`);
+            return;
+        }
+        if (source === record.source && record.pendingSource === undefined) return;
+        record.pendingSource = source;
+        void this.swapSource(id, source, handle);
+    }
+
+    private async swapSource(id: string, source: string, handle: IndicatorHandleImpl): Promise<void> {
+        const engine = this.registry.get(id)?.engine ?? this.engineFor(this.registry.get(id)?.options?.language);
+        let prepared: PreparedScript;
+        try {
+            prepared = await engine.prepare(source, id);
+        } catch (err) {
+            const record = this.registry.get(id);
+            // Only the LATEST pending edit reports; a superseded one failing is noise.
+            if (record?.pendingSource === source) {
+                record.pendingSource = undefined;
+                this.fail(id, handle, err);
+            }
+            return;
+        }
+        const record = this.registry.get(id);
+        // Removed, or superseded by a later updateCode, while preparing.
+        if (!record || record.pendingSource !== source) return;
+        record.pendingSource = undefined;
+        record.source = source;
+        record.engine = engine;
+        record.prepared = prepared;
+        handle.setSource(source);
+        // Values survive on the keys (or titles) the new schema still declares; the rest
+        // fall back to the new declaration defaults — a renamed input is a new input.
+        record.inputValues = valuesOnSchema(prepared.inputs, record.inputValues);
+        record.propValues = valuesOnSchema(prepared.props ?? [], record.propValues);
+        handle.setSchema(prepared.inputs);
+        handle.setPropsSchema(prepared.props ?? []);
+        record.session?.stop();
+        record.session = undefined;
+        record.pendingStructural = true; // the first model of the new source remounts over the old visuals
+        record.pendingCause = 'code';
+        if (record.hidden) return; // showing runs the (now replaced) prepared script
+        if (record.renderHandle) {
+            this.renderer.setIndicatorInputs(record.renderHandle, record.inputValues, record.propValues);
+            this.setLoading(record, true);
+        } else {
+            this.mountLoadingPlaceholder(id, record); // updated before its first prepare ever landed
+        }
+        this.executeIndicator(id, handle);
+    }
+
     /** IndicatorController: tear down an indicator and (if now empty) its pane. */
     /** Live handles of every indicator on the chart (script + native), insertion order. */
     listIndicators(): IndicatorHandle[] {
@@ -1498,6 +1559,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             record.engine = engine;
 
             const prepared = await engine.prepare(source, id);
+            // An updateCode that landed during this prepare owns the record now — the
+            // original source must not overwrite the replacement's schema and session.
+            if (record.source !== source) return;
             record.prepared = prepared;
             const defaults: Record<string, InputValue> = {};
             for (const input of prepared.inputs) defaults[input.key] = input.defval;
@@ -1981,7 +2045,9 @@ export class EngineOrchestrator implements IndicatorController, PaneController {
             // so its pane is never re-derived here.)
             const routed = this.routePane(id, model, record.options ?? {});
             if (routed !== paneId) {
-                if (paneId !== 'price') {
+                // A placeholder's pane is its own; after a code update the pane may also hold
+                // indicators merged into it since — those keep it.
+                if (paneId !== 'price' && !this.registry.all().some((r) => r.id !== id && r.model?.paneId === paneId)) {
                     this.renderer.removePane(paneId);
                     this.forgetPane(paneId); // keep core paneOrder in sync (was left stale → desynced list()/anchors/undo)
                 }
@@ -2162,6 +2228,23 @@ function yieldToPaint(): Promise<void> {
         return new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
     }
     return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Re-seat stored values on a NEW schema: every declared key takes its default, then a
+ * previous value is kept where the schema still declares its key (or title — add-time
+ * overrides may be title-keyed). Stale keys drop.
+ */
+function valuesOnSchema(schema: InputSchema[], previous: Record<string, InputValue>): Record<string, InputValue> {
+    const out: Record<string, InputValue> = {};
+    const declared = new Set<string>();
+    for (const s of schema) {
+        out[s.key] = s.defval;
+        declared.add(s.key);
+        declared.add(s.title);
+    }
+    for (const [k, v] of Object.entries(previous)) if (declared.has(k)) out[k] = v;
+    return out;
 }
 
 /** Build a value-only patch from a freshly-run model (used on live ticks / re-runs). */

--- a/src/core/engine/IndicatorHandleImpl.ts
+++ b/src/core/engine/IndicatorHandleImpl.ts
@@ -11,6 +11,7 @@ export interface IndicatorController {
     inputValuesOf(id: string): Record<string, InputValue>;
     propValuesOf(id: string): Record<string, InputValue>;
     applyProps(id: string, values: Record<string, InputValue>): void;
+    updateCode(id: string, source: string): void;
     removeIndicator(id: string): void;
     setVisible(id: string, visible: boolean): void;
     moveIndicator(id: string, target: MoveTarget): void;
@@ -20,8 +21,9 @@ export interface IndicatorController {
 export class IndicatorHandleImpl implements IndicatorHandle {
     readonly id: string;
     title: string;
-    /** The script source (see {@link IndicatorHandle.source}); undefined for natives. */
-    readonly source?: string;
+    /** The script source (see {@link IndicatorHandle.source}); undefined for natives.
+     *  Revised by the orchestrator when {@link updateCode} lands (never before). */
+    source?: string;
     /** The native type (see {@link IndicatorHandle.nativeType}); undefined for scripts. */
     readonly nativeType?: string;
     private schema: InputSchema[] = [];
@@ -78,6 +80,10 @@ export class IndicatorHandleImpl implements IndicatorHandle {
         this.controller.applyProps(this.id, values);
     }
 
+    updateCode(source: string): void {
+        this.controller.updateCode(this.id, source);
+    }
+
     setVisible(visible: boolean): void {
         this.controller.setVisible(this.id, visible);
     }
@@ -105,6 +111,11 @@ export class IndicatorHandleImpl implements IndicatorHandle {
 
     setPropsSchema(schema: InputSchema[]): void {
         this.propsSchema = schema;
+    }
+
+    /** Sync the public `source` once a code update has been prepared and taken over. */
+    setSource(source: string): void {
+        this.source = source;
     }
 
     /** Sync the public `visible` getter when the orchestrator changes visibility (API or legend eye). */

--- a/src/core/engine/IndicatorRegistry.ts
+++ b/src/core/engine/IndicatorRegistry.ts
@@ -30,6 +30,12 @@ export interface IndicatorRecord {
     /** Declaration-prop values (effective defaults merged with user/add-time overrides).
      *  Stays empty for engines without props support and for natives. */
     propValues: Record<string, InputValue>;
+    /**
+     * A source handed to `updateCode` that is still being prepared. The latest call wins:
+     * a prepare that resolves for any other source is discarded, so two quick edits never
+     * race the older one onto the chart.
+     */
+    pendingSource?: string;
     /** The live execution session (static or streaming) — poked on input/viewport/bar changes. */
     session?: ExecutionSession;
     /**

--- a/src/core/script-run.ts
+++ b/src/core/script-run.ts
@@ -18,6 +18,8 @@ export type ScriptRunCause =
     | 'bar'
     /** An input was edited. */
     | 'inputs'
+    /** The script's source was replaced in place (`handle.updateCode`). */
+    | 'code'
     /** The visible range moved (viewport-aware scripts only). */
     | 'viewport'
     /** The chart's market changed and the script re-executed over the new bars. */

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -221,11 +221,16 @@ class MockEngine implements ScriptingEngine {
     private liveSinks: Record<string, { handlers: ExecutionHandlers; req: ExecutionRequest; inputs?: Record<string, InputValue> }> = {};
 
     prepare(source: string, instanceId: string): Promise<PreparedScript> {
+        // A `// broken` marker fails to compile (the updateCode "keep the working script" path).
+        if (/\/\/ broken/.test(source)) return Promise.reject(new Error('mock: syntax error'));
         const overlay = /overlay\s*=\s*true/.test(source);
         const reactsToViewport = /visible/i.test(source);
+        // `// inputs: A,B` declares that input set (default: one `Length`) — how a code update
+        // that renames/adds/drops inputs is expressed to this engine.
+        const keys = /\/\/ inputs:\s*([\w,]+)/.exec(source)?.[1]?.split(',') ?? ['Length'];
         return Promise.resolve({
             language: 'pine',
-            inputs: [{ key: 'Length', title: 'Length', type: 'int', defval: 14 }],
+            inputs: keys.map((key) => ({ key, title: key, type: 'int', defval: 14 })),
             meta: { title: 'Mock', overlay, ...(this.declareShortTitle ? { shorttitle: this.declareShortTitle } : {}) },
             reactsToViewport,
             token: { instanceId, overlay },
@@ -2502,5 +2507,171 @@ describe('native indicators — legend: false (host-owned chrome)', () => {
         } finally {
             unregisterNativeIndicator(testNativeDescriptor.type);
         }
+    });
+});
+
+// ── handle.updateCode — replace the script in place ────────────────────────────────
+
+describe('handle.updateCode — the same indicator runs new code', () => {
+    const OVERLAY = '//@version=5\nindicator("A", overlay=true)\nplot(close)';
+    const OVERLAY_V2 = '//@version=5\nindicator("A", overlay=true)\nplot(open)';
+    const STUDY = '//@version=5\nindicator("A")\nplot(close)';
+
+    async function makeChart(opts: { live?: boolean } = {}) {
+        const renderer = new FakeRenderer();
+        const engine = new MockEngine();
+        const chart = new Vela({} as unknown as HTMLElement, { live: opts.live ?? false, volume: false }, { renderer, engines: [engine], dataFeed: new MockDataFeed() });
+        await chart.ready();
+        await flush();
+        return { chart, renderer, engine };
+    }
+
+    it('keeps the id, handle and legend row: the new source re-runs and remounts idempotently', async () => {
+        const { chart, renderer, engine } = await makeChart();
+        const causes: string[] = [];
+        chart.on('script:run', (run) => causes.push(run.cause));
+        const ind = chart.addIndicator(OVERLAY);
+        await flush();
+        const mountsBefore = renderer.mountedModels.filter((m) => m.id === ind.id).length;
+        const runsBefore = engine.runCount[ind.id] ?? 0;
+
+        ind.updateCode(OVERLAY_V2);
+        await flush();
+
+        expect(ind.source).toBe(OVERLAY_V2); // the handle reports what runs now
+        expect(engine.runCount[ind.id]).toBe(runsBefore + 1); // one fresh execution of the new source
+        expect(renderer.mountedModels.filter((m) => m.id === ind.id).length).toBe(mountsBefore + 1); // remount, same id
+        expect(renderer.removed).not.toContain(ind.id); // never torn down — the row and the handle survive
+        expect(chart.indicators().map((h) => h.id)).toEqual([ind.id]); // no second instance appeared
+        expect(causes[causes.length - 1]).toBe('code'); // the run says why it happened
+    });
+
+    it('stops the previous live session and streams the new script under the same id', async () => {
+        const { renderer, engine, chart } = await makeChart({ live: true });
+        const ind = chart.addIndicator(OVERLAY);
+        await flush();
+        engine.emitStream(ind.id);
+        await flush();
+        expect(engine.streamStarts[ind.id]).toBe(1);
+
+        ind.updateCode(OVERLAY_V2);
+        await flush();
+        expect(engine.streamStops[ind.id]).toBe(1); // the old stream is stopped…
+        expect(engine.streamStarts[ind.id]).toBe(2); // …and a new one opened for the new code
+        const mountsBefore = renderer.mountedModels.filter((m) => m.id === ind.id).length;
+        engine.emitStream(ind.id);
+        await flush();
+        expect(renderer.mountedModels.filter((m) => m.id === ind.id).length).toBe(mountsBefore + 1); // its first model remounts
+    });
+
+    it('a source that fails to compile leaves the running script untouched and reports through error', async () => {
+        const { engine, chart } = await makeChart({ live: true });
+        const ind = chart.addIndicator(OVERLAY);
+        await flush();
+        engine.emitStream(ind.id);
+        await flush();
+        const errors: string[] = [];
+        ind.on('error', ({ error }) => errors.push(error.message));
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        try {
+            ind.updateCode(OVERLAY_V2 + '\n// broken');
+            await flush();
+        } finally {
+            errorSpy.mockRestore();
+        }
+        expect(errors).toEqual(['mock: syntax error']);
+        expect(ind.source).toBe(OVERLAY); // still the working code
+        expect(engine.streamStops[ind.id] ?? 0).toBe(0); // the working session was never stopped
+        expect(engine.streamStarts[ind.id]).toBe(1);
+        expect(chart.indicators()).toHaveLength(1);
+    });
+
+    it('keeps input values the new script still declares, drops the rest, seeds new ones with their defaults', async () => {
+        const { chart } = await makeChart();
+        const ind = chart.addIndicator(OVERLAY);
+        await flush();
+        ind.setInput('Length', 50);
+        await flush();
+
+        ind.updateCode(OVERLAY_V2 + '\n// inputs: Length,Speed');
+        await flush();
+        expect(ind.inputs.map((i) => i.key)).toEqual(['Length', 'Speed']); // the schema follows the code
+        expect(ind.inputValues()).toEqual({ Length: 50, Speed: 14 }); // kept where declared, default where new
+
+        ind.updateCode(OVERLAY_V2 + '\n// inputs: Speed');
+        await flush();
+        expect(ind.inputValues()).toEqual({ Speed: 14 }); // a dropped input leaves no stale value behind
+    });
+
+    it('re-routes the pane when the new script flips overlay, and drops the pane it leaves empty', async () => {
+        const { chart, renderer } = await makeChart();
+        const ind = chart.addIndicator(STUDY);
+        await flush();
+        const studyPane = renderer.mountedModels.filter((m) => m.id === ind.id).pop()!.paneId!;
+        expect(studyPane).not.toBe('price');
+
+        ind.updateCode(OVERLAY);
+        await flush();
+        expect(renderer.mountedModels.filter((m) => m.id === ind.id).pop()!.paneId).toBe('price');
+        expect(renderer.removedPanes).toContain(studyPane); // its old pane had nothing else in it
+        expect(chart.panes.list().map((p) => p.id)).not.toContain(studyPane);
+
+        ind.updateCode(STUDY);
+        await flush();
+        expect(renderer.mountedModels.filter((m) => m.id === ind.id).pop()!.paneId).toBe(studyPane); // back on its own pane
+    });
+
+    it('while hidden it stays suspended; showing runs the NEW source', async () => {
+        const { chart, engine } = await makeChart();
+        const ind = chart.addIndicator(OVERLAY);
+        await flush();
+        ind.setVisible(false);
+        const runsBefore = engine.runCount[ind.id] ?? 0;
+
+        ind.updateCode(OVERLAY_V2);
+        await flush();
+        expect(ind.source).toBe(OVERLAY_V2); // prepared and adopted…
+        expect(engine.runCount[ind.id] ?? 0).toBe(runsBefore); // …but a hidden indicator computes nothing
+
+        ind.setVisible(true);
+        await flush();
+        expect(engine.runCount[ind.id]).toBe(runsBefore + 1);
+    });
+
+    it('is a no-op for the same source and for a native indicator', async () => {
+        const { chart, engine } = await makeChart();
+        const ind = chart.addIndicator(OVERLAY);
+        await flush();
+        const runsBefore = engine.runCount[ind.id]!;
+        ind.updateCode(OVERLAY);
+        await flush();
+        expect(engine.runCount[ind.id]).toBe(runsBefore);
+
+        registerNativeIndicator(testNativeDescriptor);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        try {
+            const native = chart.addNativeIndicator(testNativeDescriptor.type);
+            await flush();
+            native.updateCode(OVERLAY);
+            await flush();
+            expect(native.source).toBeUndefined();
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('native indicator has no script'));
+        } finally {
+            warn.mockRestore();
+            unregisterNativeIndicator(testNativeDescriptor.type);
+        }
+    });
+
+    it('two quick edits: only the LATEST source lands', async () => {
+        const { chart, engine } = await makeChart();
+        const ind = chart.addIndicator(OVERLAY);
+        await flush();
+        const runsBefore = engine.runCount[ind.id]!;
+        ind.updateCode(OVERLAY_V2 + '\n// inputs: A');
+        ind.updateCode(OVERLAY_V2 + '\n// inputs: B');
+        await flush();
+        expect(ind.source).toBe(OVERLAY_V2 + '\n// inputs: B');
+        expect(ind.inputs.map((i) => i.key)).toEqual(['B']);
+        expect(engine.runCount[ind.id]).toBe(runsBefore + 1); // the superseded edit never executed
     });
 });


### PR DESCRIPTION
## What

Adds `IndicatorHandle.updateCode(source)`: re-run a script indicator on new source **in place** — same `id`, legend row, pane placement, visibility and handle.

Until now the only way to change an indicator's code was `remove()` + `addIndicator()`, which mints a new instance (`ind-N+1`) and loses pane lock, stacking, own-scale, the open settings dialog and any handle a host still holds. The Pro Pine editor works around it with a run-then-remove-previous dance and still ends up with a second copy when "Edit code" is used from a legend row.

## Behaviour

- **Prepare first.** The new source is compiled before the running session is stopped. A source that fails to compile leaves the current indicator computing and painting and reports through the handle's `error` event.
- **Values carry over** on the keys (or titles) the new schema still declares; anything else takes the new declaration default. A dropped input leaves no stale value.
- **Latest edit wins.** Two `updateCode` calls in flight resolve to the most recent one only; the superseded prepare is discarded and never executes.
- **Pane re-routing.** The first model after the swap re-routes when the script flips overlay (existing placeholder → computed path). The old pane is dropped only when no other indicator was merged into it.
- **Hidden** indicators adopt the new source but stay suspended; showing runs the new code.
- **Natives** warn and ignore the call; an unchanged source is a no-op.
- `script:run` reports `cause: 'code'` for runs triggered this way (new member of `ScriptRunCause`).

## Public API impact

Additive, minor: one new method on `IndicatorHandle`, one new `ScriptRunCause` member, `IndicatorHandle.source` now documented as "the source currently running". `docs/user/api-reference.md` and `CHANGELOG.md` (`[Unreleased]` → Added) updated; the api-reference row for `id` was also corrected (it described the instance id as content-addressed, which is the per-element id contract, not the instance's).

## Tests

`test/orchestrator.test.ts` — new `handle.updateCode` block (8 cases): same-id remount, live-session stop/restart, compile failure keeps the working script, input merge/drop/seed, overlay flip re-routes and drops the empty pane, hidden stays suspended, native/same-source no-op, latest-of-two-edits wins. The mock engine gained two source-driven knobs (`// broken`, `// inputs: A,B`).

Gate: `typecheck` · `lint` · `test` (138 files / 1692 passed) · `build` — all green.

## Follow-ups (not in this PR)

- Vela-pro: switch the Pine editor's `EditorSession` to `updateCode`, adopt the legend row's handle on "Edit code", and key library persistence by slug/`codeId` instead of exact source text.
- Widget/workspace undo: an `updateCode` on a manifest instance is not recorded in the cell's undo timeline (a redo re-adds the original manifest script). Decide whether the shell should record source swaps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core indicator lifecycle (session stop/start, schema merge, pane routing) on a hot path for editors, though prepare-first and supersede logic limit blast radius.
> 
> **Overview**
> Adds **`IndicatorHandle.updateCode(source)`** so script indicators can run new source **without** remove/re-add: same **`id`**, legend row, pane placement, visibility, and handle reference.
> 
> The orchestrator **prepares first** — only after compile succeeds does it stop the live session, refresh **`handle.source`** and input/prop schemas, merge stored values onto keys the new script still declares (`valuesOnSchema`), and re-execute with **`script:run` `cause: 'code'`**. Failed compiles emit **`error`** and leave the running indicator untouched; concurrent edits use **`pendingSource`** so only the latest wins. Pane cleanup on placeholder→computed routing avoids removing panes that gained other indicators since the swap.
> 
> **Natives** and unchanged source are no-ops. Docs/changelog and **`ScriptRunCause`** gain **`'code'`**; **`IndicatorHandle.source`** is documented as the currently running script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7afb711adb43ceac00b0a3426358a04d4c6890f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->